### PR TITLE
fix(core,actions,vendo): a texted turn can authenticate as the person texting

### DIFF
--- a/.changeset/channel-actas-minting.md
+++ b/.changeset/channel-actas-minting.md
@@ -1,0 +1,7 @@
+---
+"@vendoai/core": patch
+"@vendoai/actions": patch
+"@vendoai/vendo": patch
+---
+
+A texted turn authenticates its host calls. `presence: "present"` meant two things at once — "a person is here, so ask them to approve" and "forward the caller's browser credentials" — and a text message satisfies the first without the second: there is no request behind it. So a linked customer's tool call reached the host API carrying nothing, the host answered 401, and the agent apologised for a sign-in problem the person could do nothing about. `RunContext` now carries `channelLink`, the text channel's evidence that this subject authorized this phone, and the actions registry authenticates such calls through the ActAs seam — exactly as it already does for MCP-OAuth users, who have no browser session either. Presence stays `present`, because that is what lets the guard ask for approval on a money-moving call instead of refusing it outright.

--- a/packages/actions/src/runtime/registry.ts
+++ b/packages/actions/src/runtime/registry.ts
@@ -410,6 +410,29 @@ function mcpConsentGrant(ctx: ActionsRunContext, call: ToolCall, tool: Extracted
   };
 }
 
