### PR TITLE
fix(core,harnesses,ui): a timed-out ask settles as expired, nobody said no (#1373)

### DIFF
--- a/.changeset/a-timeout-is-nobodys-no.md
+++ b/.changeset/a-timeout-is-nobodys-no.md
@@ -1,0 +1,18 @@
+---
+"@vendoai/core": patch
+"@vendoai/harnesses": patch
+"@vendoai/ui": patch
+---
+
+A timed-out approval ask settles as expired, not as the person's no. The
+APPROVAL_WAIT_MS settle used to ride the ai-SDK's `output-denied` state — whose
+meaning is "the person answered no" — so the thread narrated "you declined it"
+for a question nobody answered, and the persisted part carried nothing that
+could ever tell the difference. The settle now carries a typed outcome
+(`status: "blocked"` with `cause: "expired"` — a field on the existing member,
+not a new status, so already-published validators pass it through and older
+chrome degrades to "wasn't allowed", which at least blames no one), the beat
+reads "the approval expired unanswered", and the distinction survives reload
+because the part settles as `tool-output-available` with the outcome on it.
+The model-facing result is unchanged: the same denial naming the approval it
+still needs.

--- a/packages/core/src/tools.ts
+++ b/packages/core/src/tools.ts
@@ -342,12 +342,21 @@ const connectRequiredSchema = z.object({
   message: z.string(),
 }).passthrough() satisfies z.ZodType<ConnectRequired>;
 
-/** 01-core §4 */
+/** 01-core §4
+ *
+ *  `blocked.cause` narrows WHY nothing ran when the reason is nobody's doing:
+ *  `"expired"` marks an approval wait that elapsed unanswered, so a surface can
+ *  say "expired unanswered" instead of misattributing the refusal (H2-G — the
+ *  timeout used to narrate as the person's no). A FIELD, not a new status: the
+ *  union is a closed discriminator to every already-published validator, while
+ *  an optional field passes through them (an old chrome renders the refusal
+ *  attributed to the rules — imprecise, never an accusation). Vocabulary
+ *  matches `ParkedCallOutcome.state: "expired"`. */
 export type ToolOutcome =
   | { status: "ok"; output: Json }
   | { status: "error"; error: { code: string; message: string } }
   | { status: "pending-approval"; approvalId: ApprovalId }
-  | { status: "blocked"; reason: string }
+  | { status: "blocked"; reason: string; cause?: "expired" }
   | { status: "connect-required"; connect: ConnectRequired };
 
 /** 01-core §4 */
@@ -358,7 +367,11 @@ export const toolOutcomeSchema = z.discriminatedUnion("status", [
     error: z.object({ code: z.string(), message: z.string() }).passthrough(),
   }).passthrough(),
   z.object({ status: z.literal("pending-approval"), approvalId: approvalIdSchema }).passthrough(),
-  z.object({ status: z.literal("blocked"), reason: z.string() }).passthrough(),
+  z.object({
+    status: z.literal("blocked"),
+    reason: z.string(),
+    cause: z.literal("expired").optional(),
+  }).passthrough(),
   z.object({ status: z.literal("connect-required"), connect: connectRequiredSchema }).passthrough(),
 ]) satisfies z.ZodType<ToolOutcome>;
 

--- a/packages/core/tests/schemas.test.ts
+++ b/packages/core/tests/schemas.test.ts
@@ -96,12 +96,16 @@ describe("outcome, guard, and audit schemas", () => {
       { status: "error", error: { code: "upstream", message: "Unavailable", future: true } },
       { status: "pending-approval", approvalId: "apr_1" },
       { status: "blocked", reason: "Policy" },
+      // The one legal cause: an ask that expired unanswered (H2-G). A field,
+      // not a new status — the discriminated union is closed to old readers.
+      { status: "blocked", reason: "The approval request expired unanswered.", cause: "expired" },
       {
         status: "connect-required",
         connect: { connector: "composio", toolkit: "gmail", message: "Connect your gmail account" },
       },
     ]) expect(toolOutcomeSchema.safeParse(outcome).success).toBe(true);
     expect(toolOutcomeSchema.safeParse({ status: "waiting" }).success).toBe(false);
