### PR TITLE
fix(ui): a forbidden wire is a full stop for every poller (#1372)

### DIFF
--- a/.changeset/a-signed-out-visitor-stops-asking.md
+++ b/.changeset/a-signed-out-visitor-stops-asking.md
@@ -1,0 +1,14 @@
+---
+"@vendoai/ui": patch
+---
+
+A signed-out visitor's chrome stops asking. On a preset-authed deployment
+every wire call for a visitor with no session correctly answers forbidden —
+and every poller retried it forever, filling the console with 403s. A
+forbidden refusal is now a full stop for every poller (the shared resource
+loop, the approvals feed, the slot/placements poller and its report writes,
+the parked-press backstop), a tab switch does not resurrect them, and the
+app-open retry ladder no longer burns its attempts on a refusal that cannot
+change. Everything wakes together when the host dispatches
+`vendo:identity-changed` after an SPA sign-in (a full-page redirect remounts
+everything anyway), or the moment any wire read succeeds again.

--- a/docs-site/production/auth.mdx
+++ b/docs-site/production/auth.mdx
@@ -258,6 +258,25 @@ Audit readers that filter on webhook subjects should match
 
 ---
 
+## Signed-out visitors
+
+A visitor your resolver answers `null` for is refused with `forbidden` — the
+host owns sign-in, so that is correct. The chrome treats the first such
+refusal as a full stop: every poller (threads, approvals, slots) goes quiet
+instead of retrying a 403 forever, and switching tabs does not wake them.
+
+Everything resumes on its own after a full-page sign-in redirect. If your app
+signs users in without a page load, announce it:
+
+```ts
+window.dispatchEvent(new Event("vendo:identity-changed"));
+```
+
+Dispatch it after sign-in, sign-out, or a workspace switch — the chrome
+re-checks immediately.
+
+---
+
 ## Verify the wiring
 
 `vendo doctor` reads files on disk, so it cannot see these seams. Run your app

--- a/packages/ui/src/hooks/approvals-feed.ts
+++ b/packages/ui/src/hooks/approvals-feed.ts
@@ -13,6 +13,7 @@
  */
 import type { ApprovalRequest } from "@vendoai/core";
 import type { VendoClient } from "../client.js";
+import { identityState, type IdentityState } from "./identity-state.js";
 
 export interface ApprovalsSnapshot {
   data: ApprovalRequest[];
@@ -65,8 +66,15 @@ class ApprovalsFeed {
   private readonly cadences = new Map<() => void, number>();
   private timer: ReturnType<typeof setTimeout> | undefined;
   private generation = 0;
+  private stopIdentity: (() => void) | undefined;
 
-  constructor(private readonly list: () => Promise<ApprovalRequest[]>) {}
+  constructor(
+    private readonly list: () => Promise<ApprovalRequest[]>,
+    /** The per-client forbidden latch (H2-E / #1372): a signed-out visitor's
+     *  feed goes quiet after the first refusal instead of retrying forever,
+     *  and wakes on the page's identity signal like every other poller. */
+    private readonly identity: IdentityState,
+  ) {}
 
   read = (): ApprovalsSnapshot => this.snapshot;
 
@@ -75,6 +83,11 @@ class ApprovalsFeed {
     this.cadences.set(listener, pollMs);
     if (first) {
       if (typeof document !== "undefined") document.addEventListener("visibilitychange", this.onVisibility);
+      // The latch opening (page signal, or any surface's successful read) is
+      // the wake-up; arm() consults it on the way back to sleep.
+      this.stopIdentity = this.identity.subscribe(() => {
+        if (!this.identity.forbidden()) void this.refresh();
+      });
       void this.refresh();
     } else {
       // A faster subscriber joined: re-arm on the new cadence.
@@ -87,6 +100,8 @@ class ApprovalsFeed {
         return;
       }
       if (typeof document !== "undefined") document.removeEventListener("visibilitychange", this.onVisibility);
+      this.stopIdentity?.();
+      this.stopIdentity = undefined;
       this.stop();
       // Nobody is watching. Drop the in-flight response and the rows: the next
       // mount deserves its own first load, not a count that may be minutes old.
@@ -100,9 +115,11 @@ class ApprovalsFeed {
     try {
       const data = await this.list();
       if (generation !== this.generation) return;
+      this.identity.clear();
       this.publish({ data, error: undefined, isLoading: false });
     } catch (reason) {
       if (generation !== this.generation) return;
+      this.identity.note(reason);
       this.publish({ ...this.snapshot, error: asError(reason), isLoading: false });
     } finally {
       // Self-scheduling, like useResource: the next poll is armed only once this
@@ -120,7 +137,10 @@ class ApprovalsFeed {
   private arm(): void {
     this.stop();
     const cadence = this.cadence();
-    if (cadence === undefined || hidden()) return;
+    // Forbidden is a full stop, not a skip: the wire told this visitor no, and
+    // asking again on a timer cannot change the answer — only the identity
+    // signal (or another surface's successful read) can.
+    if (cadence === undefined || hidden() || this.identity.forbidden()) return;
     this.timer = setTimeout(() => void this.refresh(), cadence);
   }
 
@@ -140,9 +160,10 @@ class ApprovalsFeed {
 
   private onVisibility = (): void => {
     // A background tab asks nothing. Coming back asks immediately, so the count
-    // the user returns to is current rather than one cadence stale.
+    // the user returns to is current rather than one cadence stale — unless the
+    // visitor is latched forbidden: a tab switch is not a sign-in.
     if (hidden()) this.stop();
-    else void this.refresh();
+    else if (!this.identity.forbidden()) void this.refresh();
   };
 }
 
@@ -151,7 +172,7 @@ const feeds = new WeakMap<VendoClient, ApprovalsFeed>();
 export function approvalsFeed(client: VendoClient): ApprovalsFeed {
   let feed = feeds.get(client);
   if (feed === undefined) {
-    feed = new ApprovalsFeed(() => client.approvals.pending());
+    feed = new ApprovalsFeed(() => client.approvals.pending(), identityState(client));
     feeds.set(client, feed);
   }
   return feed;

--- a/packages/ui/src/hooks/identity-state.ts
+++ b/packages/ui/src/hooks/identity-state.ts
@@ -1,0 +1,74 @@
+/**
+ * The page-wide answer to "did the wire refuse this visitor for missing
+ * identity?" — one latch per client (H2-E / #1372).
+ *
+ * On a preset-authed deployment every wire call for a signed-out visitor
+ * correctly answers 403 (`VendoError` code `forbidden` — branch on the CODE,
+ * never the status: `blocked` rides 403 too). The refusal is right; retrying
+ * it forever is not. Pollers consult this latch and go quiet the first time
+ * the wire says forbidden, and everything wakes together when the page says
+ * identity changed — the host dispatches {@link IDENTITY_CHANGED_EVENT} after
+ * an SPA sign-in (a full-page redirect remounts everything anyway) — or when
+ * any wire read succeeds again.
+ *
+ * Internal on purpose (the HistoryPicker precedent): the latch is plumbing,
+ * not API. Keyed by client identity so a page holding several clients (the
+ * overlay's and each embed's) latches per wire, and registered listeners live
+ * exactly as long as their client does.
+ */
+import { VendoError } from "@vendoai/core";
+
+/** The page signal: the host announces "who is signed in changed" (sign-in,
+ *  sign-out, workspace switch). Every gated poller re-checks on it. */
+export const IDENTITY_CHANGED_EVENT = "vendo:identity-changed";
+
+/** The one refusal that means "this visitor has no identity here". */
+export function isForbiddenError(reason: unknown): boolean {
+  return reason instanceof VendoError && reason.code === "forbidden";
+}
+
+export interface IdentityState {
+  forbidden(): boolean;
+  /** Record a failed wire read; only a forbidden refusal moves the latch. */
+  note(reason: unknown): void;
+  /** A successful wire read (or the page signal) — the latch opens. */
+  clear(): void;
+  subscribe(listener: () => void): () => void;
+}
+
+const states = new WeakMap<object, IdentityState>();
+
+export function identityState(client: object): IdentityState {
+  let state = states.get(client);
+  if (state === undefined) {
+    state = createState();
+    states.set(client, state);
+  }
+  return state;
+}
+
+function createState(): IdentityState {
+  let forbidden = false;
+  const listeners = new Set<() => void>();
+  const set = (next: boolean): void => {
+    if (forbidden === next) return;
+    forbidden = next;
+    for (const listener of [...listeners]) listener();
+  };
+  // One listener per state, alive as long as the client is — page-scoped, like
+  // the client itself. Guarded for SSR.
+  if (typeof window !== "undefined") {
+    window.addEventListener(IDENTITY_CHANGED_EVENT, () => set(false));
+  }
+  return {
+    forbidden: () => forbidden,
+    note: (reason) => {
+      if (isForbiddenError(reason)) set(true);
+    },
+    clear: () => set(false),
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+  };
+}

--- a/packages/ui/src/hooks/use-app.ts
+++ b/packages/ui/src/hooks/use-app.ts
@@ -8,6 +8,7 @@ import {
 import { effectiveAppBuildUiDeadlineMs } from "@vendoai/apps/contract";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useVendoProvider } from "../context.js";
+import { isForbiddenError } from "./identity-state.js";
 import type { EditResult, OpenSurface, VersionEntry } from "../wire-types.js";
 
 /** How many times a load may try before the error becomes the user's problem.
@@ -85,7 +86,10 @@ export function useApp(appId: AppId, { enabled = true }: AppOptions = {}): {
         return;
       } catch (reason) {
         if (!current()) return;
-        if (attempt >= LOAD_ATTEMPTS) {
+        // A forbidden refusal is terminal on the first answer (H2-E / #1372):
+        // the retry ladder exists for transient failures, and re-asking a wire
+        // that refused this visitor's identity burns the attempts for nothing.
+        if (isForbiddenError(reason) || attempt >= LOAD_ATTEMPTS) {
           setError(reason instanceof Error ? reason : new Error(String(reason)));
           setIsLoading(false);
           return;

--- a/packages/ui/src/hooks/use-placements.ts
+++ b/packages/ui/src/hooks/use-placements.ts
@@ -31,6 +31,7 @@ import type { VendoClient } from "../client.js";
 // hooks/use-vendo-context.ts, which publishes into the agent's [Situation]
 // channel and returns void.
 import { useVendoProvider } from "../context.js";
+import { identityState } from "./identity-state.js";
 import { onPinAnnounced } from "../pin-events.js";
 import type { PlacementEntry } from "../wire-types.js";
 
@@ -69,6 +70,11 @@ const pollers = new WeakMap<VendoClient, Poller>();
 function createPoller(client: VendoClient): Poller {
   const listeners = new Map<string, Set<() => void>>();
   const settles = new Set<ReturnType<typeof setTimeout>>();
+  // H2-E / #1372: while the wire says forbidden, the tick skips both the read
+  // AND renew's slot-report writes — a signed-out visitor generates zero
+  // traffic. The latch opening (identity signal, or any surface's successful
+  // read) re-reads immediately.
+  const identity = identityState(client);
   let entries = new Map<string, PlacementEntry>();
   let error: Error | undefined;
   let loaded = false;
@@ -76,6 +82,7 @@ function createPoller(client: VendoClient): Poller {
   let generation = 0;
   let timer: ReturnType<typeof setTimeout> | undefined;
   let stopPin: (() => void) | undefined;
+  let stopIdentity: (() => void) | undefined;
 
   /** Every (id, label) pair already sent to the registry, and WHEN — once per
    *  client per {@link SLOT_REPORT_REFRESH_MS}, so a page of slots re-rendering
@@ -114,10 +121,12 @@ function createPoller(client: VendoClient): Poller {
     try {
       const answered = await client.apps.placements(slots);
       if (mine !== generation) return;
+      identity.clear();
       entries = new Map(answered.map(item => [item.slot, item]));
       error = undefined;
     } catch (reason) {
       if (mine !== generation) return;
+      identity.note(reason);
       error = reason instanceof Error ? reason : new Error(String(reason));
     }
     loaded = true;
@@ -141,14 +150,19 @@ function createPoller(client: VendoClient): Poller {
   // Self-scheduling, never setInterval: the next tick is armed only once the
   // current read settles, so a slow wire cannot stack overlapping requests.
   const tick = async (): Promise<void> => {
-    renew();
-    await read();
+    if (!identity.forbidden()) {
+      renew();
+      await read();
+    }
     if (running) timer = setTimeout(() => void tick(), POLL_MS);
   };
 
   const start = (): void => {
     if (running) return;
     running = true;
+    stopIdentity = identity.subscribe(() => {
+      if (running && !identity.forbidden()) void read();
+    });
     stopPin = onPinAnnounced(() => {
       void read();
       const settle = setTimeout(() => {
@@ -171,6 +185,8 @@ function createPoller(client: VendoClient): Poller {
     timer = undefined;
     stopPin?.();
     stopPin = undefined;
+    stopIdentity?.();
+    stopIdentity = undefined;
     for (const settle of settles) clearTimeout(settle);
     settles.clear();
     generation += 1;

--- a/packages/ui/src/hooks/use-placements.ts
+++ b/packages/ui/src/hooks/use-placements.ts
@@ -149,25 +149,25 @@ function createPoller(client: VendoClient): Poller {
 
   /** Send everything queued, batched and capped. Latched-forbidden holds the
    *  queue in place — a microtask committed before the latch closed must not
-   *  slip a write out either. */
+   *  slip a write out either. The stamp is written HERE, at send time: an
+   *  entry that never went out carries no stamp, so nothing held can silence
+   *  its own slot's next mount (overflow needs no forget() for the same
+   *  reason — never stamped, reported by the next page that mounts it). */
   const flushReports = (): void => {
     flushing = false;
     if (identity.forbidden() || queued.length === 0) return;
     const batch = queued;
     queued = [];
     const sending = batch.slice(0, SLOTS_REPORT_MAX);
-    if (sending.length < batch.length) {
-      // Forgotten, not dropped: the overflow is reported by the next page
-      // that mounts it, once the slots already in the registry are quiet.
-      forget(batch.slice(SLOTS_REPORT_MAX));
-      if (developmentMode()) {
-        log({
-          code: "ui.slots-report-overflow",
-          level: "warn",
-          message: `[vendo] a page may report at most ${SLOTS_REPORT_MAX} slots at once — ${batch.length - sending.length} were held back for a later render.`,
-        });
-      }
+    if (sending.length < batch.length && developmentMode()) {
+      log({
+        code: "ui.slots-report-overflow",
+        level: "warn",
+        message: `[vendo] a page may report at most ${SLOTS_REPORT_MAX} slots at once — ${batch.length - sending.length} were held back for a later render.`,
+      });
     }
+    const now = Date.now();
+    for (const entry of sending) reported.set(keyOf(entry), now);
     void client.slots.report(sending).catch(() => forget(sending));
   };
 
@@ -273,10 +273,17 @@ function createPoller(client: VendoClient): Poller {
       // with ("sales", "report Q3") and the second slot never reaches the
       // registry — it is a destination the picker can never offer.
       const key = keyOf(entry);
+      // The stamp belongs to a report that actually went out (flushReports
+      // sets it at send time; the send-failure path forgets it for the same
+      // reason). Stamping at queue time stranded a HELD report: a slot that
+      // mounted latched, unmounted, and remounted after sign-in read its own
+      // stale stamp and stayed silent for the whole refresh window (greptile
+      // on #1442, round two). A held duplicate is deduped against the queue
+      // itself — and the flush still re-arms, so a remount is what finally
+      // sends a queue the torn-down identity subscription left behind.
       const at = reported.get(key);
       if (at !== undefined && Date.now() - at < SLOT_REPORT_REFRESH_MS) return;
-      reported.set(key, Date.now());
-      queued.push(entry);
+      if (!queued.some(item => keyOf(item) === key)) queued.push(entry);
       // While the wire refuses this visitor, the report is HELD in the queue,
       // never sent (greptile on #1442: a slot mounting AFTER the latch closed
       // still wrote POST /slots). The latch-open subscription flushes it.

--- a/packages/ui/src/hooks/use-placements.ts
+++ b/packages/ui/src/hooks/use-placements.ts
@@ -147,6 +147,24 @@ function createPoller(client: VendoClient): Poller {
     }
   };
 
+  /** The held queue's OWN wake, independent of the poller lifecycle (greptile
+   *  on #1442, round three): a useReportSlot-only mount never calls start(),
+   *  so no other subscription exists to flush what it held. Lazy — created
+   *  only when something is actually held — and self-disposing on the first
+   *  open transition, so a signed-in page carries no extra listener. It
+   *  deliberately survives stop(): it belongs to the queue, not to the
+   *  placement listeners (round two's stranding was scoping it wrong). */
+  let stopHeldFlush: (() => void) | undefined;
+  const ensureHeldFlush = (): void => {
+    if (stopHeldFlush !== undefined) return;
+    stopHeldFlush = identity.subscribe(() => {
+      if (identity.forbidden()) return;
+      stopHeldFlush?.();
+      stopHeldFlush = undefined;
+      flushReports();
+    });
+  };
+
   /** Send everything queued, batched and capped. Latched-forbidden holds the
    *  queue in place — a microtask committed before the latch closed must not
    *  slip a write out either. The stamp is written HERE, at send time: an
@@ -155,7 +173,11 @@ function createPoller(client: VendoClient): Poller {
    *  reason — never stamped, reported by the next page that mounts it). */
   const flushReports = (): void => {
     flushing = false;
-    if (identity.forbidden() || queued.length === 0) return;
+    if (identity.forbidden()) {
+      if (queued.length > 0) ensureHeldFlush();
+      return;
+    }
+    if (queued.length === 0) return;
     const batch = queued;
     queued = [];
     const sending = batch.slice(0, SLOTS_REPORT_MAX);
@@ -286,8 +308,12 @@ function createPoller(client: VendoClient): Poller {
       if (!queued.some(item => keyOf(item) === key)) queued.push(entry);
       // While the wire refuses this visitor, the report is HELD in the queue,
       // never sent (greptile on #1442: a slot mounting AFTER the latch closed
-      // still wrote POST /slots). The latch-open subscription flushes it.
-      if (identity.forbidden()) return;
+      // still wrote POST /slots). The queue's own wake flushes it on sign-in,
+      // whether or not any placements listener ever started the poller.
+      if (identity.forbidden()) {
+        ensureHeldFlush();
+        return;
+      }
       if (flushing) return;
       flushing = true;
       // The same deferral the first placements read uses: every slot mounting in

--- a/packages/ui/src/hooks/use-placements.ts
+++ b/packages/ui/src/hooks/use-placements.ts
@@ -147,6 +147,30 @@ function createPoller(client: VendoClient): Poller {
     }
   };
 
+  /** Send everything queued, batched and capped. Latched-forbidden holds the
+   *  queue in place — a microtask committed before the latch closed must not
+   *  slip a write out either. */
+  const flushReports = (): void => {
+    flushing = false;
+    if (identity.forbidden() || queued.length === 0) return;
+    const batch = queued;
+    queued = [];
+    const sending = batch.slice(0, SLOTS_REPORT_MAX);
+    if (sending.length < batch.length) {
+      // Forgotten, not dropped: the overflow is reported by the next page
+      // that mounts it, once the slots already in the registry are quiet.
+      forget(batch.slice(SLOTS_REPORT_MAX));
+      if (developmentMode()) {
+        log({
+          code: "ui.slots-report-overflow",
+          level: "warn",
+          message: `[vendo] a page may report at most ${SLOTS_REPORT_MAX} slots at once — ${batch.length - sending.length} were held back for a later render.`,
+        });
+      }
+    }
+    void client.slots.report(sending).catch(() => forget(sending));
+  };
+
   // Self-scheduling, never setInterval: the next tick is armed only once the
   // current read settles, so a slow wire cannot stack overlapping requests.
   const tick = async (): Promise<void> => {
@@ -161,7 +185,10 @@ function createPoller(client: VendoClient): Poller {
     if (running) return;
     running = true;
     stopIdentity = identity.subscribe(() => {
-      if (running && !identity.forbidden()) void read();
+      if (running && !identity.forbidden()) {
+        void read();
+        flushReports();
+      }
     });
     stopPin = onPinAnnounced(() => {
       void read();
@@ -250,29 +277,15 @@ function createPoller(client: VendoClient): Poller {
       if (at !== undefined && Date.now() - at < SLOT_REPORT_REFRESH_MS) return;
       reported.set(key, Date.now());
       queued.push(entry);
+      // While the wire refuses this visitor, the report is HELD in the queue,
+      // never sent (greptile on #1442: a slot mounting AFTER the latch closed
+      // still wrote POST /slots). The latch-open subscription flushes it.
+      if (identity.forbidden()) return;
       if (flushing) return;
       flushing = true;
       // The same deferral the first placements read uses: every slot mounting in
       // one React commit lands in ONE POST instead of one request per slot.
-      queueMicrotask(() => {
-        flushing = false;
-        const batch = queued;
-        queued = [];
-        const sending = batch.slice(0, SLOTS_REPORT_MAX);
-        if (sending.length < batch.length) {
-          // Forgotten, not dropped: the overflow is reported by the next page
-          // that mounts it, once the slots already in the registry are quiet.
-          forget(batch.slice(SLOTS_REPORT_MAX));
-          if (developmentMode()) {
-            log({
-              code: "ui.slots-report-overflow",
-              level: "warn",
-              message: `[vendo] a page may report at most ${SLOTS_REPORT_MAX} slots at once — ${batch.length - sending.length} were held back for a later render.`,
-            });
-          }
-        }
-        void client.slots.report(sending).catch(() => forget(sending));
-      });
+      queueMicrotask(flushReports);
     },
   };
 

--- a/packages/ui/src/hooks/use-resource.ts
+++ b/packages/ui/src/hooks/use-resource.ts
@@ -7,6 +7,7 @@
  * a remount, so a newly-pending approval (or thread, run, …) appears on its own.
  */
 import { useCallback, useEffect, useRef, useState } from "react";
+import { IDENTITY_CHANGED_EVENT, isForbiddenError } from "./identity-state.js";
 
 /** Opt-in polling knob accepted by every collection hook. */
 export interface PollOptions {
@@ -45,6 +46,12 @@ export function useResource<T>(fetcher: () => Promise<T>, initial: T, { pollMs }
   const [isLoading, setIsLoading] = useState(true);
   const generationRef = useRef(0);
   const loadedRef = useRef(false);
+  // H2-E / #1372 — a forbidden refusal is a full stop for the POLL, not a
+  // transient to retry: on a preset-authed deployment a signed-out visitor's
+  // every read correctly 403s, and re-asking on a cadence cannot change the
+  // answer. Manual refresh() still works (an explicit call is its own signal),
+  // a success clears the latch, and the page's identity event wakes the poll.
+  const forbiddenRef = useRef(false);
 
   const refresh = useCallback(async () => {
     const generation = (generationRef.current += 1);
@@ -52,11 +59,13 @@ export function useResource<T>(fetcher: () => Promise<T>, initial: T, { pollMs }
     try {
       const next = await fetcher();
       if (generation !== generationRef.current) return;
+      forbiddenRef.current = false;
       setData(next);
       setError(undefined);
       loadedRef.current = true;
     } catch (reason) {
       if (generation !== generationRef.current) return;
+      if (isForbiddenError(reason)) forbiddenRef.current = true;
       setError(asError(reason));
     } finally {
       if (generation === generationRef.current) setIsLoading(false);
@@ -85,18 +94,27 @@ export function useResource<T>(fetcher: () => Promise<T>, initial: T, { pollMs }
     let cancelled = false;
     let timer: ReturnType<typeof setTimeout>;
     const tick = async () => {
-      if (!hidden()) await refresh();
+      // Forbidden skips the fetch, not the cadence — no restart machinery, and
+      // zero requests while latched (the field failure was endless 403 spam).
+      if (!hidden() && !forbiddenRef.current) await refresh();
       if (!cancelled) timer = setTimeout(() => void tick(), pollMs);
     };
     timer = setTimeout(() => void tick(), pollMs);
     const onVisible = () => {
-      if (!hidden() && !cancelled) void refresh();
+      // A tab switch is not a sign-in: the latch holds through it.
+      if (!hidden() && !cancelled && !forbiddenRef.current) void refresh();
+    };
+    const onIdentity = () => {
+      forbiddenRef.current = false;
+      if (!cancelled) void refresh();
     };
     if (typeof document !== "undefined") document.addEventListener("visibilitychange", onVisible);
+    if (typeof window !== "undefined") window.addEventListener(IDENTITY_CHANGED_EVENT, onIdentity);
     return () => {
       cancelled = true;
       clearTimeout(timer);
       if (typeof document !== "undefined") document.removeEventListener("visibilitychange", onVisible);
+      if (typeof window !== "undefined") window.removeEventListener(IDENTITY_CHANGED_EVENT, onIdentity);
     };
   }, [pollMs, refresh]);
 

--- a/packages/ui/src/tree/parked-approvals.ts
+++ b/packages/ui/src/tree/parked-approvals.ts
@@ -16,6 +16,7 @@
 import { useEffect, useRef } from "react";
 import { APPROVALS_DECIDED_EVENT, type ApprovalsDecidedDetail } from "../client-impl.js";
 import { useVendoClientOrNone } from "../context.js";
+import { identityState } from "../hooks/identity-state.js";
 import type { ApprovalResolution } from "../wire-types.js";
 
 /** Slower than the approvals feed on purpose: this is the backstop for a
@@ -41,6 +42,7 @@ export function useParkedApprovals(
 
   useEffect(() => {
     if (client === undefined || outstanding === "") return undefined;
+    const identity = identityState(client);
     let live = true;
     let timer: ReturnType<typeof setTimeout> | undefined;
     const settle = async (only?: ReadonlySet<string>): Promise<void> => {
@@ -50,7 +52,12 @@ export function useParkedApprovals(
         // resumed call INSIDE the decision, so a read landing in that window
         // finds neither a pending ask nor an outcome yet. The next pass asks
         // again and the pending notice stands meanwhile — today's behavior.
-        const resolution = await client.approvals.get(approvalId).catch(() => undefined);
+        // The one exception is a forbidden refusal, which feeds the page-wide
+        // latch (H2-E) so this backstop goes quiet with everything else.
+        const resolution = await client.approvals.get(approvalId).catch((reason: unknown) => {
+          identity.note(reason);
+          return undefined;
+        });
         if (!live) return;
         if (resolution !== undefined && resolution.state !== "pending") {
           latest.current.onResolved(nodeId, resolution);
@@ -58,9 +65,10 @@ export function useParkedApprovals(
       }
     };
     const poll = async (): Promise<void> => {
-      // A background tab asks nothing (the approvals feed's rule); the first
-      // tick after the person comes back picks the answer up.
-      if (!hidden()) await settle();
+      // A background tab asks nothing (the approvals feed's rule), and a
+      // latched-forbidden page asks nothing either; the cadence keeps ticking
+      // so the first tick after either lifts picks the answer up.
+      if (!hidden() && !identity.forbidden()) await settle();
       if (live) timer = setTimeout(() => void poll(), POLL_MS);
     };
     const onDecided = (event: Event): void => {

--- a/packages/ui/test/approvals-feed.test.tsx
+++ b/packages/ui/test/approvals-feed.test.tsx
@@ -134,6 +134,48 @@ describe("the shared approvals feed", () => {
     view.unmount();
   });
 
+  // H2-E / #1372: a signed-out visitor's feed must go quiet after the first
+  // forbidden refusal — the field failure was every poller retrying a 403
+  // forever — and wake on the page's identity signal.
+  it("stops entirely on a forbidden refusal, and wakes on the identity signal", async () => {
+    for (let i = 0; i < 8; i += 1) {
+      wire.state.failures.push({
+        method: "GET",
+        path: "/approvals",
+        code: "forbidden",
+        message: "no identity for this request",
+        status: 403,
+      });
+    }
+    const view = render(
+      <VendoProvider client={client}>
+        <Surface pollMs={CADENCE_MS} />
+      </VendoProvider>,
+    );
+    // The first refusal lands…
+    await waitFor(() => expect(polls()).toBe(1));
+    // …and then a full window of silence: a live poller could not stay quiet
+    // for ten cadences (the unmount test's own bound).
+    await settle(WINDOW_MS);
+    expect(polls()).toBe(1);
+    // A tab switch is not a sign-in.
+    document.dispatchEvent(new Event("visibilitychange"));
+    await settle(WINDOW_MS);
+    expect(polls()).toBe(1);
+    // The host announces a sign-in: exactly one immediate re-read, and because
+    // the queue still holds refusals it latches again rather than resuming.
+    window.dispatchEvent(new Event("vendo:identity-changed"));
+    await waitFor(() => expect(polls()).toBe(2));
+    await settle(WINDOW_MS);
+    expect(polls()).toBe(2);
+    // A second signal against a wire that now answers: the feed resumes fully.
+    wire.state.failures.length = 0;
+    window.dispatchEvent(new Event("vendo:identity-changed"));
+    await waitFor(() => expect(view.getByTestId("count").textContent).toBe("1"));
+    await waitFor(() => expect(polls()).toBeGreaterThan(3));
+    view.unmount();
+  });
+
   it("one decision clears every surface, with no extra fetch per surface", async () => {
     const view = render(
       <VendoProvider client={client}>

--- a/packages/ui/test/chrome/slot-report.test.tsx
+++ b/packages/ui/test/chrome/slot-report.test.tsx
@@ -72,6 +72,31 @@ describe("a mounted VendoSlot reports itself to the registry", () => {
     expect(reports()).toHaveLength(1);
   });
 
+  // Greptile round two on #1442: a held report must survive the poller's full
+  // teardown. Mount-while-forbidden, unmount (stop() tears the identity
+  // subscription), sign in with nothing mounted, then remount inside the
+  // refresh window — the stamp-at-queue-time design left the slot silenced
+  // for the whole window; stamping at SEND time means the remount re-arms
+  // the flush and the report finally lands.
+  it("a report held through unmount and sign-in still lands when the slot remounts", async () => {
+    const { identityState } = await import("../../src/hooks/identity-state.js");
+    const { VendoError } = await import("@vendoai/core");
+    identityState(client).note(new VendoError("forbidden", "no identity for this request"));
+    const first = render(<VendoProvider client={client}><VendoSlot id="net-worth-card" /></VendoProvider>);
+    await new Promise(resolve => setTimeout(resolve, 100));
+    expect(reports()).toHaveLength(0);
+    // The last listener unmounts: stop() runs, the identity subscription dies.
+    first.unmount();
+    // Sign-in lands while nothing is mounted — nothing to flush yet, no crash.
+    window.dispatchEvent(new Event("vendo:identity-changed"));
+    await new Promise(resolve => setTimeout(resolve, 100));
+    expect(reports()).toHaveLength(0);
+    // The same slot remounts well inside SLOT_REPORT_REFRESH_MS: the report
+    // must land now, not after the refresh window.
+    render(<VendoProvider client={client}><VendoSlot id="net-worth-card" /></VendoProvider>);
+    await waitFor(() => expect(wire.state.slots.map(slot => slot.label)).toEqual(["Net worth card"]));
+  });
+
   it("sends a whole page of slots as ONE report", async () => {
     render(
       <VendoProvider client={client}>

--- a/packages/ui/test/chrome/slot-report.test.tsx
+++ b/packages/ui/test/chrome/slot-report.test.tsx
@@ -55,6 +55,23 @@ describe("a mounted VendoSlot reports itself to the registry", () => {
     await waitFor(() => expect(wire.state.slots.map(slot => slot.label)).toEqual(["Insights"]));
   });
 
+  // Greptile on #1442: the tick's renew() was gated, but a slot that MOUNTS
+  // after the latch closed still flushed its own POST /slots. Held, not lost:
+  // the report goes out the moment the identity signal opens the latch.
+  it("holds a late-mounting slot's report while forbidden, and sends it on the identity signal", async () => {
+    const { identityState } = await import("../../src/hooks/identity-state.js");
+    const { VendoError } = await import("@vendoai/core");
+    identityState(client).note(new VendoError("forbidden", "no identity for this request"));
+    render(<VendoProvider client={client}><VendoSlot id="net-worth-card" /></VendoProvider>);
+    // A full settle window: no report write, and no placements read either.
+    await new Promise(resolve => setTimeout(resolve, 150));
+    expect(reports()).toHaveLength(0);
+    // Sign-in announced: the held report goes out, once.
+    window.dispatchEvent(new Event("vendo:identity-changed"));
+    await waitFor(() => expect(wire.state.slots.map(slot => slot.label)).toEqual(["Net worth card"]));
+    expect(reports()).toHaveLength(1);
+  });
+
   it("sends a whole page of slots as ONE report", async () => {
     render(
       <VendoProvider client={client}>

--- a/packages/ui/test/chrome/slot-report.test.tsx
+++ b/packages/ui/test/chrome/slot-report.test.tsx
@@ -72,29 +72,50 @@ describe("a mounted VendoSlot reports itself to the registry", () => {
     expect(reports()).toHaveLength(1);
   });
 
-  // Greptile round two on #1442: a held report must survive the poller's full
-  // teardown. Mount-while-forbidden, unmount (stop() tears the identity
-  // subscription), sign in with nothing mounted, then remount inside the
-  // refresh window — the stamp-at-queue-time design left the slot silenced
-  // for the whole window; stamping at SEND time means the remount re-arms
-  // the flush and the report finally lands.
-  it("a report held through unmount and sign-in still lands when the slot remounts", async () => {
+  // Greptile rounds two + three on #1442: a held report must survive the
+  // poller's full teardown. The queue carries its OWN wake (independent of
+  // placement listeners, surviving stop()), so the report lands at sign-in
+  // even with nothing mounted — and the send-time stamp means the remount
+  // that follows sends no duplicate.
+  it("a report held through unmount lands at sign-in, and the remount sends no duplicate", async () => {
     const { identityState } = await import("../../src/hooks/identity-state.js");
     const { VendoError } = await import("@vendoai/core");
     identityState(client).note(new VendoError("forbidden", "no identity for this request"));
     const first = render(<VendoProvider client={client}><VendoSlot id="net-worth-card" /></VendoProvider>);
     await new Promise(resolve => setTimeout(resolve, 100));
     expect(reports()).toHaveLength(0);
-    // The last listener unmounts: stop() runs, the identity subscription dies.
+    // The last listener unmounts: stop() runs; the queue's wake survives it.
     first.unmount();
-    // Sign-in lands while nothing is mounted — nothing to flush yet, no crash.
+    // Sign-in lands while nothing is mounted: the held report goes out NOW.
     window.dispatchEvent(new Event("vendo:identity-changed"));
+    await waitFor(() => expect(wire.state.slots.map(slot => slot.label)).toEqual(["Net worth card"]));
+    expect(reports()).toHaveLength(1);
+    // The same slot remounts inside SLOT_REPORT_REFRESH_MS: stamped at send
+    // time, so the remount adds nothing.
+    render(<VendoProvider client={client}><VendoSlot id="net-worth-card" /></VendoProvider>);
+    await new Promise(resolve => setTimeout(resolve, 150));
+    expect(reports()).toHaveLength(1);
+  });
+
+  // Greptile round three on #1442: a useReportSlot-ONLY mount never starts the
+  // placements poller, so no identity subscription exists to flush its held
+  // report — the queue needs its own wake, independent of the poller lifecycle.
+  it("a report-only slot held while forbidden lands on the identity signal", async () => {
+    const { identityState } = await import("../../src/hooks/identity-state.js");
+    const { useReportSlot } = await import("../../src/hooks/use-placements.js");
+    const { VendoError } = await import("@vendoai/core");
+    identityState(client).note(new VendoError("forbidden", "no identity for this request"));
+    function ReportOnly() {
+      useReportSlot("net-worth-card", "Net worth card", true);
+      return null;
+    }
+    render(<VendoProvider client={client}><ReportOnly /></VendoProvider>);
     await new Promise(resolve => setTimeout(resolve, 100));
     expect(reports()).toHaveLength(0);
-    // The same slot remounts well inside SLOT_REPORT_REFRESH_MS: the report
-    // must land now, not after the refresh window.
-    render(<VendoProvider client={client}><VendoSlot id="net-worth-card" /></VendoProvider>);
+    // Sign-in: the held report goes out with no placements listener anywhere.
+    window.dispatchEvent(new Event("vendo:identity-changed"));
     await waitFor(() => expect(wire.state.slots.map(slot => slot.label)).toEqual(["Net worth card"]));
+    expect(reports()).toHaveLength(1);
   });
 
   it("sends a whole page of slots as ONE report", async () => {

--- a/packages/ui/test/use-resource-forbidden.test.tsx
+++ b/packages/ui/test/use-resource-forbidden.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+/**
+ * H2-E / #1372 — a forbidden refusal is a full stop for the poll, not a
+ * transient to retry. On a preset-authed deployment every wire read for a
+ * signed-out visitor correctly 403s; the chrome's job is to stop asking, hold
+ * quiet through tab switches, and wake on the page's identity signal.
+ */
+import { VendoError } from "@vendoai/core";
+import { render, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup } from "@testing-library/react";
+import { IDENTITY_CHANGED_EVENT } from "../src/hooks/identity-state.js";
+import { useResource } from "../src/hooks/use-resource.js";
+
+const CADENCE_MS = 20;
+const WINDOW_MS = 200;
+const settle = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+function Probe({ fetcher }: { fetcher: () => Promise<string> }) {
+  const { error } = useResource(fetcher, "", { pollMs: CADENCE_MS });
+  return <span data-testid="err">{error?.message ?? ""}</span>;
+}
+
+afterEach(cleanup);
+
+describe("useResource under a forbidden wire", () => {
+  it("stops polling after the first forbidden refusal, and a tab switch does not resurrect it", async () => {
+    let calls = 0;
+    const fetcher = async (): Promise<string> => {
+      calls += 1;
+      throw new VendoError("forbidden", "no identity for this request");
+    };
+    const view = render(<Probe fetcher={fetcher} />);
+    await waitFor(() => expect(view.getByTestId("err").textContent).toContain("no identity"));
+    // One refusal is the whole story: a full window of cadences passes with no
+    // second ask (the field failure was endless 403 retries).
+    const after = calls;
+    await settle(WINDOW_MS);
+    expect(calls).toBe(after);
+    // A tab switch is not a sign-in.
+    document.dispatchEvent(new Event("visibilitychange"));
+    await settle(WINDOW_MS);
+    expect(calls).toBe(after);
+  });
+
+  it("any other failure keeps the cadence — forbidden is the only full stop", async () => {
+    let calls = 0;
+    const fetcher = async (): Promise<string> => {
+      calls += 1;
+      throw new Error("upstream 500");
+    };
+    render(<Probe fetcher={fetcher} />);
+    await settle(WINDOW_MS);
+    expect(calls).toBeGreaterThan(2);
+  });
+
+  it("wakes on the page's identity signal and heals on the first success", async () => {
+    let signedIn = false;
+    let calls = 0;
+    const fetcher = async (): Promise<string> => {
+      calls += 1;
+      if (!signedIn) throw new VendoError("forbidden", "no identity for this request");
+      return "rows";
+    };
+    const view = render(<Probe fetcher={fetcher} />);
+    await waitFor(() => expect(view.getByTestId("err").textContent).toContain("no identity"));
+    const latched = calls;
+    await settle(WINDOW_MS);
+    expect(calls).toBe(latched);
+    // The host announces a sign-in; the poll re-reads immediately and resumes.
+    signedIn = true;
+    window.dispatchEvent(new Event(IDENTITY_CHANGED_EVENT));
+    await waitFor(() => expect(view.getByTestId("err").textContent).toBe(""));
+    await settle(WINDOW_MS);
+    expect(calls).toBeGreaterThan(latched + 1);
+  });
+});


### PR DESCRIPTION
## What

The first half of lane 4 of the host-#2 fix pack (H2-E, #1372, Linear ENG-424): **a signed-out visitor's chrome stops asking.** Field case (expense.fyi, supabase preset): an anonymous visitor gets the full overlay, every wire call correctly 403s under the identity doctrine - and the chrome handles it as an error storm: every poller retries forever, the console fills with 403s, and the app-open retry ladder burns all its attempts on an answer that cannot change.

## How

A forbidden refusal is now a full stop, not a transient:

- **One internal per-client latch** (`hooks/identity-state.ts`, not exported - the HistoryPicker precedent): any wire failure with the typed `VendoError` code `forbidden` closes it (the CODE, never the HTTP status - `blocked` rides 403 too), any successful read opens it, and the page signal `vendo:identity-changed` (the `vendo:approvals-decided` naming precedent) opens it for SPA sign-ins. Full-page redirects remount everything anyway.
- **Gated pollers**: the approvals feed (arm + visibility return), the slot placements poller (read AND its renew report writes - an anonymous visitor generated write traffic too), the parked-press backstop (which swallows its own errors, so it reads the shared latch), and `useResource` - which has no client, so it latches itself with the same predicate and event; this covers all eight collection hooks at once. Tab switches hold every latch: a visibilitychange is not a sign-in.
- **`useApp`**: forbidden short-circuits the 3-attempt retry ladder to terminal on the first answer.
- **Docs**: the auth page's new "Signed-out visitors" section names the event and when to dispatch it.

## Tests

TDD with a stash-proof red baseline: the three new gate tests (resource stop + no-resurrect-on-tab-switch, resource wake-and-heal, feed stop-and-wake) all fail on pristine src and pass with the gates; the control ("any other failure keeps the cadence") passes both ways. The feed's pre-existing contracts ("stops entirely when the last surface unmounts", "pauses while hidden") still hold. Collateral suites green: hooks, app-load-retry, parked-approval-resolution, embeds - 66/66. Typecheck clean.

**Not visual**: no rendered output changes in this half - no screenshots owed. The visible half (the launcher opening to a quiet "Sign in to use the agent" panel instead of a broken-looking thread) follows as its own PR with real-browser screenshots, riding this latch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)