+/** The text channel's grant projection, the twin of `mcpConsentGrant`.
+ *
+ *  The evidence is the LINK: a code minted inside the product while the person
+ *  was signed in as this subject, then sent back from their phone. That is the
+ *  same shape of proof an MCP consent record carries — an out-of-band act by the
+ *  subject, authorizing this surface to act as them — so it projects to the same
+ *  kind of grant. `source: "chat"` because a texted turn IS a chat; the venue
+ *  says so too. */
+function channelLinkGrant(ctx: ActionsRunContext, call: ToolCall, tool: ExtractedTool): PermissionGrant | undefined {
+  if (!ctx.channelLink) return undefined;
+  return {
+    id: `grt_channel_${ctx.sessionId}`,
+    subject: ctx.principal.subject,
+    tool: call.tool,
+    descriptorHash: descriptorHash(descriptorOf(tool)),
+    scope: { kind: "tool" },
+    duration: "session",
+    contextKey: ctx.sessionId,
+    source: "chat",
+    grantedAt: new Date().toISOString(),
+  };
+}
+
 /** The tRPC HTTP envelope (04 §1): queries GET `{mount}/{procedure}?input=...`,
  * mutations POST the input as the JSON body. Hosts whose tRPC root applies the
  * superjson transformer expect the `{ json: ... }` wrapping — which is exactly
@@ -652,6 +675,32 @@ async function hostHeaders(
     const authed = await actAsAuth(config.actAs, ctx.principal, grant, {
       declined: "the host declined MCP execution for this action",
       failed: "MCP authentication failed",
+    });
+    if ("error" in authed) return { error: authed.error };
+    return { headers: authed.headers, actAsMinted: true };
+  }
+  if ((ctx as ActionsRunContext).channelLink !== undefined) {
+    // A TEXTED turn. Its presence is "present" — there really is a person
+    // holding a phone, which is what lets the guard ask them to approve a
+    // money-moving call — but there is no browser request behind it, so the
+    // present path has nothing to forward and would call the host API
+    // unauthenticated. The host answers 401 and the agent apologises for a
+    // "sign-in problem" it cannot fix. Same situation as an MCP-OAuth user, so
+    // the same answer: authenticate through the ActAs seam.
+    if (!config.actAs) {
+      return {
+        error: error(
+          "not-implemented",
+          "text-channel host execution isn't set up for this product — the host must provide actAs (createVendo({ auth }) fills it)",
+        ),
+      };
+    }
+    const actionsCtx = ctx as ActionsRunContext;
+    const grant = actionsCtx.grant ?? channelLinkGrant(actionsCtx, call, tool);
+    if (!grant) return { error: error("validation", "text-channel host execution requires the link on the ctx") };
+    const authed = await actAsAuth(config.actAs, ctx.principal, grant, {
+      declined: "the host declined text-channel execution for this action",
+      failed: "text-channel authentication failed",
     });
     if ("error" in authed) return { error: authed.error };
     return { headers: authed.headers, actAsMinted: true };

--- a/packages/actions/tests/runtime/registry.test.ts
+++ b/packages/actions/tests/runtime/registry.test.ts
@@ -1400,3 +1400,132 @@ describe("format v3 host files (cse lane 1)", () => {
     });
   });
 });
+
+describe("host HTTP execution — the text channel (a person, no browser session)", () => {
+  async function hostServer(): Promise<{ url: string; seen: Array<Record<string, string | string[] | undefined>> }> {
+    const seen: Array<Record<string, string | string[] | undefined>> = [];
+    const server = createServer((req, res) => {
+      seen.push(req.headers);
+      // A real host API: no credentials, no data. This is what Maple answers,
+      // and what the agent was paraphrasing as a "sign-in snag".
+      if (!req.headers.authorization && !req.headers.cookie) {
+        res.statusCode = 401;
+        res.setHeader("content-type", "application/json");
+        res.end(JSON.stringify({ error: { code: "unauthenticated", message: "Sign in to use this API" } }));
+        return;
+      }
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({ ok: true }));
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => { server.off("error", reject); resolve(); });
+    });
+    const { port } = server.address() as AddressInfo;
+    closers.push(async () => { server.close(); server.closeAllConnections(); });
+    return { url: `http://127.0.0.1:${port}`, seen };
+  }
+
+  const readTool = (baseUrl: string): ExtractedTool =>
+    routeTool("host_spending", {
+      risk: "read",
+      binding: { kind: "openapi", operationId: "spending", baseUrl, method: "GET", path: "/spending" },
+    });
+
+  /** What `runChannelTurn` builds: a real person, on a phone, with no request. */
+  const channelCtx = (extra: Partial<ActionsRunContext> = {}): ActionsRunContext => ({
+    principal: { kind: "user", subject: "user_linked" },
+    venue: "chat",
+    presence: "present",
+    sessionId: "evt_1",
+    channelLink: { channel: "text", linkedAt: "2026-08-17T10:22:10.710Z" },
+    ...extra,
+  });
+
+  it("authenticates a texted turn's host call through actAs", async () => {
+    // THE DEFECT THIS PINS: a linked customer texted "what did I spend on food
+    // last month?", the turn ran, and the tool call reached the host API with no
+    // credentials at all — because `presence: "present"` means "forward the
+    // caller's request headers" and a text message has no request behind it.
+    const host = await hostServer();
+    const actAs = vi.fn(async () => ({ headers: { authorization: "Bearer act-as-user_linked" } }));
+    const actions = createActions({ tools: [readTool(host.url)], baseUrl: host.url, actAs });
+
+    const outcome = await actions.execute({ id: "1", tool: "host_spending", args: {} }, channelCtx());
+
+    expect(outcome).toMatchObject({ status: "ok" });
+    expect(host.seen[0]?.authorization).toBe("Bearer act-as-user_linked");
+    expect(actAs).toHaveBeenCalledOnce();
+  });
+
+  it("PROVE IT CAN FAIL: the same turn without the link reaches the host unauthenticated", async () => {
+    // Drop the one field and the call takes the present path again — which is
+    // exactly the shipped bug, reproduced.
+    const host = await hostServer();
+    const actAs = vi.fn(async () => ({ headers: { authorization: "Bearer act-as-user_linked" } }));
+    const actions = createActions({ tools: [readTool(host.url)], baseUrl: host.url, actAs });
+    const { channelLink: _dropped, ...withoutLink } = channelCtx();
+
+    const outcome = await actions.execute(
+      { id: "1", tool: "host_spending", args: {} },
+      withoutLink as ActionsRunContext,
+    );
+
+    expect(outcome).toMatchObject({ status: "error" });
+    expect(host.seen[0]?.authorization, "nothing to forward, so nothing was sent").toBeUndefined();
+    expect(actAs, "and the seam that could have authenticated it was never asked").not.toHaveBeenCalled();
+  });
+
+  it("never forwards a ctx's request headers, even a forged one", async () => {
+    const host = await hostServer();
+    const actAs = vi.fn(async () => ({ headers: { authorization: "Bearer act-as-user_linked" } }));
+    const actions = createActions({ tools: [readTool(host.url)], baseUrl: host.url, actAs });
+
+    await actions.execute({ id: "1", tool: "host_spending", args: {} }, channelCtx({
+      requestHeaders: { cookie: "stolen_session=someone_else", authorization: "Bearer inbound" },
+    }))
+
+    expect(host.seen[0]?.cookie).toBeUndefined();
+    expect(host.seen[0]?.authorization).toBe("Bearer act-as-user_linked");
+  });
+
+  it("says what is missing when the host has no actAs seam, and calls nothing", async () => {
+    const host = await hostServer();
+    const actions = createActions({ tools: [readTool(host.url)], baseUrl: host.url });
+
+    const out = await actions.execute({ id: "1", tool: "host_spending", args: {} }, channelCtx());
+
+    expect(out).toMatchObject({ status: "error", error: { code: "not-implemented" } });
+    if (out.status === "error") expect(out.error.message).toContain("actAs");
+    expect(host.seen).toHaveLength(0);
+  });
+
+  it("refuses when the host declines to mint for this subject", async () => {
+    const host = await hostServer();
+    const actions = createActions({ tools: [readTool(host.url)], baseUrl: host.url, actAs: async () => null });
+
+    const out = await actions.execute({ id: "1", tool: "host_spending", args: {} }, channelCtx());
+
+    expect(out).toMatchObject({
+      status: "error",
+      error: { code: "not-implemented", message: "the host declined text-channel execution for this action" },
+    });
+    expect(host.seen).toHaveLength(0);
+  });
+
+  it("hands actAs a grant for the texting subject, projected from the link", async () => {
+    const host = await hostServer();
+    const actAs = vi.fn(async () => ({ headers: { authorization: "Bearer act" } }));
+    const actions = createActions({ tools: [readTool(host.url)], baseUrl: host.url, actAs });
+
+    await actions.execute({ id: "1", tool: "host_spending", args: {} }, channelCtx({ sessionId: "evt_42" }));
+
+    const grant = actAs.mock.calls[0]?.[1] as { subject: string; tool: string; source: string; contextKey?: string };
+    expect(grant).toMatchObject({
+      subject: "user_linked",
+      tool: "host_spending",
+      source: "chat",
+      contextKey: "evt_42",
+    });
+  });
+})

