### PR TITLE
fix(ui): a component that does not yet know it is empty reads as loading, never "No data"

### DIFF
--- a/packages/ui/src/kit/charts/bar.tsx
+++ b/packages/ui/src/kit/charts/bar.tsx
@@ -66,10 +66,7 @@ export function BarChart({
   const keys = cols.map((c) => c.key);
   const clean = sanitizeSeries(data, keys);
   if (clean.length === 0 || seriesIsEmpty(clean, keys)) {
-    // The slot replaces the dashed box, not its TEXT: what goes in one is an
-    // EmptyState, which draws that same frame itself — nested, it read as a
-    // box inside a box.
-    return empty ?? <ChartEmpty height={height} style={style}>{emptyState}</ChartEmpty>;
+    return <ChartEmpty height={height} slot={empty} style={style}>{emptyState}</ChartEmpty>;
   }
   const fmt = (v: unknown) => applyFormat(v, format) ?? "";
   return (

--- a/packages/ui/src/kit/charts/donut.tsx
+++ b/packages/ui/src/kit/charts/donut.tsx
@@ -55,10 +55,7 @@ export function DonutChart({
     .map((row) => ({ ...row, name: String(row[categoryKey] ?? ""), value: row[valueKey] }))
     .filter((s) => isRenderableNumber(s.value) && (s.value as number) > 0) as Array<{ name: string; value: number }>;
   if (slices.length === 0) {
-    // The slot replaces the dashed box, not its TEXT: what goes in one is an
-    // EmptyState, which draws that same frame itself — nested, it read as a
-    // box inside a box.
-    return empty ?? <ChartEmpty height={height} style={style}>{emptyState}</ChartEmpty>;
+    return <ChartEmpty height={height} slot={empty} style={style}>{emptyState}</ChartEmpty>;
   }
   const fmt = (v: unknown) => applyFormat(v, format) ?? "";
   return (

--- a/packages/ui/src/kit/charts/line.tsx
+++ b/packages/ui/src/kit/charts/line.tsx
@@ -63,10 +63,7 @@ export function LineChart({ data, xKey, series, format = "number", height = 220,
   const keys = cols.map((c) => c.key);
   const clean = sanitizeSeries(data, keys);
   if (clean.length === 0 || seriesIsEmpty(clean, keys)) {
-    // The slot replaces the dashed box, not its TEXT: what goes in one is an
-    // EmptyState, which draws that same frame itself — nested, it read as a
-    // box inside a box.
-    return empty ?? <ChartEmpty height={height} style={style}>{emptyState}</ChartEmpty>;
+    return <ChartEmpty height={height} slot={empty} style={style}>{emptyState}</ChartEmpty>;
   }
   const fmt = (v: unknown) => applyFormat(v, format) ?? "";
   return (

--- a/packages/ui/src/kit/charts/sanitize.tsx
+++ b/packages/ui/src/kit/charts/sanitize.tsx
@@ -61,8 +61,15 @@ export function ChartFrame({ height = 220, children }: ChartFrameProps) {
  *
  *  ONE element, because a chart's `style` has to land on the same root whether it
  *  has points or not: nested, the caller's margin sat on an inner box while the
- *  populated chart put it on the outer one, so an empty chart moved. */
-export function ChartEmpty({ height = 220, children, style }: { height?: number; children: ReactNode } & KitStyled) {
+ *  populated chart put it on the outer one, so an empty chart moved.
+ *
+ *  `slot` is the author's own empty content, and it replaces this box rather than
+ *  its TEXT: what goes in one is an EmptyState, which draws that same frame
+ *  itself — nested, it read as a box inside a box. All three charts return this
+ *  ONE branch, so the author's copy and the default copy are held back by the
+ *  same rule while the build is still forming. */
+export function ChartEmpty({ height = 220, children, slot, style }: { height?: number; children: ReactNode; slot?: ReactNode } & KitStyled) {
+  if (slot !== undefined) return <EmptyOrForming>{slot}</EmptyOrForming>;
   const box: CSSProperties = {
     ...font,
     display: "flex",

--- a/packages/ui/src/kit/charts/sanitize.tsx
+++ b/packages/ui/src/kit/charts/sanitize.tsx
@@ -5,6 +5,7 @@
  */
 import type { CSSProperties, ReactNode } from "react";
 import type { TooltipContentProps } from "recharts";
+import { EmptyOrForming } from "../../tree/forming-skeleton.js";
 import { isRenderableNumber } from "../format.js";
 import { RowContext } from "../row.js";
 import { font, hairline, t, type KitStyled } from "../tokens.js";
@@ -79,7 +80,7 @@ export function ChartEmpty({ height = 220, children, style }: { height?: number;
     padding: 12,
     ...style,
   };
-  return <div data-kit="ChartEmpty" style={box}>{children}</div>;
+  return <div data-kit="ChartEmpty" style={box}><EmptyOrForming>{children}</EmptyOrForming></div>;
 }
 
 /** The hover surface all three charts share — recharts paints its own content

--- a/packages/ui/src/kit/data/card-list.tsx
+++ b/packages/ui/src/kit/data/card-list.tsx
@@ -43,7 +43,7 @@ export function CardList({ items: rawItems, titleField, badgeField, fields = [],
     // The slot replaces the dashed box, not its TEXT: what goes in one is an
     // EmptyState, which draws that same frame itself — nested, it read as a
     // box inside a box.
-    return empty !== undefined ? <div data-kit="CardList" style={style}>{empty}</div> : (
+    return empty !== undefined ? <div data-kit="CardList" style={style}><EmptyOrForming>{empty}</EmptyOrForming></div> : (
       <div
         data-kit="CardList"
         style={{

--- a/packages/ui/src/kit/data/card-list.tsx
+++ b/packages/ui/src/kit/data/card-list.tsx
@@ -1,5 +1,6 @@
 /** CardList — one branded card per record, semantically formatted (W2 §The Kit). */
 import type { ReactNode } from "react";
+import { EmptyOrForming } from "../../tree/forming-skeleton.js";
 import { applyFormat, type ValueFormat } from "../format.js";
 import { readField, RowContext } from "../row.js";
 import { densityVars, font, hairline, numeric, t, type KitDensity, type KitStyled } from "../tokens.js";
@@ -55,7 +56,7 @@ export function CardList({ items: rawItems, titleField, badgeField, fields = [],
           ...style,
         }}
       >
-        {emptyState}
+        <EmptyOrForming>{emptyState}</EmptyOrForming>
       </div>
     );
   }

--- a/packages/ui/src/kit/data/data-table.tsx
+++ b/packages/ui/src/kit/data/data-table.tsx
@@ -15,6 +15,7 @@ import {
   type ColumnDef,
   type SortingState,
 } from "@tanstack/react-table";
+import { EmptyOrForming } from "../../tree/forming-skeleton.js";
 import { applyFormat, formatDateTime, type ValueFormat } from "../format.js";
 import { readField, RowContext } from "../row.js";
 import { densityVars, font, hairline, microLabel, numeric, t, transitionFor, type KitDensity, type KitStyled } from "../tokens.js";
@@ -468,7 +469,7 @@ export function DataTable(props: DataTableProps) {
                   colSpan={Math.max(1, shown(columns).length) + (rowActions === undefined ? 0 : 1)}
                   style={{ color: t.muted, padding: "calc(var(--vendo-font-size, 15px) * 1.6) 12px", textAlign: "center" }}
                 >
-                  {empty ?? emptyState}
+                  <EmptyOrForming>{empty ?? emptyState}</EmptyOrForming>
                 </td>
               </tr>
             ) : painted.length > 0 ? (

--- a/packages/ui/src/kit/data/timeline.tsx
+++ b/packages/ui/src/kit/data/timeline.tsx
@@ -1,5 +1,6 @@
 /** Timeline — a record history down a spine, dot-marked (W2 §The Kit). */
 import type { ReactNode } from "react";
+import { EmptyOrForming } from "../../tree/forming-skeleton.js";
 import { applyFormat } from "../format.js";
 import { readField, RowContext } from "../row.js";
 import { font, hairline, microLabel, numeric, t, type KitStyled } from "../tokens.js";
@@ -59,7 +60,7 @@ export function Timeline({
           ...style,
         }}
       >
-        {emptyState}
+        <EmptyOrForming>{emptyState}</EmptyOrForming>
       </div>
     );
   }

--- a/packages/ui/src/kit/data/timeline.tsx
+++ b/packages/ui/src/kit/data/timeline.tsx
@@ -47,7 +47,7 @@ export function Timeline({
   const entries = Array.isArray(rawEntries) ? rawEntries : [];
   if (entries.length === 0) {
     // The slot replaces the dashed box, not its TEXT — see CardList.
-    return empty !== undefined ? <div data-kit="Timeline" style={style}>{empty}</div> : (
+    return empty !== undefined ? <div data-kit="Timeline" style={style}><EmptyOrForming>{empty}</EmptyOrForming></div> : (
       <div
         data-kit="Timeline"
         style={{

--- a/packages/ui/src/tree/forming-skeleton.tsx
+++ b/packages/ui/src/tree/forming-skeleton.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties } from "react";
+import { createContext, useContext, type CSSProperties, type ReactNode } from "react";
 
 export type FormShape = "slab" | "tiles" | "rows" | "pill" | "chart" | "control";
 
@@ -32,6 +32,24 @@ export function Skeleton(props: { width?: string | number; height?: string | num
       }}
     />
   );
+}
+
+/**
+ * Is a build still painting this surface? `StatefulTreeView` publishes the
+ * tree's own `streaming` flag here — the same one that holds the skeletons
+ * above — so a Kit component nested anywhere under it can read it without a
+ * prop threaded through the whole vocabulary.
+ */
+export const FormingContext = createContext(false);
+
+/**
+ * A Kit empty state's copy, held back while the build is still in flight: a
+ * component handed no rows YET does not know whether it is empty, and "No data"
+ * on a table that is about to be full is a lie. Settled, the copy is the truth
+ * and shows exactly as before.
+ */
+export function EmptyOrForming({ children }: { children: ReactNode }) {
+  return useContext(FormingContext) ? <Skeleton /> : <>{children}</>;
 }
 
 /**

--- a/packages/ui/src/tree/renderer.tsx
+++ b/packages/ui/src/tree/renderer.tsx
@@ -40,7 +40,7 @@ import { resolvePointer } from "./bindings.js";
 import { DISPLAY_BRICKS, SURFACE_CONTAINMENT } from "./display-bricks.js";
 import { NodeErrorBoundary } from "./error-boundary.js";
 import { FluidReveal } from "./fluid-reveal.js";
-import { deriveFormShape, FormingSkeleton, PendingLeaf } from "./forming-skeleton.js";
+import { deriveFormShape, FormingContext, FormingSkeleton, PendingLeaf } from "./forming-skeleton.js";
 import { InClientMount, type InClientFurnishing } from "./host-mount.js";
 import { ContainedNotice } from "./notice.js";
 import { playNodeMotion, useMotionLayoutEffect, useRepaintMotion, type NodeMark } from "./repaint-motion.js";
@@ -1046,32 +1046,36 @@ function StatefulTreeView({
     : null;
 
   return (
-    <div data-vendo-surface="" style={{ ...themeCssVariables(theme), ...SURFACE_CONTAINMENT } as CSSProperties}>
-      <NodeErrorBoundary nodeId={validation.tree.root} retryKey={data ?? validation.tree.data} streaming={streaming}>
-        {dataNotice}
-        {dropBackNotice}
-        {driftNotice}
-        <NodeRenderer
-          nodeId={validation.tree.root}
-          ancestry={new Set()}
-          nodes={repaint.nodes}
-          marks={repaint.marks}
-          generated={streaming ? tree.components ?? {} : validation.tree.components ?? {}}
-          inClientGranted={inClientGranted}
-          furnishings={furnishings}
-          components={components}
-          data={data ?? validation.tree.data ?? {}}
-          state={viewState}
-          streaming={streaming}
-          outcomes={outcomes}
-          orphans={orphans}
-          runAction={runAction}
-          {...(onReview === undefined ? {} : { onReview })}
-          setViewState={updateState}
-          {...(interactive === undefined ? {} : { screen })}
-        />
-      </NodeErrorBoundary>
-    </div>
+    // A Kit empty state deep in the walk reads `streaming` off this provider:
+    // mid-build it holds a skeleton instead of claiming "No data".
+    <FormingContext.Provider value={streaming}>
+      <div data-vendo-surface="" style={{ ...themeCssVariables(theme), ...SURFACE_CONTAINMENT } as CSSProperties}>
+        <NodeErrorBoundary nodeId={validation.tree.root} retryKey={data ?? validation.tree.data} streaming={streaming}>
+          {dataNotice}
+          {dropBackNotice}
+          {driftNotice}
+          <NodeRenderer
+            nodeId={validation.tree.root}
+            ancestry={new Set()}
+            nodes={repaint.nodes}
+            marks={repaint.marks}
+            generated={streaming ? tree.components ?? {} : validation.tree.components ?? {}}
+            inClientGranted={inClientGranted}
+            furnishings={furnishings}
+            components={components}
+            data={data ?? validation.tree.data ?? {}}
+            state={viewState}
+            streaming={streaming}
+            outcomes={outcomes}
+            orphans={orphans}
+            runAction={runAction}
+            {...(onReview === undefined ? {} : { onReview })}
+            setViewState={updateState}
+            {...(interactive === undefined ? {} : { screen })}
+          />
+        </NodeErrorBoundary>
+      </div>
+    </FormingContext.Provider>
   );
 }
 

--- a/packages/ui/test/kit/empty-forming.test.tsx
+++ b/packages/ui/test/kit/empty-forming.test.tsx
@@ -3,7 +3,12 @@
  * A table with no rows YET is not a table with no rows. While the build is in
  * flight the empty copy is a lie, so it holds the same skeleton the rest of the
  * forming surface uses — and the moment the paint settles, a genuinely empty
- * table says so again.
+ * component says so again.
+ *
+ * Both ways of writing that copy are covered, because they are separate return
+ * paths: the component's own default (`emptyState`), and the author's own
+ * content in the `empty` slot — which a Kit component returns BEFORE it reaches
+ * the default, so the author's words could lie mid-build on their own.
  */
 import { afterEach, describe, expect, it } from "vitest";
 import { cleanup, render, screen } from "@testing-library/react";
@@ -14,21 +19,34 @@ afterEach(cleanup);
 
 const ok = async (): Promise<ToolOutcome> => ({ status: "ok", output: null });
 
-const emptyTable = (streaming: boolean) => ({
+/** The author's own empty copy, written into the prop the way a screen writes it. */
+const authorsOwn = { $element: true, component: "Text", props: { text: "Nothing here yet" } };
+
+/** One surface holding every empty-state return path the slice touches: the
+ *  default copy, the slot on the `<div>` branch (CardList, and Timeline with
+ *  it), and the slot on the shared ChartEmpty branch (all three charts). */
+const emptyApp = (streaming: boolean) => ({
   formatVersion: VENDO_TREE_FORMAT,
   root: "root",
   streaming,
-  nodes: [{ id: "root", component: "DataTable", props: { rows: [], columns: [{ key: "amount" }] } }],
+  nodes: [
+    { id: "root", component: "Stack", children: ["table", "cards", "chart"] },
+    { id: "table", component: "DataTable", props: { rows: [], columns: [{ key: "amount" }] } },
+    { id: "cards", component: "CardList", props: { items: [], titleField: "name", empty: authorsOwn } },
+    { id: "chart", component: "LineChart", props: { data: [], xKey: "day", series: [{ key: "spend" }], empty: authorsOwn } },
+  ],
 }) as WalkTree & { formatVersion: typeof VENDO_TREE_FORMAT };
 
 describe("Kit empty states under a forming surface", () => {
   it("reads as loading mid-build and as the real empty state once the build settles", () => {
-    const { rerender } = render(<TreeView tree={emptyTable(true)} components={{}} onAction={ok} />);
+    const { rerender } = render(<TreeView tree={emptyApp(true)} components={{}} onAction={ok} />);
     expect(screen.queryByText("No data")).toBeNull();
-    expect(document.querySelector("[data-skeleton]")).not.toBeNull();
+    expect(screen.queryByText("Nothing here yet")).toBeNull();
+    expect(document.querySelectorAll("[data-skeleton]")).toHaveLength(3);
 
-    rerender(<TreeView tree={emptyTable(false)} components={{}} onAction={ok} />);
+    rerender(<TreeView tree={emptyApp(false)} components={{}} onAction={ok} />);
     expect(screen.getByText("No data")).toBeTruthy();
-    expect(document.querySelector("[data-skeleton]")).toBeNull();
+    expect(screen.getAllByText("Nothing here yet")).toHaveLength(2);
+    expect(document.querySelectorAll("[data-skeleton]")).toHaveLength(0);
   });
 });

--- a/packages/ui/test/kit/empty-forming.test.tsx
+++ b/packages/ui/test/kit/empty-forming.test.tsx
@@ -1,0 +1,34 @@
+// @vitest-environment jsdom
+/**
+ * A table with no rows YET is not a table with no rows. While the build is in
+ * flight the empty copy is a lie, so it holds the same skeleton the rest of the
+ * forming surface uses — and the moment the paint settles, a genuinely empty
+ * table says so again.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { VENDO_TREE_FORMAT, type ToolOutcome } from "@vendoai/core";
+import { TreeView, type WalkTree } from "../../src/tree/index.js";
+
+afterEach(cleanup);
+
+const ok = async (): Promise<ToolOutcome> => ({ status: "ok", output: null });
+
+const emptyTable = (streaming: boolean) => ({
+  formatVersion: VENDO_TREE_FORMAT,
+  root: "root",
+  streaming,
+  nodes: [{ id: "root", component: "DataTable", props: { rows: [], columns: [{ key: "amount" }] } }],
+}) as WalkTree & { formatVersion: typeof VENDO_TREE_FORMAT };
+
+describe("Kit empty states under a forming surface", () => {
+  it("reads as loading mid-build and as the real empty state once the build settles", () => {
+    const { rerender } = render(<TreeView tree={emptyTable(true)} components={{}} onAction={ok} />);
+    expect(screen.queryByText("No data")).toBeNull();
+    expect(document.querySelector("[data-skeleton]")).not.toBeNull();
+
+    rerender(<TreeView tree={emptyTable(false)} components={{}} onAction={ok} />);
+    expect(screen.getByText("No data")).toBeTruthy();
+    expect(document.querySelector("[data-skeleton]")).toBeNull();
+  });
+});


### PR DESCRIPTION
# 🚦 Merge unit for the "how generated apps appear" stack (slices 1-8)

**This is the PR that merges.** Slices 1-7 below it are review windows, not merge units — everything in them is contained in this branch.

---

**Slice 8 — a component that does not yet know it is empty reads as loading, never "No data".**

A Kit component handed no rows *yet* was claiming to be empty: a `DataTable` that was about to be full said "No data" mid-build, which is simply a lie the build then corrected. Now, while the surface is still streaming, Kit empty states hold the same skeleton the rest of the forming surface uses. The moment the build settles, a genuinely empty component says so again, exactly as before.

Covers `DataTable`, `CardList`, `Timeline` and `ChartEmpty`, and routes the author's **own** custom `empty` slot through the same wrapper as the default copy — a hand-written "Nothing here yet" was still a lie mid-build.

Reuses the tree's existing `streaming` flag via a context published by the renderer and read by an `<EmptyOrForming>` wrapper, so no prop is threaded through the whole Kit vocabulary. The context defaults to `false`, so a Kit component rendered outside a tree surface is unaffected.

### What the whole stack does
1. **Pin ceremony** — the ghost lands flush; the ring waits on a real confirmation in every host config.
2. **Shape-true skeleton** — a slot waits in the silhouette of the app that is coming, from an on-device layout-only digest.
3. **✦ chrome** — a pinned app gets a handle: Edit in chat / Refresh / Unpin.
4. **Wet paint** — unfinished sections read unfinished and dry to full ink, with one hairline pulse at the end.
5. **Partial trees** — the embed paints stepped assembly off geometry-only pending answers, on the existing 1.2s poll.
6. **Seen/unseen** — a per-person server-side arrival flag lights a quiet dot; only rendering to a person clears it.
7. **Docs** — `VendoAppEmbed` off an MCP receipt is the documented React-only path.
8. **Empty-vs-loading** — this slice.

A changeset covering the shipped public surface is included (`.changeset/an-app-arrives-and-takes-shape-where-you-can-see-it.md`, minor on `@vendoai/apps`, `core`, `ui`, `vendo`).

### Not built, deliberately
Page dock · web component packaging · MCP Apps UI resources · notification beacon · stale-while-revalidate paint · in-place composer · auto-opening panel · History in the ✦ popover · SSE · any new host integration surface. Swept for all of these; the only textual match in the diff is the docs line stating the negative.

### Base — rebased onto current `main`
`main` moved three times while this stack was in flight. The stack is rebased onto `origin/main` at `5f1482f24`; `main` has since gained one README-only commit (#1423), which touches nothing this stack does. The stack is rebased onto current `origin/main`, and the one real conflict (`packages/ui/src/tree/renderer.tsx` — `main`'s `overlay: boolean` → `shell: "box"|"contents"|"none"` refactor meeting slice 4's `wet: boolean`) was resolved by slice 4, which owns that file. Details in PR 4.

### Live proof — the honest scoreboard
Driven in a real browser (headed Playwright, demo-bank/Maple) by a worker that built none of this. 55 screenshots, 3 recordings and 9 logs, with controls on every claim.

**Proof vintage** — this journey was driven before the reviewer-found fixes and the final restack. Each fix lane re-proves its own change in a real browser at its own post-fix SHA before it pushes; a clean `--onto` restack replays identical patches and changes no semantics, so the journey above is not re-driven for it. A restack that conflicts instead of replaying cleanly sends its lane back for a fresh browser proof. The green `ci`, `integration`, `conformance` and `audit` checks are the authority of record.

**PASS, with controls**
- Pin flight and the **write-gated** ring — proven with non-GET calls delayed 1500ms so the write lags the animation; a refused `apps.place` draws no ring (`pC-*`, `pG-01`, `pH-01`, `video-pC`).
- The remembered silhouette — bones with a cached shape, generic ghost with the cache wiped, same slot (`pF-*`, `pI-*`); the stored digest is layout-only, `boxes:[line,line,slab,line,slab]`, no values.
- The ✦ keyboard path — seed on focus, popover, Edit-in-chat prefill, and no History item (`pD2-10..15`, `video-pD2`).
- Reduced motion across build, card, pinned app, popover and slot bones (`pG-02..06`).
- The arrival dot — live ~10.5s after load on one navigation, cleared by a render with `navigation count == 1`, and the ask badge outranking it (`p0.log`, `pA.log`, `pF.log`).

**NOT PROVEN**
- Embed stepped assembly — demo-bank mounts no embed (`[data-vendo-embed=app] count on home: 0`). No surface exists to exercise it.
- Kit empty-state loading (slice 8) — demo-bank's fixtures never go empty, so the mid-build empty case was never reached in the browser. Covered by `packages/ui/test/kit/empty-forming.test.tsx`.

**Ruled limitation, accepted**
- Wet paint dries **whole-card**, not section-by-section: wet node count goes `0/0 → 48/48` in one step, because component screens carry no forming geometry. Yousef ruled ship-as-is; the producer-side fix is declined.

**Two findings from my own read of the logs, both cleared**
- The "mid-build figures" in `pB.log` are a false alarm — identical to the final values, a strict subset of the positive control. No draft number was shown and taken back; the "Building…" label just lingers a beat.
- The remembered silhouette arrives a couple of seconds in (generic at 392ms, bones at 2816ms), not on the first frame. Slice 2's cold-load fix likely improved this; **not re-measured** after that fix.

### Test edits — five, all authorized
Adds a fifth to the four listed above: `packages/ui/test/chrome/slot-cta-pin.test.tsx`, in its own labelled commit, where the empty-invite queries are **awaited** (`getByRole` → `await findByRole`) because slice 2's cold-load fix makes the invite asynchronous by design. Assertions preserved verbatim. Across all five files: nothing deleted, loosened, skipped, or rebudgeted.

### Gate
Last full local gate (tip `3b70a7016`): `pnpm build` **PASS** (21/21 tasks); `pnpm test:affected` — 9,500+ tests green across 23 packages, with `@vendoai/vendo` 2,370 passed and `demo-bank` 123 passed. Two known issues at that run, both since addressed or explained:

- `examples/demo-bank/tests/vendo/away-drill.test.ts` — a **known load flake**, not a product failure: under full-suite load its `beforeAll` dev-server boot hook timed out at 240s and the suite's 4 tests were skipped. Run alone it is **4/4 PASS in 24.5s**. Unrelated to this stack (grants/automations/session).
- 3 failures in `packages/vendo/tests/server.test.ts`, bisected to lane 6 and **fixed in lane 6** (the arrival mark was inside the response's success path; it now cannot fail or alter a render).

**This gate predates the rebase onto newer `main`, so it is not the authority — CI is the gate of record.** The stack has since been rebased onto current `origin/main`, which moved three times during this work.

### Test-edit audit
Exactly four existing test files are modified, all four authorized, and **no assertion was deleted, loosened, skipped, or rebudgeted**:
- `packages/vendo/tests/build-terminal-mount.e2e.test.ts` — restored to its original whole-body equality; net change vs `main` is a comment.
- `packages/core/tests/engine-collections.test.ts` — `ENGINE_ALLOWLIST_VERSION`/count bump, mechanical.
- `packages/apps/tests/lifecycle.test.ts` — one `unseen: true`.
- `packages/ui/test/chrome/pin-ceremony.test.tsx` — 8 call sites gain `confirmed: Promise.resolve()`, 6 bodies gain one microtask flush; the flight+ring `toBeLessThan(500)` budget is untouched.

No `.skip`/`.only`/`.todo` anywhere, no `any` or `@ts-ignore` in production code (the four `as unknown as` casts are all fixture/WAAPI-stub construction in new test files), and no forward-pointing TODO referencing declined work.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Kit empty states render a skeleton while the surface is streaming and only show “No data” once the build settles. Previously, both default copy and author-provided `empty` content could appear mid-build.

- Publishes the tree’s `streaming` flag via `FormingContext` in `StatefulTreeView`; `EmptyOrForming` shows `Skeleton` when streaming.
- Routes empty paths through `EmptyOrForming` for `DataTable`, `CardList`, `Timeline`, and all charts via `ChartEmpty` (now accepts `slot` so default and custom copy follow the same rule). Settled behavior is unchanged; the slot still replaces the frame text.
- No prop threading; the context defaults to `false`, so Kit components outside a tree surface are unaffected.
- No new animation is introduced; uses the existing static skeleton, so the `data-vendo-motion="reduced"` path is unchanged.
- Adds `packages/ui/test/kit/empty-forming.test.tsx` covering default and custom empty copy during and after streaming.

<sup>Written for commit 9f313508842590fad5aa6e7903a87820019edfe3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

