### PR TITLE
feat(core,store,apps,vendo): a store may keep no app rows

### DIFF
--- a/.changeset/a-store-may-keep-no-app-rows.md
+++ b/.changeset/a-store-may-keep-no-app-rows.md
@@ -1,0 +1,20 @@
+---
+"@vendoai/core": patch
+"@vendoai/apps": patch
+"@vendoai/store": patch
+"@vendoai/vendo": patch
+---
+
+`StoreOps.appData` is OPTIONAL, on the same rule the other four optional members
+already follow: a store with nowhere to keep app rows says so by OMITTING the
+family, rather than shipping a stub that accepts the call and does something
+else. A store that omits it is refused at the door onto app rows — `/box/rows`
+answers the `not-implemented` refusal it already gave a store with no
+named-operation surface at all — and the app-storage backing falls through to
+the same façade path that store already took.
+
+Nothing changes for the stores this repo ships: `createStoreOps` (the local
+backend) and `hostedStoreOps` (the Cloud client) both serve the family, and both
+now say so in their return type, `StoreOpsWithAppData`. The StoreOps conformance
+kit reports its appData cases as OMITTED for a mount without the family instead
+of crashing on the first verb.

--- a/packages/apps/src/server/persistence/app-data.ts
+++ b/packages/apps/src/server/persistence/app-data.ts
@@ -38,18 +38,20 @@ export const resolveAppStorage = (
  *  guards below already wrap. The owner rides in the target, so the store
  *  stamps it onto every write and scopes every read to it — nothing here may
  *  set `refs.subject`, which the family refuses. */
-const appDataRecords = (ops: StoreOps, target: AppDataTarget): RecordStore => ({
-  get: (id) => ops.appData.get(target, id),
-  put: (record) => ops.appData.put(target, record),
-  delete: (id) => ops.appData.delete(target, id),
-  list: (query) => ops.appData.list(target, query),
+type AppDataOps = NonNullable<StoreOps["appData"]>;
+
+const appDataRecords = (rows: AppDataOps, target: AppDataTarget): RecordStore => ({
+  get: (id) => rows.get(target, id),
+  put: (record) => rows.put(target, record),
+  delete: (id) => rows.delete(target, id),
+  list: (query) => rows.list(target, query),
 });
 
-const appDataBlobs = (ops: StoreOps, target: AppDataTarget): BlobStore => ({
-  put: (key, bytes, meta) => ops.appData.putFile(target, key, bytes, meta),
-  get: (key) => ops.appData.getFile(target, key),
-  delete: (key) => ops.appData.deleteFile(target, key),
-  list: (prefix) => ops.appData.listFiles(target, prefix),
+const appDataBlobs = (rows: AppDataOps, target: AppDataTarget): BlobStore => ({
+  put: (key, bytes, meta) => rows.putFile(target, key, bytes, meta),
+  get: (key) => rows.getFile(target, key),
+  delete: (key) => rows.deleteFile(target, key),
+  list: (prefix) => rows.listFiles(target, prefix),
 });
 
 /** The ONE spelling of "which store backs this collection". `selectStoreOps`
@@ -58,17 +60,19 @@ const appDataBlobs = (ops: StoreOps, target: AppDataTarget): BlobStore => ({
  *  crash composition at boot for that third store, where today it refuses at
  *  the op that needed one; so a store without an ops surface keeps exactly
  *  today's façade behavior, unowned, and a store with one gets owner stamping.
- *  No other branch. */
+ *  An ops surface that OMITS the optional appData family reads as the same
+ *  answer — it has no app-row door either. No other branch. */
 const backingFor = (
   ops: StoreOps | undefined,
   store: StoreAdapter,
   target: AppDataTarget,
   declaration: StorageDecl,
 ): AppStorage => {
-  if (ops === undefined) return resolveAppStorage(store, target.appId, target.collection, declaration);
+  const rows = ops?.appData;
+  if (rows === undefined) return resolveAppStorage(store, target.appId, target.collection, declaration);
   return declaration.kind === "files"
-    ? { kind: "files", blobs: appDataBlobs(ops, target) }
-    : { kind: "records", records: appDataRecords(ops, target) };
+    ? { kind: "files", blobs: appDataBlobs(rows, target) }
+    : { kind: "records", records: appDataRecords(rows, target) };
 };
 
 const allRecordIds = async (records: RecordStore): Promise<string[]> =>

--- a/packages/core/src/conformance/memory-store-ops.ts
+++ b/packages/core/src/conformance/memory-store-ops.ts
@@ -13,6 +13,7 @@ import {
   type RecordInput,
   type RecordQuery,
   type StoreOps,
+  type StoreOpsWithAppData,
   type UsageEvent,
   type UsageTallyRow,
   type VendoRecord,
@@ -90,7 +91,7 @@ const copyRecord = (r: VendoRecord): VendoRecord => ({
 // memory StoreOps — just enough to pass the conformance suite
 // ---------------------------------------------------------------------------
 
-export function memoryStoreOps(): StoreOps {
+export function memoryStoreOps(): StoreOpsWithAppData {
   // records: Map<collection, Map<id, record>>
   const collections = new Map<string, Map<string, VendoRecord & { seq: number }>>();
   let sequence = 0;
@@ -380,7 +381,7 @@ export function memoryStoreOps(): StoreOps {
     }
   };
 
-  const appData: StoreOps["appData"] = {
+  const appData: NonNullable<StoreOps["appData"]> = {
     async put(target, record) {
       const collection = appCollection(target);
       refuseSubject(record.refs, "put");

--- a/packages/core/src/conformance/store-ops.ts
+++ b/packages/core/src/conformance/store-ops.ts
@@ -3,7 +3,7 @@ import { ENGINE_ALLOWLIST_VERSION, engineAppHistory } from "../engine-collection
 import type { VendoErrorCode } from "../errors.js";
 import { isoDateTimeSchema, type IsoDateTime } from "../ids.js";
 import { STORE_WIRE_APPEND_MESSAGES_OPS, STORE_WIRE_PATHS, STORE_WIRE_TURN_OPS, VENDO_STORE_WIRE_FORMAT } from "../store-wire.js";
-import type { AuditQuery, CollectionFootprint, StoreOps, UsageCountQuery } from "../store.js";
+import type { AuditQuery, CollectionFootprint, StoreOps, StoreOpsWithAppData, UsageCountQuery } from "../store.js";
 import { assert, assertBytesEqual, assertDeepEqual } from "./assertions.js";
 import { omitted, type ConformanceCase, type ConformanceOmission, type ConformanceSuite } from "./index.js";
 
@@ -148,6 +148,9 @@ const USAGE_ABSENT = "this mount omits the usage family (optional — a store wi
 /** ...and for the turn envelopes, optional on the same rule. */
 const TURN_ABSENT = "this mount omits the turn family (optional — a caller that finds it absent makes the individual calls it always did)";
 
+/** ...and for the app-row drawers, optional on the same rule. */
+const APP_DATA_ABSENT = "this mount omits the appData family (optional — a store with nowhere to keep app rows leaves it off, and the doors onto them refuse rather than write elsewhere)";
+
 /** appData rows live in the app's own drawer, and the local backend fails an
     app-scoped write closed when the app has no row — so every appData case
     seeds one first, with the shape the typed `vendo_apps` door accepts. */
@@ -200,6 +203,17 @@ const opsCase = (
     }
   },
 });
+
+/** A case whose SUBJECT is the optional appData family: the mount that omits it
+    omits every one of them, the way {@link APPEND_ABSENT}'s cases report. Cases
+    over another family that merely LOOK at an app row guard that leg instead,
+    so the family's absence never takes their subject down with it. */
+const appDataCase = (
+  opts: StoreOpsConformanceOptions,
+  name: string,
+  body: (ops: StoreOpsWithAppData) => Promise<void | ConformanceOmission>,
+): ConformanceCase => opsCase(opts, name, async (ops) =>
+  ops.appData === undefined ? omitted(APP_DATA_ABSENT) : await body(ops as StoreOpsWithAppData));
 
 export function storeOpsConformance(opts: StoreOpsConformanceOptions): ConformanceSuite {
   return {
@@ -549,10 +563,14 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
           "blocked",
           "an app-scoped collection on engine.put",
         );
-        assert(
-          await ops.appData.get({ appId: "app_gate", collection: "invoices", owner: "user_1" }, "inv_1") === null,
-          "the refused put wrote its row anyway",
-        );
+        // Only a mount that serves the OPTIONAL appData family has a door to
+        // look through; the refusal above is this case's subject either way.
+        if (ops.appData !== undefined) {
+          assert(
+            await ops.appData.get({ appId: "app_gate", collection: "invoices", owner: "user_1" }, "inv_1") === null,
+            "the refused put wrote its row anyway",
+          );
+        }
       }),
 
       /** `engine` is a NEW door onto the same routed doors the local backend
@@ -692,7 +710,7 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
       // appData
       // =====================================================================
 
-      opsCase(opts, "appData.put stamps the target owner as refs.subject", async (ops) => {
+      appDataCase(opts, "appData.put stamps the target owner as refs.subject", async (ops) => {
         await seedApp(ops, "app_stamp");
         const target = { appId: "app_stamp", collection: "notes", owner: "own_a" };
         const put = await ops.appData.put(target, { id: "n1", data: { text: "hi" } });
@@ -707,7 +725,7 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
       /** Generated code has no field for the owner, so a `refs.subject` in the
           record is a caller trying to write as someone else. Refused, never
           silently overwritten with the real owner. */
-      opsCase(opts, "appData.put refuses a caller-supplied refs.subject", async (ops) => {
+      appDataCase(opts, "appData.put refuses a caller-supplied refs.subject", async (ops) => {
         await seedApp(ops, "app_putsub");
         const target = { appId: "app_putsub", collection: "notes", owner: "own_a" };
         await assertThrowsCode(
@@ -718,7 +736,7 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
         assert(await ops.appData.get(target, "n1") === null, "the refused put wrote its row anyway");
       }),
 
-      opsCase(opts, "appData.list refuses a caller-supplied refs.subject", async (ops) => {
+      appDataCase(opts, "appData.list refuses a caller-supplied refs.subject", async (ops) => {
         await seedApp(ops, "app_listsub");
         const target = { appId: "app_listsub", collection: "notes", owner: "own_a" };
         await assertThrowsCode(
@@ -728,7 +746,7 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
         );
       }),
 
-      opsCase(opts, "appData.list never returns another owner's rows", async (ops) => {
+      appDataCase(opts, "appData.list never returns another owner's rows", async (ops) => {
         await seedApp(ops, "app_scope");
         const a = { appId: "app_scope", collection: "notes", owner: "own_a" };
         const b = { appId: "app_scope", collection: "notes", owner: "own_b" };
@@ -749,7 +767,7 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
       /** Both halves, deliberately — the same trap `delete` below calls out: a
           `get` that returns null for EVERYONE also passes the negative
           assertion on its own, so the owner's own read is asserted too. */
-      opsCase(opts, "appData.get returns null for another owner's row", async (ops) => {
+      appDataCase(opts, "appData.get returns null for another owner's row", async (ops) => {
         await seedApp(ops, "app_getscope");
         const owner = { appId: "app_getscope", collection: "notes", owner: "own_a" };
         const other = { appId: "app_getscope", collection: "notes", owner: "own_b" };
@@ -763,7 +781,7 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
       /** Both halves, deliberately: a `delete` that does nothing at all also
           leaves the other owner's row alone, so the negative assertion on its
           own is passed by an empty function. */
-      opsCase(opts, "appData.delete deletes only the caller's own row", async (ops) => {
+      appDataCase(opts, "appData.delete deletes only the caller's own row", async (ops) => {
         await seedApp(ops, "app_delscope");
         const owner = { appId: "app_delscope", collection: "notes", owner: "own_a" };
         const other = { appId: "app_delscope", collection: "notes", owner: "own_b" };
@@ -778,7 +796,7 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
           (collection, id) — so an id another owner holds must be refused, not
           overwritten and re-stamped into a row the loser can neither read nor
           delete. */
-      opsCase(opts, "appData.put refuses an id another owner holds", async (ops) => {
+      appDataCase(opts, "appData.put refuses an id another owner holds", async (ops) => {
         await seedApp(ops, "app_putconflict");
         const owner = { appId: "app_putconflict", collection: "notes", owner: "own_a" };
         const other = { appId: "app_putconflict", collection: "notes", owner: "own_b" };
@@ -799,7 +817,7 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
           its own cursor without re-applying it hands page two of everybody's
           rows to whoever paged first — and every case above passes, because
           none of them asks for a second page. */
-      opsCase(opts, "appData.list paginates one owner's drawer without loss, duplicates, or a neighbour's rows", async (ops) => {
+      appDataCase(opts, "appData.list paginates one owner's drawer without loss, duplicates, or a neighbour's rows", async (ops) => {
         await seedApp(ops, "app_pager");
         const owner = { appId: "app_pager", collection: "notes", owner: "own_a" };
         const other = { appId: "app_pager", collection: "notes", owner: "own_b" };
@@ -817,7 +835,7 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
           one collection name is the ordinary case (every generated app invents
           `notes`), and an implementation that scopes on the owner alone puts
           both apps' rows in one drawer for the user who installed both. */
-      opsCase(opts, "appData keeps two apps' drawers apart", async (ops) => {
+      appDataCase(opts, "appData keeps two apps' drawers apart", async (ops) => {
         await seedApp(ops, "app_one");
         await seedApp(ops, "app_two");
         const one = { appId: "app_one", collection: "notes", owner: "own_a" };
@@ -838,7 +856,7 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
         assert(await ops.appData.getFile(two, "f.bin") !== null, "deleting in one app destroyed another app's file");
       }),
 
-      opsCase(opts, "appData.list honors caller refs alongside the owner scope", async (ops) => {
+      appDataCase(opts, "appData.list honors caller refs alongside the owner scope", async (ops) => {
         await seedApp(ops, "app_refs");
         const a = { appId: "app_refs", collection: "notes", owner: "own_a" };
         const b = { appId: "app_refs", collection: "notes", owner: "own_b" };
@@ -852,7 +870,7 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
         );
       }),
 
-      opsCase(opts, "appData file twins round-trip and stay owner-isolated", async (ops) => {
+      appDataCase(opts, "appData file twins round-trip and stay owner-isolated", async (ops) => {
         await seedApp(ops, "app_files");
         const owner = { appId: "app_files", collection: "notes", owner: "own_a" };
         const other = { appId: "app_files", collection: "notes", owner: "own_b" };
@@ -874,7 +892,7 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
       /** The owner prefix is the backend's scoping mechanism, not part of the
           caller's key space: a generated app that stored `receipt.bin` must get
           `receipt.bin` back, and its prefix filters are its own keys' prefixes. */
-      opsCase(opts, "appData.listFiles returns keys without the owner prefix", async (ops) => {
+      appDataCase(opts, "appData.listFiles returns keys without the owner prefix", async (ops) => {
         await seedApp(ops, "app_listfiles");
         const owner = { appId: "app_listfiles", collection: "notes", owner: "own_a" };
         const other = { appId: "app_listfiles", collection: "notes", owner: "own_b" };
@@ -901,7 +919,7 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
           path-like ones are ordinary, so the fence is the grammar and the
           answer is a refusal — a sanitised owner would land two people in one
           drawer. Every verb, because every verb composes the key. */
-      opsCase(opts, "appData refuses an owner outside the grammar", async (ops) => {
+      appDataCase(opts, "appData refuses an owner outside the grammar", async (ops) => {
         await seedApp(ops, "app_owner");
         const owner = { appId: "app_owner", collection: "notes", owner: "own_a" };
         await ops.appData.put(owner, { id: "n1", data: { v: 1 } });
@@ -944,7 +962,7 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
         }
       }),
 
-      opsCase(opts, "appData refuses a collection name outside the grammar", async (ops) => {
+      appDataCase(opts, "appData refuses a collection name outside the grammar", async (ops) => {
         await seedApp(ops, "app_grammar");
         const legal = { appId: "app_grammar", collection: "box:inbox", owner: "own_a" };
         const put = await ops.appData.put(legal, { id: "ok", data: {} });
@@ -1694,7 +1712,7 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
           is all still there, and a deletion request answered with a receipt.
           Scoped to the app and nothing else: the user who installed it keeps
           their conversations, and the app NEXT to it keeps everything. */
-      opsCase(opts, "lifecycle.erase removes one app's data, and only that app's", async (ops) => {
+      appDataCase(opts, "lifecycle.erase removes one app's data, and only that app's", async (ops) => {
         await seedApp(ops, "app_gone");
         await seedApp(ops, "app_stays");
         const gone = { appId: "app_gone", collection: "notes", owner: "user_1" };
@@ -2343,7 +2361,9 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
             for (const [ops, whose] of [[mine, "mine"], [theirs, "theirs"]] as const) {
               await ops.engine.put("vendo_placement_slots", { id: "slot_1", data: { whose } });
               await ops.blobs.put("conf_tenant", "file.bin", new TextEncoder().encode(whose));
-              await ops.appData.put(target, { id: "row_1", data: { whose } });
+              // The app-row leg only where the OPTIONAL family is served; every
+              // other drawer here is required, so the case still runs without it.
+              await ops.appData?.put(target, { id: "row_1", data: { whose } });
               await ops.transcripts.putThread({ id: "thr_1", subject: "user_1", messages: [{ whose }] });
               await ops.secrets.set("conf_token", whose);
               await ops.workspace.commit([{ path: "w.json", data: { whose } }], { owner: "user_1" });
@@ -2361,7 +2381,9 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
                 new TextEncoder().encode(whose),
                 "a blob crossed the tenant line",
               );
-              assertDeepEqual((await ops.appData.get(target, "row_1"))?.data, { whose }, "an app row crossed the tenant line");
+              if (ops.appData !== undefined) {
+                assertDeepEqual((await ops.appData.get(target, "row_1"))?.data, { whose }, "an app row crossed the tenant line");
+              }
               assertDeepEqual(
                 ((await ops.transcripts.getThread("thr_1"))!.data as Record<string, unknown>)["messages"],
                 [{ whose }],
@@ -2386,7 +2408,9 @@ export function storeOpsConformance(opts: StoreOpsConformanceOptions): Conforman
             // where a missing tenant predicate is worst.
             await mine.lifecycle.erase({ subject: "user_1" });
             assert(await theirs.transcripts.getThread("thr_1") !== null, "one tenant's erase took the neighbour's thread");
-            assert(await theirs.appData.get(target, "row_1") !== null, "one tenant's erase took the neighbour's app row");
+            if (theirs.appData !== undefined) {
+              assert(await theirs.appData.get(target, "row_1") !== null, "one tenant's erase took the neighbour's app row");
+            }
           } finally {
             await neighbour.close?.();
             await made.close?.();

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -474,11 +474,11 @@ export interface TurnCommit {
 /** The typed contract for all 50 store operations across 14 families.
     Lean by design — this is the CONTRACT interface, not the implementation.
 
-    Four members are OPTIONAL, and all four mean the same thing: an
+    Five members are OPTIONAL, and all five mean the same thing: an
     implementation that cannot serve the family says so by OMITTING it, never by
-    accepting the call and doing something else (`transcripts.appendMessages`,
-    `retention`, `usage` and `turn`, following `RecordStore.claim`/`atomic`).
-    Everything else is required. */
+    accepting the call and doing something else (`appData`,
+    `transcripts.appendMessages`, `retention`, `usage` and `turn`, following
+    `RecordStore.claim`/`atomic`). Everything else is required. */
 export interface StoreOps {
   /** Vendo's OWN engine data — grants, approvals, audit, threads, runs, apps,
       effects, and the automations and guard drawers — reached through seven
@@ -502,8 +502,13 @@ export interface StoreOps {
     list(namespace: string, prefix?: string): Promise<string[]>;
   };
   /** Everything generated apps invent. Reads are auto-scoped to the target's
-      owner and writes are stamped with it, so no verb here takes a subject. */
-  appData: {
+      owner and writes are stamped with it, so no verb here takes a subject.
+
+      OPTIONAL: a store with nowhere to keep app rows leaves the family off, and
+      the doors onto it refuse the way a store with no ops surface at all is
+      already refused. Every store this repo ships serves it — see
+      {@link StoreOpsWithAppData}. */
+  appData?: {
     put(target: AppDataTarget, record: RecordInput): Promise<VendoRecord>;
     get(target: AppDataTarget, id: string): Promise<VendoRecord | null>;
     list(target: AppDataTarget, query?: RecordQuery): Promise<{ records: VendoRecord[]; cursor?: string }>;
@@ -667,3 +672,8 @@ export interface StoreOps {
   footprint(): Promise<CollectionFootprint[]>;
   status(): Promise<StoreWireStatus>;
 }
+
+/** A `StoreOps` that serves the optional `appData` family. The stores this repo
+    ships answer with this, so their callers reach app rows without a check —
+    only a THIRD-PARTY surface may omit the family. */
+export type StoreOpsWithAppData = StoreOps & Required<Pick<StoreOps, "appData">>;

--- a/packages/core/tests/conformance/store-ops-mutations.test.ts
+++ b/packages/core/tests/conformance/store-ops-mutations.test.ts
@@ -348,6 +348,15 @@ describe("the omission bucket is a bucket, not a pass", () => {
     });
     await expect(one.run()).resolves.toBeUndefined();
   });
+
+  /** The appData family reads the same way: a mount that omits it reports every
+      case over it as omitted, rather than crashing on the first verb. */
+  it("a case over an absent appData family answers omitted, not a TypeError", async () => {
+    const one = caseNamed("appData.put stamps the target owner as refs.subject", {
+      makeOps: async () => ({ ops: { ...memoryStoreOps(), appData: undefined } }),
+    });
+    await expect(one.run()).resolves.toEqual({ omitted: expect.stringContaining("omits the appData family") });
+  });
 });
 
 /** Not a mutation proof — a guard on the reference itself. `memoryStoreOps` is

--- a/packages/store/src/hosted-store.ts
+++ b/packages/store/src/hosted-store.ts
@@ -14,6 +14,7 @@ import {
   STORE_WIRE_PATHS,
   STORE_WIRE_TURN_OPS,
   type StoreOps,
+  type StoreOpsWithAppData,
   storeWireErrorSchema,
   type StoreWireStatus,
   storeWireStatusSchema,
@@ -386,7 +387,7 @@ const raiseWireError = async (response: Response): Promise<never> => {
  * client that spelled its own route was free to drift from the contract third
  * parties build against (it did, for as long as erase was hardcoded here).
  */
-export function hostedStoreOps(options: HostedStoreOptions): StoreOps {
+export function hostedStoreOps(options: HostedStoreOptions): StoreOpsWithAppData {
   return storeWireClient(options, raiseWireError);
 }
 
@@ -401,7 +402,7 @@ export function hostedStoreOps(options: HostedStoreOptions): StoreOps {
 function storeWireClient(
   options: HostedStoreOptions,
   raise: (response: Response) => Promise<never>,
-): StoreOps {
+): StoreOpsWithAppData {
   const base = (options.baseUrl ?? "https://console.vendo.run").replace(/\/$/, "");
   const send = consoleSender({
     base,
@@ -603,7 +604,7 @@ function storeWireClient(
   };
   const servesTurn = async (): Promise<boolean> => (await status()).ops >= STORE_WIRE_TURN_OPS;
 
-  const ops: StoreOps = {
+  const ops: StoreOpsWithAppData = {
     // Vendo's OWN engine drawers, over collection-addressed bodies, with the
     // allowlist gated service-side on every verb.
     engine: {

--- a/packages/store/src/ops.ts
+++ b/packages/store/src/ops.ts
@@ -11,7 +11,7 @@ import {
   type FilesAdapter,
   type Json,
   type RecordStore,
-  type StoreOps,
+  type StoreOpsWithAppData,
   type UsageCountQuery,
   type UsageTallyQuery,
   type UsageTallyRow,
@@ -288,7 +288,7 @@ const rowIdOf = (message: unknown): string => {
 export function createStoreOps(
   store: VendoStore,
   options: { files?: FilesAdapter; workspaceOwner?: string } = {},
-): StoreOps {
+): StoreOpsWithAppData {
   const db = dbFor(store);
   /** Whose drawer a workspace verb addresses. The call names it when the mount
    *  serves more than one user (`/user/**` is the subject's, `/orgs/<org>/**`
@@ -400,7 +400,7 @@ export function createStoreOps(
       messages: input.messages.map((message) => ({ id: rowIdOf(message), message })),
     });
 
-  const ops: StoreOps = {
+  const ops: StoreOpsWithAppData = {
     // -----------------------------------------------------------------------
     // engine — seven verbs onto the routed doors, with the per-collection
     // policy living there; the ONE addition is the allowlist gate, which is why

--- a/packages/vendo/src/wire/box.ts
+++ b/packages/vendo/src/wire/box.ts
@@ -201,10 +201,14 @@ async function handleRows(wire: WireContext, appId: string, owner: string): Prom
   if (collection === undefined || !COLLECTION_PATTERN.test(collection)) {
     throw new VendoError("validation", "rows collection must match [A-Za-z0-9_-]{1,64}");
   }
-  if (deps.ops === undefined) {
+  // The appData family is optional on StoreOps, so "no ops surface" and "an ops
+  // surface that omits app rows" are the same answer here: this door is nothing
+  // but app rows.
+  const rows = deps.ops?.appData;
+  if (rows === undefined) {
     throw new VendoError(
       "not-implemented",
-      "A box row is owner-stamped app data, so this door needs the store's named-operation surface: "
+      "A box row is owner-stamped app data, so this door needs the store's appData family: "
       + "it needs a SQL-backed store (`store: postgres(url)`, or the local default) or a "
       + "StoreOps-capable store (the Cloud hosted store). The configured store is neither.",
     );
@@ -214,7 +218,6 @@ async function handleRows(wire: WireContext, appId: string, owner: string): Prom
   // and the owner is the app token's subject — stamped here, on the box's
   // behalf, because the box is never told who the user is.
   const target = { appId, collection: `box:${collection}`, owner };
-  const rows = deps.ops.appData;
 
   // Lane E redaction guard — nothing a box writes or reads through this door
   // may carry a known secret value into a store row or a response body.

--- a/packages/vendo/tests/box-wire.test.ts
+++ b/packages/vendo/tests/box-wire.test.ts
@@ -5,6 +5,7 @@ import {
   VENDO_APP_FORMAT,
   type AppDocument,
   type Principal,
+  type StoreOps,
 } from "@vendoai/core";
 import { createAppTokens, type SandboxAdapter, type SandboxMachine } from "@vendoai/apps";
 import { inMemoryBoxFiles } from "@vendoai/apps/testing";
@@ -96,7 +97,13 @@ interface Skin {
   token: string;
 }
 
-async function setup(handler: BoxHandler = () => ({ status: 200 })): Promise<Skin> {
+async function setup(
+  handler: BoxHandler = () => ({ status: 200 }),
+  /** The named-operation surface the composition should see over this store —
+   *  `selectStoreOps` takes `store.ops` when the store carries one. Omitted, it
+   *  resolves the local backend as it always does. */
+  opsOf?: (store: VendoStore) => StoreOps,
+): Promise<Skin> {
   // The machine-env assembler composes the box's callback doors from the
   // operator-set public origin, so the composition requires it.
   vi.stubEnv("VENDO_BASE_URL", "http://wire.test");
@@ -107,6 +114,7 @@ async function setup(handler: BoxHandler = () => ({ status: 200 })): Promise<Ski
     data: { subject: ADA.subject, enabled: false, doc: doc() },
     refs: { subject: ADA.subject },
   });
+  if (opsOf !== undefined) Object.assign(store, { ops: opsOf(store) });
   const vendo = createVendo({
     models: { default: {} as LanguageModel },
     principal: async (req) => {
@@ -225,6 +233,27 @@ describe("the /box callback surface (app-token bearer)", () => {
     }));
     expect(remove.status).toBe(200);
     expect(await store.records("app:app_skin:box:notes").get("note_1")).toBeNull();
+  });
+
+  /** `appData` is OPTIONAL on StoreOps: a store that cannot serve app rows says
+   *  so by omitting the family, and this door is nothing BUT app rows. It has to
+   *  answer the same refusal a store with no ops at all gets. The message is
+   *  asserted because an unhandled crash answers 501 too (`internalError`), so
+   *  the status alone cannot tell "refused" from "blew up". */
+  it("rows: a store whose ops omit the appData family is refused, not crashed", async () => {
+    const { vendo, token } = await setup(undefined, (store) => ({
+      ...createStoreOps(store, { files: storeFiles(store) }),
+      appData: undefined,
+    }));
+    const response = await vendo.handler(wireRequest("/box/rows/notes/note_1", {
+      method: "PUT",
+      headers: { ...bearer(token), "content-type": "application/json" },
+      body: JSON.stringify({ data: { text: "chase inv_1" } }),
+    }));
+    expect(response.status).toBe(501);
+    expect(await response.json()).toMatchObject({
+      error: { code: "not-implemented", message: expect.stringContaining("appData") },
+    });
   });
 
   it("refuses a missing, malformed, or unknown bearer with 401", async () => {


### PR DESCRIPTION
`StoreOps.appData` becomes OPTIONAL, joining the four members that already were
(`transcripts.appendMessages`, `retention`, `usage`, `turn`). Same rule, stated
once in `store.ts`: an implementation that cannot serve a family says so by
OMITTING it, never by shipping a stub that accepts the call and does something
else. Vendo Cloud's last legacy appData stub can go away once this releases.

## The doors narrow, they do not crash

- **`/box/rows`** (`packages/vendo/src/wire/box.ts`) is nothing BUT app rows, so
  it fails closed: a store whose ops omit the family gets the same
  `not-implemented` (501) refusal a store with no named-operation surface at all
  already got, with the message pointing at the appData family.
- **App storage** (`packages/apps/.../app-data.ts`) already had a fallback for a
  store with no ops; an ops surface without appData reads as the same answer and
  takes that same façade path. One `?.`, no new branch.
- **The conformance kit** reports its 15 appData cases as OMITTED for a mount
  without the family, the way the other optional families already report — cases
  over OTHER families that merely look at an app row guard that leg instead, so
  the family's absence never takes their subject down with it.

## Nothing changes for the stores this repo ships

`createStoreOps` (local backend) and `hostedStoreOps` (Cloud client) both serve
appData and now say so in their return type, `StoreOpsWithAppData` — so every
caller of theirs reaches app rows with no check and no diff.

## Tests

Both written first, watched fail, then made green:

- `packages/vendo/tests/box-wire.test.ts` — a store whose ops omit appData is
  refused 501 with a message naming the family. The message is asserted because
  an unhandled crash answers 501 too (`internalError`), which is exactly how
  this test failed before the fix. The neighbouring round-trip test keeps the
  default store's appData path honest.
- `packages/core/tests/conformance/store-ops-mutations.test.ts` — an appData
  case against a mount without the family answers `omitted`, not a TypeError.

Gate (scoped): `pnpm build`, `pnpm typecheck` (all 42 tasks, cache-missed),
`pnpm lint` (dependency-guard OK), and vitest over `packages/core` (765),
`packages/store` app-data/hosted/conformance (205), `packages/apps` app-data +
conformance + box-door (38), `packages/vendo` box-wire (16) — all green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `StoreOps.appData` optional so stores without app-row storage can omit the family. Old behavior assumed `appData` was present; new behavior fails closed at app-row doors with 501 and treats missing `appData` like missing `ops`, while shipped stores still serve it via `StoreOpsWithAppData`.

- `/box/rows` now refuses when `ops.appData` is absent with a 501 not-implemented message naming the `appData` family (`packages/vendo/src/wire/box.ts`).
- App storage reads missing `ops.appData` the same as missing `ops` and falls back to the façade path (`packages/apps/src/server/persistence/app-data.ts`).
- Conformance reports appData cases as omitted instead of crashing; cases that only read app rows guard that leg (`packages/core/src/conformance/store-ops.ts`).
- Types: `appData` is optional on `StoreOps`; new `StoreOpsWithAppData` expresses surfaces that serve app rows. `createStoreOps`, `hostedStoreOps`, and `memoryStoreOps` now return `StoreOpsWithAppData` (`packages/core/src/store.ts`, `packages/store/src/ops.ts`, `packages/store/src/hosted-store.ts`, `packages/core/src/conformance/memory-store-ops.ts`).

- Migration: Third-party stores should omit `appData` if they cannot serve app rows (do not stub). Callers that require app rows should type against `StoreOpsWithAppData` or handle absent `ops.appData`. Users of `/box/rows` should expect 501 on stores that omit `appData`.

<sup>Written for commit 4b3608af2a4a67cc9768df1d115afac28411aa0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1433?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

