### PR TITLE
fix(vendo): a human typing npx is a human, not a lifecycle script

### DIFF
--- a/.changeset/a-human-typing-npx-is-a-human.md
+++ b/.changeset/a-human-typing-npx-is-a-human.md
@@ -1,0 +1,12 @@
+---
+"@vendoai/vendo": patch
+---
+
+A human typing `npx vendo init` is a human, not a script. `npx`/`npm exec` runs
+its target as a synthetic package script literally named `npx`, and the CLI read
+any `npm_lifecycle_event` as proof a lifecycle hook had started the run — so the
+command every doc prints came up mute: the use-case question, the auth confirm,
+the deploy URL and the AI-grading consent were all skipped and the run silently
+took "embedded". Only that one synthetic name is exempt now; real hooks
+(`predev`, `postinstall`, any `npm run …`) keep their exemption, and the TTY
+requirement is unchanged, so CI and piped runs stay as quiet as they were.

--- a/packages/vendo/src/cli/shared.ts
+++ b/packages/vendo/src/cli/shared.ts
@@ -35,9 +35,15 @@ export async function askYesNo(question: string, defaultYes = false): Promise<bo
     on a TTY: npm inherits the terminal, so a command that stops to ask would
     block what the human thinks is a dev-server start — and a reflexive Enter on
     a default-yes prompt would spend money. A run the human did not invoke never
