### PR TITLE
fix(actions): reject path-traversal segments in route tool arguments (#988)

### DIFF
--- a/.changeset/a-dot-arg-cannot-climb-out-of-its-route.md
+++ b/.changeset/a-dot-arg-cannot-climb-out-of-its-route.md
@@ -1,0 +1,12 @@
+---
+"@vendoai/actions": patch
+---
+
+Security: a route tool argument of `.` or `..` can no longer climb above the
+tool's declared path. `withPathArgs` substituted call args with
+`encodeURIComponent`, which leaves dot-segments intact (and the array branch
+joins with a raw `/`), so an arg like `id: ".."` or `id: ["..","..","admin"]`
+resolved through `new URL` to escape the route (e.g. `/users/{id}` → `/admin`).
+Args are never validated against `inputSchema` and are steerable by end-user
+chat, so each substituted segment is now rejected with a `validation` error
+before any request is made (#988).

--- a/packages/actions/src/runtime/registry.ts
+++ b/packages/actions/src/runtime/registry.ts
@@ -225,6 +225,20 @@ function appendQuery(url: URL, key: string, value: unknown): void {
   }
 }
 
+/** Encode one substituted path segment. `encodeURIComponent` neutralizes a
+ *  slash (→ `%2F`) but leaves `.` and `..` intact, so a call arg of "." or ".."
+ *  would substitute as a literal dot-segment that `new URL` later normalizes to
+ *  climb above the tool's declared route (path traversal / SSRF, #988). Args are
+ *  never validated against `inputSchema` and are steerable by end-user chat, so
+ *  reject the traversal segment at the source. */
+function encodePathSegment(raw: string): string {
+  const encoded = encodeURIComponent(raw);
+  if (encoded === "." || encoded === "..") {
+    throw new VendoError("validation", `Path parameter cannot be a "${encoded}" traversal segment`);
+  }
+  return encoded;
+}
+
 function withPathArgs(path: string, args: Record<string, unknown>): { path: string; remaining: Record<string, unknown> } {
   const consumed = new Set<string>();
   const resolved = path.replace(/\{([^{}]+)\}/g, (_match, param: string) => {
@@ -234,8 +248,8 @@ function withPathArgs(path: string, args: Record<string, unknown>): { path: stri
     consumed.add(param);
     const value = args[param];
     return Array.isArray(value)
-      ? value.map((segment) => encodeURIComponent(String(segment))).join("/")
-      : encodeURIComponent(String(value));
+      ? value.map((segment) => encodePathSegment(String(segment))).join("/")
+      : encodePathSegment(String(value));
   });
   return {
     path: resolved,

--- a/packages/actions/tests/runtime/registry.test.ts
+++ b/packages/actions/tests/runtime/registry.test.ts
@@ -622,6 +622,41 @@ describe("host HTTP execution", () => {
     )).resolves.toMatchObject({ status: "ok" });
     expect((request.mock.calls[0]?.[0] as URL).pathname).toBe("/files/folder%20one/child%2Fname");
   });
+
+  // #988: a route tool's declared path is its boundary. Tool-call args are
+  // described to the model but never validated against inputSchema, and the
+  // value can be steered by end-user chat text — so a "."/".." arg must never
+  // substitute as a literal dot-segment that `new URL` then normalizes to climb
+  // above the route. encodeURIComponent leaves "." and ".." intact, and the
+  // array branch joins with a raw "/", so both forms are exploitable.
+  it("rejects a `..`/`.` path argument instead of climbing above the tool's route (#988)", async () => {
+    const requested: string[] = [];
+    const actions = createActions({
+      tools: [routeTool("host_user", {
+        binding: { kind: "route", method: "GET", path: "/users/{id}", argsIn: "query" },
+      })],
+      baseUrl: "https://api.example.com",
+      fetch: async (input) => {
+        requested.push(String(input));
+        return Response.json({ ok: true });
+      },
+    });
+
+    // Scalar: a bare ".." climbs out of the /users boundary (→ the origin root).
+    const scalar = await actions.execute({ id: "1", tool: "host_user", args: { id: ".." } }, ctx);
+    // Array catch-all: ["..","..","admin"] joins to `../../admin` → /admin.
+    const array = await actions.execute(
+      { id: "2", tool: "host_user", args: { id: ["..", "..", "admin"] } },
+      ctx,
+    );
+
+    // The guard refuses BEFORE the outbound fetch, so the host never sees a
+    // climbed request. Unpatched, this array holds the escaped URLs
+    // (https://api.example.com/ and https://api.example.com/admin).
+    expect(requested).toEqual([]);
+    expect(scalar).toMatchObject({ status: "error", error: { code: "validation" } });
+    expect(array).toMatchObject({ status: "error", error: { code: "validation" } });
+  });
 });
 
 describe("host HTTP execution — venue=mcp (10-mcp §3 / 04 §4 ActAs auth)", () => {


### PR DESCRIPTION
## What

Fixes #988. Route-tool call arguments are substituted into a binding's path (e.g. `/users/{id}`) in `withPathArgs` (`packages/actions/src/runtime/registry.ts`). Substitution used `encodeURIComponent`, which encodes a slash (`/` -> `%2F`) but leaves `.` and `..` untouched — and the array branch joins segments with a **raw** `/`. So:

- scalar `id: ".."` -> path `/users/..`, which `new URL()` normalizes to the origin root, and
- array `id: ["..","..","admin"]` -> `/users/../../admin`, which normalizes to `/admin`.

The substituted path flows to `resolveUrl` -> `joinUrl(baseUrl, path)`, so the request **climbs above the tool's declared route**. Tool-call args are never validated against `tool.inputSchema` (it is only described to the model) and can be steered by end-user chat text — a reachable path-traversal / SSRF-shaped escape of the route boundary.

## Why it's reachable

`inputSchema` is descriptive only; nothing enforces the arg shape at execution, and the value originates from model output driven by end-user chat. No other arg-driven vector exists: query args go through `url.searchParams` (fully encoded), and tRPC/OpenAPI URLs are built from the binding definition (trusted extraction output), not call args.

## The fix

A small `encodePathSegment` helper: after `encodeURIComponent`, reject a `.` or `..` segment with a `VendoError("validation", ...)` before any request is made. Applied to **both** the scalar and each array-element branch. Minimal, at the source; legitimate values (including `%2F`-encoded slashes and dotted filenames like `report.v2`) are unaffected.

## Failing-first proof

Added a test in `packages/actions/tests/runtime/registry.test.ts` that executes a `/users/{id}` route tool with `id: ".."` and `id: ["..","..","admin"]`, capturing outgoing request URLs via a `fetch` stub. Against the unpatched code the test failed showing the climb (`https://api.example.com/` and `https://api.example.com/admin`); with the fix both calls return a `validation` outcome and no request reaches the host. Prove-it-can-fail: reverting the fix turns the test red again; restoring it goes green.

## Verification

Scoped local gate on `@vendoai/actions` (touched scope): `build` pass, `typecheck` pass, lint (dependency-guard + eslint blocking config on the changed files) pass, `registry.test.ts` (worker-capped) 71 passed. CI is the gate of record; the required `ci` check runs the full suite. Includes a `patch` changeset for `@vendoai/actions`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks path traversal in route-tool path parameters so requests cannot escape the declared route. Previously, `.`/`..` segments (including array-joined forms) were substituted literally and normalized by URL; now they are rejected with a validation error before any request.

- New `encodePathSegment` in `packages/actions/src/runtime/registry.ts` encodes values and rejects `.`/`..`; used for both scalar and array substitutions in `withPathArgs`.
- Adds tests in `packages/actions/tests/runtime/registry.test.ts` that assert no outbound fetch occurs and a `validation` error is returned for dot-segment inputs.
- Publishes a patch for `@vendoai/actions`.

**Migration**
- No action required for normal usage. Calls that intentionally passed `.` or `..` in path params will now fail with `validation`; update those calls or prompts to avoid dot-segments.

<sup>Written for commit 45cf665e178d0a9fcf79ecb387f3458fc9981e9e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1439?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

