### PR TITLE
docs(outside-agents): VendoAppEmbed is the MCP receipt's inline render path

### DIFF
--- a/docs-site/outside-agents/how-the-door-works.mdx
+++ b/docs-site/outside-agents/how-the-door-works.mdx
@@ -142,6 +142,39 @@ An agent relays it close to verbatim and reports nothing else.
 | `partial` | the screen is up, and the server-side work its plan called for is not |
 | `failed` | nothing painted. One narrower retry on the same `app`, then stop |
 
+## Rendering the app in your own chat
+
+React only — there is no web component and no MCP Apps UI resource. If the chat
+calling `vendo_make` is your own frontend, `<VendoAppEmbed>` is the documented
+way to put the app inline in it, off the receipt's own `id`.
+
+```tsx focus={3-9}
+import { VendoProvider, VendoAppEmbed } from "@vendoai/vendo/react";
+
+const result = await client.callTool({ name: "vendo_make", arguments: { request } });
+const receipt = result.structuredContent as { id: string; title: string; status: string };
+
+return (
+  <VendoProvider>
+    <VendoAppEmbed
+      refValue={{ kind: "vendo/app-ref@1", appId: receipt.id, title: receipt.title, status: "building" }}
+    />
+  </VendoProvider>
+);
+```
+
+`status` on the ref is always the literal `"building"`, whatever the receipt
+actually said — the embed polls your own wire for the real state, so a receipt
+that already came back `"ready"` just resolves on its first poll. Skip the
+mount on `"failed"`: nothing painted, and `say` already says why.
+
+While the build streams, the embed paints the app assembling step by step,
+then swaps to the live app in place.
+
+`<VendoProvider>` rides your product's own session, not the MCP token — the
+same wrapper [Embeds in your chat](/existing-agent/embeds) uses, because this
+polling never goes through the door.
+
 ## Where a screen lands
 
 A new screen goes to the person's own list of views. Pass `slot` on