+    expect(toolOutcomeSchema.safeParse({ status: "blocked", reason: "x", cause: "timeout" }).success).toBe(false);
     expect(toolOutcomeSchema.safeParse({ status: "connect-required" }).success).toBe(false);
     expect(toolOutcomeSchema.safeParse({
       status: "connect-required",

--- a/packages/harnesses/src/turn-tools.ts
+++ b/packages/harnesses/src/turn-tools.ts
@@ -364,11 +364,24 @@ export function createTurnTools(options: TurnToolsOptions): RuntimeTurnTools {
           const approved = await waiter.wait(approvalId, approvalWaitMs);
           approval = approved === undefined ? "timed-out" : approved ? "approved" : "denied";
           if (approved === undefined) {
-            return finish({
-              status: "denied",
-              reason: "The approval timed out.",
-              needs: { kind: "approval", approvalId },
-            });
+            // An elapsed wait is nobody's no (H2-G): the model still reads a
+            // denial that names what it needs, but the typed outcome the
+            // screen persists carries `cause: "expired"` so the beat can say
+            // the question expired instead of blaming the person — the
+            // ai-SDK's output-denied state MEANS "the person answered no",
+            // which is exactly what did not happen here.
+            return finish(
+              {
+                status: "denied",
+                reason: "The approval timed out.",
+                needs: { kind: "approval", approvalId },
+              },
+              {
+                status: "blocked",
+                reason: "The approval request expired unanswered.",
+                cause: "expired",
+              },
+            );
           }
           if (!approved) return finish({ status: "denied", reason: "You turned this down." });
         }

--- a/packages/harnesses/tests/runtime.test.ts
+++ b/packages/harnesses/tests/runtime.test.ts
@@ -50,6 +50,7 @@ function fixture(options: {
    *  is pinned in `packages/vendo/tests/render-wrap-slot.test.ts`, where both
    *  blocks are legal; here a fake wrap pins the slot's own mechanics. */
   wrapWorkspace?: Parameters<typeof createHarnessRuntime>[0]["wrapWorkspace"];
+  approvalWaitMs?: number;
 } = {}) {
   const guard = options.guard ?? testGuard();
   const registry = boundRegistry(
@@ -73,6 +74,7 @@ function fixture(options: {
     harnessState: options.harnessState ?? memoryHarnessStateStore(),
     ...(options.liveTurn === undefined ? {} : { liveTurn: options.liveTurn }),
     ...(options.wrapWorkspace === undefined ? {} : { wrapWorkspace: options.wrapWorkspace }),
+    ...(options.approvalWaitMs === undefined ? {} : { approvalWaitMs: options.approvalWaitMs }),
   });
   /** Run a turn AND drain the response, exactly as a host route does. The
    *  stream's onFinish (persistence, state, audit) only fires on consumption —
@@ -371,6 +373,20 @@ describe("mirroring — tool calls are the runtime's job, never a yield", () => 
     expect(parts.some((part) => part.type === "tool-output-denied")).toBe(false);
     expect(parts.find((part) => part.type === "tool-output-available"))
       .toMatchObject({ output: { status: "blocked", reason: "blocked" } });
+    await expect(convertToModelMessages(await persisted(f))).resolves.toBeDefined();
+  });
+
+  it("mirrors a TIMED-OUT ask as expired — never output-denied, and the transcript still converts", async () => {
+    const deafGuard = testGuard({ maple_invoices_list: "ask" });
+    // Decisions never arrive: the frozen bound is the only exit.
+    deafGuard.onApprovalDecision = () => () => undefined;
+    const f = fixture({ guard: deafGuard, tools, approvalWaitMs: 25 });
+    const parts = await f.run(callingHarness());
+    // Nobody answered, so the part must not carry the state whose ai-SDK
+    // meaning is "the person answered no".
+    expect(parts.some((part) => part.type === "tool-output-denied")).toBe(false);
+    expect(parts.find((part) => part.type === "tool-output-available"))
+      .toMatchObject({ output: { status: "blocked", cause: "expired" } });
     await expect(convertToModelMessages(await persisted(f))).resolves.toBeDefined();
   });
 

--- a/packages/harnesses/tests/turn-tools.test.ts
+++ b/packages/harnesses/tests/turn-tools.test.ts
@@ -377,6 +377,19 @@ describe("turn.tools.call — §1.4 approvals", () => {
     await expect(tools.call("pay", {})).resolves.toEqual({ status: "ok", output: { sent: true } });
   });
 
+  it("interactive=true: a timeout settles as expired for the screen, denied only for the model", async () => {
+    const { tools, mirrored } = harness({ registry, guard, approvalWaitMs: 20 });
+    const result = await tools.call("pay", { amount: 10 });
+    // The model reads the same denial it always did (parity H1 rests on it)…
+    expect(result).toMatchObject({ status: "denied", needs: { kind: "approval" } });
+    // …but the typed outcome the screen persists is NOT the person's no:
+    // nobody answered, and only the cause lets the beat say so.
+    const settled = mirrored.find((event) => event.kind === "result") as
+      Extract<MirrorEvent, { kind: "result" }>;
+    expect(settled.outcome).toMatchObject({ status: "blocked", cause: "expired" });
+    expect(registry.invocations.pay).toBeUndefined();
+  });
+
   it("interactive=true: an unresolvable approval still resolves — call() never suspends the run", async () => {
     const deafGuard = testGuard({ pay: "ask" });
     // A guard whose decisions never arrive: the frozen bound is the only exit.

--- a/packages/ui/src/chrome/build-beat.tsx
+++ b/packages/ui/src/chrome/build-beat.tsx
@@ -10,7 +10,7 @@ import { useVendoProvider } from "../context.js";
 import { developmentMode } from "./dev-mode.js";
 import { memberSchema, type CardFieldRow } from "./field-rows.js";
 import { argValue, humanizeToolName, toolTitle, type ToolMeta } from "./humanize.js";
-import { toolCallRefused } from "./thread/message-data.js";
+import { toolCallExpired, toolCallRefused } from "./thread/message-data.js";
 import type { VendoBeat } from "./run-activity.js";
 
 /**
@@ -551,6 +551,9 @@ export function BuildBeat({
   // The host's own rules saying no, which is nobody's decline: the person was
   // never asked, so the line has to name the rules instead of them.
   const refused = toolCallRefused(part);
+  // Narrower still: an ask that expired unanswered is nobody's no at all —
+  // not the person's and not the rules' — so the line blames no one (H2-G).
+  const expired = toolCallExpired(part);
   const label = toolTitle(name, tools[name]);
   const result = done && !refused ? toolResultSummary(part.output) : undefined;
   const mark: BeatMark = error ? "error" : declined || refused ? "declined" : done ? "done"
@@ -569,6 +572,7 @@ export function BuildBeat({
         mark={mark}
         label={waiting ? `${label} — waiting for your approval`
           : error ? `${label} — couldn't finish`
+          : expired ? `${label} — the approval expired unanswered`
           : refused ? `${label} — wasn't allowed`
           : declined ? `${label} — you declined it`
           : done ? label

--- a/packages/ui/src/chrome/thread/message-data.ts
+++ b/packages/ui/src/chrome/thread/message-data.ts
@@ -285,6 +285,15 @@ export function toolCallRefused(part: UIMessage["parts"][number]): boolean {
     && (part.output as { status?: unknown } | null | undefined)?.status === "blocked";
 }
 
+/** The narrower case inside `toolCallRefused`: an ask whose wait elapsed with
+    no answer (H2-G). Nobody's no at all — not the person's (they never
+    answered) and not the rules' — so the beat says the question expired
+    instead of attributing the refusal to anyone. */
+export function toolCallExpired(part: UIMessage["parts"][number]): boolean {
+  return isToolUIPart(part) && toolCallRefused(part)
+    && (part.output as { cause?: unknown } | null | undefined)?.cause === "expired";
+}
+
 /** A failed, refused or declined call is CONTENT, not progress: its beat stays
     visible after the turn folds, and it never counts as a thing the agent did.
     Everything else is progress, and progress folds into the summary. */

--- a/packages/ui/test/chrome/transcript-beats.test.tsx
+++ b/packages/ui/test/chrome/transcript-beats.test.tsx
@@ -244,6 +244,32 @@ describe("the transcript's beats", () => {
     expect(document.querySelector(".fl-beatsummary")?.textContent).toBe("Did 1 thing");
   });
 
+  // An ask that expired unanswered is nobody's no — not the person's (they
+  // never saw it) and not the rules' (nothing refused it). The beat says the
+  // question expired, blaming no one. (H2-G: the timeout used to ride
+  // output-denied and narrate as "you declined it".)
+  it("narrates a timed-out ask as expired, never as the person's no", async () => {
+    await mount([
+      {
+        type: "dynamic-tool",
+        toolName: "host_send_payment",
+        toolCallId: "call_expired",
+        state: "output-available",
+        input: { amount: 4750 },
+        output: {
+          status: "blocked",
+          reason: "The approval request expired unanswered.",
+          cause: "expired",
+        },
+      },
+    ] as unknown as Thread["messages"][number]["parts"]);
+    const expired = document.querySelector("[data-vendo-tool='host_send_payment']");
+    expect(expired?.textContent).toContain("the approval expired unanswered");
+    expect(expired?.textContent).not.toContain("you declined it");
+    expect(expired?.textContent).not.toContain("wasn't allowed");
+    expect(expired?.className).toBe("fl-beat fl-beat-done");
+  });
+
   // The HOST's own rules refusing a call is not the person declining one. The
   // beat used to read "you declined it" directly above the card explaining they
   // had hit a limit — the two lines contradicting each other about who said no.


### PR DESCRIPTION
## What

Lane 5a of the host-#2 fix pack (H2-G, #1373, Linear ENG-425/426): **a timed-out approval ask is not a decline.** Field case (expense.fyi, ungraded catalog so every call asks): asks timed out at APPROVAL_WAIT_MS and the thread narrated each one as "you declined it" - blaming the person for a question they never answered - with no persisted distinction that could ever say otherwise.

## How

The settle (`turn-tools.ts`) now emits a typed screen-facing outcome alongside the unchanged model-facing denial, extending #1324's `refused()` doctrine: nobody's no must never ride the ai-SDK's `output-denied`, whose meaning is "the person answered no".

- **core**: `ToolOutcome`'s `blocked` member gains `cause?: "expired"` - deliberately a **field, not a new status**: `toolOutcomeSchema` is a closed discriminated union to every already-published validator, while an optional field passes through them (`.passthrough()`). Old chrome degrades to "wasn't allowed" - imprecise, but it blames no one. Vocabulary matches the parked lane's `ParkedCallOutcome.state: "expired"`.
- **harnesses**: the timeout branch returns two-arg `finish(...)` - model reads the same `{status:"denied", needs:{kind:"approval"}}` it always did (parity H1 unchanged), screen persists `{status:"blocked", reason:"The approval request expired unanswered.", cause:"expired"}` riding the existing `tool-output-available` transport, so the distinction survives reload and the transcript still converts to model messages.
- **ui**: `toolCallExpired` (narrower than `toolCallRefused`) and a beat branch: "the approval expired unanswered" - never "you declined it", never "wasn't allowed".

## Tests

TDD, all red-first: harness mirror-level settle pin, runtime transcript-level pin (no `output-denied`, converts), UI beat copy pin (asserts both wrong copies absent), core schema round-trip + rejection of any other `cause` value. Affected scopes fully green locally: core schemas 11/11, harnesses turn-tools+runtime 63/63, stale-approvals+parity 29/29, ui transcript-beats+thread-and-overlay 34/34; typecheck clean on all three packages.

**Screenshot note (UI-affecting rule):** no visual geometry changes - the expired beat reuses the refused beat's mark, class, and layout exactly (asserted in the test); only the label string differs. Happy to add a browser screenshot if wanted.

## Not in this PR

Lane 5b (the undiagnosed 0.20 field case where asks never *rendered*) is an investigation, tracked on #1373 - re-repro on current npm next. Lane 4 (signed-out chrome state, #1372) follows separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)