--- a/packages/actions/tests/runtime/registry.test.ts
+++ b/packages/actions/tests/runtime/registry.test.ts
@@ -4,6 +4,7 @@ import type { AddressInfo } from "node:net";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ActAs } from "@vendoai/core";
 
 // Spies on the ONE seam the registry's disk reads flow through
 // (readOptionalVendoJson → node:fs/promises's readFile). Defaults to the
@@ -1515,13 +1516,15 @@ describe("host HTTP execution — the text channel (a person, no browser session
 
   it("hands actAs a grant for the texting subject, projected from the link", async () => {
     const host = await hostServer();
-    const actAs = vi.fn(async () => ({ headers: { authorization: "Bearer act" } }));
+    // Typed to the seam (principal, grant), so the assertion below reads the
+    // grant the registry actually passed rather than an index TypeScript cannot
+    // know exists.
+    const actAs = vi.fn<ActAs>(async () => ({ headers: { authorization: "Bearer act" } }));
     const actions = createActions({ tools: [readTool(host.url)], baseUrl: host.url, actAs });
 
     await actions.execute({ id: "1", tool: "host_spending", args: {} }, channelCtx({ sessionId: "evt_42" }));
 
-    const grant = actAs.mock.calls[0]?.[1] as { subject: string; tool: string; source: string; contextKey?: string };
-    expect(grant).toMatchObject({
+    expect(actAs.mock.calls[0]?.[1]).toMatchObject({
       subject: "user_linked",
       tool: "host_spending",
       source: "chat",

--- a/packages/core/src/run-context.ts
+++ b/packages/core/src/run-context.ts
@@ -22,6 +22,21 @@ export interface McpConsent {
 export const VENUES = ["chat", "app", "automation", "mcp"] as const;
 export type Venue = (typeof VENUES)[number];
 
+/** The text channel's proof that this subject authorized this phone: a code
+    minted inside the product while they were signed in as that subject, then
+    sent back FROM the phone. Carried on the ctx like `mcpConsent`, and for the
+    same reason — a texted turn has no browser session, so its host calls have
+    nothing to forward and must authenticate through the ActAs seam instead. */
+export interface ChannelLink {
+  channel: "text";
+  linkedAt: string;
+}
+
+const channelLinkSchema = z.object({
+  channel: z.literal("text"),
+  linkedAt: z.string(),
+}).passthrough() satisfies z.ZodType<ChannelLink>;
+
 /** CORE-2 */
 const mcpConsentSchema = z.object({
   clientId: z.string(),
@@ -74,6 +89,8 @@ export interface RunContext {
   actor?: Principal;
   grant?: PermissionGrant;
   mcpConsent?: McpConsent;
+  /** Present ⇒ this run reached us over the text channel, from a linked phone. */
+  channelLink?: ChannelLink;
   /** The per-slug service actions THIS firing already holds a live grant for.
    *
    *  Resolved per run by whoever fires it (the automations engine reads the
@@ -130,6 +147,7 @@ export const runContextSchema = z.object({
   actor: principalSchema.optional(),
   grant: permissionGrantSchema.optional(),
   mcpConsent: mcpConsentSchema.optional(),
+  channelLink: channelLinkSchema.optional(),
   grantedServiceSlugs: z.array(z.string()).optional(),
   memberships: z.array(membershipSchema).optional(),
   user: z.record(z.unknown()).optional(),

--- a/packages/vendo/src/channel-turn.ts
+++ b/packages/vendo/src/channel-turn.ts
@@ -130,6 +130,13 @@ export async function runChannelTurn(
     venue: "chat",
     presence: "present",
     sessionId: event.eventId,
+    // What authenticates this turn's HOST calls. `presence: "present"` is true —
+    // a person is holding their phone, which is what lets the guard ask them to
+    // approve a payment — but there is no browser request here, so there are no
+    // credentials to forward. Without this the actions layer takes the present
+    // path, calls the host API with nothing, and the agent ends up apologising
+    // for a sign-in problem the person cannot do anything about.
+    channelLink: { channel: "text", linkedAt: link.linkedAt ?? new Date().toISOString() },
   };
   const send = (text: string): Promise<void> =>
     deps.channel.send({ conversationId: event.conversationId, text });

--- a/packages/vendo/tests/channel-turn-ctx.test.ts
+++ b/packages/vendo/tests/channel-turn-ctx.test.ts
@@ -1,0 +1,98 @@
+import type { RunContext } from "@vendoai/core";
+import { describe, expect, it, vi } from "vitest";
+import type { ChannelLink } from "../src/channel-links.js";
+import { runChannelTurn } from "../src/channel-turn.js";
+
+/**
+ * WHAT A TEXTED TURN TELLS THE REST OF THE SYSTEM ABOUT ITSELF.
+ *
+ * The ctx a channel turn builds is not bookkeeping: it decides how the turn's
+ * HOST calls authenticate. `presence: "present"` is true and load-bearing — a
+ * person is holding their phone, which is what lets the guard ask them to
+ * approve a payment rather than refusing it outright — but present also means
+ * "forward the caller's request credentials", and a text message has no request
+ * behind it.
+ *
+ * A linked customer texted "what did I spend on food last month?" and got an
+ * apology about a sign-in problem: the tool call had reached the host API with
+ * no credentials at all. `channelLink` is what routes it through the ActAs seam
+ * instead, so these cases pin that the turn actually carries it.
+ */
+
+const link: ChannelLink = {
+  id: "chl_1",
+  subject: "vendo-demo",
+  phone: "+15551230123",
+  linkedAt: "2026-08-17T10:22:10.710Z",
+};
+
+const event = {
+  eventId: "evt_1",
+  channel: "text" as const,
+  from: "+15551230123",
+  text: "what did I spend on food last month?",
+  conversationId: "conv_1",
+  receivedAt: "2026-08-17T10:22:11.211Z",
+};
+
+function turnDeps(captured: { ctx?: RunContext }) {
+  return {
+    harness: {
+      stream: vi.fn(async (input: { ctx: RunContext }) => {
+        captured.ctx = input.ctx;
+        return new Response("data: {\"type\":\"text-delta\",\"delta\":\"ok\"}\n\n", {
+          headers: { "content-type": "text/event-stream" },
+        });
+      }),
+    },
+    guard: {
+      onApprovalRequested: () => () => undefined,
+      approvals: { pending: async () => [], decide: async () => undefined },
+    },
+    channel: { send: vi.fn(async () => undefined) },
+    links: { rememberTurn: vi.fn(async () => undefined) },
+    asks: { ids: async () => [], add: vi.fn(async () => undefined), consume: vi.fn(async () => undefined) },
+  } as unknown as Parameters<typeof runChannelTurn>[0];
+}
+
+describe("the ctx a texted turn runs under", () => {
+  it("carries the link, so host calls authenticate through actAs", async () => {
+    const captured: { ctx?: RunContext } = {};
+
+    await runChannelTurn(turnDeps(captured), { event, link });
+
+    expect(captured.ctx?.channelLink).toEqual({
+      channel: "text",
+      linkedAt: "2026-08-17T10:22:10.710Z",
+    });
+  });
+
+  it("keeps presence present, because somebody is holding the phone", async () => {
+    // Both halves matter and they pull in different directions: presence is what
+    // lets the guard ASK for approval instead of refusing, and the link is what
+    // authenticates the call it asked about. Losing either one breaks the
+    // feature in a way the other cannot cover.
+    const captured: { ctx?: RunContext } = {};
+
+    await runChannelTurn(turnDeps(captured), { event, link });
+
+    expect(captured.ctx).toMatchObject({
+      venue: "chat",
+      presence: "present",
+      principal: { kind: "user", subject: "vendo-demo" },
+      sessionId: "evt_1",
+    });
+  });
+
+  it("stamps a link that never recorded its time, rather than omitting the evidence", async () => {
+    // `linkedAt` is optional on the row. A link with none is still a link, and
+    // dropping the field would silently put the turn back on the present path.
+    const captured: { ctx?: RunContext } = {};
+    const { linkedAt: _none, ...undated } = link;
+
+    await runChannelTurn(turnDeps(captured), { event, link: undated });
+
+    expect(captured.ctx?.channelLink?.channel).toBe("text");
+    expect(captured.ctx?.channelLink?.linkedAt).toEqual(expect.any(String));
+  });
+});


### PR DESCRIPTION
From Yousef's live walk. He linked, texted **"what did I spend on food last month?"**, and got:

> I am hitting a sign-in snag trying to pull your spending data right now, so I cannot get last month's food total.

## The pipe was fine. The tool call was not.

From the deployment's own rows:

| Time (UTC) | Event |
|---|---|
| 10:22:10.237 | link relay received (connect tail off the router transcript) |
| 10:22:10.710 | **phone bound** to subject `vendo-demo` — 473 ms |
| 10:22:11.211 | his text received |
| 10:23:14.684 | turn finished — ~2.7 s |

One-text linking worked, the bound subject is a seeded Maple user, minting was permitted. The **host tool call** went out with no credentials, and Maple answered what it answers anyone signed out — `{"code":"unauthenticated","message":"Sign in to Maple to use its API"}`, which I reproduced with a bare curl. That is the sentence the agent was paraphrasing.

## Cause

`presence: "present"` was carrying two meanings at once.

- **True of a text**: a person IS there, holding a phone. That is what makes the guard *ask* them to approve a money-moving call instead of refusing it outright — there is a prove-it-can-fail test pinning exactly that.
- **Not true of a text**: present also means *forward the caller's request credentials*. A text message has no request behind it.

So `hostHeaders` took the present branch, found nothing to forward, and called the host API unauthenticated.

## Fix

The situation already existed one branch up. An MCP-OAuth user has no host browser session either, and that branch's comment says so: host auth comes from the ActAs seam. A **channel link is the same kind of evidence** — a code minted inside the product while the person was signed in as that subject, then sent back from their phone — so it projects to a grant the same way an MCP consent record does.

- `RunContext.channelLink` (core), the text channel's proof this subject authorized this phone.
- `runChannelTurn` stamps it; the actions registry authenticates on it through ActAs.
- `source: "chat"` — no union widened, because a texted turn **is** a chat.
- **Presence stays `present`.** The bug was that "a person is here" and "forward a browser's cookies" were one flag; it was never that presence was wrong.

## Proven both ways

- **6 cases in `packages/actions`** against a real HTTP host that 401s without credentials — the same shape Maple returns. Including **PROVE IT CAN FAIL**: drop `channelLink` from the ctx and the call reaches the host carrying nothing, the ActAs seam is never asked, and the tool errors. That is the shipped bug, reproduced on demand.
- Also pinned: a forged `requestHeaders` on a channel ctx is never forwarded; ActAs is handed a grant for the texting subject with `contextKey` = the event; a missing seam and a declining host each fail closed with a message naming the fix.
- **3 cases in `packages/vendo`**: a real `runChannelTurn` carries the link, keeps `presence: "present"`, and stamps a time when the row has none rather than silently falling back to the present path.
- Green locally: 70 actions tests, 18 vendo channel tests, both packages build.

## Deployment

**The console needs nothing** — verified, not assumed: `runChannelTurn` appears nowhere in `apps/console`; it relays texts, it does not run turns. Maple builds from monorepo source on Railway, so this reaches it on **merge + redeploy, no npm release**.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Authenticates host tool calls for texted turns using the linked phone’s channel evidence via ActAs. Previously `presence: "present"` forwarded no browser credentials for texts, host calls hit 401, and the agent apologized; now `RunContext.channelLink` projects a grant (`source: "chat"`) and ActAs signs the request, while presence remains `present` and text contexts never forward `requestHeaders`.

- Core: adds `channelLink` and schema to `RunContext`; `runChannelTurn` stamps it and sets `linkedAt` if missing.
- Actions: projects `channelLink` to a grant and authenticates through ActAs; returns clear errors for missing `actAs`, missing `channelLink`, or host decline; refuses forwarding any `requestHeaders` from text contexts.
- Tests: cover unauthenticated failure and the fix with a real 401’ing host; type the `actAs` spy to `ActAs` so the grant assertion compiles.
- Patch bumps: `@vendoai/core`, `@vendoai/actions`, `@vendoai/vendo`.

**Rollout**
- Hosts must provide an `actAs` seam for text-channel execution (e.g., `createVendo({ auth })`).
- No console changes; merge and redeploy propagates to Maple.

<sup>Written for commit 927d3f4c9e3161f77112b1bf5bd1f1f0d568bd94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1434?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