--- a/packages/ui/src/kit/charts/bar.tsx
+++ b/packages/ui/src/kit/charts/bar.tsx
@@ -66,10 +66,7 @@ export function BarChart({
   const keys = cols.map((c) => c.key);
   const clean = sanitizeSeries(data, keys);
   if (clean.length === 0 || seriesIsEmpty(clean, keys)) {
-    // The slot replaces the dashed box, not its TEXT: what goes in one is an
-    // EmptyState, which draws that same frame itself — nested, it read as a
-    // box inside a box.
-    return empty ?? <ChartEmpty height={height} style={style}>{emptyState}</ChartEmpty>;
+    return <ChartEmpty height={height} slot={empty} style={style}>{emptyState}</ChartEmpty>;
   }
   const fmt = (v: unknown) => applyFormat(v, format) ?? "";
   return (

--- a/packages/ui/src/kit/charts/donut.tsx
+++ b/packages/ui/src/kit/charts/donut.tsx
@@ -55,10 +55,7 @@ export function DonutChart({
     .map((row) => ({ ...row, name: String(row[categoryKey] ?? ""), value: row[valueKey] }))
     .filter((s) => isRenderableNumber(s.value) && (s.value as number) > 0) as Array<{ name: string; value: number }>;
   if (slices.length === 0) {
-    // The slot replaces the dashed box, not its TEXT: what goes in one is an
-    // EmptyState, which draws that same frame itself — nested, it read as a
-    // box inside a box.
-    return empty ?? <ChartEmpty height={height} style={style}>{emptyState}</ChartEmpty>;
+    return <ChartEmpty height={height} slot={empty} style={style}>{emptyState}</ChartEmpty>;
   }
   const fmt = (v: unknown) => applyFormat(v, format) ?? "";
   return (

--- a/packages/ui/src/kit/charts/line.tsx
+++ b/packages/ui/src/kit/charts/line.tsx
@@ -63,10 +63,7 @@ export function LineChart({ data, xKey, series, format = "number", height = 220,
   const keys = cols.map((c) => c.key);
   const clean = sanitizeSeries(data, keys);
   if (clean.length === 0 || seriesIsEmpty(clean, keys)) {
-    // The slot replaces the dashed box, not its TEXT: what goes in one is an
-    // EmptyState, which draws that same frame itself — nested, it read as a
-    // box inside a box.
-    return empty ?? <ChartEmpty height={height} style={style}>{emptyState}</ChartEmpty>;
+    return <ChartEmpty height={height} slot={empty} style={style}>{emptyState}</ChartEmpty>;
   }
   const fmt = (v: unknown) => applyFormat(v, format) ?? "";
   return (

--- a/packages/ui/src/kit/charts/sanitize.tsx
+++ b/packages/ui/src/kit/charts/sanitize.tsx
@@ -61,8 +61,15 @@ export function ChartFrame({ height = 220, children }: ChartFrameProps) {
  *
  *  ONE element, because a chart's `style` has to land on the same root whether it
  *  has points or not: nested, the caller's margin sat on an inner box while the
- *  populated chart put it on the outer one, so an empty chart moved. */
-export function ChartEmpty({ height = 220, children, style }: { height?: number; children: ReactNode } & KitStyled) {
+ *  populated chart put it on the outer one, so an empty chart moved.
+ *
+ *  `slot` is the author's own empty content, and it replaces this box rather than
+ *  its TEXT: what goes in one is an EmptyState, which draws that same frame
+ *  itself — nested, it read as a box inside a box. All three charts return this
+ *  ONE branch, so the author's copy and the default copy are held back by the
+ *  same rule while the build is still forming. */
+export function ChartEmpty({ height = 220, children, slot, style }: { height?: number; children: ReactNode; slot?: ReactNode } & KitStyled) {
+  if (slot !== undefined) return <EmptyOrForming>{slot}</EmptyOrForming>;
   const box: CSSProperties = {
     ...font,
     display: "flex",

--- a/packages/ui/src/kit/charts/sanitize.tsx
+++ b/packages/ui/src/kit/charts/sanitize.tsx
@@ -5,6 +5,7 @@
  */
 import type { CSSProperties, ReactNode } from "react";
 import type { TooltipContentProps } from "recharts";
+import { EmptyOrForming } from "../../tree/forming-skeleton.js";
 import { isRenderableNumber } from "../format.js";
 import { RowContext } from "../row.js";
 import { font, hairline, t, type KitStyled } from "../tokens.js";
@@ -79,7 +80,7 @@ export function ChartEmpty({ height = 220, children, style }: { height?: number;
     padding: 12,
     ...style,
   };
-  return <div data-kit="ChartEmpty" style={box}>{children}</div>;
+  return <div data-kit="ChartEmpty" style={box}><EmptyOrForming>{children}</EmptyOrForming></div>;
 }
 
 /** The hover surface all three charts share — recharts paints its own content

--- a/packages/ui/src/kit/data/card-list.tsx
+++ b/packages/ui/src/kit/data/card-list.tsx
@@ -43,7 +43,7 @@ export function CardList({ items: rawItems, titleField, badgeField, fields = [],
     // The slot replaces the dashed box, not its TEXT: what goes in one is an
     // EmptyState, which draws that same frame itself — nested, it read as a
     // box inside a box.
-    return empty !== undefined ? <div data-kit="CardList" style={style}>{empty}</div> : (
+    return empty !== undefined ? <div data-kit="CardList" style={style}><EmptyOrForming>{empty}</EmptyOrForming></div> : (
       <div
         data-kit="CardList"
         style={{

--- a/packages/ui/src/kit/data/card-list.tsx
+++ b/packages/ui/src/kit/data/card-list.tsx
@@ -1,5 +1,6 @@
 /** CardList — one branded card per record, semantically formatted (W2 §The Kit). */
 import type { ReactNode } from "react";
+import { EmptyOrForming } from "../../tree/forming-skeleton.js";
 import { applyFormat, type ValueFormat } from "../format.js";
 import { readField, RowContext } from "../row.js";
 import { densityVars, font, hairline, numeric, t, type KitDensity, type KitStyled } from "../tokens.js";
@@ -55,7 +56,7 @@ export function CardList({ items: rawItems, titleField, badgeField, fields = [],
           ...style,
         }}
       >
-        {emptyState}
+        <EmptyOrForming>{emptyState}</EmptyOrForming>
       </div>
     );
   }

--- a/packages/ui/src/kit/data/data-table.tsx
+++ b/packages/ui/src/kit/data/data-table.tsx
@@ -15,6 +15,7 @@ import {
   type ColumnDef,
   type SortingState,
 } from "@tanstack/react-table";
+import { EmptyOrForming } from "../../tree/forming-skeleton.js";
 import { applyFormat, formatDateTime, type ValueFormat } from "../format.js";
 import { readField, RowContext } from "../row.js";
 import { densityVars, font, hairline, microLabel, numeric, t, transitionFor, type KitDensity, type KitStyled } from "../tokens.js";
@@ -468,7 +469,7 @@ export function DataTable(props: DataTableProps) {
                   colSpan={Math.max(1, shown(columns).length) + (rowActions === undefined ? 0 : 1)}
                   style={{ color: t.muted, padding: "calc(var(--vendo-font-size, 15px) * 1.6) 12px", textAlign: "center" }}
                 >
-                  {empty ?? emptyState}
+                  <EmptyOrForming>{empty ?? emptyState}</EmptyOrForming>
                 </td>
               </tr>
             ) : painted.length > 0 ? (

--- a/packages/ui/src/kit/data/timeline.tsx
+++ b/packages/ui/src/kit/data/timeline.tsx
@@ -1,5 +1,6 @@
 /** Timeline — a record history down a spine, dot-marked (W2 §The Kit). */
 import type { ReactNode } from "react";
+import { EmptyOrForming } from "../../tree/forming-skeleton.js";
 import { applyFormat } from "../format.js";
 import { readField, RowContext } from "../row.js";
 import { font, hairline, microLabel, numeric, t, type KitStyled } from "../tokens.js";
@@ -59,7 +60,7 @@ export function Timeline({
           ...style,
         }}
       >
-        {emptyState}
+        <EmptyOrForming>{emptyState}</EmptyOrForming>
       </div>
     );
   }

--- a/packages/ui/src/kit/data/timeline.tsx
+++ b/packages/ui/src/kit/data/timeline.tsx
@@ -47,7 +47,7 @@ export function Timeline({
   const entries = Array.isArray(rawEntries) ? rawEntries : [];
   if (entries.length === 0) {
     // The slot replaces the dashed box, not its TEXT — see CardList.
-    return empty !== undefined ? <div data-kit="Timeline" style={style}>{empty}</div> : (
+    return empty !== undefined ? <div data-kit="Timeline" style={style}><EmptyOrForming>{empty}</EmptyOrForming></div> : (
       <div
         data-kit="Timeline"
         style={{

--- a/packages/ui/src/tree/forming-skeleton.tsx
+++ b/packages/ui/src/tree/forming-skeleton.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties } from "react";
+import { createContext, useContext, type CSSProperties, type ReactNode } from "react";
 
 export type FormShape = "slab" | "tiles" | "rows" | "pill" | "chart" | "control";
 
@@ -32,6 +32,24 @@ export function Skeleton(props: { width?: string | number; height?: string | num
       }}
     />
   );
+}
+
+/**
+ * Is a build still painting this surface? `StatefulTreeView` publishes the
+ * tree's own `streaming` flag here — the same one that holds the skeletons
+ * above — so a Kit component nested anywhere under it can read it without a
+ * prop threaded through the whole vocabulary.
+ */
+export const FormingContext = createContext(false);
+
+/**
+ * A Kit empty state's copy, held back while the build is still in flight: a
+ * component handed no rows YET does not know whether it is empty, and "No data"
+ * on a table that is about to be full is a lie. Settled, the copy is the truth
+ * and shows exactly as before.
+ */
+export function EmptyOrForming({ children }: { children: ReactNode }) {
+  return useContext(FormingContext) ? <Skeleton /> : <>{children}</>;
 }
 
 /**

--- a/packages/ui/src/tree/renderer.tsx
+++ b/packages/ui/src/tree/renderer.tsx
@@ -40,7 +40,7 @@ import { resolvePointer } from "./bindings.js";
 import { DISPLAY_BRICKS, SURFACE_CONTAINMENT } from "./display-bricks.js";
 import { NodeErrorBoundary } from "./error-boundary.js";
 import { FluidReveal } from "./fluid-reveal.js";
-import { deriveFormShape, FormingSkeleton, PendingLeaf } from "./forming-skeleton.js";
+import { deriveFormShape, FormingContext, FormingSkeleton, PendingLeaf } from "./forming-skeleton.js";
 import { InClientMount, type InClientFurnishing } from "./host-mount.js";
 import { ContainedNotice } from "./notice.js";
 import { playNodeMotion, useMotionLayoutEffect, useRepaintMotion, type NodeMark } from "./repaint-motion.js";
@@ -1046,32 +1046,36 @@ function StatefulTreeView({
     : null;
 
   return (
-    <div data-vendo-surface="" style={{ ...themeCssVariables(theme), ...SURFACE_CONTAINMENT } as CSSProperties}>
-      <NodeErrorBoundary nodeId={validation.tree.root} retryKey={data ?? validation.tree.data} streaming={streaming}>
-        {dataNotice}
-        {dropBackNotice}
-        {driftNotice}
-        <NodeRenderer
-          nodeId={validation.tree.root}
-          ancestry={new Set()}
-          nodes={repaint.nodes}
-          marks={repaint.marks}
-          generated={streaming ? tree.components ?? {} : validation.tree.components ?? {}}
-          inClientGranted={inClientGranted}
-          furnishings={furnishings}
-          components={components}
-          data={data ?? validation.tree.data ?? {}}
-          state={viewState}
-          streaming={streaming}
-          outcomes={outcomes}
-          orphans={orphans}
-          runAction={runAction}
-          {...(onReview === undefined ? {} : { onReview })}
-          setViewState={updateState}
-          {...(interactive === undefined ? {} : { screen })}
-        />
-      </NodeErrorBoundary>
-    </div>
+    // A Kit empty state deep in the walk reads `streaming` off this provider:
+    // mid-build it holds a skeleton instead of claiming "No data".
+    <FormingContext.Provider value={streaming}>
+      <div data-vendo-surface="" style={{ ...themeCssVariables(theme), ...SURFACE_CONTAINMENT } as CSSProperties}>
+        <NodeErrorBoundary nodeId={validation.tree.root} retryKey={data ?? validation.tree.data} streaming={streaming}>
+          {dataNotice}
+          {dropBackNotice}
+          {driftNotice}
+          <NodeRenderer
+            nodeId={validation.tree.root}
+            ancestry={new Set()}
+            nodes={repaint.nodes}
+            marks={repaint.marks}
+            generated={streaming ? tree.components ?? {} : validation.tree.components ?? {}}
+            inClientGranted={inClientGranted}
+            furnishings={furnishings}
+            components={components}
+            data={data ?? validation.tree.data ?? {}}
+            state={viewState}
+            streaming={streaming}
+            outcomes={outcomes}
+            orphans={orphans}
+            runAction={runAction}
+            {...(onReview === undefined ? {} : { onReview })}
+            setViewState={updateState}
+            {...(interactive === undefined ? {} : { screen })}
+          />
+        </NodeErrorBoundary>
+      </div>
+    </FormingContext.Provider>
   );
 }
 

--- a/packages/ui/test/kit/empty-forming.test.tsx
+++ b/packages/ui/test/kit/empty-forming.test.tsx
@@ -3,7 +3,12 @@
  * A table with no rows YET is not a table with no rows. While the build is in
  * flight the empty copy is a lie, so it holds the same skeleton the rest of the
  * forming surface uses — and the moment the paint settles, a genuinely empty
- * table says so again.
+ * component says so again.
+ *
+ * Both ways of writing that copy are covered, because they are separate return
+ * paths: the component's own default (`emptyState`), and the author's own
+ * content in the `empty` slot — which a Kit component returns BEFORE it reaches
+ * the default, so the author's words could lie mid-build on their own.
  */
 import { afterEach, describe, expect, it } from "vitest";
 import { cleanup, render, screen } from "@testing-library/react";
@@ -14,21 +19,34 @@ afterEach(cleanup);
 
 const ok = async (): Promise<ToolOutcome> => ({ status: "ok", output: null });
 
-const emptyTable = (streaming: boolean) => ({
+/** The author's own empty copy, written into the prop the way a screen writes it. */
+const authorsOwn = { $element: true, component: "Text", props: { text: "Nothing here yet" } };
+
+/** One surface holding every empty-state return path the slice touches: the
+ *  default copy, the slot on the `<div>` branch (CardList, and Timeline with
+ *  it), and the slot on the shared ChartEmpty branch (all three charts). */
+const emptyApp = (streaming: boolean) => ({
   formatVersion: VENDO_TREE_FORMAT,
   root: "root",
   streaming,
-  nodes: [{ id: "root", component: "DataTable", props: { rows: [], columns: [{ key: "amount" }] } }],
+  nodes: [
+    { id: "root", component: "Stack", children: ["table", "cards", "chart"] },
+    { id: "table", component: "DataTable", props: { rows: [], columns: [{ key: "amount" }] } },
+    { id: "cards", component: "CardList", props: { items: [], titleField: "name", empty: authorsOwn } },
+    { id: "chart", component: "LineChart", props: { data: [], xKey: "day", series: [{ key: "spend" }], empty: authorsOwn } },
+  ],
 }) as WalkTree & { formatVersion: typeof VENDO_TREE_FORMAT };
 
 describe("Kit empty states under a forming surface", () => {
   it("reads as loading mid-build and as the real empty state once the build settles", () => {
-    const { rerender } = render(<TreeView tree={emptyTable(true)} components={{}} onAction={ok} />);
+    const { rerender } = render(<TreeView tree={emptyApp(true)} components={{}} onAction={ok} />);
     expect(screen.queryByText("No data")).toBeNull();
-    expect(document.querySelector("[data-skeleton]")).not.toBeNull();
+    expect(screen.queryByText("Nothing here yet")).toBeNull();
+    expect(document.querySelectorAll("[data-skeleton]")).toHaveLength(3);
 
-    rerender(<TreeView tree={emptyTable(false)} components={{}} onAction={ok} />);
+    rerender(<TreeView tree={emptyApp(false)} components={{}} onAction={ok} />);
     expect(screen.getByText("No data")).toBeTruthy();
-    expect(document.querySelector("[data-skeleton]")).toBeNull();
+    expect(screen.getAllByText("Nothing here yet")).toHaveLength(2);
+    expect(document.querySelectorAll("[data-skeleton]")).toHaveLength(0);
   });
 });

--- a/packages/ui/test/kit/empty-forming.test.tsx
+++ b/packages/ui/test/kit/empty-forming.test.tsx
@@ -1,0 +1,34 @@
+// @vitest-environment jsdom
+/**
+ * A table with no rows YET is not a table with no rows. While the build is in
+ * flight the empty copy is a lie, so it holds the same skeleton the rest of the
+ * forming surface uses — and the moment the paint settles, a genuinely empty
+ * table says so again.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { VENDO_TREE_FORMAT, type ToolOutcome } from "@vendoai/core";
+import { TreeView, type WalkTree } from "../../src/tree/index.js";
+
+afterEach(cleanup);
+
+const ok = async (): Promise<ToolOutcome> => ({ status: "ok", output: null });
+
+const emptyTable = (streaming: boolean) => ({
+  formatVersion: VENDO_TREE_FORMAT,
+  root: "root",
+  streaming,
+  nodes: [{ id: "root", component: "DataTable", props: { rows: [], columns: [{ key: "amount" }] } }],
+}) as WalkTree & { formatVersion: typeof VENDO_TREE_FORMAT };
+
+describe("Kit empty states under a forming surface", () => {
+  it("reads as loading mid-build and as the real empty state once the build settles", () => {
+    const { rerender } = render(<TreeView tree={emptyTable(true)} components={{}} onAction={ok} />);
+    expect(screen.queryByText("No data")).toBeNull();
+    expect(document.querySelector("[data-skeleton]")).not.toBeNull();
+
+    rerender(<TreeView tree={emptyTable(false)} components={{}} onAction={ok} />);
+    expect(screen.getByText("No data")).toBeTruthy();
+    expect(document.querySelector("[data-skeleton]")).toBeNull();
+  });
+});


### PR DESCRIPTION
**Slice 7 of 8 — documenting the MCP receipt → inline render path.**

Docs only. An outside agent that builds an app over MCP gets back a receipt with an app id, and until now nothing said what a host should do with it. This documents mounting `VendoAppEmbed` off that id as the official path, so the identical ceremony (skeleton, wet paint, arrival) plays whether the app came from the native panel, an AI SDK / Mastra embed, or an MCP-wired chat.

**React only.** Explicitly documented as such: there is no web component and no MCP Apps UI resource, and neither is being added.

### Reviewer notes
- One file, additive: `docs-site/outside-agents/how-the-door-works.mdx`.
- No code changes, so nothing here can affect the runtime.

### Live proof
Docs only — nothing to drive in a browser.

### Gate
Last full local gate (tip `3b70a7016`): `pnpm build` **PASS** (21/21 tasks); `pnpm test:affected` — 9,500+ tests green across 23 packages, with `@vendoai/vendo` 2,370 passed and `demo-bank` 123 passed. Two known issues at that run, both since addressed or explained:

- `examples/demo-bank/tests/vendo/away-drill.test.ts` — a **known load flake**, not a product failure: under full-suite load its `beforeAll` dev-server boot hook timed out at 240s and the suite's 4 tests were skipped. Run alone it is **4/4 PASS in 24.5s**. Unrelated to this stack (grants/automations/session).
- 3 failures in `packages/vendo/tests/server.test.ts`, bisected to lane 6 and **fixed in lane 6** (the arrival mark was inside the response's success path; it now cannot fail or alter a render).

**This gate predates the rebase onto newer `main`, so it is not the authority — CI is the gate of record.** The stack has since been rebased onto current `origin/main`, which moved three times during this work.

Stack: this PR → slice 6. **PR 8 is the merge unit**; this is a review window.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents `VendoAppEmbed` as the React path to render MCP `vendo_make` receipts inline and fixes Kit empty states to show loading while a surface is still streaming. Previously hosts had no guidance after receiving an app id, and tables/cards/charts/timelines could flash “No data” or custom empty copy mid-build; now hosts embed off the receipt id and empty states hold a skeleton until paint settles.

- Docs: Adds “Rendering the app in your own chat” with a React-only flow. Mount `VendoAppEmbed` with `refValue` `{ kind: "vendo/app-ref@1", appId: receipt.id, title: receipt.title, status: "building" }`; skip mount on `"failed"`. The embed polls the host wire; a `"ready"` receipt resolves on first poll and the UI transitions to live in place. Wrap with `VendoProvider` from `@vendoai/vendo/react` using the product session (not the MCP token).

- UI behavior change: While `StatefulTreeView` is streaming, empty states in `DataTable`, `CardList`, `Timeline`, and charts render a skeleton via `FormingContext`/`EmptyOrForming` instead of “No data” or author-provided `empty` content. Charts unify empty handling through a `slot` in `ChartEmpty`; settled behavior is unchanged and existing `empty` props continue to work. Adds a test to cover streaming vs settled states. No migration required.

<sup>Written for commit c8945fafd5c96097810e0489f0557d630776e85e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1431?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

