### PR TITLE
fix(cli): the extraction harness stops silently dropping large prompts on Windows and leaving tools ungraded

### DIFF
--- a/.changeset/a-large-extraction-prompt-survives-windows.md
+++ b/.changeset/a-large-extraction-prompt-survives-windows.md
@@ -1,0 +1,9 @@
+---
+"@vendoai/vendo": patch
+---
+
+The claude CLI extraction harness passed its whole prompt as a single argv element, and Windows caps an entire command line at 32,767 characters. A prompt past that ceiling throws `ENAMETOOLONG` before the child process ever starts, while the same prompt sits far under the limit on macOS (~256KB) and Linux (~2MB) — so the failure cannot reproduce off Windows, and it only surfaces once a catalog is large enough to make a stage prompt big. The skeptic re-ask reaches it first, since it carries the judge's proposed fields plus quoted code evidence for every tool in the batch.
+
+It failed quietly, which is why it survived. The re-ask's own handler rejects every field it could not examine, `sync` exits 0, and `doctor` stays green, so a run that discarded most of its completed analysis is indistinguishable from one that worked — the judge had already read the handlers and graded them correctly, and the output was thrown away because the verifier could not be spawned. On a host with ~50 extracted tools, judgments captured went from 10/50 to 40/50 once the ceiling was gone, input schemas from 2/50 to 32/50, and output schemas from 0/50 to 31/50.
+
+The prompt now rides stdin, which `claude -p` already reads when no positional prompt is given, so the ceiling is gone on every platform rather than moved further away. The injected-`exec` seam takes the payload as an optional third argument, leaving existing two-argument stubs untouched, and a regression test drives a 64KB prompt through the harness and asserts no argv element carries it.

--- a/packages/vendo/src/cli/extract/claude-cli-harness.ts
+++ b/packages/vendo/src/cli/extract/claude-cli-harness.ts
@@ -50,11 +50,19 @@ interface ExecResult {
   code: number;
 }
 
-type Exec = (args: string[], options: { cwd: string; env: NodeJS.ProcessEnv }) => Promise<ExecResult>;
+type Exec = (
+  args: string[],
+  options: { cwd: string; env: NodeJS.ProcessEnv },
+  stdinPayload?: string,
+) => Promise<ExecResult>;
 
