### PR TITLE
fix(demo-bank): the away-drill's dist dir is an artifact, not source

### DIFF
--- a/examples/demo-bank/eslint.config.mjs
+++ b/examples/demo-bank/eslint.config.mjs
@@ -13,6 +13,11 @@ const eslintConfig = defineConfig([
     // and not a child (CLAUDE.md: `next build` wipes its whole distDir), which
     // is exactly why the `.next/**` line above does not already cover it.
     ".next-context-e2e/**",
+    // The away-drill fixture's dev server, same rule and same reason: its dist
+    // dir (MAPLE_DIST_DIR=.next-away-drill) is a SIBLING of `.next`, so nothing
+    // above covers it. Release's publish job runs the browser tests and THEN
+    // `pnpm lint`, so an unignored artifact dir aborts the publish.
+    ".next-away-drill/**",
     "out/**",
     "build/**",
     "next-env.d.ts",


### PR DESCRIPTION
The 0.27.0 release run published 0 packages with its tag already pushed: the publish job runs the browser tests, which create `examples/demo-bank/.next-away-drill/` by design (a fixture dev server's dist dir is a SIBLING of the build's, per CLAUDE.md), and then runs `pnpm lint`, which walked that artifact dir and failed on `@typescript-eslint/no-require-imports` inside a built chunk. The dir is git-ignored, but demo-bank's eslint `globalIgnores` covered only `.next/**` and the context-e2e sibling, so this adds `.next-away-drill/**` beside them.

Release workflow, lint walks the away-drill artifact.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ignores the away-drill dev server dist directory in demo-bank’s `eslint` config to prevent linting built artifacts during release. Previously `pnpm lint` walked `.next-away-drill/**` after browser tests and failed on `@typescript-eslint/no-require-imports`; now it skips that directory.

**Review notes**
- Adds `.next-away-drill/**` to `globalIgnores`, alongside `.next/**` and `.next-context-e2e/**`.
- The dist dir is a sibling of `.next/` by design; browser tests create it before `pnpm lint` in the publish job.
- Lint-only change; no runtime or build behavior changes.

<sup>Written for commit 5c0a6ee572e68ed775f5ce22cf0b77ee505be60d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

