### PR TITLE
feat(apps,ui,vendo,core): an app you have never laid eyes on arrives with a dot

### DIFF
--- a/.changeset/an-app-arrives-and-takes-shape-where-you-can-see-it.md
+++ b/.changeset/an-app-arrives-and-takes-shape-where-you-can-see-it.md
@@ -1,0 +1,37 @@
+---
+"@vendoai/apps": minor
+"@vendoai/core": minor
+"@vendoai/ui": minor
+"@vendoai/vendo": minor
+---
+
+An app now arrives somewhere a person can see it, and takes shape while they
+watch. Generated apps used to appear by surprise and load behind a generic
+shimmer: nothing said an app was new, a build in flight was a spinner with no
+information in it, and a pinned app had no handle at all.
+
+Arrival is a per-person flag, server-side. `AppsRuntime.seen(appId, ctx)` is the
+idempotent mark, `AppsRuntime.list` now answers `AppListRow[]` — the document
+plus an `unseen?: boolean` this caller's read alone can say — and the rows
+carry it through `VendoClient.apps.list()` to `useAttention().unseenApps`, which
+lights the launcher's quiet dot. Precedence is unchanged: a waiting decision
+still shows the numbered badge instead, and `unseenResults` now means a finished
+run OR an app nobody has looked at (the pill's spoken line names neither half).
+Rendering marks it, and only rendering to a PERSON does: `GET /apps/:id/open`
+records it, while the same runtime door an MCP client or an automation reaches
+through does not, so an agent reading a tree never clears somebody's dot. Rows
+live in `vendo_app_seen`, which puts the engine allowlist at
+`ENGINE_ALLOWLIST_VERSION` 3, and they are swept when the app is deleted.
+
+A build in flight is now visible instead of merely slow. `AppsRuntime.open`
+takes `{ pending?: true }` and answers `PendingSurface` with an optional `tree`
+— the forming payload's GEOMETRY, node ids and nesting and no data values — so
+the embed's existing 1.2s poll paints stepped assembly off the same request
+rather than a bar, and never shows a number it will take back. Unfinished
+sections render wet (dim, desaturated) and dry to full ink as they land, once,
+with the hairline ring following the last one. Slots remember the shape of the
+app they held and wait in its silhouette rather than a shimmer, and a placed app
+carries the ✦ handle: Edit in chat (`OpenConversationOptions.appId` features the
+app on the stage and prefills the composer), Refresh, Unpin. The pin flight
+lands flush and its confirmation ring now waits for the placement write
+(`PinCeremonyOptions.confirmed`) instead of an animation timer.

--- a/docs-site/outside-agents/how-the-door-works.mdx
+++ b/docs-site/outside-agents/how-the-door-works.mdx
@@ -142,6 +142,39 @@ An agent relays it close to verbatim and reports nothing else.
 | `partial` | the screen is up, and the server-side work its plan called for is not |
 | `failed` | nothing painted. One narrower retry on the same `app`, then stop |
 
+## Rendering the app in your own chat
+
+React only — there is no web component and no MCP Apps UI resource. If the chat
+calling `vendo_make` is your own frontend, `<VendoAppEmbed>` is the documented
+way to put the app inline in it, off the receipt's own `id`.
+
+```tsx focus={3-9}
+import { VendoProvider, VendoAppEmbed } from "@vendoai/vendo/react";
+
+const result = await client.callTool({ name: "vendo_make", arguments: { request } });
+const receipt = result.structuredContent as { id: string; title: string; status: string };
+
+return (
+  <VendoProvider>
+    <VendoAppEmbed
+      refValue={{ kind: "vendo/app-ref@1", appId: receipt.id, title: receipt.title, status: "building" }}
+    />
+  </VendoProvider>
+);
+```
+
+`status` on the ref is always the literal `"building"`, whatever the receipt
+actually said — the embed polls your own wire for the real state, so a receipt
+that already came back `"ready"` just resolves on its first poll. Skip the
+mount on `"failed"`: nothing painted, and `say` already says why.
+
+While the build streams, the embed paints the app assembling step by step,
+then swaps to the live app in place.
+
+`<VendoProvider>` rides your product's own session, not the MCP token — the
+same wrapper [Embeds in your chat](/existing-agent/embeds) uses, because this
+polling never goes through the door.
+
 ## Where a screen lands
 
 A new screen goes to the person's own list of views. Pass `slot` on

--- a/packages/apps/src/contract/wire-types.ts
+++ b/packages/apps/src/contract/wire-types.ts
@@ -26,6 +26,14 @@ import {
   type UIPayload,
 } from "@vendoai/core";
 
+/** One row of `GET /apps` — the document, plus what only THIS caller's read can
+ *  say about it. `unseen` is derived per caller and never stored on the row
+ *  every reader shares: set while the app has never rendered for them, absent
+ *  once it has (`persistence/app-seen.ts`). */
+export interface AppListRow extends AppDocument {
+  unseen?: boolean;
+}
+
 /** 06-apps §1 — what `GET /apps/:id/open` returns. */
 export type OpenSurface =
   | { kind: "tree"; payload: UIPayload; components?: Record<string, string> }

--- a/packages/apps/src/server/doors/apps-surface.ts
+++ b/packages/apps/src/server/doors/apps-surface.ts
@@ -88,7 +88,12 @@ const createAppReadDoors = (
       // placed slot, the palette), so "rendering marks it seen" needs no client
       // to remember anything. Idempotent, so the build-window poll that calls
       // open() every 1.2s writes once.
-      await appSeen.mark(appId, ctx.principal.subject);
+      //
+      // A build still in flight has rendered NOTHING yet, whatever this door
+      // answers it with — so it is not seen. That poll is the same caller
+      // asking again, and the first answer carrying a finished app is the one
+      // that marks it.
+      if (app.building === undefined) await appSeen.mark(appId, ctx.principal.subject);
       // Review-kind (2026-08-02): an unapproved current version is invisible —
       // open() serves the newest APPROVED version from the existing history
       // instead (or the pending state when none was ever approved). Instant

--- a/packages/apps/src/server/doors/apps-surface.ts
+++ b/packages/apps/src/server/doors/apps-surface.ts
@@ -13,6 +13,7 @@ import {
 } from "../../contract/index.js";
 import { createAgentTools } from "./agent-tools.js";
 import { allRecords } from "./access-checks.js";
+import { appSeenStore } from "../persistence/app-seen.js";
 import { APPS_COLLECTION, appRecordInput, documentFromRecord, withoutSession } from "../persistence/persistence.js";
 import type { AppsRuntimeContext } from "../runtime/runtime-context.js";
 import type { AppsRuntime } from "../runtime/types.js";
@@ -21,9 +22,10 @@ const createAppReadDoors = (
   deps: Pick<AppsRuntimeContext,
     "config" | "engine" | "caller" | "history" | "review" | "opener" | "owned" | "requireOwned"
     | "grantedRecords">,
-): Pick<AppsRuntime, "get" | "list" | "history" | "open" | "call"> => {
+): Pick<AppsRuntime, "get" | "list" | "history" | "open" | "call" | "seen"> => {
   const { config, engine, caller, history, review, opener, owned, requireOwned } = deps;
   const { grantedRecords } = deps;
+  const appSeen = appSeenStore(engine);
   return {
     async get(appId, ctx) {
       const app = await owned(appId, ctx, "viewer");
@@ -51,7 +53,11 @@ const createAppReadDoors = (
           // Corrupt rows cannot be surfaced, but must not hide valid owned apps.
         }
       }
-      return documents;
+      // Arrival — read state is the CALLER's, so it rides the answer rather
+      // than the row: one query for the whole page, on the fetch every surface
+      // already makes.
+      const unseen = await appSeen.unseen(documents.map((document) => document.id), ctx.principal.subject);
+      return documents.map((document) => unseen.has(document.id) ? { ...document, unseen: true } : document);
     },
 
     /**
@@ -71,8 +77,18 @@ const createAppReadDoors = (
       });
     },
 
+    async seen(appId, ctx) {
+      await requireOwned(appId, ctx, "viewer");
+      await appSeen.mark(appId, ctx.principal.subject);
+    },
+
     async open(appId, ctx, options) {
       const app = await requireOwned(appId, ctx, "viewer");
+      // Arrival — this is the door every render goes through (the embed, a
+      // placed slot, the palette), so "rendering marks it seen" needs no client
+      // to remember anything. Idempotent, so the build-window poll that calls
+      // open() every 1.2s writes once.
+      await appSeen.mark(appId, ctx.principal.subject);
       // Review-kind (2026-08-02): an unapproved current version is invisible —
       // open() serves the newest APPROVED version from the existing history
       // instead (or the pending state when none was ever approved). Instant
@@ -185,7 +201,7 @@ export const createAppsSurface = (
     | "grantedRecords" | "reportLifecycle" | "claimSlot" | "markUnbuilt"
     | "runtime">,
 ): Pick<AppsRuntime,
-  "get" | "list" | "delete" | "fork" | "share" | "publish"
+  "get" | "list" | "delete" | "fork" | "share" | "publish" | "seen"
   | "exportApp" | "importApp" | "history" | "open" | "call" | "agentTools"> => {
   const { config, engine, data, history, review, inClientApprovals } = deps;
   const { egressApprovals, parkedActions, placementRows, lifecycle } = deps;

--- a/packages/apps/src/server/doors/apps-surface.ts
+++ b/packages/apps/src/server/doors/apps-surface.ts
@@ -84,16 +84,11 @@ const createAppReadDoors = (
 
     async open(appId, ctx, options) {
       const app = await requireOwned(appId, ctx, "viewer");
-      // Arrival — this is the door every render goes through (the embed, a
-      // placed slot, the palette), so "rendering marks it seen" needs no client
-      // to remember anything. Idempotent, so the build-window poll that calls
-      // open() every 1.2s writes once.
-      //
-      // A build still in flight has rendered NOTHING yet, whatever this door
-      // answers it with — so it is not seen. That poll is the same caller
-      // asking again, and the first answer carrying a finished app is the one
-      // that marks it.
-      if (app.building === undefined) await appSeen.mark(appId, ctx.principal.subject);
+      // Arrival deliberately does NOT mark here. This door is also how an agent
+      // reads a tree (`vendo_apps_open` through compose-mcp.ts) and how an
+      // automation resolves a surface, and neither is a person looking at a
+      // screen — marking here cleared a human's dot for an app only Claude ever
+      // saw. The person's own render route does the marking (wire/apps.ts).
       // Review-kind (2026-08-02): an unapproved current version is invisible —
       // open() serves the newest APPROVED version from the existing history
       // instead (or the pending state when none was ever approved). Instant
@@ -236,6 +231,8 @@ export const createAppsSurface = (
       // the deleter cannot enumerate, and those pages are the ones that would
       // be left holding it.
       await placementRows.clearForApp(appId);
+      // Every person's read state for an id that can never come back.
+      await appSeenStore(engine).clearForApp(appId);
       await reportLifecycle("delete", appId, ctx);
     },
 

--- a/packages/apps/src/server/persistence/app-seen.ts
+++ b/packages/apps/src/server/persistence/app-seen.ts
@@ -1,0 +1,58 @@
+/**
+ * Per-(app, person) READ STATE — has this person laid eyes on this app yet.
+ *
+ * One row per pair, written the first time the app renders for them and never
+ * rewritten: `insertIfAbsent` IS the idempotence, so a mark costs one write on
+ * the first render and one refused write after that, with no read in front of
+ * it. `seenAt` is therefore first-seen, not last-seen — the arrival dot asks
+ * "has this ever been looked at", which a later view cannot un-answer.
+ *
+ * The rows live in the GENERIC records collection, like the placement and slot
+ * rows beside them: `vendo_app_seen` is neither reserved nor dedicated
+ * (`packages/store/src/routing.ts`), so it routes to `vendo_records` on every
+ * adapter with no migration to run.
+ *
+ * `refs` carries `subject` — the key the erase cascade matches
+ * (`vendo_records WHERE refs @> '{"subject": …}'::jsonb`, `packages/store/src/
+ * erase.ts`), and the only query this surface makes — plus `app_id`, the same
+ * ref name the rest of this package sweeps an app by.
+ */
+import type { AppId, IsoDateTime } from "@vendoai/core";
+import type { EngineOps } from "./engine.js";
+import { listAllEngineRecords } from "./persistence.js";
+
+/** The generic collection the seen rows live in (never a dedicated table). */
+export const APP_SEEN_COLLECTION = "vendo_app_seen";
+
+/** What one row holds. */
+export interface AppSeenRow {
+  seenAt: IsoDateTime;
+}
+
+export interface AppSeenStore {
+  /** Idempotent: the first render wins and every later one costs one refusal. */
+  mark(appId: AppId, subject: string): Promise<void>;
+  /** Which of `appIds` this person has never had rendered to them. */
+  unseen(appIds: readonly AppId[], subject: string): Promise<ReadonlySet<AppId>>;
+}
+
+/** An app id is colon-free by its own grammar (`packages/core/src/ids.ts`), so
+ *  the pair cannot shift however the subject is spelled. */
+const rowId = (appId: AppId, subject: string): string => `${appId}:${subject}`;
+
+export const appSeenStore = (engine: EngineOps): AppSeenStore => ({
+  async mark(appId, subject) {
+    const row: AppSeenRow = { seenAt: new Date().toISOString() };
+    await engine.insertIfAbsent(APP_SEEN_COLLECTION, {
+      id: rowId(appId, subject),
+      data: row,
+      refs: { subject, app_id: appId },
+    });
+  },
+
+  async unseen(appIds, subject) {
+    const rows = await listAllEngineRecords(engine, APP_SEEN_COLLECTION, { refs: { subject } });
+    const seen = new Set(rows.map((record) => record.id));
+    return new Set(appIds.filter((appId) => !seen.has(rowId(appId, subject))));
+  },
+});

--- a/packages/apps/src/server/persistence/app-seen.ts
+++ b/packages/apps/src/server/persistence/app-seen.ts
@@ -34,10 +34,16 @@ export interface AppSeenStore {
   mark(appId: AppId, subject: string): Promise<void>;
   /** Which of `appIds` this person has never had rendered to them. */
   unseen(appIds: readonly AppId[], subject: string): Promise<ReadonlySet<AppId>>;
+  /** Drop every person's read state for one app (app-deletion cleanup). */
+  clearForApp(appId: AppId): Promise<void>;
 }
 
-/** An app id is colon-free by its own grammar (`packages/core/src/ids.ts`), so
- *  the pair cannot shift however the subject is spelled. */
+/** `appIdSchema` pins only the `app_` PREFIX (`packages/core/src/ids.ts:39`), so
+ *  the type does not forbid a colon and this pair is not unambiguous by grammar.
+ *  It is unambiguous by the MINT: every app id Vendo writes is `app_` + a uuid
+ *  (`doors/build-surface.ts`, `apps-surface.ts` fork), which carries no colon.
+ *  Nothing parses this id — both halves are known at every call — so the pair
+ *  only has to be unique, and it is. */
 const rowId = (appId: AppId, subject: string): string => `${appId}:${subject}`;
 
 export const appSeenStore = (engine: EngineOps): AppSeenStore => ({
@@ -51,8 +57,20 @@ export const appSeenStore = (engine: EngineOps): AppSeenStore => ({
   },
 
   async unseen(appIds, subject) {
-    const rows = await listAllEngineRecords(engine, APP_SEEN_COLLECTION, { refs: { subject } });
-    const seen = new Set(rows.map((record) => record.id));
-    return new Set(appIds.filter((appId) => !seen.has(rowId(appId, subject))));
+    // Point reads for the page in hand, never a scan of this person's history:
+    // the row set grows with every app they have ever opened, and the answer
+    // only ever concerns the ids being listed.
+    const rows = await Promise.all(
+      appIds.map((appId) => engine.get(APP_SEEN_COLLECTION, rowId(appId, subject))),
+    );
+    return new Set(appIds.filter((_appId, index) => rows[index] === null));
+  },
+
+  async clearForApp(appId) {
+    // Swept by APP, not by one subject: a shared app was seen by people the
+    // deleter cannot enumerate (the same argument placements.ts makes).
+    for (const record of await listAllEngineRecords(engine, APP_SEEN_COLLECTION, { refs: { app_id: appId } })) {
+      await engine.delete(APP_SEEN_COLLECTION, record.id);
+    }
   },
 });

--- a/packages/apps/src/server/runtime/types.ts
+++ b/packages/apps/src/server/runtime/types.ts
@@ -34,6 +34,7 @@ import type {
 } from "@vendoai/core";
 import type {
   AppDocument,
+  AppListRow,
   BriefingPack,
   NormalizedCatalog,
   PendingSurface,
@@ -568,9 +569,19 @@ export interface AppsRuntime {
    */
   toolShapeBrief(ctx: RunContext): Promise<string>;
   get(appId: AppId, ctx: RunContext): Promise<AppDocument | null>;
-  list(ctx: RunContext): Promise<AppDocument[]>;
+  list(ctx: RunContext): Promise<AppListRow[]>;
   delete(appId: AppId, ctx: RunContext): Promise<void>;
   fork(appId: AppId, ctx: RunContext): Promise<AppDocument>;
+  /**
+   * Arrival (2026-08-17) — mark this app seen BY THIS CALLER, so the launcher's
+   * dot and the panel's "New" marker stop pointing at it. Idempotent, and
+   * viewer-scoped: being able to see the app is the whole act being recorded.
+   *
+   * Rendering marks it on its own — `open` is the one door every render passes
+   * through, so nothing has to remember to call this. The door (and its wire
+   * route) is for a surface that shows an app it never opened.
+   */
+  seen(appId: AppId, ctx: RunContext): Promise<void>;
   /**
    * Placement (2026-08-05) — "show this app in that slot", as a ROW keyed by
    * (subject, slot) rather than a string on the document.

--- a/packages/apps/src/server/runtime/types.ts
+++ b/packages/apps/src/server/runtime/types.ts
@@ -574,12 +574,13 @@ export interface AppsRuntime {
   fork(appId: AppId, ctx: RunContext): Promise<AppDocument>;
   /**
    * Arrival (2026-08-17) — mark this app seen BY THIS CALLER, so the launcher's
-   * dot and the panel's "New" marker stop pointing at it. Idempotent, and
-   * viewer-scoped: being able to see the app is the whole act being recorded.
+   * quiet dot stops pointing at it. Idempotent, and viewer-scoped: being able to
+   * see the app is the whole act being recorded.
    *
-   * Rendering marks it on its own — `open` is the one door every render passes
-   * through, so nothing has to remember to call this. The door (and its wire
-   * route) is for a surface that shows an app it never opened.
+   * Called by the one route a PERSON's render comes through (`GET /apps/:id/open`,
+   * wire/apps.ts). Deliberately not called by `open` itself: an agent reading a
+   * tree over MCP and an automation resolving a surface both go through that
+   * door, and neither is anybody looking at a screen.
    */
   seen(appId: AppId, ctx: RunContext): Promise<void>;
   /**

--- a/packages/apps/tests/app-seen.test.ts
+++ b/packages/apps/tests/app-seen.test.ts
@@ -1,0 +1,57 @@
+/**
+ * The arrival seam. The mark goes in through the real door (`runtime.seen`) and
+ * comes back out of the real read (`runtime.list`), over a real store — nothing
+ * is stubbed on either side, so the writer and the reader cannot agree on a
+ * shape neither of them actually uses.
+ */
+import { engineOverAdapter } from "@vendoai/core";
+import type { RunContext, ToolRegistry } from "@vendoai/core";
+import { describe, expect, it } from "vitest";
+import type { AppDocument } from "../src/contract/index.js";
+import { createApps } from "../src/server/index.js";
+import { guardFixture } from "../src/server/testing/guard-fixture.js";
+import { memoryStore } from "../src/server/testing/memory-store.js";
+import { seedAppRow } from "../src/server/testing/seed-app-row.js";
+
+const ctx: RunContext = {
+  principal: { kind: "user", subject: "user_ada" },
+  venue: "app",
+  presence: "present",
+  sessionId: "session_ada",
+};
+
+const tools: ToolRegistry = {
+  async descriptors() { return []; },
+  async execute() { return { status: "error", error: { code: "not-found", message: "no tools" } }; },
+};
+
+const doc = (id: string, name: string): AppDocument => ({
+  format: "vendo/app@1",
+  id,
+  name,
+  ui: "tree",
+  tree: {
+    formatVersion: "vendo-genui/v2",
+    root: "root",
+    nodes: [{ id: "root", component: "Stack", source: "prewired" }],
+  },
+});
+
+describe("app arrival", () => {
+  it("marks one app seen and leaves the other unseen in the list", async () => {
+    const store = memoryStore();
+    const engine = engineOverAdapter(store);
+    await seedAppRow(engine, doc("app_1", "Spending"), ctx.principal.subject);
+    await seedAppRow(engine, doc("app_2", "Travel"), ctx.principal.subject);
+    const runtime = createApps({ store, guard: guardFixture(), tools, catalog: [] });
+    // Read as a map: `list` orders by recency, which is not what this is about.
+    const unseenByApp = async () =>
+      Object.fromEntries((await runtime.list(ctx)).map((app) => [app.id, app.unseen === true]));
+
+    expect(await unseenByApp()).toEqual({ app_1: true, app_2: true });
+
+    await runtime.seen("app_1", ctx);
+
+    expect(await unseenByApp()).toEqual({ app_1: false, app_2: true });
+  });
+});

--- a/packages/apps/tests/app-seen.test.ts
+++ b/packages/apps/tests/app-seen.test.ts
@@ -9,6 +9,7 @@ import type { RunContext, ToolRegistry } from "@vendoai/core";
 import { describe, expect, it } from "vitest";
 import type { AppDocument } from "../src/contract/index.js";
 import { createApps } from "../src/server/index.js";
+import { APP_SEEN_COLLECTION } from "../src/server/persistence/app-seen.js";
 import { guardFixture } from "../src/server/testing/guard-fixture.js";
 import { memoryStore } from "../src/server/testing/memory-store.js";
 import { seedAppRow } from "../src/server/testing/seed-app-row.js";
@@ -53,5 +54,22 @@ describe("app arrival", () => {
     await runtime.seen("app_1", ctx);
 
     expect(await unseenByApp()).toEqual({ app_1: false, app_2: true });
+  });
+
+  it("takes every person's read state with the app when it is deleted", async () => {
+    const store = memoryStore();
+    const engine = engineOverAdapter(store);
+    await seedAppRow(engine, doc("app_1", "Spending"), ctx.principal.subject);
+    const runtime = createApps({ store, guard: guardFixture(), tools, catalog: [] });
+    await runtime.seen("app_1", ctx);
+    const rows = async () => (await store.records(APP_SEEN_COLLECTION).list({})).records.length;
+
+    expect(await rows()).toBe(1);
+
+    await runtime.delete("app_1", ctx);
+
+    // Not "the deleter's rows": a shared app was seen by people the owner
+    // cannot enumerate, and an id that can never come back must leave none.
+    expect(await rows()).toBe(0);
   });
 });

--- a/packages/apps/tests/lifecycle.test.ts
+++ b/packages/apps/tests/lifecycle.test.ts
@@ -295,7 +295,10 @@ describe("apps lifecycle", () => {
       data: { entry: { at: "not-a-date", intent: "bad", rung: 1 }, doc: null },
     });
 
-    await expect(runtime.list(ctx)).resolves.toEqual([edited.app]);
+    // `unseen` because this app was created and edited but never RENDERED:
+    // nothing has called open() on it, so the arrival dot still points at it
+    // (packages/apps/src/server/persistence/app-seen.ts).
+    await expect(runtime.list(ctx)).resolves.toEqual([{ ...edited.app, unseen: true }]);
     await expect(runtime.history(valid.id, ctx).list()).resolves.toEqual([edited.version]);
   });
 

--- a/packages/core/src/engine-collections.ts
+++ b/packages/core/src/engine-collections.ts
@@ -3,7 +3,7 @@ import { VendoError } from "./errors.js";
 /** Named in every refusal so a caller can tell "this name was never an engine
     collection" from "this build's list is older than yours". Bump it whenever
     ENGINE_COLLECTIONS or ENGINE_COLLECTION_PATTERNS changes. */
-export const ENGINE_ALLOWLIST_VERSION = 2;
+export const ENGINE_ALLOWLIST_VERSION = 3;
 
 /** What a collection HOLDS. `knowledge` is the retrieval corpus — documents and
     the chunks an engine mints from them; everything else is `storage`.
@@ -81,6 +81,7 @@ export const ENGINE_COLLECTION_REGISTRY = {
   vendo_inclient_approvals: { kind: "storage" }, // COLLECTION, packages/apps/src/server/remix/inclient.ts:76
   vendo_remix_rejections: { kind: "storage" }, // COLLECTION, packages/apps/src/server/remix/review.ts:65
   vendo_slots: { kind: "storage" }, // SLOTS_COLLECTION, packages/apps/src/server/persistence/slots.ts:24
+  vendo_app_seen: { kind: "storage" }, // APP_SEEN_COLLECTION, packages/apps/src/server/persistence/app-seen.ts:26
   vendo_workspace_commits: { kind: "storage" }, // WORKSPACE_COMMITS, packages/store/src/ops.ts:27
   "automations:captures": { kind: "storage" }, // CAPTURES, packages/automations/src/types.ts:29
   "automations:armed": { kind: "storage" }, // ARMED, packages/automations/src/types.ts:43

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -48,6 +48,7 @@ export * from "./skills.js";
 export * from "./slot-limits.js";
 export * from "./sse-keepalive.js";
 export * from "./store.js";
+export * from "./thread-window.js";
 export * from "./store-wire.js";
 export * from "./style.js";
 export * from "./engine-collections.js";

--- a/packages/core/src/thread-window.ts
+++ b/packages/core/src/thread-window.ts
@@ -1,0 +1,18 @@
+/**
+ * How much of a long transcript is actually on screen.
+ *
+ * A reopened 200-turn thread does not mount every turn: the client renders only
+ * a trailing window and defers the head behind a "Show N earlier messages"
+ * control (`packages/ui/src/chrome/thread/scrolling.ts`). A deferred message is
+ * not merely scrolled out of view — it is not in the DOM at all, so nothing it
+ * contains has been drawn.
+ *
+ * The number lives HERE, in core, because it stopped being a rendering detail
+ * the moment the server needed the same answer: arrival marks an app seen when a
+ * person's thread read renders it (`packages/vendo/src/wire/threads.ts`), and a
+ * server that walked the whole stored transcript would mark apps buried in the
+ * deferred head — permanently, since a first-seen record cannot be un-answered.
+ * The render window and the mark window are ONE invariant, and `packages/vendo`
+ * cannot import `packages/ui`.
+ */
+export const THREAD_WINDOW_INITIAL = 60;

--- a/packages/core/tests/engine-collections.test.ts
+++ b/packages/core/tests/engine-collections.test.ts
@@ -29,10 +29,10 @@ function messageOf(run: () => unknown): string {
 }
 
 describe("engine allowlist", () => {
-  it("holds 38 distinct static collections", () => {
-    expect(ENGINE_ALLOWLIST_VERSION).toBe(2);
-    expect(ENGINE_COLLECTIONS).toHaveLength(38);
-    expect(new Set(ENGINE_COLLECTIONS).size).toBe(38);
+  it("holds 39 distinct static collections", () => {
+    expect(ENGINE_ALLOWLIST_VERSION).toBe(3);
+    expect(ENGINE_COLLECTIONS).toHaveLength(39);
+    expect(new Set(ENGINE_COLLECTIONS).size).toBe(39);
   });
 
   it("admits one name from each group and refuses host/app data", () => {

--- a/packages/ui/e2e/arrival-dot.spec.ts
+++ b/packages/ui/e2e/arrival-dot.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * The arrival dot, in a real browser: it lights for an app nobody has looked at,
+ * and it clears once the person's render lands — on the shared apps poll, with no
+ * reload. The reload was the whole defect: the count used to be computed once at
+ * the mount of whichever surface happened to list apps, so a dot could neither
+ * appear nor go away while someone sat there.
+ *
+ * Full motion on purpose (the Maple host theme sets `motion: "full"`): the dot is
+ * a painted mark on the pill, and the reduced-motion scenarios are the wrong
+ * place to judge one.
+ */
+test("the launcher dot lights for an unseen app and clears after the render", async ({ page }) => {
+  await page.goto("/arrival-dot");
+
+  const launcher = page.locator(".fl-launcher");
+  await expect(launcher).toBeVisible();
+
+  // The pill carries the quiet dot, and no numbered badge: nothing is waiting on
+  // a decision, something merely arrived.
+  const dot = page.locator(".fl-launcher-dot");
+  await expect(dot).toBeVisible();
+  await expect(page.locator(".fl-launcher-badge")).toHaveCount(0);
+
+  // The spoken half names neither half of what the dot can mean.
+  await expect(launcher).toContainText("Something new to look at");
+
+  await page.getByRole("button", { name: "Render Spending" }).click();
+
+  // No reload, no re-mount: the shared feed's next poll (5s) carries rows without
+  // the flag and the dot withdraws on its own.
+  await expect(dot).toHaveCount(0, { timeout: 15_000 });
+  await expect(launcher).not.toContainText("Something new to look at");
+});

--- a/packages/ui/e2e/arrival-dot.spec.ts
+++ b/packages/ui/e2e/arrival-dot.spec.ts
@@ -3,15 +3,18 @@ import { expect, test } from "@playwright/test";
 /**
  * The arrival dot, in a real browser: it lights for an app nobody has looked at,
  * and it clears once the person's render lands — on the shared apps poll, with no
- * reload. The reload was the whole defect: the count used to be computed once at
- * the mount of whichever surface happened to list apps, so a dot could neither
- * appear nor go away while someone sat there.
+ * reload. Two defects met here. The reload was the first: the count used to be
+ * computed once at the mount of whichever surface happened to list apps, so a dot
+ * could neither appear nor go away while someone sat there. The second was that a
+ * render IN THE THREAD never marked anything, so the dot survived the exact act
+ * that should clear it — which is why the gesture below is opening the
+ * conversation rather than mounting a slot.
  *
  * Full motion on purpose (the Maple host theme sets `motion: "full"`): the dot is
  * a painted mark on the pill, and the reduced-motion scenarios are the wrong
  * place to judge one.
  */
-test("the launcher dot lights for an unseen app and clears after the render", async ({ page }) => {
+test("the launcher dot lights for an unseen app and clears after the thread render", async ({ page }) => {
   await page.goto("/arrival-dot");
 
   const launcher = page.locator(".fl-launcher");
@@ -26,7 +29,7 @@ test("the launcher dot lights for an unseen app and clears after the render", as
   // The spoken half names neither half of what the dot can mean.
   await expect(launcher).toContainText("Something new to look at");
 
-  await page.getByRole("button", { name: "Render Spending" }).click();
+  await page.getByRole("button", { name: "Open the conversation" }).click();
 
   // No reload, no re-mount: the shared feed's next poll (5s) carries rows without
   // the flag and the dot withdraws on its own.

--- a/packages/ui/e2e/harness/main.tsx
+++ b/packages/ui/e2e/harness/main.tsx
@@ -1688,20 +1688,26 @@ function composerThreadClient(client: VendoClient): VendoClient {
  */
 function arrivalClient(client: VendoClient): VendoClient {
   const app = { format: "vendo/app@1", id: "app_arrival", name: "Spending", ui: "tree" as const };
-  let opened = false;
+  let rendered = false;
   return {
     ...client,
     // No pending asks: a waiting decision outranks the dot by design (the pill
     // shows the numbered badge instead), so the arrival mark can only be judged
     // on a pill with nothing else to say.
     approvals: { ...client.approvals, pending: async () => [] },
+    // The render under proof is the one in the THREAD: the card draws the app
+    // from its view part and opens nothing, so the server marks it when the
+    // person reads the conversation back (wire/threads.ts).
+    threads: {
+      ...client.threads,
+      get: (async (id: string) => {
+        rendered = true;
+        return { id, subject: "browser-user", messages: [], createdAt: NOW, updatedAt: NOW };
+      }) as VendoClient["threads"]["get"],
+    },
     apps: {
       ...client.apps,
-      list: async () => [opened ? app : { ...app, unseen: true }],
-      open: (async () => {
-        opened = true;
-        return { kind: "tree", payload: { formatVersion: "vendo-genui/v2", root: "root", nodes: [] } };
-      }) as VendoClient["apps"]["open"],
+      list: async () => [rendered ? app : { ...app, unseen: true }],
     },
   };
 }
@@ -1710,9 +1716,9 @@ function ArrivalDotScenario() {
   const client = useMemo(() => arrivalClient(baseClient), []);
   return (
     <VendoProvider client={client} components={components} theme={mapleTheme}>
-      {/* The person's render, in the one gesture a spec can drive: this is the
-          same call the embed makes when it puts the app on screen. */}
-      <button type="button" onClick={() => void client.apps.open("app_arrival")}>Render Spending</button>
+      {/* The person's render, in the one gesture a spec can drive: reading the
+          conversation back is what a thread render costs on the wire. */}
+      <button type="button" onClick={() => void client.threads.get("thr_arrival")}>Open the conversation</button>
       <VendoOverlay />
     </VendoProvider>
   );

--- a/packages/ui/e2e/harness/main.tsx
+++ b/packages/ui/e2e/harness/main.tsx
@@ -1675,6 +1675,49 @@ function composerThreadClient(client: VendoClient): VendoClient {
   };
 }
 
+/**
+ * Arrival — the launcher's quiet dot for an app nobody has looked at.
+ *
+ * The rows carry `unseen` and opening the app is what drops it, which is exactly
+ * what the real deployment does: the person's `GET /apps/:id/open` marks it
+ * server-side (packages/vendo/src/wire/apps.ts) and the next list poll comes back
+ * without the flag. That server rule is proven over a real store and the real
+ * route table in `packages/vendo/tests/apps-seen.seam.test.ts`; what only a
+ * browser can show is the pill lighting and then clearing on its own, with no
+ * reload — so this client is the two answers, in order.
+ */
+function arrivalClient(client: VendoClient): VendoClient {
+  const app = { format: "vendo/app@1", id: "app_arrival", name: "Spending", ui: "tree" as const };
+  let opened = false;
+  return {
+    ...client,
+    // No pending asks: a waiting decision outranks the dot by design (the pill
+    // shows the numbered badge instead), so the arrival mark can only be judged
+    // on a pill with nothing else to say.
+    approvals: { ...client.approvals, pending: async () => [] },
+    apps: {
+      ...client.apps,
+      list: async () => [opened ? app : { ...app, unseen: true }],
+      open: (async () => {
+        opened = true;
+        return { kind: "tree", payload: { formatVersion: "vendo-genui/v2", root: "root", nodes: [] } };
+      }) as VendoClient["apps"]["open"],
+    },
+  };
+}
+
+function ArrivalDotScenario() {
+  const client = useMemo(() => arrivalClient(baseClient), []);
+  return (
+    <VendoProvider client={client} components={components} theme={mapleTheme}>
+      {/* The person's render, in the one gesture a spec can drive: this is the
+          same call the embed makes when it puts the app on screen. */}
+      <button type="button" onClick={() => void client.apps.open("app_arrival")}>Render Spending</button>
+      <VendoOverlay />
+    </VendoProvider>
+  );
+}
+
 function ComposerScenario({ theme }: { theme: Partial<VendoTheme> }) {
   return (
     <VendoProvider client={composerThreadClient(baseClient)} components={components} theme={theme}>
@@ -1877,6 +1920,7 @@ function scenario(pathname: string): { title: string; theme?: Partial<VendoTheme
     case "/thread-citations": return { title: "Thread — knowledge citations (K1)", content: <ThreadCitationsScenario />, ownProvider: true };
     case "/overlay": return { title: "Overlay", content: <AutoOpen selector='button[aria-controls="vendo-overlay-dialog"]'><VendoOverlay /></AutoOpen> };
     case "/overlay-manual": return { title: "Overlay — manual launcher", content: <VendoOverlay /> };
+    case "/arrival-dot": return { title: "Arrival — the dot for an app nobody has seen", content: <ArrivalDotScenario />, ownProvider: true };
     case "/concurrent": return { title: "Concurrent surfaces", content: <ConcurrentScenario />, ownProvider: true };
     case "/palette": return { title: "Command palette", content: <OpenPalette /> };
     case "/palette-host": return { title: "Palette — host input collision", content: <PaletteHostInputScenario /> };

--- a/packages/ui/src/chrome/launcher-status.tsx
+++ b/packages/ui/src/chrome/launcher-status.tsx
@@ -156,7 +156,9 @@ export function LauncherFace({ status, label, icon }: {
     ? `${status.label}…`
     : status.askCount > 0
       ? `${status.askCount} waiting on you`
-      : status.unseenResults ? "New results in your conversation" : "";
+      // The dot means a finished run OR an app that has never rendered for
+      // them, so the spoken half names neither: it says something arrived.
+      : status.unseenResults ? "Something new to look at" : "";
   return (
     <>
       {status.working

--- a/packages/ui/src/chrome/launcher-status.tsx
+++ b/packages/ui/src/chrome/launcher-status.tsx
@@ -39,7 +39,8 @@ export interface LauncherStatus {
   progress?: { done: number; total: number };
   /** Asks waiting on the user (the numbered badge). */
   askCount: number;
-  /** A finished run the user hasn't looked at (the quiet dot). */
+  /** Something the user hasn't looked at (the quiet dot): a finished run, or an
+   *  app that has never rendered for them. */
   unseenResults: boolean;
   /** The completion toast currently showing, if any. */
   toast?: RunResult;
@@ -63,7 +64,7 @@ export function useLauncherStatus({ open, threadId, onOpen }: {
   const { tools } = useVendoProvider();
   const activity = useSyncExternalStore(subscribeRunActivity, runActivity, () => IDLE_RUN_ACTIVITY);
   const result = useSyncExternalStore(subscribeRunActivity, unseenRunResult, NO_RESULT);
-  const { askCount } = useAttention({ pollMs: ASK_POLL_MS });
+  const { askCount, unseenResults } = useAttention({ pollMs: ASK_POLL_MS });
   const [toast, setToast] = useState<RunResult>();
 
   // While the panel is open, results are seen as they land — the user is
@@ -99,7 +100,7 @@ export function useLauncherStatus({ open, threadId, onOpen }: {
     // open-ended step gets the quiet indeterminate ring instead of a fake bar.
     ...(activity.total > 1 ? { progress: { done: activity.done, total: activity.total } } : {}),
     askCount,
-    unseenResults: !open && result !== undefined,
+    unseenResults: !open && unseenResults,
     ...(!open && toast !== undefined ? { toast } : {}),
     view() {
       setToast(undefined);

--- a/packages/ui/src/chrome/thread/scrolling.ts
+++ b/packages/ui/src/chrome/thread/scrolling.ts
@@ -1,3 +1,6 @@
+// The window size lives in core because the server marks arrival off the same
+// number: see `THREAD_WINDOW_INITIAL`'s own note for why the two cannot drift.
+import { THREAD_WINDOW_INITIAL as WINDOW_INITIAL } from "@vendoai/core";
 import type { UIMessage } from "ai";
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { isAgentContext } from "./message-data.js";
@@ -11,7 +14,6 @@ import { isAgentContext } from "./message-data.js";
     The trailing window is what stick-to-bottom and jump-to-latest already care
     about (both operate at the end), so those behaviors are untouched. Only the
     unseen head of a genuinely long thread is deferred. */
-const WINDOW_INITIAL = 60;
 const WINDOW_STEP = 40;
 const NEAR_TOP_PX = 200;
 

--- a/packages/ui/src/client-impl.ts
+++ b/packages/ui/src/client-impl.ts
@@ -234,9 +234,6 @@ export function createVendoClient(config: VendoClientConfig): VendoClient {
           body: bytes as BodyInit,
         }),
       fork: id => json(`/apps/${idPath(id)}/fork`, "POST"),
-      seen: async id => {
-        await json(`/apps/${idPath(id)}/seen`, "POST");
-      },
       shipDiff: id => readJson(`/apps/${idPath(id)}/ship-diff`),
       reseed: id => json(`/apps/${idPath(id)}/reseed`, "POST"),
       seedFrom: body => json("/apps/seed", "POST", body),

--- a/packages/ui/src/client-impl.ts
+++ b/packages/ui/src/client-impl.ts
@@ -234,6 +234,9 @@ export function createVendoClient(config: VendoClientConfig): VendoClient {
           body: bytes as BodyInit,
         }),
       fork: id => json(`/apps/${idPath(id)}/fork`, "POST"),
+      seen: async id => {
+        await json(`/apps/${idPath(id)}/seen`, "POST");
+      },
       shipDiff: id => readJson(`/apps/${idPath(id)}/ship-diff`),
       reseed: id => json(`/apps/${idPath(id)}/reseed`, "POST"),
       seedFrom: body => json("/apps/seed", "POST", body),

--- a/packages/ui/src/client.ts
+++ b/packages/ui/src/client.ts
@@ -112,9 +112,6 @@ export interface VendoClient {
     exportApp(id: AppId): Promise<Uint8Array>;
     importApp(bytes: Uint8Array): Promise<AppDocument>;
     fork(id: AppId): Promise<AppDocument>;
-    /** POST /apps/:id/seen — the idempotent arrival mark. Rendering an app marks
-        it server-side; this is for a surface that only LISTED it. */
-    seen(id: AppId): Promise<void>;
     /** GET /apps/:id/ship-diff — the reviewable diff vs the captured host baselines (06 §8–§9). */
     shipDiff(id: AppId): Promise<ShipDiff>;
     /** POST /apps/:id/reseed — rebuild the remix against the host's current

--- a/packages/ui/src/client.ts
+++ b/packages/ui/src/client.ts
@@ -21,6 +21,7 @@ import {
 } from "@vendoai/core";
 import type { UIMessage } from "ai";
 import type {
+  AppListRow,
   ApprovalResolution,
   AutomationEntry,
   ConnectableToolkit,
@@ -95,7 +96,7 @@ export interface VendoClient {
   };
 
   apps: {
-    list(): Promise<AppDocument[]>;
+    list(): Promise<AppListRow[]>;
     create(input: { prompt: string }): Promise<AppDocument>;
     get(id: AppId): Promise<AppDocument>;
     delete(id: AppId): Promise<void>;
@@ -111,6 +112,9 @@ export interface VendoClient {
     exportApp(id: AppId): Promise<Uint8Array>;
     importApp(bytes: Uint8Array): Promise<AppDocument>;
     fork(id: AppId): Promise<AppDocument>;
+    /** POST /apps/:id/seen — the idempotent arrival mark. Rendering an app marks
+        it server-side; this is for a surface that only LISTED it. */
+    seen(id: AppId): Promise<void>;
     /** GET /apps/:id/ship-diff — the reviewable diff vs the captured host baselines (06 §8–§9). */
     shipDiff(id: AppId): Promise<ShipDiff>;
     /** POST /apps/:id/reseed — rebuild the remix against the host's current

--- a/packages/ui/src/hooks/apps-feed.ts
+++ b/packages/ui/src/hooks/apps-feed.ts
@@ -1,0 +1,148 @@
+/**
+ * ONE apps poller per client.
+ *
+ * The same shape as `approvals-feed.ts`, and for the same reason: the app
+ * collection is read by more than one surface — a panel that lists apps, and the
+ * launcher pill, which needs the unseen count to light its dot. A module store
+ * fed by whichever surface happened to mount cannot do that: the count froze at
+ * the moment of mount, so an app that arrived mid-session never lit the dot and
+ * rendering one never cleared it, and a host with no app panel at all read zero
+ * forever.
+ *
+ * One request between them, at the FASTEST cadence any subscriber asked for.
+ * `unseen` rides the rows that fetch already returns, so the dot costs no
+ * request of its own — there is no second poller to keep in step with this one.
+ */
+import type { VendoClient } from "../client.js";
+import type { AppListRow } from "../wire-types.js";
+
+export interface AppsSnapshot {
+  data: AppListRow[];
+  error: Error | undefined;
+  isLoading: boolean;
+}
+
+const NO_APPS: AppListRow[] = [];
+
+/** Stable first-render / SSR snapshot (useSyncExternalStore compares identity). */
+export const APPS_LOADING: AppsSnapshot = { data: NO_APPS, error: undefined, isLoading: true };
+
+function asError(reason: unknown): Error {
+  return reason instanceof Error ? reason : new Error(String(reason));
+}
+
+/** Whole-row comparison, like the asks feed: `unseen` flips on a row whose id
+ *  and name never change, and that flip IS the dot. */
+function sameApps(a: AppListRow[], b: AppListRow[]): boolean {
+  return a.length === b.length && a.every((app, index) => {
+    const other = b[index];
+    return other !== undefined && app.id === other.id && JSON.stringify(app) === JSON.stringify(other);
+  });
+}
+
+function unchanged(a: AppsSnapshot, b: AppsSnapshot): boolean {
+  return a.error === b.error && a.isLoading === b.isLoading && sameApps(a.data, b.data);
+}
+
+function hidden(): boolean {
+  return typeof document !== "undefined" && document.visibilityState === "hidden";
+}
+
+class AppsFeed {
+  private snapshot = APPS_LOADING;
+  /** Subscriber → the cadence it asked for (0 = read-only, no polling). */
+  private readonly cadences = new Map<() => void, number>();
+  private timer: ReturnType<typeof setTimeout> | undefined;
+  private generation = 0;
+
+  constructor(private readonly list: () => Promise<AppListRow[]>) {}
+
+  read = (): AppsSnapshot => this.snapshot;
+
+  subscribe = (listener: () => void, pollMs: number): (() => void) => {
+    const first = this.cadences.size === 0;
+    this.cadences.set(listener, pollMs);
+    if (first) {
+      if (typeof document !== "undefined") document.addEventListener("visibilitychange", this.onVisibility);
+      void this.refresh();
+    } else {
+      // A faster subscriber joined: re-arm on the new cadence.
+      this.arm();
+    }
+    return () => {
+      this.cadences.delete(listener);
+      if (this.cadences.size > 0) {
+        this.arm();
+        return;
+      }
+      if (typeof document !== "undefined") document.removeEventListener("visibilitychange", this.onVisibility);
+      this.stop();
+      // Nobody is watching. Drop the in-flight response and the rows: the next
+      // mount deserves its own first load, not a list that may be minutes old.
+      this.generation += 1;
+      this.snapshot = APPS_LOADING;
+    };
+  };
+
+  refresh = async (): Promise<void> => {
+    const generation = (this.generation += 1);
+    try {
+      const data = await this.list();
+      if (generation !== this.generation) return;
+      this.publish({ data, error: undefined, isLoading: false });
+    } catch (reason) {
+      if (generation !== this.generation) return;
+      this.publish({ ...this.snapshot, error: asError(reason), isLoading: false });
+    } finally {
+      if (generation === this.generation) this.arm();
+    }
+  };
+
+  /** How many rows nobody has had rendered to them — the launcher's dot. */
+  unseenCount = (): number => this.snapshot.data.filter((app) => app.unseen === true).length;
+
+  private publish(next: AppsSnapshot): void {
+    if (unchanged(this.snapshot, next)) return;
+    this.snapshot = next;
+    for (const listener of [...this.cadences.keys()]) listener();
+  }
+
+  private arm(): void {
+    this.stop();
+    const cadence = this.cadence();
+    if (cadence === undefined || hidden()) return;
+    this.timer = setTimeout(() => void this.refresh(), cadence);
+  }
+
+  private stop(): void {
+    if (this.timer !== undefined) clearTimeout(this.timer);
+    this.timer = undefined;
+  }
+
+  /** The fastest cadence anybody asked for; undefined = nobody polls. */
+  private cadence(): number | undefined {
+    let fastest: number | undefined;
+    for (const pollMs of this.cadences.values()) {
+      if (pollMs > 0 && (fastest === undefined || pollMs < fastest)) fastest = pollMs;
+    }
+    return fastest;
+  }
+
+  private onVisibility = (): void => {
+    if (hidden()) this.stop();
+    else void this.refresh();
+  };
+}
+
+const feeds = new WeakMap<VendoClient, AppsFeed>();
+
+export function appsFeed(client: VendoClient): AppsFeed {
+  let feed = feeds.get(client);
+  if (feed === undefined) {
+    feed = new AppsFeed(() => client.apps.list());
+    feeds.set(client, feed);
+  }
+  return feed;
+}
+
+export type { AppsFeed };

--- a/packages/ui/src/hooks/apps-feed.ts
+++ b/packages/ui/src/hooks/apps-feed.ts
@@ -2,12 +2,12 @@
  * ONE apps poller per client.
  *
  * The same shape as `approvals-feed.ts`, and for the same reason: the app
- * collection is read by more than one surface — a panel that lists apps, and the
- * launcher pill, which needs the unseen count to light its dot. A module store
- * fed by whichever surface happened to mount cannot do that: the count froze at
- * the moment of mount, so an app that arrived mid-session never lit the dot and
- * rendering one never cleared it, and a host with no app panel at all read zero
- * forever.
+ * collection has more than one reader — every `useApps` caller, and the launcher
+ * pill, which needs the unseen count to light its dot. A module store fed by
+ * whichever of them happened to mount cannot do that: the count froze at the
+ * moment of mount, so an app that arrived mid-session never lit the dot,
+ * rendering one never cleared it, and a host whose surfaces never list apps read
+ * zero forever.
  *
  * One request between them, at the FASTEST cadence any subscriber asked for.
  * `unseen` rides the rows that fetch already returns, so the dot costs no

--- a/packages/ui/src/hooks/use-approvals.ts
+++ b/packages/ui/src/hooks/use-approvals.ts
@@ -9,6 +9,7 @@ import {
   type RunResult,
 } from "../chrome/run-activity.js";
 import { APPROVALS_LOADING, approvalsFeed } from "./approvals-feed.js";
+import { subscribeUnseenApps, unseenApps } from "./use-apps.js";
 import { type PollOptions } from "./use-resource.js";
 
 /** SSR / first-render snapshot, stable across calls. */
@@ -43,6 +44,8 @@ export function useApprovals(options?: PollOptions): {
 }
 
 const NO_RESULT = (): RunResult | undefined => undefined;
+/** SSR / first-render snapshot for the unseen count. */
+const NO_UNSEEN = () => 0;
 
 /**
  * The ONE attention source. Everything that asks for the user's attention
@@ -59,8 +62,11 @@ export function useAttention(options?: PollOptions): ReturnType<typeof useApprov
   askCount: number;
   /** Alias for the rows behind that count, in the strip's own words. */
   asks: ApprovalRequest[];
-  /** A finished run whose result nobody has looked at yet (the quiet dot). */
+  /** Something arrived that nobody has looked at yet (the quiet dot): a
+   *  finished run's result, or an app that has never rendered for this person. */
   unseenResults: boolean;
+  /** How many of those are apps — the arrival half of the dot. */
+  unseenApps: number;
   /** The finished run itself — headline + the thread to deep-link into. */
   lastResult: RunResult | undefined;
   /** The user looked: clears the dot (and any completion toast). */
@@ -68,11 +74,15 @@ export function useAttention(options?: PollOptions): ReturnType<typeof useApprov
 } {
   const approvals = useApprovals(options);
   const lastResult = useSyncExternalStore(subscribeRunActivity, unseenRunResult, NO_RESULT);
+  // Arrival — the count rides `useApps`'s existing list fetch (use-apps.ts), so
+  // reading it here adds no request and cannot disagree with the panel's rows.
+  const apps = useSyncExternalStore(subscribeUnseenApps, unseenApps, NO_UNSEEN);
   return {
     ...approvals,
     askCount: approvals.pending.length,
     asks: approvals.pending,
-    unseenResults: lastResult !== undefined,
+    unseenResults: lastResult !== undefined || apps > 0,
+    unseenApps: apps,
     lastResult,
     markResultsSeen: markRunResultsSeen,
   };

--- a/packages/ui/src/hooks/use-approvals.ts
+++ b/packages/ui/src/hooks/use-approvals.ts
@@ -8,8 +8,8 @@ import {
   unseenRunResult,
   type RunResult,
 } from "../chrome/run-activity.js";
+import { appsFeed } from "./apps-feed.js";
 import { APPROVALS_LOADING, approvalsFeed } from "./approvals-feed.js";
-import { subscribeUnseenApps, unseenApps } from "./use-apps.js";
 import { type PollOptions } from "./use-resource.js";
 
 /** SSR / first-render snapshot, stable across calls. */
@@ -47,6 +47,11 @@ const NO_RESULT = (): RunResult | undefined => undefined;
 /** SSR / first-render snapshot for the unseen count. */
 const NO_UNSEEN = () => 0;
 
+/** The apps cadence, matching the ask cadence: the badge and the dot ride two
+ *  different collections, and a person reads them as one signal, so they must
+ *  not be able to sit a poll apart. */
+const APPS_POLL_MS = 5_000;
+
 /**
  * The ONE attention source. Everything that asks for the user's attention
  * counts from here: the launcher's numbered badge, the approvals queue, and the
@@ -72,11 +77,19 @@ export function useAttention(options?: PollOptions): ReturnType<typeof useApprov
   /** The user looked: clears the dot (and any completion toast). */
   markResultsSeen(): void;
 } {
+  const { client } = useVendoProvider();
   const approvals = useApprovals(options);
   const lastResult = useSyncExternalStore(subscribeRunActivity, unseenRunResult, NO_RESULT);
-  // Arrival — the count rides `useApps`'s existing list fetch (use-apps.ts), so
-  // reading it here adds no request and cannot disagree with the panel's rows.
-  const apps = useSyncExternalStore(subscribeUnseenApps, unseenApps, NO_UNSEEN);
+  // Arrival — the SHARED apps feed, at this hook's own cadence. Whoever else is
+  // listing apps shares the request; nobody listing them at all (a host with no
+  // app panel) still gets a live count, which a store fed by someone else's
+  // mount could never do.
+  const feed = appsFeed(client);
+  const subscribeApps = useCallback(
+    (listener: () => void) => feed.subscribe(listener, options?.pollMs ?? APPS_POLL_MS),
+    [feed, options?.pollMs],
+  );
+  const apps = useSyncExternalStore(subscribeApps, feed.unseenCount, NO_UNSEEN);
   return {
     ...approvals,
     askCount: approvals.pending.length,

--- a/packages/ui/src/hooks/use-apps.ts
+++ b/packages/ui/src/hooks/use-apps.ts
@@ -3,26 +3,14 @@ import {
   type AppDocument,
   type AppId,
 } from "@vendoai/core";
-import { useCallback, useEffect } from "react";
+import { useCallback, useSyncExternalStore } from "react";
 import { useVendoProvider } from "../context.js";
 import type { AppListRow } from "../wire-types.js";
-import { type PollOptions, useResource } from "./use-resource.js";
+import { APPS_LOADING, appsFeed } from "./apps-feed.js";
+import { type PollOptions } from "./use-resource.js";
 
-/** How many apps have never rendered for this person — what the launcher's dot
- *  reads. Published by the list fetch every surface already makes (the row
- *  carries `unseen`), so the pill costs no request of its own and there is no
- *  second poller to keep in step with this one. */
-let unseen = 0;
-const listeners = new Set<() => void>();
-
-export const unseenApps = (): number => unseen;
-
-export const subscribeUnseenApps = (listener: () => void): (() => void) => {
-  listeners.add(listener);
-  return () => {
-    listeners.delete(listener);
-  };
-};
+/** SSR / first-render snapshot, stable across calls. */
+const loadingSnapshot = () => APPS_LOADING;
 
 export function useApps(options?: PollOptions): {
   apps: AppListRow[];
@@ -34,20 +22,16 @@ export function useApps(options?: PollOptions): {
   fork(id: AppId): Promise<AppDocument>;
   exportApp(id: AppId): Promise<Uint8Array>;
   importApp(bytes: Uint8Array): Promise<AppDocument>;
-  /** The arrival mark for a surface that LISTS an app without rendering it —
-   *  rendering marks it on its own, server-side. Idempotent. */
-  markSeen(id: AppId): Promise<void>;
 } {
   const { client } = useVendoProvider();
-  const list = useCallback(() => client.apps.list(), [client]);
-  const { data, error, isLoading, refresh } = useResource(list, [] as AppListRow[], options);
-
-  useEffect(() => {
-    const next = data.filter((app) => app.unseen === true).length;
-    if (next === unseen) return;
-    unseen = next;
-    for (const listener of listeners) listener();
-  }, [data]);
+  // H15 — one apps poller per client (apps-feed), shared with the launcher's
+  // dot: a panel listing apps and the pill reading the unseen count off the same
+  // rows cost ONE request between them, and cannot disagree in front of anyone.
+  const feed = appsFeed(client);
+  const pollMs = options?.pollMs ?? 0;
+  const subscribe = useCallback((listener: () => void) => feed.subscribe(listener, pollMs), [feed, pollMs]);
+  const { data, error, isLoading } = useSyncExternalStore(subscribe, feed.read, loadingSnapshot);
+  const refresh = useCallback(() => feed.refresh(), [feed]);
 
   const create = useCallback(
     async (prompt: string) => {
@@ -72,13 +56,6 @@ export function useApps(options?: PollOptions): {
     },
     [client, refresh],
   );
-  const markSeen = useCallback(
-    async (id: AppId) => {
-      await client.apps.seen(id);
-      await refresh();
-    },
-    [client, refresh],
-  );
   const exportApp = useCallback((id: AppId) => client.apps.exportApp(id), [client]);
   const importApp = useCallback(
     async (bytes: Uint8Array) => {
@@ -89,5 +66,5 @@ export function useApps(options?: PollOptions): {
     [client, refresh],
   );
 
-  return { apps: data, error, isLoading, refresh, create, remove, fork, exportApp, importApp, markSeen };
+  return { apps: data, error, isLoading, refresh, create, remove, fork, exportApp, importApp };
 }

--- a/packages/ui/src/hooks/use-apps.ts
+++ b/packages/ui/src/hooks/use-apps.ts
@@ -3,12 +3,29 @@ import {
   type AppDocument,
   type AppId,
 } from "@vendoai/core";
-import { useCallback } from "react";
+import { useCallback, useEffect } from "react";
 import { useVendoProvider } from "../context.js";
+import type { AppListRow } from "../wire-types.js";
 import { type PollOptions, useResource } from "./use-resource.js";
 
+/** How many apps have never rendered for this person — what the launcher's dot
+ *  reads. Published by the list fetch every surface already makes (the row
+ *  carries `unseen`), so the pill costs no request of its own and there is no
+ *  second poller to keep in step with this one. */
+let unseen = 0;
+const listeners = new Set<() => void>();
+
+export const unseenApps = (): number => unseen;
+
+export const subscribeUnseenApps = (listener: () => void): (() => void) => {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+};
+
 export function useApps(options?: PollOptions): {
-  apps: AppDocument[];
+  apps: AppListRow[];
   error: Error | undefined;
   isLoading: boolean;
   refresh(): Promise<void>;
@@ -17,10 +34,20 @@ export function useApps(options?: PollOptions): {
   fork(id: AppId): Promise<AppDocument>;
   exportApp(id: AppId): Promise<Uint8Array>;
   importApp(bytes: Uint8Array): Promise<AppDocument>;
+  /** The arrival mark for a surface that LISTS an app without rendering it —
+   *  rendering marks it on its own, server-side. Idempotent. */
+  markSeen(id: AppId): Promise<void>;
 } {
   const { client } = useVendoProvider();
   const list = useCallback(() => client.apps.list(), [client]);
-  const { data, error, isLoading, refresh } = useResource(list, [] as AppDocument[], options);
+  const { data, error, isLoading, refresh } = useResource(list, [] as AppListRow[], options);
+
+  useEffect(() => {
+    const next = data.filter((app) => app.unseen === true).length;
+    if (next === unseen) return;
+    unseen = next;
+    for (const listener of listeners) listener();
+  }, [data]);
 
   const create = useCallback(
     async (prompt: string) => {
@@ -45,6 +72,13 @@ export function useApps(options?: PollOptions): {
     },
     [client, refresh],
   );
+  const markSeen = useCallback(
+    async (id: AppId) => {
+      await client.apps.seen(id);
+      await refresh();
+    },
+    [client, refresh],
+  );
   const exportApp = useCallback((id: AppId) => client.apps.exportApp(id), [client]);
   const importApp = useCallback(
     async (bytes: Uint8Array) => {
@@ -55,5 +89,5 @@ export function useApps(options?: PollOptions): {
     [client, refresh],
   );
 
-  return { apps: data, error, isLoading, refresh, create, remove, fork, exportApp, importApp };
+  return { apps: data, error, isLoading, refresh, create, remove, fork, exportApp, importApp, markSeen };
 }

--- a/packages/ui/src/hooks/use-apps.ts
+++ b/packages/ui/src/hooks/use-apps.ts
@@ -25,8 +25,8 @@ export function useApps(options?: PollOptions): {
 } {
   const { client } = useVendoProvider();
   // H15 — one apps poller per client (apps-feed), shared with the launcher's
-  // dot: a panel listing apps and the pill reading the unseen count off the same
-  // rows cost ONE request between them, and cannot disagree in front of anyone.
+  // dot: this hook and the pill reading the unseen count off the same rows cost
+  // ONE request between them, and cannot disagree in front of anyone.
   const feed = appsFeed(client);
   const pollMs = options?.pollMs ?? 0;
   const subscribe = useCallback((listener: () => void) => feed.subscribe(listener, pollMs), [feed, pollMs]);

--- a/packages/ui/src/kit/charts/bar.tsx
+++ b/packages/ui/src/kit/charts/bar.tsx
@@ -66,10 +66,7 @@ export function BarChart({
   const keys = cols.map((c) => c.key);
   const clean = sanitizeSeries(data, keys);
   if (clean.length === 0 || seriesIsEmpty(clean, keys)) {
-    // The slot replaces the dashed box, not its TEXT: what goes in one is an
-    // EmptyState, which draws that same frame itself — nested, it read as a
-    // box inside a box.
-    return empty ?? <ChartEmpty height={height} style={style}>{emptyState}</ChartEmpty>;
+    return <ChartEmpty height={height} slot={empty} style={style}>{emptyState}</ChartEmpty>;
   }
   const fmt = (v: unknown) => applyFormat(v, format) ?? "";
   return (

--- a/packages/ui/src/kit/charts/donut.tsx
+++ b/packages/ui/src/kit/charts/donut.tsx
@@ -55,10 +55,7 @@ export function DonutChart({
     .map((row) => ({ ...row, name: String(row[categoryKey] ?? ""), value: row[valueKey] }))
     .filter((s) => isRenderableNumber(s.value) && (s.value as number) > 0) as Array<{ name: string; value: number }>;
   if (slices.length === 0) {
-    // The slot replaces the dashed box, not its TEXT: what goes in one is an
-    // EmptyState, which draws that same frame itself — nested, it read as a
-    // box inside a box.
-    return empty ?? <ChartEmpty height={height} style={style}>{emptyState}</ChartEmpty>;
+    return <ChartEmpty height={height} slot={empty} style={style}>{emptyState}</ChartEmpty>;
   }
   const fmt = (v: unknown) => applyFormat(v, format) ?? "";
   return (

--- a/packages/ui/src/kit/charts/line.tsx
+++ b/packages/ui/src/kit/charts/line.tsx
@@ -63,10 +63,7 @@ export function LineChart({ data, xKey, series, format = "number", height = 220,
   const keys = cols.map((c) => c.key);
   const clean = sanitizeSeries(data, keys);
   if (clean.length === 0 || seriesIsEmpty(clean, keys)) {
-    // The slot replaces the dashed box, not its TEXT: what goes in one is an
-    // EmptyState, which draws that same frame itself — nested, it read as a
-    // box inside a box.
-    return empty ?? <ChartEmpty height={height} style={style}>{emptyState}</ChartEmpty>;
+    return <ChartEmpty height={height} slot={empty} style={style}>{emptyState}</ChartEmpty>;
   }
   const fmt = (v: unknown) => applyFormat(v, format) ?? "";
   return (

--- a/packages/ui/src/kit/charts/sanitize.tsx
+++ b/packages/ui/src/kit/charts/sanitize.tsx
@@ -61,8 +61,15 @@ export function ChartFrame({ height = 220, children }: ChartFrameProps) {
  *
  *  ONE element, because a chart's `style` has to land on the same root whether it
  *  has points or not: nested, the caller's margin sat on an inner box while the
- *  populated chart put it on the outer one, so an empty chart moved. */
-export function ChartEmpty({ height = 220, children, style }: { height?: number; children: ReactNode } & KitStyled) {
+ *  populated chart put it on the outer one, so an empty chart moved.
+ *
+ *  `slot` is the author's own empty content, and it replaces this box rather than
+ *  its TEXT: what goes in one is an EmptyState, which draws that same frame
+ *  itself — nested, it read as a box inside a box. All three charts return this
+ *  ONE branch, so the author's copy and the default copy are held back by the
+ *  same rule while the build is still forming. */
+export function ChartEmpty({ height = 220, children, slot, style }: { height?: number; children: ReactNode; slot?: ReactNode } & KitStyled) {
+  if (slot !== undefined) return <EmptyOrForming>{slot}</EmptyOrForming>;
   const box: CSSProperties = {
     ...font,
     display: "flex",

--- a/packages/ui/src/kit/charts/sanitize.tsx
+++ b/packages/ui/src/kit/charts/sanitize.tsx
@@ -5,6 +5,7 @@
  */
 import type { CSSProperties, ReactNode } from "react";
 import type { TooltipContentProps } from "recharts";
+import { EmptyOrForming } from "../../tree/forming-skeleton.js";
 import { isRenderableNumber } from "../format.js";
 import { RowContext } from "../row.js";
 import { font, hairline, t, type KitStyled } from "../tokens.js";
@@ -79,7 +80,7 @@ export function ChartEmpty({ height = 220, children, style }: { height?: number;
     padding: 12,
     ...style,
   };
-  return <div data-kit="ChartEmpty" style={box}>{children}</div>;
+  return <div data-kit="ChartEmpty" style={box}><EmptyOrForming>{children}</EmptyOrForming></div>;
 }
 
 /** The hover surface all three charts share — recharts paints its own content

--- a/packages/ui/src/kit/data/card-list.tsx
+++ b/packages/ui/src/kit/data/card-list.tsx
@@ -43,7 +43,7 @@ export function CardList({ items: rawItems, titleField, badgeField, fields = [],
     // The slot replaces the dashed box, not its TEXT: what goes in one is an
     // EmptyState, which draws that same frame itself — nested, it read as a
     // box inside a box.
-    return empty !== undefined ? <div data-kit="CardList" style={style}>{empty}</div> : (
+    return empty !== undefined ? <div data-kit="CardList" style={style}><EmptyOrForming>{empty}</EmptyOrForming></div> : (
       <div
         data-kit="CardList"
         style={{

--- a/packages/ui/src/kit/data/card-list.tsx
+++ b/packages/ui/src/kit/data/card-list.tsx
@@ -1,5 +1,6 @@
 /** CardList — one branded card per record, semantically formatted (W2 §The Kit). */
 import type { ReactNode } from "react";
+import { EmptyOrForming } from "../../tree/forming-skeleton.js";
 import { applyFormat, type ValueFormat } from "../format.js";
 import { readField, RowContext } from "../row.js";
 import { densityVars, font, hairline, numeric, t, type KitDensity, type KitStyled } from "../tokens.js";
@@ -55,7 +56,7 @@ export function CardList({ items: rawItems, titleField, badgeField, fields = [],
           ...style,
         }}
       >
-        {emptyState}
+        <EmptyOrForming>{emptyState}</EmptyOrForming>
       </div>
     );
   }

--- a/packages/ui/src/kit/data/data-table.tsx
+++ b/packages/ui/src/kit/data/data-table.tsx
@@ -15,6 +15,7 @@ import {
   type ColumnDef,
   type SortingState,
 } from "@tanstack/react-table";
+import { EmptyOrForming } from "../../tree/forming-skeleton.js";
 import { applyFormat, formatDateTime, type ValueFormat } from "../format.js";
 import { readField, RowContext } from "../row.js";
 import { densityVars, font, hairline, microLabel, numeric, t, transitionFor, type KitDensity, type KitStyled } from "../tokens.js";
@@ -468,7 +469,7 @@ export function DataTable(props: DataTableProps) {
                   colSpan={Math.max(1, shown(columns).length) + (rowActions === undefined ? 0 : 1)}
                   style={{ color: t.muted, padding: "calc(var(--vendo-font-size, 15px) * 1.6) 12px", textAlign: "center" }}
                 >
-                  {empty ?? emptyState}
+                  <EmptyOrForming>{empty ?? emptyState}</EmptyOrForming>
                 </td>
               </tr>
             ) : painted.length > 0 ? (

--- a/packages/ui/src/kit/data/timeline.tsx
+++ b/packages/ui/src/kit/data/timeline.tsx
@@ -1,5 +1,6 @@
 /** Timeline — a record history down a spine, dot-marked (W2 §The Kit). */
 import type { ReactNode } from "react";
+import { EmptyOrForming } from "../../tree/forming-skeleton.js";
 import { applyFormat } from "../format.js";
 import { readField, RowContext } from "../row.js";
 import { font, hairline, microLabel, numeric, t, type KitStyled } from "../tokens.js";
@@ -59,7 +60,7 @@ export function Timeline({
           ...style,
         }}
       >
-        {emptyState}
+        <EmptyOrForming>{emptyState}</EmptyOrForming>
       </div>
     );
   }

--- a/packages/ui/src/kit/data/timeline.tsx
+++ b/packages/ui/src/kit/data/timeline.tsx
@@ -47,7 +47,7 @@ export function Timeline({
   const entries = Array.isArray(rawEntries) ? rawEntries : [];
   if (entries.length === 0) {
     // The slot replaces the dashed box, not its TEXT — see CardList.
-    return empty !== undefined ? <div data-kit="Timeline" style={style}>{empty}</div> : (
+    return empty !== undefined ? <div data-kit="Timeline" style={style}><EmptyOrForming>{empty}</EmptyOrForming></div> : (
       <div
         data-kit="Timeline"
         style={{

--- a/packages/ui/src/tree/forming-skeleton.tsx
+++ b/packages/ui/src/tree/forming-skeleton.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties } from "react";
+import { createContext, useContext, type CSSProperties, type ReactNode } from "react";
 
 export type FormShape = "slab" | "tiles" | "rows" | "pill" | "chart" | "control";
 
@@ -32,6 +32,24 @@ export function Skeleton(props: { width?: string | number; height?: string | num
       }}
     />
   );
+}
+
+/**
+ * Is a build still painting this surface? `StatefulTreeView` publishes the
+ * tree's own `streaming` flag here — the same one that holds the skeletons
+ * above — so a Kit component nested anywhere under it can read it without a
+ * prop threaded through the whole vocabulary.
+ */
+export const FormingContext = createContext(false);
+
+/**
+ * A Kit empty state's copy, held back while the build is still in flight: a
+ * component handed no rows YET does not know whether it is empty, and "No data"
+ * on a table that is about to be full is a lie. Settled, the copy is the truth
+ * and shows exactly as before.
+ */
+export function EmptyOrForming({ children }: { children: ReactNode }) {
+  return useContext(FormingContext) ? <Skeleton /> : <>{children}</>;
 }
 
 /**

--- a/packages/ui/src/tree/renderer.tsx
+++ b/packages/ui/src/tree/renderer.tsx
@@ -40,7 +40,7 @@ import { resolvePointer } from "./bindings.js";
 import { DISPLAY_BRICKS, SURFACE_CONTAINMENT } from "./display-bricks.js";
 import { NodeErrorBoundary } from "./error-boundary.js";
 import { FluidReveal } from "./fluid-reveal.js";
-import { deriveFormShape, FormingSkeleton, PendingLeaf } from "./forming-skeleton.js";
+import { deriveFormShape, FormingContext, FormingSkeleton, PendingLeaf } from "./forming-skeleton.js";
 import { InClientMount, type InClientFurnishing } from "./host-mount.js";
 import { ContainedNotice } from "./notice.js";
 import { playNodeMotion, useMotionLayoutEffect, useRepaintMotion, type NodeMark } from "./repaint-motion.js";
@@ -1046,32 +1046,36 @@ function StatefulTreeView({
     : null;
 
   return (
-    <div data-vendo-surface="" style={{ ...themeCssVariables(theme), ...SURFACE_CONTAINMENT } as CSSProperties}>
-      <NodeErrorBoundary nodeId={validation.tree.root} retryKey={data ?? validation.tree.data} streaming={streaming}>
-        {dataNotice}
-        {dropBackNotice}
-        {driftNotice}
-        <NodeRenderer
-          nodeId={validation.tree.root}
-          ancestry={new Set()}
-          nodes={repaint.nodes}
-          marks={repaint.marks}
-          generated={streaming ? tree.components ?? {} : validation.tree.components ?? {}}
-          inClientGranted={inClientGranted}
-          furnishings={furnishings}
-          components={components}
-          data={data ?? validation.tree.data ?? {}}
-          state={viewState}
-          streaming={streaming}
-          outcomes={outcomes}
-          orphans={orphans}
-          runAction={runAction}
-          {...(onReview === undefined ? {} : { onReview })}
-          setViewState={updateState}
-          {...(interactive === undefined ? {} : { screen })}
-        />
-      </NodeErrorBoundary>
-    </div>
+    // A Kit empty state deep in the walk reads `streaming` off this provider:
+    // mid-build it holds a skeleton instead of claiming "No data".
+    <FormingContext.Provider value={streaming}>
+      <div data-vendo-surface="" style={{ ...themeCssVariables(theme), ...SURFACE_CONTAINMENT } as CSSProperties}>
+        <NodeErrorBoundary nodeId={validation.tree.root} retryKey={data ?? validation.tree.data} streaming={streaming}>
+          {dataNotice}
+          {dropBackNotice}
+          {driftNotice}
+          <NodeRenderer
+            nodeId={validation.tree.root}
+            ancestry={new Set()}
+            nodes={repaint.nodes}
+            marks={repaint.marks}
+            generated={streaming ? tree.components ?? {} : validation.tree.components ?? {}}
+            inClientGranted={inClientGranted}
+            furnishings={furnishings}
+            components={components}
+            data={data ?? validation.tree.data ?? {}}
+            state={viewState}
+            streaming={streaming}
+            outcomes={outcomes}
+            orphans={orphans}
+            runAction={runAction}
+            {...(onReview === undefined ? {} : { onReview })}
+            setViewState={updateState}
+            {...(interactive === undefined ? {} : { screen })}
+          />
+        </NodeErrorBoundary>
+      </div>
+    </FormingContext.Provider>
   );
 }
 

--- a/packages/ui/src/wire-types.ts
+++ b/packages/ui/src/wire-types.ts
@@ -54,6 +54,7 @@ export type { PlacementEntry, ReviewStanding };
 /** 06-apps §1/§8/§9 — the app-generation half of the wire. One definition,
  *  on the producer's browser-safe contract door. */
 export type {
+  AppListRow,
   EditResult,
   InClientVenue,
   OpenSurface,

--- a/packages/ui/test/kit/empty-forming.test.tsx
+++ b/packages/ui/test/kit/empty-forming.test.tsx
@@ -3,7 +3,12 @@
  * A table with no rows YET is not a table with no rows. While the build is in
  * flight the empty copy is a lie, so it holds the same skeleton the rest of the
  * forming surface uses — and the moment the paint settles, a genuinely empty
- * table says so again.
+ * component says so again.
+ *
+ * Both ways of writing that copy are covered, because they are separate return
+ * paths: the component's own default (`emptyState`), and the author's own
+ * content in the `empty` slot — which a Kit component returns BEFORE it reaches
+ * the default, so the author's words could lie mid-build on their own.
  */
 import { afterEach, describe, expect, it } from "vitest";
 import { cleanup, render, screen } from "@testing-library/react";
@@ -14,21 +19,34 @@ afterEach(cleanup);
 
 const ok = async (): Promise<ToolOutcome> => ({ status: "ok", output: null });
 
-const emptyTable = (streaming: boolean) => ({
+/** The author's own empty copy, written into the prop the way a screen writes it. */
+const authorsOwn = { $element: true, component: "Text", props: { text: "Nothing here yet" } };
+
+/** One surface holding every empty-state return path the slice touches: the
+ *  default copy, the slot on the `<div>` branch (CardList, and Timeline with
+ *  it), and the slot on the shared ChartEmpty branch (all three charts). */
+const emptyApp = (streaming: boolean) => ({
   formatVersion: VENDO_TREE_FORMAT,
   root: "root",
   streaming,
-  nodes: [{ id: "root", component: "DataTable", props: { rows: [], columns: [{ key: "amount" }] } }],
+  nodes: [
+    { id: "root", component: "Stack", children: ["table", "cards", "chart"] },
+    { id: "table", component: "DataTable", props: { rows: [], columns: [{ key: "amount" }] } },
+    { id: "cards", component: "CardList", props: { items: [], titleField: "name", empty: authorsOwn } },
+    { id: "chart", component: "LineChart", props: { data: [], xKey: "day", series: [{ key: "spend" }], empty: authorsOwn } },
+  ],
 }) as WalkTree & { formatVersion: typeof VENDO_TREE_FORMAT };
 
 describe("Kit empty states under a forming surface", () => {
   it("reads as loading mid-build and as the real empty state once the build settles", () => {
-    const { rerender } = render(<TreeView tree={emptyTable(true)} components={{}} onAction={ok} />);
+    const { rerender } = render(<TreeView tree={emptyApp(true)} components={{}} onAction={ok} />);
     expect(screen.queryByText("No data")).toBeNull();
-    expect(document.querySelector("[data-skeleton]")).not.toBeNull();
+    expect(screen.queryByText("Nothing here yet")).toBeNull();
+    expect(document.querySelectorAll("[data-skeleton]")).toHaveLength(3);
 
-    rerender(<TreeView tree={emptyTable(false)} components={{}} onAction={ok} />);
+    rerender(<TreeView tree={emptyApp(false)} components={{}} onAction={ok} />);
     expect(screen.getByText("No data")).toBeTruthy();
-    expect(document.querySelector("[data-skeleton]")).toBeNull();
+    expect(screen.getAllByText("Nothing here yet")).toHaveLength(2);
+    expect(document.querySelectorAll("[data-skeleton]")).toHaveLength(0);
   });
 });

--- a/packages/ui/test/kit/empty-forming.test.tsx
+++ b/packages/ui/test/kit/empty-forming.test.tsx
@@ -1,0 +1,34 @@
+// @vitest-environment jsdom
+/**
+ * A table with no rows YET is not a table with no rows. While the build is in
+ * flight the empty copy is a lie, so it holds the same skeleton the rest of the
+ * forming surface uses — and the moment the paint settles, a genuinely empty
+ * table says so again.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { VENDO_TREE_FORMAT, type ToolOutcome } from "@vendoai/core";
+import { TreeView, type WalkTree } from "../../src/tree/index.js";
+
+afterEach(cleanup);
+
+const ok = async (): Promise<ToolOutcome> => ({ status: "ok", output: null });
+
+const emptyTable = (streaming: boolean) => ({
+  formatVersion: VENDO_TREE_FORMAT,
+  root: "root",
+  streaming,
+  nodes: [{ id: "root", component: "DataTable", props: { rows: [], columns: [{ key: "amount" }] } }],
+}) as WalkTree & { formatVersion: typeof VENDO_TREE_FORMAT };
+
+describe("Kit empty states under a forming surface", () => {
+  it("reads as loading mid-build and as the real empty state once the build settles", () => {
+    const { rerender } = render(<TreeView tree={emptyTable(true)} components={{}} onAction={ok} />);
+    expect(screen.queryByText("No data")).toBeNull();
+    expect(document.querySelector("[data-skeleton]")).not.toBeNull();
+
+    rerender(<TreeView tree={emptyTable(false)} components={{}} onAction={ok} />);
+    expect(screen.getByText("No data")).toBeTruthy();
+    expect(document.querySelector("[data-skeleton]")).toBeNull();
+  });
+});

--- a/packages/vendo/src/wire/apps.ts
+++ b/packages/vendo/src/wire/apps.ts
@@ -84,7 +84,12 @@ async function openWithPendingWindow(wire: WireContext, appId: string, ctx: RunC
     // tree's geometry, so the embed's poll has something to show. Everything
     // below stays the not-found disambiguation it was: no row, another subject's
     // row, a terminal failure.
-    return json(await deps.apps.open(appId, ctx, { pending: true }));
+    const surface = await deps.apps.open(appId, ctx, { pending: true });
+    // Arrival — a `pending` answer put nothing on screen (that is the whole
+    // point of the flag), so it is not a render. The opener's own build-window
+    // decision is the gate here; nothing re-reads `building` to guess at it.
+    if (surface.kind !== "pending") await deps.apps.seen(appId, ctx);
+    return json(surface);
   } catch (reason) {
     if (!(reason instanceof VendoError && reason.code === "not-found")) throw reason;
     // Build contract §9.4 — the probe is a DIAGNOSTIC for a caller who
@@ -245,7 +250,14 @@ export const appRoutes: RouteEntry[] = [
     }
     if (op(wire, "GET", "open")) {
       if (wire.url.searchParams.get("pending") === "1") return openWithPendingWindow(wire, appId, ctx);
-      return json(await deps.apps.open(appId, ctx));
+      const surface = await deps.apps.open(appId, ctx);
+      // Arrival — THIS is what "rendering marks it seen" means: a person's
+      // browser asked for a surface to put on screen. The runtime door is not
+      // the place for it (an agent's `vendo_apps_open` and an automation both
+      // pass through there); a build still in flight never reaches this line,
+      // because open() answers not-found until it can serve.
+      await deps.apps.seen(appId, ctx);
+      return json(surface);
     }
     if (op(wire, "POST", "call")) {
       const body = await requestJson(request);
@@ -322,13 +334,6 @@ export const appRoutes: RouteEntry[] = [
     }
     if (op(wire, "POST", "fork")) {
       return json(await deps.apps.fork(appId, ctx));
-    }
-    // Arrival (2026-08-17) — an idempotent per-caller mark. Rendering already
-    // marks through open(); this is the mark for a surface that shows an app it
-    // never opened.
-    if (op(wire, "POST", "seen")) {
-      await deps.apps.seen(appId, ctx);
-      return json({});
     }
     return undefined;
   }),

--- a/packages/vendo/src/wire/apps.ts
+++ b/packages/vendo/src/wire/apps.ts
@@ -76,22 +76,29 @@ function decodeSlot(slot: string): string {
     answers the terminal failed vocabulary (with the principal-mismatch
     diagnosis) so the embed resolves promptly instead of skeleton-polling
     to its deadline (0.4.1 E2E cert B4). */
-async function openWithPendingWindow(wire: WireContext, appId: string, ctx: RunContext): Promise<Response> {
+/**
+ * Arrival bookkeeping, which is TELEMETRY: it records that a person's render
+ * happened, and nothing they see may depend on it. `seen` re-checks access
+ * (`apps-surface.ts`), so it can throw `not-found` — and in the response's
+ * success path that throw BECAME the answer: a served 200 turning into a 404,
+ * and, inside the pending window's `catch`, a successfully served tree silently
+ * reported as `{kind:"pending"}` while the embed polled forever.
+ *
+ * So a failed mark is dropped, here and at every call site. This is the only
+ * swallow in this file, and it is sound for one narrow reason: what is dropped is
+ * not part of the answer, and its absence costs a dot that clears one render
+ * later.
+ */
+const markArrival = async (deps: WireContext["deps"], appId: string, ctx: RunContext): Promise<void> => {
+  await deps.apps.seen(appId, ctx).catch(() => {});
+};
+
+/** The ?pending=1 not-found disambiguation. Lifted out of the `catch` it used to
+ *  be the whole body of, so that arm guards nothing but the open itself and no
+ *  later failure can be mistaken for the open's own not-found. */
+async function answerUnservableApp(wire: WireContext, appId: string, ctx: RunContext): Promise<Response> {
   const { deps } = wire;
-  try {
-    // The flag rides through to the runtime, which answers a build still in
-    // flight with `{kind:"pending"}` plus — when the draft paints — the forming
-    // tree's geometry, so the embed's poll has something to show. Everything
-    // below stays the not-found disambiguation it was: no row, another subject's
-    // row, a terminal failure.
-    const surface = await deps.apps.open(appId, ctx, { pending: true });
-    // Arrival — a `pending` answer put nothing on screen (that is the whole
-    // point of the flag), so it is not a render. The opener's own build-window
-    // decision is the gate here; nothing re-reads `building` to guess at it.
-    if (surface.kind !== "pending") await deps.apps.seen(appId, ctx);
-    return json(surface);
-  } catch (reason) {
-    if (!(reason instanceof VendoError && reason.code === "not-found")) throw reason;
+  {
     // Build contract §9.4 — the probe is a DIAGNOSTIC for a caller who
     // can already see the app, never a lookup for one who cannot. It
     // reads UNSCOPED rows, so running it for a non-viewer made
@@ -131,6 +138,27 @@ async function openWithPendingWindow(wire: WireContext, appId: string, ctx: RunC
     // served to the caller.
     return json({ kind: "pending" });
   }
+}
+
+async function openWithPendingWindow(wire: WireContext, appId: string, ctx: RunContext): Promise<Response> {
+  const { deps } = wire;
+  // The ONLY thing this arm guards is the open. The flag rides through to the
+  // runtime, which answers a build still in flight with `{kind:"pending"}` plus —
+  // when the draft paints — the forming tree's geometry, so the embed's poll has
+  // something to show.
+  let surface: Awaited<ReturnType<typeof deps.apps.open>>;
+  try {
+    surface = await deps.apps.open(appId, ctx, { pending: true });
+  } catch (reason) {
+    if (!(reason instanceof VendoError && reason.code === "not-found")) throw reason;
+    return await answerUnservableApp(wire, appId, ctx);
+  }
+  // Arrival, outside that catch on purpose — a mark's own not-found must never be
+  // read as the open's. A `pending` answer put nothing on screen (the whole point
+  // of the flag), so it is not a render; the opener's build-window decision is the
+  // gate, and nothing re-reads `building` to guess at it.
+  if (surface.kind !== "pending") await markArrival(deps, appId, ctx);
+  return json(surface);
 }
 
 async function handleHistory(wire: WireContext, appId: string, ctx: RunContext): Promise<Response | undefined> {
@@ -255,8 +283,9 @@ export const appRoutes: RouteEntry[] = [
       // browser asked for a surface to put on screen. The runtime door is not
       // the place for it (an agent's `vendo_apps_open` and an automation both
       // pass through there); a build still in flight never reaches this line,
-      // because open() answers not-found until it can serve.
-      await deps.apps.seen(appId, ctx);
+      // because open() answers not-found until it can serve. Non-fatal: the
+      // surface is already served, and bookkeeping does not get to unserve it.
+      await markArrival(deps, appId, ctx);
       return json(surface);
     }
     if (op(wire, "POST", "call")) {

--- a/packages/vendo/src/wire/apps.ts
+++ b/packages/vendo/src/wire/apps.ts
@@ -323,6 +323,13 @@ export const appRoutes: RouteEntry[] = [
     if (op(wire, "POST", "fork")) {
       return json(await deps.apps.fork(appId, ctx));
     }
+    // Arrival (2026-08-17) — an idempotent per-caller mark. Rendering already
+    // marks through open(); this is the mark for a surface that shows an app it
+    // never opened.
+    if (op(wire, "POST", "seen")) {
+      await deps.apps.seen(appId, ctx);
+      return json({});
+    }
     return undefined;
   }),
 ];

--- a/packages/vendo/src/wire/threads.ts
+++ b/packages/vendo/src/wire/threads.ts
@@ -1,4 +1,4 @@
-import { defineOwn, isPlainObject, VendoError, vendoViewWirePartSchema, withSseKeepalive } from "@vendoai/core";
+import { defineOwn, isPlainObject, THREAD_WINDOW_INITIAL, VendoError, vendoViewWirePartSchema, withSseKeepalive } from "@vendoai/core";
 import { UI_MESSAGE_STREAM_HEADERS } from "ai";
 import { registerActiveTurn, steerActiveTurn, touchActiveTurn, trackTurnResponse } from "../turn-liveness.js";
 import { recordResumableTurn, resumableTurnStream } from "../turn-resume.js";
@@ -230,8 +230,24 @@ export const threadRoutes: RouteEntry[] = [
       // deleted app would otherwise turn the whole conversation into a 404 —
       // `seen` re-checks access and throws not-found. A dropped mark costs a dot
       // that clears one render later.
+      // Only the TRAILING WINDOW, because that is all the client mounts: a long
+      // thread defers its head behind "Show N earlier messages"
+      // (`chrome/thread/scrolling.ts`), and a deferred message is absent from the
+      // DOM, so the app card inside it was never drawn. Marking the whole stored
+      // transcript cleared the dot for apps the person never saw — and the record
+      // is first-seen (`app-seen.ts`), so nothing could take it back.
+      //
+      // The asymmetry is deliberate. An app buried behind the deferred head does
+      // NOT clear on thread open; it still clears the moment the person opens the
+      // app itself (`wire/apps.ts`). A dot that lingers one render too long is a
+      // small annoyance; a dot that clears for something never seen is the exact
+      // failure this whole mechanism exists to prevent, so under-clearing is the
+      // direction to err in. Acknowledging a window as it renders would need a new
+      // client→server signal, which the note at the top of this file says the
+      // architecture deliberately does without.
       if (deps.mounted.apps) {
-        await Promise.allSettled(renderedApps(thread.messages).map((appId) => deps.apps.seen(appId, ctx)));
+        const rendered = renderedApps(thread.messages.slice(-THREAD_WINDOW_INITIAL));
+        await Promise.allSettled(rendered.map((appId) => deps.apps.seen(appId, ctx)));
       }
       return json(thread);
     }

--- a/packages/vendo/src/wire/threads.ts
+++ b/packages/vendo/src/wire/threads.ts
@@ -1,4 +1,4 @@
-import { defineOwn, isPlainObject, VendoError, withSseKeepalive } from "@vendoai/core";
+import { defineOwn, isPlainObject, VendoError, vendoViewWirePartSchema, withSseKeepalive } from "@vendoai/core";
 import { UI_MESSAGE_STREAM_HEADERS } from "ai";
 import { registerActiveTurn, steerActiveTurn, touchActiveTurn, trackTurnResponse } from "../turn-liveness.js";
 import { recordResumableTurn, resumableTurnStream } from "../turn-resume.js";
@@ -6,6 +6,31 @@ import { json, requestJson, route, string, type RouteEntry } from "./shared.js";
 
 /** The effective thread id the agent stamps on every turn response (03 §1). */
 const THREAD_ID_HEADER = "x-vendo-thread-id";
+
+/**
+ * Arrival — the apps a transcript RENDERS.
+ *
+ * The thread card draws each `data-vendo-view` part straight from the part
+ * (`chrome/thread/parts.tsx`), with no `open()` of its own, so nothing in a
+ * thread render reaches the route that marks an app seen. Reading the thread back
+ * IS that render, and it is the one server event a thread render has.
+ *
+ * Parsed with the part's own validator rather than by reaching into its shape:
+ * `vendoViewPart` is the single producer and this is the matching consumer, so a
+ * part the producer would not emit is not counted as a render here either.
+ */
+const renderedApps = (messages: readonly unknown[]): string[] => {
+  const ids = new Set<string>();
+  for (const message of messages) {
+    const parts = isPlainObject(message) ? message["parts"] : undefined;
+    if (!Array.isArray(parts)) continue;
+    for (const part of parts) {
+      const view = vendoViewWirePartSchema.safeParse(part);
+      if (view.success) ids.add(view.data.data.appId);
+    }
+  }
+  return [...ids];
+};
 
 /** Decision 3 (spec 2026-08-05): the situation channel is capped at 8 KB on
     BOTH ends. The client truncates before sending; this is the server's own
@@ -191,6 +216,23 @@ export const threadRoutes: RouteEntry[] = [
     if (request.method === "GET") {
       const thread = await deps.harness.threads.get(id, ctx);
       if (thread === null) throw new VendoError("not-found", `thread not found: ${id}`);
+      // Arrival — opening the conversation renders the apps its view parts name,
+      // so this is where that render is recorded. Person-only by construction,
+      // which is what keeps the property the mark was moved off `open` for: this
+      // route mints `kind:"user"` / `presence:"present"` (wire/context.ts) and the
+      // repository answers only the caller's own threads, so an agent, an
+      // automation, an export or an MCP tool cannot reach it — an away run can
+      // WRITE a view part into a sponsor's thread, and still only the sponsor
+      // reading it back marks it seen.
+      //
+      // Settled, never awaited outright: arrival is bookkeeping and may not change
+      // the answer. A transcript outlives the app it drew, so a view part for a
+      // deleted app would otherwise turn the whole conversation into a 404 —
+      // `seen` re-checks access and throws not-found. A dropped mark costs a dot
+      // that clears one render later.
+      if (deps.mounted.apps) {
+        await Promise.allSettled(renderedApps(thread.messages).map((appId) => deps.apps.seen(appId, ctx)));
+      }
       return json(thread);
     }
     if (request.method === "DELETE") {

--- a/packages/vendo/tests/apps-seen.seam.test.ts
+++ b/packages/vendo/tests/apps-seen.seam.test.ts
@@ -1,0 +1,115 @@
+/**
+ * THE ARRIVAL SEAM — who is allowed to clear a person's dot.
+ *
+ * "Rendering marks it seen" has to mean rendering TO A PERSON, and the only way
+ * to prove that is a real deployment where both callers exist:
+ *
+ *   person  `GET /apps/:id/open` — the route a browser's embed asks for a
+ *           surface through
+ *   agent   `AppsRuntime.open` — the SAME door `vendo_apps_open` hands an MCP
+ *           client (compose-mcp.ts) and an automation resolves a surface with
+ *
+ * Real store, real route table, real apps pack, and the answer read back through
+ * the real `GET /apps`. A stub on either side would let the route and the door
+ * agree about a rule neither of them actually runs — which is how the mark ended
+ * up on the door in the first place, where an agent inspecting a tree cleared a
+ * dot for a screen its owner had never seen.
+ *
+ * The one that must be able to fail: move the `apps.seen` call out of the open
+ * route and phase 3 goes red; put one back inside `AppsRuntime.open` and phase 2
+ * goes red.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  VENDO_APP_FORMAT,
+  type AppDocument,
+  type Principal,
+  type RunContext,
+} from "@vendoai/core";
+import { createStore, type VendoStore } from "@vendoai/store";
+import type { LanguageModel } from "ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { createVendo, type Vendo } from "../src/server.js";
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+const ADA: Principal = { kind: "user", subject: "user_ada" };
+
+const doc = (id: string, name: string): AppDocument => ({
+  format: VENDO_APP_FORMAT,
+  id,
+  name,
+  ui: "tree",
+  tree: {
+    formatVersion: "vendo-genui/v2",
+    root: "root",
+    nodes: [{ id: "root", component: "Stack", source: "prewired" }],
+  },
+});
+
+/** The agent's context: the venue an MCP call really arrives on. */
+const agentCtx: RunContext = {
+  principal: ADA,
+  venue: "mcp",
+  presence: "present",
+  sessionId: "s_agent",
+};
+
+async function setup(): Promise<Vendo> {
+  const dataDir = await mkdtemp(join(tmpdir(), "vendo-apps-seen-"));
+  const store: VendoStore = createStore({ dataDir });
+  cleanups.push(async () => {
+    await store.close();
+    await rm(dataDir, { recursive: true, force: true });
+  });
+  await store.ensureSchema();
+  await store.records("vendo_apps").put({
+    id: "app_arrival",
+    data: { subject: ADA.subject, enabled: false, doc: doc("app_arrival", "Spending") },
+    refs: { subject: ADA.subject },
+  });
+  return createVendo({
+    models: { default: {} as LanguageModel },
+    principal: async (req) => (req.headers.get("x-test-user") === null
+      ? null
+      : { kind: "user", subject: req.headers.get("x-test-user") as string }),
+    store,
+  });
+}
+
+const request = (vendo: Vendo, path: string): Promise<Response> =>
+  vendo.handler(new Request(`http://arrival.test/api/vendo${path}`, {
+    headers: { "x-test-user": ADA.subject },
+  }));
+
+/** Read the arrival flag back through the route a panel really lists with. */
+async function unseen(vendo: Vendo): Promise<boolean | undefined> {
+  const response = await request(vendo, "/apps");
+  expect(response.status).toBe(200);
+  const rows = await response.json() as Array<{ id: string; unseen?: boolean }>;
+  return rows.find((row) => row.id === "app_arrival")?.unseen;
+}
+
+describe("an app is seen when a PERSON renders it, not when an agent reads it", () => {
+  it("stays unseen through an agent's open and clears on the person's own", async () => {
+    const vendo = await setup();
+
+    // 1 — nobody has looked at it yet.
+    expect(await unseen(vendo)).toBe(true);
+
+    // 2 — the agent reads the whole tree through the runtime door. This is a
+    // real render for Claude and no render at all for Ada.
+    const opened = await vendo.apps.open("app_arrival", agentCtx);
+    expect(opened.kind).toBe("tree");
+    expect(await unseen(vendo)).toBe(true);
+
+    // 3 — Ada's browser asks for the surface.
+    expect((await request(vendo, "/apps/app_arrival/open")).status).toBe(200);
+    expect(await unseen(vendo)).toBeUndefined();
+  });
+});

--- a/packages/vendo/tests/apps-seen.seam.test.ts
+++ b/packages/vendo/tests/apps-seen.seam.test.ts
@@ -23,7 +23,9 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  toVendoWirePart,
   VENDO_APP_FORMAT,
+  vendoViewPart,
   type AppDocument,
   type Principal,
   type RunContext,
@@ -60,7 +62,7 @@ const agentCtx: RunContext = {
   sessionId: "s_agent",
 };
 
-async function setup(): Promise<Vendo> {
+async function setup(): Promise<{ vendo: Vendo; store: VendoStore }> {
   const dataDir = await mkdtemp(join(tmpdir(), "vendo-apps-seen-"));
   const store: VendoStore = createStore({ dataDir });
   cleanups.push(async () => {
@@ -73,12 +75,36 @@ async function setup(): Promise<Vendo> {
     data: { subject: ADA.subject, enabled: false, doc: doc("app_arrival", "Spending") },
     refs: { subject: ADA.subject },
   });
-  return createVendo({
+  const vendo = createVendo({
     models: { default: {} as LanguageModel },
     principal: async (req) => (req.headers.get("x-test-user") === null
       ? null
       : { kind: "user", subject: req.headers.get("x-test-user") as string }),
     store,
+  });
+  return { vendo, store };
+}
+
+/** The thread the person will open, carrying the view part a turn left behind.
+ *  Built with the REAL producer (`vendoViewPart` plus its wire envelope), so the
+ *  part this consumer counts is the one the four emitters actually write. */
+async function seedRenderedThread(store: VendoStore): Promise<void> {
+  const view = vendoViewPart({
+    appId: "app_arrival",
+    payload: {
+      formatVersion: "vendo-genui/v2",
+      root: "root",
+      nodes: [{ id: "root", component: "Stack", source: "prewired" }],
+    },
+  });
+  if (view === undefined) throw new Error("the view part fixture does not parse");
+  await store.records("vendo_threads").put({
+    id: "thr_arrival",
+    data: {
+      subject: ADA.subject,
+      messages: [{ id: "m_view", role: "assistant", parts: [toVendoWirePart(view.part, view.streamId)] }],
+    },
+    refs: { subject: ADA.subject },
   });
 }
 
@@ -97,7 +123,7 @@ async function unseen(vendo: Vendo): Promise<boolean | undefined> {
 
 describe("an app is seen when a PERSON renders it, not when an agent reads it", () => {
   it("stays unseen through an agent's open and clears on the person's own", async () => {
-    const vendo = await setup();
+    const { vendo } = await setup();
 
     // 1 — nobody has looked at it yet.
     expect(await unseen(vendo)).toBe(true);
@@ -110,6 +136,27 @@ describe("an app is seen when a PERSON renders it, not when an agent reads it", 
 
     // 3 — Ada's browser asks for the surface.
     expect((await request(vendo, "/apps/app_arrival/open")).status).toBe(200);
+    expect(await unseen(vendo)).toBeUndefined();
+  });
+
+  /**
+   * The thread render. The card draws the app from the `data-vendo-view` part
+   * itself and never opens anything, so the transcript read is the only server
+   * event a thread render has — and an away run WRITES that part into a sponsor's
+   * thread while nobody is watching, which is why the part existing cannot be the
+   * mark.
+   */
+  it("stays unseen while the view part merely sits in the transcript, and clears when the person opens it", async () => {
+    const { vendo, store } = await setup();
+    expect(await unseen(vendo)).toBe(true);
+
+    // The negative control: the part is in the thread — written exactly as an
+    // away run leaves it — and nobody has read the conversation.
+    await seedRenderedThread(store);
+    expect(await unseen(vendo)).toBe(true);
+
+    // The positive: Ada opens the conversation, which renders the app.
+    expect((await request(vendo, "/threads/thr_arrival")).status).toBe(200);
     expect(await unseen(vendo)).toBeUndefined();
   });
 });

--- a/packages/vendo/tests/apps-seen.seam.test.ts
+++ b/packages/vendo/tests/apps-seen.seam.test.ts
@@ -23,6 +23,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  THREAD_WINDOW_INITIAL,
   toVendoWirePart,
   VENDO_APP_FORMAT,
   vendoViewPart,
@@ -70,11 +71,13 @@ async function setup(): Promise<{ vendo: Vendo; store: VendoStore }> {
     await rm(dataDir, { recursive: true, force: true });
   });
   await store.ensureSchema();
-  await store.records("vendo_apps").put({
-    id: "app_arrival",
-    data: { subject: ADA.subject, enabled: false, doc: doc("app_arrival", "Spending") },
-    refs: { subject: ADA.subject },
-  });
+  for (const [id, name] of [["app_arrival", "Spending"], ["app_buried", "Old receipts"]] as const) {
+    await store.records("vendo_apps").put({
+      id,
+      data: { subject: ADA.subject, enabled: false, doc: doc(id, name) },
+      refs: { subject: ADA.subject },
+    });
+  }
   const vendo = createVendo({
     models: { default: {} as LanguageModel },
     principal: async (req) => (req.headers.get("x-test-user") === null
@@ -88,9 +91,9 @@ async function setup(): Promise<{ vendo: Vendo; store: VendoStore }> {
 /** The thread the person will open, carrying the view part a turn left behind.
  *  Built with the REAL producer (`vendoViewPart` plus its wire envelope), so the
  *  part this consumer counts is the one the four emitters actually write. */
-async function seedRenderedThread(store: VendoStore): Promise<void> {
+const viewMessage = (id: string, appId: string): Record<string, unknown> => {
   const view = vendoViewPart({
-    appId: "app_arrival",
+    appId,
     payload: {
       formatVersion: "vendo-genui/v2",
       root: "root",
@@ -98,15 +101,23 @@ async function seedRenderedThread(store: VendoStore): Promise<void> {
     },
   });
   if (view === undefined) throw new Error("the view part fixture does not parse");
-  await store.records("vendo_threads").put({
-    id: "thr_arrival",
-    data: {
-      subject: ADA.subject,
-      messages: [{ id: "m_view", role: "assistant", parts: [toVendoWirePart(view.part, view.streamId)] }],
-    },
+  return { id, role: "assistant", parts: [toVendoWirePart(view.part, view.streamId)] };
+};
+
+const seedThread = (store: VendoStore, id: string, messages: Array<Record<string, unknown>>): Promise<unknown> =>
+  store.records("vendo_threads").put({
+    id,
+    data: { subject: ADA.subject, messages },
     refs: { subject: ADA.subject },
   });
-}
+
+/** Filler turns, to push a message out of the trailing window. */
+const chatter = (count: number): Array<Record<string, unknown>> =>
+  Array.from({ length: count }, (_unused, index) => ({
+    id: `m_chat_${index}`,
+    role: index % 2 === 0 ? "user" : "assistant",
+    parts: [{ type: "text", text: `turn ${index}` }],
+  }));
 
 const request = (vendo: Vendo, path: string): Promise<Response> =>
   vendo.handler(new Request(`http://arrival.test/api/vendo${path}`, {
@@ -114,11 +125,11 @@ const request = (vendo: Vendo, path: string): Promise<Response> =>
   }));
 
 /** Read the arrival flag back through the route a panel really lists with. */
-async function unseen(vendo: Vendo): Promise<boolean | undefined> {
+async function unseen(vendo: Vendo, appId = "app_arrival"): Promise<boolean | undefined> {
   const response = await request(vendo, "/apps");
   expect(response.status).toBe(200);
   const rows = await response.json() as Array<{ id: string; unseen?: boolean }>;
-  return rows.find((row) => row.id === "app_arrival")?.unseen;
+  return rows.find((row) => row.id === appId)?.unseen;
 }
 
 describe("an app is seen when a PERSON renders it, not when an agent reads it", () => {
@@ -152,11 +163,39 @@ describe("an app is seen when a PERSON renders it, not when an agent reads it", 
 
     // The negative control: the part is in the thread — written exactly as an
     // away run leaves it — and nobody has read the conversation.
-    await seedRenderedThread(store);
+    await seedThread(store, "thr_arrival", [viewMessage("m_view", "app_arrival")]);
     expect(await unseen(vendo)).toBe(true);
 
     // The positive: Ada opens the conversation, which renders the app.
     expect((await request(vendo, "/threads/thr_arrival")).status).toBe(200);
     expect(await unseen(vendo)).toBeUndefined();
+  });
+
+  /**
+   * A LONG conversation, which is where marking the stored transcript and marking
+   * what is on screen stop being the same thing. The client mounts only a trailing
+   * window and defers the head behind "Show N earlier messages"
+   * (`chrome/thread/scrolling.ts`; `packages/ui/test/chrome/extreme-content.test.tsx`
+   * holds it to ≤60 articles in a 400-message thread), so a card in the head is
+   * not drawn — and a mark cannot be taken back.
+   */
+  it("marks the apps inside the trailing window and leaves one buried in the deferred head unseen", async () => {
+    const { vendo, store } = await setup();
+    await seedThread(store, "thr_long", [
+      viewMessage("m_buried", "app_buried"),
+      ...chatter(THREAD_WINDOW_INITIAL),
+      viewMessage("m_recent", "app_arrival"),
+    ]);
+    expect(await unseen(vendo, "app_buried")).toBe(true);
+    expect(await unseen(vendo, "app_arrival")).toBe(true);
+
+    expect((await request(vendo, "/threads/thr_long")).status).toBe(200);
+
+    // On screen, so seen…
+    expect(await unseen(vendo, "app_arrival")).toBeUndefined();
+    // …and never drawn, so still waiting. It clears when she opens the app
+    // itself; it must not clear because a scrollback she never expanded
+    // mentioned it.
+    expect(await unseen(vendo, "app_buried")).toBe(true);
   });
 });


### PR DESCRIPTION
**Slice 6 of 8 — seen/unseen arrival.**

Nothing told you an app was new. Now every app carries a per-person seen flag, server-side, and an app nobody has laid eyes on lights a quiet dot on the launcher pill.

Rows live in `vendo_app_seen`, keyed per `(app, user)`, which puts the engine allowlist at `ENGINE_ALLOWLIST_VERSION` 3. `AppsRuntime.list` now answers `AppListRow[]` — the document plus an `unseen?: boolean` that only this caller's read can say — and the flag rides the list fetch every surface already makes, so the dot costs no request of its own.

**Rendering marks it, and only rendering to a person does.** `GET /apps/:id/open` records the mark; the same runtime door an MCP client, an automation, an agent tool or an export reaches through does **not**. An agent reading a tree never clears somebody's dot. A `pending` answer marks nothing either, because it put nothing on screen.

No notifications, no beacon, no agent detection. That is the entire arrival system.

### Reviewer notes
- **The dot is live without a page reload.** It reads a shared per-client apps poller (`packages/ui/src/hooks/apps-feed.ts`), the same shape as the existing `approvals-feed.ts`: one request shared between every reader at the fastest cadence anybody asked for, visibility-aware, 5s from the launcher. An earlier revision fed the count from a module global written by whichever surface happened to mount, so the count froze at mount — an app arriving mid-session never lit the dot and rendering one never cleared it. Fixed.
- Precedence is unchanged: **a waiting decision still outranks the dot** and shows its numbered badge instead.
- **The "New" marker in panel lists was descoped** — the panel app list surface does not exist, so there is nowhere to put it. Its absence is correct by decision; a marker appearing anywhere would be the finding.
- **`POST /apps/:id/seen`, `VendoClient.apps.seen` and `useApps().markSeen` were deleted as uncalled.** Rendering is what marks, so an explicit client-side mark had no caller; the runtime door `AppsRuntime.seen` remains because the wire route uses it.
- `unseen()` is point reads for the ids on the page in hand, never a scan of the person's whole history. `mark` is `insertIfAbsent`, so the 1.2s build-window poll writes once. Seen rows are swept when an app is deleted (`clearForApp`).
- A build still in flight has rendered nothing to anybody, so it is not marked seen.
- Two authorized existing-test edits: the `ENGINE_ALLOWLIST_VERSION`/count bump in `packages/core/tests/engine-collections.test.ts`, and one `unseen: true` in `packages/apps/tests/lifecycle.test.ts` (that app was created and edited but never rendered). No assertion weakened.

### Live proof — real browser, with controls
**PASS.** The dot is live with no reload: `p0.log` records `.fl-launcher-dot APPEARED at ~10500ms after load` on a single navigation, which is the shared poller doing its job, with the spoken line "Something new to look at". Precedence is proven with a control — `pA.log` shows dot-only at rest and the numbered badge **outranking** the dot once a decision waits (`pA-01-dot-only.png`, `pA-03-badge-outranks-dot.png`). `pF.log` STEP 6c proves clearing without a reload: unseen `10/10` before, `9/10` after the app mounts, `navigation count == 1`.

`pE.log` also confirms a persisting dot is *correct* when other never-opened apps remain — 9 seed apps still carried `unseen=true`, so the pill is right to stay lit.

### The regression this lane fixed after the gate
The last full local gate turned up 3 deterministic failures in `packages/vendo/tests/server.test.ts` — a file this stack does not edit — bisected to this lane by per-lane isolation on that single file (lane 5 green 126/126, lane 6 red). The arrival mark had been placed inside the response's success path: an unguarded `await deps.apps.seen(...)` between `open()` and the response turned a served 200 into a 404, and inside the pending window the mark sat within the `try` whose `catch` swallows `not-found` into `{kind:"pending"}`, so a failed mark silently converted a served tree into a spinning "pending".

Both sites now go through one named `markArrival` helper (`wire/apps.ts:92`) that drops a failed mark, and the not-found disambiguation moved **out** of the pending `catch` into `answerUnservableApp` (`:99`), so a mark's own not-found can never be mistaken for the open's. One swallow, one named helper, the reason in the comment. `server.test.ts` is green again at 126/126.

**Arrival bookkeeping can no longer fail a render, change a status, or alter what the user sees.**

### The in-thread render, and what is not yet proven
An in-thread render previously left `unseen = true` — only a slot mount cleared it. The mark now also fires on `GET /threads/:id`: a live turn has no server event to hang it on, but reading the conversation back does, and that read is person-only by construction (`wire/context.ts:85` mints `presence:"present"`/`kind:"user"`, `threads.ts:188` answers only the caller's own threads, and `packages/mcp/src/door.ts` exposes three app tools and zero thread tools). So an away run can write a view part into a sponsor's thread and only the sponsor reading it marks it seen — the agent-never-marks property holds.

**Not yet proven in production:** a production-build browser re-proof of thread-render clearing is still outstanding and will be added as a comment. It passed in dev at 9.7s before an interrupted run; the production run is being done separately rather than holding this push. Stated plainly rather than implied.

### Gate
Last full local gate (tip `3b70a7016`): `pnpm build` **PASS** (21/21 tasks); `pnpm test:affected` — 9,500+ tests green across 23 packages, with `@vendoai/vendo` 2,370 passed and `demo-bank` 123 passed. Two known issues at that run, both since addressed or explained:

- `examples/demo-bank/tests/vendo/away-drill.test.ts` — a **known load flake**, not a product failure: under full-suite load its `beforeAll` dev-server boot hook timed out at 240s and the suite's 4 tests were skipped. Run alone it is **4/4 PASS in 24.5s**. Unrelated to this stack (grants/automations/session).
- 3 failures in `packages/vendo/tests/server.test.ts`, bisected to lane 6 and **fixed in lane 6** (the arrival mark was inside the response's success path; it now cannot fail or alter a render).

**This gate predates the rebase onto newer `main`, so it is not the authority — CI is the gate of record.** The stack has since been rebased onto current `origin/main`, which moved three times during this work.

Stack: this PR → slice 5. **PR 8 is the merge unit**; this is a review window.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Apps track per-person seen state and the launcher lights a quiet dot for anything unseen (a finished run or an app). Only a person’s successful render clears it; pending opens do not; thread reads mark only apps inside the on-screen trailing window. While a build streams, empty states show skeletons instead of “No data.”

- `GET /apps` returns `AppListRow[]` with per-caller `unseen`; computed by point reads, never stored.
- Marking: `AppsRuntime.seen` records arrival; `GET /apps/:id/open` marks after a non‑pending open; `GET /threads/:id` marks apps rendered in the trailing window only (`THREAD_WINDOW_INITIAL` in `@vendoai/core`). Marks are idempotent and dropped on failure; deleting an app sweeps all seen rows.
- One shared apps poller feeds both `useApps()` and the launcher dot; the dot’s spoken label is “Something new to look at,” and the ask badge still outranks it.
- Empty UX: charts/tables/lists hold skeletons while streaming and show the same empty copy or `empty` slot once settled. Docs add `<VendoAppEmbed>` as the React path to render an MCP `vendo_make` receipt inline.
- Data lives in `vendo_app_seen` (engine allowlist v3); no storage migration.

**Migration/QA**
- Remove `POST /apps/:id/seen`, `VendoClient.apps.seen`, and `useApps().markSeen`.
- Update typings: `VendoClient.apps.list()` returns `AppListRow[]`.
- Validate: the dot lights for an unseen app, clears after opening the app or reading a thread that renders it; does not clear on agent/automation opens; does not clear for apps only in the deferred thread head; the dot updates without a reload and the ask badge still outranks it; forming screens show skeletons instead of empty copy until the build settles.

<sup>Written for commit 566379970ce45cb170800d6f8b37d00b3a77aa7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1430?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

