### PR TITLE
feat(ui): the overlay answers a signed-out visitor with one quiet line (#1372)

### DIFF
--- a/.changeset/the-panel-says-sign-in.md
+++ b/.changeset/the-panel-says-sign-in.md
@@ -1,0 +1,12 @@
+---
+"@vendoai/ui": patch
+---
+
+A signed-out visitor sees a quiet panel, not a broken agent. When the wire
+refuses a visitor for missing identity, the overlay's launcher still renders —
+nothing about wire health hides it — but opening it now shows one
+host-brandable line ("Sign in to use the agent.", or the new `signedOutNotice`
+overlay prop) instead of a conversation that can only error. The server's
+developer-facing resolver message never reaches the surface, and the
+conversation returns on `vendo:identity-changed` or the first successful wire
+read. Completes the signed-out state the poller latch started.

--- a/packages/ui/e2e/harness/main.tsx
+++ b/packages/ui/e2e/harness/main.tsx
@@ -1971,8 +1971,29 @@ function scenario(pathname: string): { title: string; theme?: Partial<VendoTheme
     case "/affordances": return { title: "Affordances (Maple) — copy, attach, connect dock", content: <AffordancesScenario theme={mapleTheme} />, ownProvider: true };
     case "/affordances-dark": return { title: "Affordances — dark", content: <AffordancesScenario theme={darkTheme} />, ownProvider: true };
     case "/toasts": return { title: "Toasts", content: <ToastsScenario />, ownProvider: true };
+    case "/signed-out": return { title: "Overlay — signed out (H2-E)", content: <SignedOutScenario />, ownProvider: true };
     default: return { title: "Unknown scenario", content: <p role="alert">Unknown browser scenario: {pathname}</p> };
   }
+}
+
+/** H2-E — the overlay for a visitor the wire refuses: its OWN client (the
+ *  latch is per client; the other scenarios' clients stay signed in) whose
+ *  every read the wire answers 403 via the force header, so the latch trips
+ *  through the REAL path — the warm call or the badge poll, whichever lands
+ *  first — and the panel opens to the signed-out line. */
+const signedOutClient = createVendoClient({
+  baseUrl: "/api/vendo",
+  headers: { "x-vendo-force-forbidden": "1" },
+});
+
+function SignedOutScenario() {
+  return (
+    <VendoProvider client={signedOutClient} theme={mapleTheme}>
+      <AutoOpen selector='button[aria-controls="vendo-overlay-dialog"]'>
+        <VendoOverlay />
+      </AutoOpen>
+    </VendoProvider>
+  );
 }
 
 function Harness() {

--- a/packages/ui/e2e/helpers.ts
+++ b/packages/ui/e2e/helpers.ts
@@ -1,6 +1,10 @@
 import { expect, type Page } from "@playwright/test";
+import { fileURLToPath } from "node:url";
 
-export const screenshotPath = (name: string) => new URL(`./screenshots/${name}.png`, import.meta.url).pathname;
+// fileURLToPath, not URL#pathname: pathname renders a Windows file URL as
+// "/C:/…", which the fs then reads as "C:\C:\…" — every capture on a Windows
+// machine failed at the write, after the page had already proven ready.
+export const screenshotPath = (name: string) => fileURLToPath(new URL(`./screenshots/${name}.png`, import.meta.url));
 
 /**
  * Hold one real wire request open, and hand back its release. Nothing about the

--- a/packages/ui/e2e/screenshots.spec.ts
+++ b/packages/ui/e2e/screenshots.spec.ts
@@ -13,6 +13,7 @@ const shots = [
   { scenario: "tree", file: "tree", ready: '[data-dangling-node="not-yet-streamed"]' },
   { scenario: "tree-themed", file: "tree-themed", ready: '[data-vendo-node-id="host"]' },
   { scenario: "appframe", file: "appframe", ready: 'section[aria-label="HTTP app frame same-origin"] iframe' },
+  { scenario: "signed-out", file: "signed-out", ready: ".fl-signedout" },
 ] as const;
 
 for (const shot of shots) {

--- a/packages/ui/src/chrome/chrome-css.ts
+++ b/packages/ui/src/chrome/chrome-css.ts
@@ -970,6 +970,10 @@ export const CHROME_CSS = ONEST_FONT_CSS + `/* @vendoai/ui chrome — the S1 des
   transition: opacity .28s ease .1s, border-right-width 0s .45s; }
 .fl-split-rail { flex: 0 0 100%; min-width: 0; display: flex; flex-direction: column;
   transition: flex-basis .45s cubic-bezier(.22, 1, .36, 1), filter .22s ease; }
+/* The signed-out panel (H2-E): one centered quiet line where the thread would
+   be — same ground, no chrome, nothing that looks broken. */
+.fl-signedout { flex: 1; display: flex; align-items: center; justify-content: center; padding: 24px; }
+.fl-signedout-line { margin: 0; font-size: 15px; color: var(--vendo-muted-foreground, #6b7280); text-align: center; }
 .fl-overlay-panel[data-vendo-expanded] { width: min(1500px, 96vw); height: min(940px, 94vh); }
 .fl-overlay-panel[data-vendo-expanded] .fl-split-rail { flex-basis: max(360px, 33.5%); }
 .fl-overlay-panel[data-vendo-expanded] .fl-split-stage { opacity: 1; border-right-width: 1px;

--- a/packages/ui/src/chrome/vendo-overlay.tsx
+++ b/packages/ui/src/chrome/vendo-overlay.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useReducer, useRef, useState, useSyncE
 import { createPortal } from "react-dom";
 import { useVendoProvider, useVendoDiscoverability, useVendoTheme } from "../context.js";
 import { useMobileTakeover } from "../hooks/use-mobile-takeover.js";
+import { useSignedOut } from "../hooks/identity-state.js";
 import { themeCssVariables } from "../theme.js";
 import { PayloadView } from "../tree/renderer.js";
 import { useApprovalModal } from "./approval-modal.js";
@@ -113,6 +114,16 @@ export interface VendoOverlayProps {
   /** Docked panel width in CSS px (default 420) — also the amount the host
    *  page reflows by, so the two can never disagree. */
   dockWidth?: number;
+  /**
+   * The one line the panel shows a visitor the wire refused for missing
+   * identity (H2-E / #1372) — host-brandable, defaulting to
+   * "Sign in to use the agent." The launcher still renders (nothing about
+   * wire health hides it); only the panel content changes, and the server's
+   * developer-facing resolver message never reaches this surface. The panel
+   * returns to the conversation on `vendo:identity-changed` or the first
+   * successful wire read.
+   */
+  signedOutNotice?: string;
 }
 
 /** Whisper caption duration — long enough to read two short lines, short
@@ -583,6 +594,19 @@ function WorkspaceToggle({ hidden, expanded, suggest, onToggle }: {
   );
 }
 
+/** The panel's whole answer to a visitor the wire refused for missing
+ *  identity: one quiet, host-brandable line (never the server's
+ *  developer-facing resolver paragraph — consumer voice law; the
+ *  `connectRefusalCopy` precedent). Internal like HistoryPicker: the notice
+ *  is the overlay's plumbing, not API. */
+function SignedOutNotice({ notice }: { notice?: string | undefined }) {
+  return (
+    <div className="fl-signedout" role="status">
+      <p className="fl-signedout-line">{notice ?? "Sign in to use the agent."}</p>
+    </div>
+  );
+}
+
 /** 08-ui §4 — floating modal launcher with focus containment and restoration.
  *  Supported entry API (ENG-220): positioned launcher by default, controlled +
  *  uncontrolled programmatic open/close, panel portaled to document.body with
@@ -598,6 +622,7 @@ export function VendoOverlay({
   greeting,
   placement = "center",
   dockWidth = 420,
+  signedOutNotice,
 }: VendoOverlayProps = {}) {
   const controlled = openProp !== undefined;
   const [uncontrolledOpen, setUncontrolledOpen] = useState(defaultOpen);
@@ -617,6 +642,11 @@ export function VendoOverlay({
   const { resumeThreadId, setResumeThreadId, historyOpen, setHistoryOpen, forgetForFreshStart } =
     useRememberedConversation(conversationKey);
   const theme = useVendoTheme();
+  const { client } = useVendoProvider();
+  // H2-E / #1372 — the wire refused this visitor for missing identity. The
+  // launcher stays (nothing about wire health hides it); the PANEL answers
+  // with one quiet line instead of a conversation that can only error.
+  const signedOut = useSignedOut(client);
   const takeover = useMobileTakeover();
   const { docked, dockedOpen } = dockPosture(placement, takeover.active, open);
   const pin = usePinAction();
@@ -1072,15 +1102,19 @@ export function VendoOverlay({
               }}
             />
             <div className="fl-split-rail" key="rail">
-              <PrefillScopeContext.Provider value={prefillScope.current}>
-                <Thread
-                  key={`${conversationKey ?? 0}:${conversationEpoch}:${resumeThreadId ?? "new"}`}
-                  {...resumeThreadProps(resumeThreadId)}
-                  discoverability={dial}
-                  firstRunGreeting={greeting}
-                  onThreadId={adoptThreadId}
-                />
-              </PrefillScopeContext.Provider>
+              {signedOut ? (
+                <SignedOutNotice notice={signedOutNotice} />
+              ) : (
+                <PrefillScopeContext.Provider value={prefillScope.current}>
+                  <Thread
+                    key={`${conversationKey ?? 0}:${conversationEpoch}:${resumeThreadId ?? "new"}`}
+                    {...resumeThreadProps(resumeThreadId)}
+                    discoverability={dial}
+                    firstRunGreeting={greeting}
+                    onThreadId={adoptThreadId}
+                  />
+                </PrefillScopeContext.Provider>
+              )}
             </div>
           </div>
         </SplitViewContext.Provider>

--- a/packages/ui/src/chrome/vendo-overlay.tsx
+++ b/packages/ui/src/chrome/vendo-overlay.tsx
@@ -1,5 +1,5 @@
 import type { UIPayload } from "@vendoai/core";
-import { useCallback, useEffect, useMemo, useReducer, useRef, useState, useSyncExternalStore, type ComponentType, type CSSProperties, type KeyboardEvent, type ReactNode } from "react";
+import { useCallback, useEffect, useMemo, useReducer, useRef, useState, useSyncExternalStore, type ComponentProps, type ComponentType, type CSSProperties, type KeyboardEvent, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { useVendoProvider, useVendoDiscoverability, useVendoTheme } from "../context.js";
 import { useMobileTakeover } from "../hooks/use-mobile-takeover.js";
@@ -607,6 +607,20 @@ function SignedOutNotice({ notice }: { notice?: string | undefined }) {
   );
 }
 
+/** The rail's one branch, outside the shell function on purpose: VendoOverlay
+ *  sits at the lint complexity ceiling, and where the conversation yields to
+ *  the signed-out line is its own small decision. The thread element is built
+ *  by the caller either way — it only MOUNTS when the visitor is signed in. */
+function RailBody({ signedOut, notice, prefillScope, children }: {
+  signedOut: boolean;
+  notice?: string | undefined;
+  prefillScope: ComponentProps<typeof PrefillScopeContext.Provider>["value"];
+  children: ReactNode;
+}) {
+  if (signedOut) return <SignedOutNotice notice={notice} />;
+  return <PrefillScopeContext.Provider value={prefillScope}>{children}</PrefillScopeContext.Provider>;
+}
+
 /** 08-ui §4 — floating modal launcher with focus containment and restoration.
  *  Supported entry API (ENG-220): positioned launcher by default, controlled +
  *  uncontrolled programmatic open/close, panel portaled to document.body with
@@ -1102,19 +1116,15 @@ export function VendoOverlay({
               }}
             />
             <div className="fl-split-rail" key="rail">
-              {signedOut ? (
-                <SignedOutNotice notice={signedOutNotice} />
-              ) : (
-                <PrefillScopeContext.Provider value={prefillScope.current}>
-                  <Thread
-                    key={`${conversationKey ?? 0}:${conversationEpoch}:${resumeThreadId ?? "new"}`}
-                    {...resumeThreadProps(resumeThreadId)}
-                    discoverability={dial}
-                    firstRunGreeting={greeting}
-                    onThreadId={adoptThreadId}
-                  />
-                </PrefillScopeContext.Provider>
-              )}
+              <RailBody signedOut={signedOut} notice={signedOutNotice} prefillScope={prefillScope.current}>
+                <Thread
+                  key={`${conversationKey ?? 0}:${conversationEpoch}:${resumeThreadId ?? "new"}`}
+                  {...resumeThreadProps(resumeThreadId)}
+                  discoverability={dial}
+                  firstRunGreeting={greeting}
+                  onThreadId={adoptThreadId}
+                />
+              </RailBody>
             </div>
           </div>
         </SplitViewContext.Provider>

--- a/packages/ui/src/hooks/identity-state.ts
+++ b/packages/ui/src/hooks/identity-state.ts
@@ -17,6 +17,7 @@
  * exactly as long as their client does.
  */
 import { VendoError } from "@vendoai/core";
+import { useSyncExternalStore } from "react";
 
 /** The page signal: the host announces "who is signed in changed" (sign-in,
  *  sign-out, workspace switch). Every gated poller re-checks on it. */
@@ -45,6 +46,14 @@ export function identityState(client: object): IdentityState {
     states.set(client, state);
   }
   return state;
+}
+
+/** React view of the latch — the overlay's signed-out panel reads this. SSR
+ *  and the first client render answer false: the latch can only close after a
+ *  real wire read, so hydration always agrees with the server. */
+export function useSignedOut(client: object): boolean {
+  const state = identityState(client);
+  return useSyncExternalStore(state.subscribe, state.forbidden, () => false);
 }
 
 function createState(): IdentityState {

--- a/packages/ui/src/hooks/identity-state.ts
+++ b/packages/ui/src/hooks/identity-state.ts
@@ -30,8 +30,15 @@ export function isForbiddenError(reason: unknown): boolean {
 
 export interface IdentityState {
   forbidden(): boolean;
-  /** Record a failed wire read; only a forbidden refusal moves the latch. */
-  note(reason: unknown): void;
+  /** The current open-signal generation — bumped by every `clear()` and every
+   *  identity event. Capture it when a request BEGINS and pass it to `note`:
+   *  a refusal from before the latest open signal is stale evidence (greptile
+   *  on #1445: an in-flight warm's 403 landing after sign-in re-closed the
+   *  latch and took the composer away from a signed-in visitor). */
+  epoch(): number;
+  /** Record a failed wire read; only a forbidden refusal moves the latch, and
+   *  only when `since` (the epoch at request start) is still current. */
+  note(reason: unknown, since?: number): void;
   /** A successful wire read (or the page signal) — the latch opens. */
   clear(): void;
   subscribe(listener: () => void): () => void;
@@ -58,23 +65,33 @@ export function useSignedOut(client: object): boolean {
 
 function createState(): IdentityState {
   let forbidden = false;
+  let epoch = 0;
   const listeners = new Set<() => void>();
   const set = (next: boolean): void => {
     if (forbidden === next) return;
     forbidden = next;
     for (const listener of [...listeners]) listener();
   };
+  // Every open signal — a success or the page event — starts a new epoch,
+  // whether or not the latch was closed: it invalidates the refusals of every
+  // request already in flight when it fired.
+  const open = (): void => {
+    epoch += 1;
+    set(false);
+  };
   // One listener per state, alive as long as the client is — page-scoped, like
   // the client itself. Guarded for SSR.
   if (typeof window !== "undefined") {
-    window.addEventListener(IDENTITY_CHANGED_EVENT, () => set(false));
+    window.addEventListener(IDENTITY_CHANGED_EVENT, open);
   }
   return {
     forbidden: () => forbidden,
-    note: (reason) => {
+    epoch: () => epoch,
+    note: (reason, since) => {
+      if (since !== undefined && since !== epoch) return;
       if (isForbiddenError(reason)) set(true);
     },
-    clear: () => set(false),
+    clear: open,
     subscribe(listener) {
       listeners.add(listener);
       return () => listeners.delete(listener);

--- a/packages/ui/src/hooks/use-vendo-thread.ts
+++ b/packages/ui/src/hooks/use-vendo-thread.ts
@@ -11,6 +11,7 @@ import {
 } from "ai";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useVendoProvider } from "../context.js";
+import { identityState } from "./identity-state.js";
 import { currentSituation } from "../situation.js";
 import { publishThreadRun, retireThreadRun, type VendoBeat } from "../chrome/run-activity.js";
 import { publishWorkbenchPart } from "../chrome/workbench-store.js";
@@ -195,7 +196,10 @@ export function useVendoThread(threadId?: string) {
   useEffect(() => {
     if (warmedClients.has(client)) return;
     warmedClients.add(client);
-    client.threads.warm().catch(() => {});
+    // Still best-effort, but a forbidden refusal feeds the page-wide latch
+    // (H2-E): the warm call is often the overlay's FIRST wire contact, so it
+    // is what tells the signed-out panel to render without waiting for a poll.
+    client.threads.warm().catch((reason: unknown) => identityState(client).note(reason));
   }, [client]);
   // Beats belong to the RUNNING turn: clearing on the settle (rather than on the
   // next turn's start) is one rule that answers both halves of §3.4's ephemeral

--- a/packages/ui/src/hooks/use-vendo-thread.ts
+++ b/packages/ui/src/hooks/use-vendo-thread.ts
@@ -199,7 +199,15 @@ export function useVendoThread(threadId?: string) {
     // Still best-effort, but a forbidden refusal feeds the page-wide latch
     // (H2-E): the warm call is often the overlay's FIRST wire contact, so it
     // is what tells the signed-out panel to render without waiting for a poll.
-    client.threads.warm().catch((reason: unknown) => identityState(client).note(reason));
+    // A refused warm also FORGETS its mark (greptile on #1445): it primed
+    // nothing, and the conversation that remounts after sign-in deserves the
+    // warm cache the mark would have denied it. Ordinary failures keep the
+    // mark — once per page life stays the rule for everything but a refusal.
+    client.threads.warm().catch((reason: unknown) => {
+      const identity = identityState(client);
+      identity.note(reason);
+      if (identity.forbidden()) warmedClients.delete(client);
+    });
   }, [client]);
   // Beats belong to the RUNNING turn: clearing on the settle (rather than on the
   // next turn's start) is one rule that answers both halves of §3.4's ephemeral

--- a/packages/ui/src/hooks/use-vendo-thread.ts
+++ b/packages/ui/src/hooks/use-vendo-thread.ts
@@ -80,7 +80,7 @@ const NO_BEATS: readonly VendoBeat[] = [];
 /** Clients whose provider prompt-cache this page already primed — the warm
  *  call is per-deployment-per-user, so once per client instance is the
  *  whole job (and strict-mode double effects must not pay it twice). */
-const warmedClients = new WeakSet<object>();
+const warmedClients = new WeakMap<object, number>();
 
 function vendoApproval(part: UIMessage["parts"][number]): VendoApprovalPart | undefined {
   if (part.type !== "data-vendo-approval") return undefined;
@@ -194,20 +194,17 @@ export function useVendoThread(threadId?: string) {
   // the provider entry outlives any single mount, and strict-mode double
   // effects must not buy the cache write twice. Best-effort by design.
   useEffect(() => {
-    if (warmedClients.has(client)) return;
-    warmedClients.add(client);
-    // Still best-effort, but a forbidden refusal feeds the page-wide latch
-    // (H2-E): the warm call is often the overlay's FIRST wire contact, so it
-    // is what tells the signed-out panel to render without waiting for a poll.
-    // A refused warm also FORGETS its mark (greptile on #1445): it primed
-    // nothing, and the conversation that remounts after sign-in deserves the
-    // warm cache the mark would have denied it. Ordinary failures keep the
-    // mark — once per page life stays the rule for everything but a refusal.
-    client.threads.warm().catch((reason: unknown) => {
-      const identity = identityState(client);
-      identity.note(reason);
-      if (identity.forbidden()) warmedClients.delete(client);
-    });
+    // The mark is EPOCH-KEYED (greptile on #1445, twice): a refused warm at
+    // epoch N primed nothing, and the conversation remounting after sign-in
+    // (epoch N+1) deserves the warm-up the plain once-per-client mark denied
+    // it — no delete-vs-remount ordering to race. And the refusal is stamped
+    // with the epoch its request BEGAN in, so a stale 403 landing after the
+    // sign-in cannot re-close the latch and un-render the composer.
+    const identity = identityState(client);
+    const at = identity.epoch();
+    if (warmedClients.get(client) === at) return;
+    warmedClients.set(client, at);
+    client.threads.warm().catch((reason: unknown) => identity.note(reason, at));
   }, [client]);
   // Beats belong to the RUNNING turn: clearing on the settle (rather than on the
   // next turn's start) is one rule that answers both halves of §3.4's ephemeral

--- a/packages/ui/src/tree/parked-approvals.ts
+++ b/packages/ui/src/tree/parked-approvals.ts
@@ -53,9 +53,12 @@ export function useParkedApprovals(
         // finds neither a pending ask nor an outcome yet. The next pass asks
         // again and the pending notice stands meanwhile — today's behavior.
         // The one exception is a forbidden refusal, which feeds the page-wide
-        // latch (H2-E) so this backstop goes quiet with everything else.
+        // latch (H2-E) so this backstop goes quiet with everything else —
+        // stamped with the epoch its request began in, so a stale refusal
+        // landing after a sign-in cannot re-close the latch.
+        const at = identity.epoch();
         const resolution = await client.approvals.get(approvalId).catch((reason: unknown) => {
-          identity.note(reason);
+          identity.note(reason, at);
           return undefined;
         });
         if (!live) return;

--- a/packages/ui/test/chrome/signed-out-overlay.test.tsx
+++ b/packages/ui/test/chrome/signed-out-overlay.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+/**
+ * H2-E / #1372, the visible half — a visitor the wire refused for missing
+ * identity gets a quiet signed-out panel, not a broken-looking conversation.
+ * The launcher still renders (nothing about wire health hides it), the copy is
+ * host-brandable, the server's developer-facing resolver paragraph never
+ * reaches the surface (consumer-voice law; the connect.test.tsx:360 shape),
+ * and the conversation returns on the page's identity signal.
+ */
+import { VendoError } from "@vendoai/core";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { VendoProvider, createVendoClient, type VendoClient } from "../../src/index.js";
+import { VendoOverlay } from "../../src/chrome/index.js";
+import { identityState } from "../../src/hooks/identity-state.js";
+import { createWireServer } from "../wire-server.js";
+
+const RESOLVER_PARAGRAPH = "no identity for this request: the `principal:` resolver returned null.";
+
+describe("the overlay's signed-out panel", () => {
+  let wire: Awaited<ReturnType<typeof createWireServer>>;
+  let client: VendoClient;
+
+  beforeEach(async () => {
+    wire = await createWireServer();
+    client = createVendoClient({ baseUrl: wire.url });
+  });
+
+  afterEach(async () => {
+    cleanup();
+    await wire.close();
+  });
+
+  function mount(props: Parameters<typeof VendoOverlay>[0] = {}) {
+    return render(
+      <VendoProvider client={client}>
+        <VendoOverlay defaultOpen {...props} />
+      </VendoProvider>,
+    );
+  }
+
+  it("latched: the panel shows the one line, the launcher stays, the resolver paragraph never renders", async () => {
+    identityState(client).note(new VendoError("forbidden", RESOLVER_PARAGRAPH));
+    mount();
+    await waitFor(() => expect(document.querySelector(".fl-signedout")).toBeTruthy());
+    expect(document.querySelector(".fl-signedout")?.textContent).toBe("Sign in to use the agent.");
+    // The launcher is untouched by wire health.
+    expect(document.querySelector(".fl-launcher")).toBeTruthy();
+    // No conversation furniture for a visitor who cannot converse.
+    expect(document.querySelector(".fl-composer")).toBeNull();
+    // The developer-facing paragraph stays with the developer.
+    expect(document.body.textContent).not.toContain("resolver returned null");
+    expect(document.body.textContent).not.toContain("principal");
+  });
+
+  it("the host's own words replace the default line", async () => {
+    identityState(client).note(new VendoError("forbidden", RESOLVER_PARAGRAPH));
+    mount({ signedOutNotice: "Log in to Maple to chat with your money." });
+    await waitFor(() => expect(document.querySelector(".fl-signedout")?.textContent)
+      .toBe("Log in to Maple to chat with your money."));
+  });
+
+  it("the wire's own forbidden answer raises the panel — no manual seeding", async () => {
+    // Every read the overlay makes on open refuses: the first one to land
+    // (warm, threads, approvals — whichever wins) must be enough.
+    for (const failure of [
+      { method: "POST", path: "/threads/warm" },
+      { method: "GET", path: "/threads" },
+      { method: "GET", path: "/approvals" },
+    ]) {
+      for (let i = 0; i < 4; i += 1) {
+        wire.state.failures.push({
+          ...failure,
+          code: "forbidden",
+          message: RESOLVER_PARAGRAPH,
+          status: 403,
+        });
+      }
+    }
+    mount();
+    await waitFor(() => expect(document.querySelector(".fl-signedout")).toBeTruthy(), { timeout: 10_000 });
+  });
+
+  it("the identity signal brings the conversation back", async () => {
+    identityState(client).note(new VendoError("forbidden", RESOLVER_PARAGRAPH));
+    mount();
+    await waitFor(() => expect(document.querySelector(".fl-signedout")).toBeTruthy());
+    window.dispatchEvent(new Event("vendo:identity-changed"));
+    await waitFor(() => expect(document.querySelector(".fl-signedout")).toBeNull());
+    await waitFor(() => expect(document.querySelector(".fl-composer")).toBeTruthy());
+  });
+});

--- a/packages/ui/test/chrome/signed-out-overlay.test.tsx
+++ b/packages/ui/test/chrome/signed-out-overlay.test.tsx
@@ -79,6 +79,13 @@ describe("the overlay's signed-out panel", () => {
     }
     mount();
     await waitFor(() => expect(document.querySelector(".fl-signedout")).toBeTruthy(), { timeout: 10_000 });
+    // Greptile on #1445: the refused warm must not permanently mark the client
+    // as warmed — after sign-in the remounted conversation re-primes the cache.
+    wire.state.failures.length = 0;
+    window.dispatchEvent(new Event("vendo:identity-changed"));
+    await waitFor(() => expect(document.querySelector(".fl-signedout")).toBeNull());
+    const warms = () => wire.requests.filter(r => r.method === "POST" && r.path === "/threads/warm").length;
+    await waitFor(() => expect(warms()).toBeGreaterThanOrEqual(2));
   });
 
   it("the identity signal brings the conversation back", async () => {

--- a/packages/ui/test/identity-state.test.ts
+++ b/packages/ui/test/identity-state.test.ts
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+/**
+ * The latch's epoch rule (greptile on #1445): a refusal is evidence about the
+ * moment its request BEGAN. Any open signal since — the page's identity event
+ * or a successful read — makes it stale, and stale refusals must not re-close
+ * the latch (the field shape: an in-flight warm's 403 landing after sign-in
+ * un-rendered the composer for a signed-in visitor).
+ */
+import { VendoError } from "@vendoai/core";
+import { describe, expect, it } from "vitest";
+import { IDENTITY_CHANGED_EVENT, identityState } from "../src/hooks/identity-state.js";
+
+const refusal = () => new VendoError("forbidden", "no identity for this request");
+
+describe("the identity latch's epoch", () => {
+  it("ignores a refusal from before the identity event, and honors a current one", () => {
+    const state = identityState({});
+    const before = state.epoch();
+    // Sign-in lands while the refused request is still in flight…
+    window.dispatchEvent(new Event(IDENTITY_CHANGED_EVENT));
+    state.note(refusal(), before);
+    expect(state.forbidden()).toBe(false);
+    // …but a refusal issued in the CURRENT epoch closes the latch as ever.
+    state.note(refusal(), state.epoch());
+    expect(state.forbidden()).toBe(true);
+  });
+
+  it("a successful read is an open signal too — it stales the refusals in flight beside it", () => {
+    const state = identityState({});
+    const before = state.epoch();
+    state.clear();
+    state.note(refusal(), before);
+    expect(state.forbidden()).toBe(false);
+  });
+
+  it("an unstamped note still latches — pollers with their own generation guards need no epoch", () => {
+    const state = identityState({});
+    state.note(refusal());
+    expect(state.forbidden()).toBe(true);
+  });
+});

--- a/packages/ui/test/wire-server.ts
+++ b/packages/ui/test/wire-server.ts
@@ -435,6 +435,15 @@ export async function createWireServer(options: WireServerOptions = {}) {
         return;
       }
 
+      // A client may declare itself identity-less via header (harness: the
+      // signed-out overlay scenario renders beside signed-in surfaces sharing
+      // this wire) — every read answers the preset hosts' real refusal, the
+      // same header-forcing pattern x-vendo-force-posture set.
+      if (request.headers["x-vendo-force-forbidden"] !== undefined) {
+        wireError(response, "forbidden", "no identity for this request: the `principal:` resolver returned null.", 403);
+        return;
+      }
+
       const failureIndex = state.failures.findIndex(failure => failure.method === method && failure.path === url.pathname);
       if (failureIndex >= 0) {
         const [failure] = state.failures.splice(failureIndex, 1);


### PR DESCRIPTION
## What

The second half of lane 4 of the host-#2 fix pack (H2-E, #1372, Linear ENG-424), completing what #1442's poller latch started: **a signed-out visitor sees a quiet panel, not a broken agent.** The launcher still renders - nothing about wire health hides it - but the panel now swaps the thread for one host-brandable line ("Sign in to use the agent.", overridable via the new `signedOutNotice` overlay prop) whenever the per-client forbidden latch is closed. The conversation returns on `vendo:identity-changed` or the first successful wire read.

## How

- `useSignedOut(client)` (internal, `useSyncExternalStore` over the #1442 latch; SSR answers false so hydration always agrees).
- `SignedOutNotice` inside vendo-overlay.tsx (the HistoryPicker not-exported precedent) replaces the thread in the split rail while latched. The server's developer-facing resolver paragraph never renders (consumer-voice law; the connect-dock precedent).
- The thread hook's warm call now feeds the latch, so the panel is up on the overlay's FIRST wire contact instead of waiting for the next badge poll.
- Wire fixture gains `x-vendo-force-forbidden` (the `x-vendo-force-posture` precedent): a client that declares itself identity-less gets the preset hosts' real 403 on every read - used by the tests and the new harness scenario.

## Verification (the UI-affecting rule)

Real-browser evidence: a new harness scenario (`/signed-out`) whose client the wire genuinely refuses - the latch trips through the real path (warm call or badge poll, whichever lands first) - captured via Playwright chromium: **[screenshot on ENG-424](https://uploads.linear.app/d2f8bfb4-6137-45b3-b628-5235c594c6c8/35f6ca6c-fbc1-4c01-a95d-509c74dd7c89/79e1c77f-f685-48f5-9fe3-f81b2485a92e)** (panel open on the Maple theme: one centered line, launcher present, no error furniture; `docs/verification/` gitignores images, so it is Linear-hosted). The scenario + spec entry are committed, so CI regenerates the same capture.

Two Windows fixes fell out of the capture: `screenshotPath` now uses `fileURLToPath` (URL#pathname produced `C:\C:\...`, so every capture on Windows failed after the page proved ready), and the run used the dev server because `vite build` crashes on this machine (known env class - CI builds fine).

## Tests

jsdom suite `signed-out-overlay.test.tsx`, 4 red-first (stash-proven): the panel + launcher + no-resolver-paragraph pin, custom copy, the wire-driven path (no manual seeding), and the identity-signal return of the conversation. Gates: export-surface green (nothing new exported), approvals-feed 7/7, typecheck clean; the eject pack-and-inspect red is the pre-existing Windows tar class (reproduced on pristine state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)