-    gets a question. */
+    gets a question.
+
+    `npx` is the one event name that is not a script: `npx`/`npm exec` runs its
+    target as a synthetic script literally named `npx`, so the docs' own
+    `npx vendo init` arrived here looking like a hook and ran mute. A human
+    typing `npx vendo …` is a human; real hooks have their own names. */
 export function invokedByPackageScript(env: Record<string, string | undefined> = process.env): boolean {
-  return (env.npm_lifecycle_event ?? "").trim() !== "";
+  const event = (env.npm_lifecycle_event ?? "").trim();
+  return event !== "" && event !== "npx";
 }
 
 export async function exists(path: string): Promise<boolean> {

--- a/packages/vendo/src/cli/sync.ts
+++ b/packages/vendo/src/cli/sync.ts
@@ -206,7 +206,9 @@ async function sync(options: SyncOptions): Promise<number> {
     const root = resolve(options.targetDir);
     // `--json` and `--yes` are non-interactive by construction, and so is a run
     // started by a package script: the `predev` hook an older init wrote has a
-    // TTY, but the human asked for a dev server, not a question.
+    // TTY, but the human asked for a dev server, not a question. `npx vendo
+    // sync` is not that run — npm names its exec script `npx`, and the person
+    // who typed it is waiting on the answer.
     const interactive = options.interactive
       ?? (options.yes !== true && !json && !invokedByPackageScript()
         && Boolean(stdin.isTTY) && Boolean(stdout.isTTY));

--- a/packages/vendo/tests/cli/init.test.ts
+++ b/packages/vendo/tests/cli/init.test.ts
@@ -15,6 +15,7 @@ import { CLI_VERSION, type Output } from "../../src/cli/shared.js";
 const cleanup: string[] = [];
 
 afterEach(async () => {
+  vi.unstubAllEnvs();
   await Promise.all(cleanup.splice(0).map((path) => rm(path, { recursive: true, force: true })));
 });
 
@@ -2520,6 +2521,38 @@ describe("the five questions", () => {
       selectUseCase: async () => { throw new Error("prompted"); },
     })).toBe(0);
     expect(quietSink.logs.join("\n")).not.toContain("How will people use your agent?");
+  });
+
+  // The interactivity JUDGMENT, not the `interactive` flag: `npx vendo init` —
+  // the command every doc prints — carries npm exec's synthetic
+  // `npm_lifecycle_event=npx`, which read as a lifecycle hook and defaulted the
+  // whole run to embedded in silence. A real hook still gets nothing.
+  it.each([
+    ["npx", true],
+    ["predev", false],
+  ] as const)("a real TTY under npm_lifecycle_event=%s asks the use case: %s", async (event, asks) => {
+    vi.stubEnv("npm_lifecycle_event", event);
+    const tty = { in: process.stdin.isTTY, out: process.stdout.isTTY };
+    process.stdin.isTTY = true;
+    process.stdout.isTTY = true;
+    const asked: string[] = [];
+    // Every other prompt seam stubbed to its decline, because a real TTY means
+    // an unstubbed one would read this process's own stdin and hang: only the
+    // use case is under test here.
+    expect(await run(await fixture(), output(), {
+      ai: false,
+      cloud: { ...NO_CLOUD, models: "later" },
+      selectUseCase: async (question) => { asked.push(question); return "embedded"; },
+      confirmAuth: async () => false,
+      selectAuth: async () => "none",
+      askText: async () => "",
+      confirmCheck: async () => false,
+      confirmZodBump: async () => false,
+    }).finally(() => {
+      process.stdin.isTTY = tty.in;
+      process.stdout.isTTY = tty.out;
+    })).toBe(0);
+    expect(asked).toEqual(asks ? ["How will people use your agent?"] : []);
   });
 
   it("--use-case agent-loop adds the snippet for the loop package.json already names", async () => {

--- a/packages/vendo/tests/cli/shared.test.ts
+++ b/packages/vendo/tests/cli/shared.test.ts
@@ -1,7 +1,7 @@
 import { readFile } from "node:fs/promises";
 import { describe, expect, it } from "vitest";
 import { VERSION } from "../../src/wire/shared.js";
-import { browserOpenCommand, CLI_VERSION } from "../../src/cli/shared.js";
+import { browserOpenCommand, CLI_VERSION, invokedByPackageScript } from "../../src/cli/shared.js";
 
 // Both constants ride user-facing surfaces (--version, doctor fix_ref URLs,
 // the cloud client user-agent, the wire /status body), but changesets only
@@ -28,5 +28,22 @@ describe("browserOpenCommand", () => {
   it("uses open on macOS and xdg-open elsewhere", () => {
     expect(browserOpenCommand("darwin", "u")).toEqual({ command: "open", args: ["u"] });
     expect(browserOpenCommand("linux", "u")).toEqual({ command: "xdg-open", args: ["u"] });
+  });
+});
+
+describe("invokedByPackageScript", () => {
+  it("counts a real lifecycle hook, and nothing at all outside npm", () => {
+    expect(invokedByPackageScript({ npm_lifecycle_event: "predev" })).toBe(true);
+    expect(invokedByPackageScript({ npm_lifecycle_event: "postinstall" })).toBe(true);
+    expect(invokedByPackageScript({})).toBe(false);
+    expect(invokedByPackageScript({ npm_lifecycle_event: "" })).toBe(false);
+    expect(invokedByPackageScript({ npm_lifecycle_event: "  " })).toBe(false);
+  });
+
+  // `npx vendo init` — the docs' own command — is a human at a keyboard, but
+  // npm exec runs its target as a synthetic script named `npx`, so treating
+  // the event as proof of a hook ran the whole quickstart mute.
+  it("does not count npm exec's synthetic `npx` event", () => {
+    expect(invokedByPackageScript({ npm_lifecycle_event: "npx" })).toBe(false);
   });
 });


### PR DESCRIPTION
## The bug

`npx vendo init` — the command every doc and the quickstart print — never asks
init's questions. The use-case question, the auth confirm, the deploy URL and
the AI-grading consent are all skipped, and the run silently takes `embedded`.
The models question still appears (it checks raw TTY), so the run *looks*
interactive while the rest of it is mute.

## The cause

One line. `npx`/`npm exec` runs its target as a synthetic package script
literally named `npx`, setting `npm_lifecycle_event=npx`.
`invokedByPackageScript()` treated ANY non-empty `npm_lifecycle_event` as
"a lifecycle script started me", and init's and sync's interactive flags all
include `!invokedByPackageScript()`.

## The fix

The synthetic `npx` event does not count as a package script:

```ts
const event = (env.npm_lifecycle_event ?? "").trim();
return event !== "" && event !== "npx";
```

Real hooks (`predev`, `postinstall`, any `npm run …`) have their own event
names and keep their exemption. The TTY conjunction is untouched at every
caller, so CI and piped `npx` runs stay non-interactive. Comments at
`shared.ts` and `sync.ts` now state the nuance.

## Accepted edge case

A package script that itself invokes `npx vendo sync` presents as `event=npx`
and would become interactive. Current init scaffolds write bare
`vendo sync --no-ai` hooks — explicit flags, still muted — so this is
acceptable.

## Proof

**Tests.** Unit tests for `invokedByPackageScript` (`npx` → false,
`predev`/`postinstall` → true, empty/blank/absent → false) and an init-level
regression that drives interactivity through env + TTY stubs *without* passing
`interactive: true` — the shape the existing test at `init.test.ts` missed. The
existing `predev`-stays-muted sync test is unchanged and green.

Both new tests were run against a temporarily reverted `shared.ts` and went red
(`expected true to be false`; `expected [] to deeply equal [ 'How will people
use your agent?' ]`), then green again once restored.

**Built binary, under a real pty.** `pnpm build`, then the built
`packages/vendo/bin/vendo.mjs` run in a scratch Next host under
`script -q /dev/null`:

`npm_lifecycle_event=npx` —
```
│  ✓ Next.js · App Router · TypeScript · pnpm
◇  How will people use your agent?
│  ● Embedded in my app — chat + generated UI (recommended)
│  ○ Through my own agent loop (AI SDK / Mastra)
│  ○ From outside agents over MCP — Claude, ChatGPT, Cursor, or any MCP agent (experimental)
```

`npm_lifecycle_event=predev` — the question never appears; the run goes
straight past it:
```
│  ✓ Next.js · App Router · TypeScript · pnpm
◆  Vendo Cloud
│  ✦ a free starter model allowance — no card, no model key of your own
```

**Local gate.** `pnpm build`, `pnpm test:affected` (2420 passed), `pnpm
typecheck`, `pnpm lint` — all green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes interactive detection so `npx vendo init` prompts users. Previously any non-empty `npm_lifecycle_event` (including `npx`) muted questions and defaulted the init flow to “embedded”. Now `npx` is not treated as a lifecycle script; real hooks remain non-interactive and TTY requirements are unchanged.

- Changes: `invokedByPackageScript()` now ignores the synthetic `npx` event; comments clarified in `shared.ts` and `sync.ts`. 
- Tests: adds unit tests for `invokedByPackageScript` and an init-level regression ensuring the use-case prompt appears under `npm_lifecycle_event=npx` with a TTY.
- Rollout: no migration. CI and piped runs stay quiet. Real hooks (`predev`, `postinstall`, `npm run …`) remain non-interactive. A package script that shells out to `npx vendo sync` may now prompt; current scaffolds use `vendo sync --no-ai` and are unaffected.

<sup>Written for commit 63531b1c3aaffefa8527658cfde8370fd227d054. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