-function execClaude(args: string[], options: { cwd: string; env: NodeJS.ProcessEnv }): Promise<ExecResult> {
+function execClaude(
+  args: string[],
+  options: { cwd: string; env: NodeJS.ProcessEnv },
+  stdinPayload?: string,
+): Promise<ExecResult> {
   return new Promise((resolve) => {
-    execFile(
+    const child = execFile(
       "claude",
       args,
       { cwd: options.cwd, env: options.env, timeout: RUN_TIMEOUT_MS, maxBuffer: MAX_BUFFER_BYTES },
@@ -63,6 +71,18 @@ function execClaude(args: string[], options: { cwd: string; env: NodeJS.ProcessE
         resolve({ stdout, stderr, code });
       },
     );
+    // The prompt rides stdin, never argv. Windows CreateProcess caps the WHOLE
+    // command line at 32,767 chars, so a large stage prompt — the skeptic re-ask
+    // over a big catalog is the one that gets there — throws ENAMETOOLONG before
+    // the child starts, while the same prompt is far under the limit on macOS
+    // (~256KB) and Linux (~2MB). `claude -p` with no positional prompt reads
+    // stdin, so this removes the ceiling on every platform.
+    if (stdinPayload !== undefined && child.stdin !== null) {
+      // The child can exit before the write drains; a broken pipe here must not
+      // outrank the real exit-code error reported by the execFile callback.
+      child.stdin.on("error", () => undefined);
+      child.stdin.end(stdinPayload);
+    }
   });
 }
 
@@ -141,7 +161,7 @@ export function claudeCliHarness(options: ClaudeCliHarnessOptions = {}): Extract
     async run(input: ExtractionRunInput): Promise<string> {
       const model = extractionModelPin(input.env);
       const args = [
-        "-p", input.instructions,
+        "-p",
         "--allowedTools", ...rootScopedToolRules(input.root),
         "--disallowedTools", ...DISALLOWED_TOOLS,
         "--setting-sources", "",
@@ -154,7 +174,7 @@ export function claudeCliHarness(options: ClaudeCliHarnessOptions = {}): Extract
       // would otherwise have used. Gateway fuel (if applicable) wins last.
       const merged = { ...process.env, ...input.env };
       const overlay = await resolveGatewayFuelOverlay(merged, probe);
-      const result = await exec(args, { cwd: input.root, env: { ...merged, ...overlay } });
+      const result = await exec(args, { cwd: input.root, env: { ...merged, ...overlay } }, input.instructions);
       if (result.code !== 0) {
         throw new Error(`claude exited with code ${result.code}: ${result.stderr.trim() || "(no stderr)"}`);
       }

--- a/packages/vendo/tests/cli/extract/claude-cli-harness.test.ts
+++ b/packages/vendo/tests/cli/extract/claude-cli-harness.test.ts
@@ -40,21 +40,44 @@ describe("claudeCliHarness", () => {
 
   it("invokes claude headless with print mode, the exact tool allowlist/denylist, and isolated settings", async () => {
     let capturedArgs: string[] = [];
+    let capturedStdin: string | undefined;
     const harness = claudeCliHarness({
-      exec: async (args) => {
+      exec: async (args, _options, stdinPayload) => {
         capturedArgs = args;
+        capturedStdin = stdinPayload;
         return { stdout: "the result", stderr: "", code: 0 };
       },
     });
     const text = await harness.run({ root: "/host/root", env: {}, instructions: "go read the codebase" });
     expect(text).toBe("the result");
+    expect(capturedStdin).toBe("go read the codebase");
     expect(capturedArgs).toEqual([
-      "-p", "go read the codebase",
+      "-p",
       "--allowedTools", "Read(//host/root/**)", "Glob(//host/root/**)", "Grep(//host/root/**)",
       "--disallowedTools",
       "Bash", "Write", "Edit", "WebFetch", "WebSearch", "Task", "TodoWrite", "NotebookEdit", "KillShell", "BashOutput",
       "--setting-sources", "",
     ]);
+  });
+
+  it("keeps the prompt out of argv entirely — Windows caps a command line at 32,767 chars", async () => {
+    let capturedArgs: string[] = [];
+    let capturedStdin: string | undefined;
+    const harness = claudeCliHarness({
+      exec: async (args, _options, stdinPayload) => {
+        capturedArgs = args;
+        capturedStdin = stdinPayload;
+        return { stdout: "ok", stderr: "", code: 0 };
+      },
+    });
+    // Comfortably past the Windows CreateProcess ceiling. Passed as an argv
+    // element this throws ENAMETOOLONG before the child starts — the failure
+    // that silently discarded a whole judge batch on a large catalog.
+    const huge = "x".repeat(64 * 1024);
+    await harness.run({ root: "/host/root", env: {}, instructions: huge });
+    expect(capturedStdin).toBe(huge);
+    expect(capturedArgs.join(" ")).not.toContain(huge);
+    expect(capturedArgs.join("").length).toBeLessThan(32_767);
   });
 
   it("confines reads to the root — a bare tool name would auto-allow Read on ANY path", async () => {


### PR DESCRIPTION

## The problem

`claude-cli-harness.ts` passes the entire prompt as a single argv element:

```ts
const args = ["-p", input.instructions, "--allowedTools", ...];
execFile("claude", args, { cwd, env, timeout: RUN_TIMEOUT_MS, maxBuffer: MAX_BUFFER_BYTES }, ...);
```

Windows `CreateProcess` caps the **entire command line** at 32,767 characters.
Past that, Node throws `ENAMETOOLONG` and the child never starts.

The stage that crosses it is the skeptic re-ask, whose prompt is roughly
"proposed fields + quoted code evidence for every tool in the batch" — so its
size scales with catalog size. When it throws, the existing handler does this:

```
warning: skeptic re-ask unusable (spawn ENAMETOOLONG) — the unexamined fields are rejected
```

The judge had already finished, correctly. Its output was discarded because the
*verifier* could not be spawned. `vendo sync --ai` then exits 0, and `doctor`
stays green, so nothing tells the user their analysis was thrown away.

## Why it hasn't shown up before

Three factors have to line up, and each one hides it from a different audience.

**Platform.** The same prompt is nowhere near the limit anywhere else:

| Platform | Limit | Same prompt |
|---|---|---|
| Windows | 32,767 chars | throws |
| macOS | ~256 KB | fine (~8x headroom) |
| Linux | ~2 MB | fine (~64x headroom) |

**Catalog size.** The ceiling is only reached once the prompt is large, and
prompt size scales with how much handler code is quoted back as evidence. A
fixture app with 5–10 routes stays under 32KB *even on Windows*. This host has
~50 extracted tools, which is what crossed it.

**Failure mode.** It degrades to one lowercase `warning:` inside a wall of
output, with `exit 0`. I only found it by diffing grade counts in `tools.json`
before and after a run — there is no surface that reports it.

## How it was measured

Real third-party Next.js host (multi-tenant, Firebase auth, ~50 extracted
tools), Windows 11 / PowerShell, Vendo 0.24.0. Identical command both runs
(`vendo sync --ai --engine claude --full`), with `.vendo/judgments.json` deleted
between them so each figure is that run's own output.

| | Before | After |
|---|---|---|
| `ENAMETOOLONG` | thrown every run | never |
| Skeptic re-ask | could not start | ran; rejected 5 proposals with reasons |
| Judgments captured | 10 / 50 | **40 / 50** |
| Input schemas | 2 / 50 | 32 / 50 |
| Output schemas | 0 / 50 | 31 / 50 |

### Where the install ended up

For completeness, the state of the same host after this fix plus a separate
retry change (see *Scope* — not part of this PR):

| | Original | This PR | + retry change |
|---|---|---|---|
| Tools ungraded | 48/50 | 11/50 | **0/50** |
| Input schemas | 2/50 | 32/50 | 48/50 |
| Output schemas | 0/50 | 31/50 | 46/50 |
| Judgments captured | 0 | 40 | 50 |
| Doctor warnings | 3 | 3 | 2 (`E-TOOLS-003` cleared) |

Attribution, precisely: the last column's gain is **not** demonstrably caused by
the retry change — in that run the third batch conformed on its own and the
retry never fired. What the retry addresses is a failure observed directly in
the preceding run: batch 3 returned JSON containing only `missedSurfaces` and no
`tools` array, while its prose claimed *"all ten catalog tools were read
end-to-end and graded."* Ten tools went ungraded, one lowercase `warning:` was
printed, and `sync` exited 0. That is model non-compliance rather than a spawn
limit — a different bug, in the same silent-degradation family, which is why it
is filed separately and why this table is context rather than a claim.

Worth noting the skeptic is not just *running* but doing real work once it can
start — among the 5 proposals it rejected:

```
host_jd_delete.description — the query db.collection("candidates")
  .where("matchData.jobId","==",jobId).get() has no .limit(); "up to 500" is
  only an illustrative figure in a comment, not an enforced cap, so the claim
  is false.
host_jd_get.outputSchema — publicView also includes work_auth_requirement and
  role_fit, both absent from the proposed schema.
```

That verification pass has presumably never executed on a Windows host with a
catalog this size.

## The change

One file, three edits, no behaviour change on any platform that was already
working:

```diff
-function execClaude(args, options) {
+function execClaude(args, options, stdinPayload) {
     return new Promise((resolve) => {
-        execFile("claude", args, { cwd, env, timeout, maxBuffer }, (error, stdout, stderr) => {
+        const child = execFile("claude", args, { cwd, env, timeout, maxBuffer }, (error, stdout, stderr) => {
             ...
         });
+        // The prompt rides stdin, never argv: Windows CreateProcess caps the
+        // whole command line at 32,767 chars, so a large re-ask throws
+        // ENAMETOOLONG there while passing fine on macOS/Linux.
+        if (stdinPayload !== undefined && child.stdin) {
+            child.stdin.on("error", () => undefined); // child may exit before the write drains
+            child.stdin.end(stdinPayload);
+        }
     });
 }

     const args = [
-        "-p", input.instructions,
+        "-p",
         "--allowedTools", ...rootScopedToolRules(input.root),

-    const result = await exec(args, { cwd: input.root, env: { ...merged, ...overlay } });
+    const result = await exec(args, { cwd: input.root, env: { ...merged, ...overlay } }, input.instructions);
```

`claude -p` with no positional prompt reads stdin — the CLI already supports
this, and its own `no stdin data received in 3s, proceeding without it` warning
is what pointed at it:

```
$ echo "reply with exactly: OK" | claude -p
OK        # exit 0
```

The injected-`exec` seam used in tests keeps working: the payload is a third
argument, so any two-argument stub is unaffected.

### If you'd rather not change the default path

A size-threshold hybrid — argv below ~30KB, stdin above — would leave behaviour
byte-identical for every existing user and engage the new path only where it
would otherwise crash. Happy to switch to that; I went with unconditional stdin
because it removes the ceiling everywhere rather than relocating it, and avoids
maintaining two code paths.

## Scope

Deliberately limited to `claude-cli-harness`. The same argv pattern exists at
`codex-cli-harness.ts` (instructions as a positional) and `npx-engine-harness.ts`
(`"-p", input.instructions`), so both carry the same exposure — but I have only
reproduced and verified the fix on the claude engine. Glad to send the other two
as a follow-up if this approach looks right to you.

## Caveats

Measurements are a single run per configuration against a nondeterministic
pipeline, so treat the schema/judgment counts as directional. The
`ENAMETOOLONG` result is not statistical: it threw on every pre-fix run and
never once after.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes the extraction prompt to `claude` via stdin instead of argv to remove Windows’ 32,767‑char command-line cap. Previously the skeptic re-ask placed the full prompt in argv and could throw ENAMETOOLONG, preventing verification and silently discarding judgments; large catalogs now verify on Windows.

- `claude-cli-harness.ts`: keep `-p` but write the prompt to child stdin with a guarded end; allowed/disallowed tool flags and settings remain unchanged.
- Exec seam: add an optional third `stdinPayload` argument; existing two-argument stubs still work (no migration).
- Tests: drive a 64KB prompt through the harness; assert it rides stdin and is absent from argv.
- Scope: limited to the Claude harness; `codex-cli-harness.ts` and `npx-engine-harness.ts` unchanged.
- Versioning: add a patch changeset for `@vendoai/vendo`.

<sup>Written for commit f08323ef8974bb2a02bac3e11e7e9dc8d9d79bd0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

