### PR TITLE
fix(demo-bank): lint ignores every test dev server's dist dir

### DIFF
--- a/examples/demo-bank/eslint.config.mjs
+++ b/examples/demo-bank/eslint.config.mjs
@@ -9,10 +9,13 @@ const eslintConfig = defineConfig([
   globalIgnores([
     // Default ignores of eslint-config-next:
     ".next/**",
-    // fixtures/context-e2e's dev server. Its dist dir is a SIBLING of `.next`
-    // and not a child (CLAUDE.md: `next build` wipes its whole distDir), which
-    // is exactly why the `.next/**` line above does not already cover it.
-    ".next-context-e2e/**",
+    // Every test dev server's dist dir (MAPLE_DIST_DIR: fixtures/context-e2e,
+    // tests/vendo/away-drill). Each is a SIBLING of `.next` and not a child
+    // (CLAUDE.md: `next build` wipes its whole distDir), which is exactly why
+    // the `.next/**` line above does not already cover them. Matched by glob,
+    // not enumerated: `pnpm test` leaves these compiled bundles on disk, and a
+    // release's `pnpm lint` ran over `.next-away-drill` and failed (v0.27.0).
+    ".next-*/**",
     "out/**",
     "build/**",
     "next-env.d.ts",


### PR DESCRIPTION
## What

`pnpm lint` no longer walks into demo-bank's test dist dirs. One glob (`.next-*/**`) replaces the single enumerated `.next-context-e2e/**`.

## Why

The v0.27.0 release run failed at `pnpm lint` and never published ([run 32046973650](https://github.com/runvendo/vendo/actions/runs/32046973650)):

1. `release.yml` runs `pnpm test` before `pnpm lint`, in the same checkout.
2. demo-bank's `tests/vendo/away-drill.test.ts` boots `next dev` with `MAPLE_DIST_DIR: ".next-away-drill"` — a SIBLING of `.next`, on purpose, so a concurrent build can't wipe it — and leaves the compiled bundles on disk.
3. demo-bank's eslint ignore list covered `.next/**` and `.next-context-e2e/**` but not `.next-away-drill/**`, so lint hard-errored on webpack chunks: 260 errors, every one inside that directory (no-require-imports, no-this-alias, ban/ban rule-not-found).

`.gitignore` already covers both dirs, so this never showed up in a commit — only in a job that tests and lints in one checkout.

## Gate

Ran with a synthetic `examples/demo-bank/.next-away-drill/dev/server/chunks/junk.js` present:

- `npx eslint` in demo-bank WITHOUT the fix: exit 1, the same two rules CI hit (proof the test can fail)
- `npx eslint` WITH the fix: exit 0
- root `pnpm build` = 0, `pnpm typecheck` = 0 (42/42), `pnpm lint` = 0 with `demo-bank:lint` a real cache miss

No changeset: nothing under `packages/*` changed, and 0.27.0 is still unpublished — this unblocks its release rather than minting a new version.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ignore demo-bank test dev server dist dirs in `eslint` using a glob. Previously `pnpm lint` ignored `.next/**` and only `.next-context-e2e/**`; it walked `.next-away-drill/**` and failed on compiled chunks. Now it skips all `.next-*` siblings of `.next`, preventing release failures when `pnpm test` leaves bundles.

- Changes are limited to `examples/demo-bank/eslint.config.mjs`: replace the single enumerated path with `.next-*/**`.
- The glob covers dist dirs produced by `MAPLE_DIST_DIR` in `fixtures/context-e2e` and `tests/vendo/away-drill` and matches `.gitignore`. No changeset needed; no package behavior changes.

<sup>Written for commit abeb007e8d380c495062e7beb0d6be0205a3eb12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1438?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

