### PR TITLE
fix(demo-bank): drop the stale automations-tool instruction

### DIFF
--- a/examples/demo-bank/src/vendo/server.ts
+++ b/examples/demo-bank/src/vendo/server.ts
@@ -119,7 +119,6 @@ export const vendo = createVendo({
     "No emojis, ever — not in prose, not in generated UI text.",
     "Format money as currency (e.g. $1,234.56), never raw cents.",
     "When you render a view, let it carry the data — don't restate it in prose.",
-    "For a recurring or scheduled payment/task, use vendo_make — describe the schedule in the request; the automation is armed automatically. There is no separate automations tool.",
   ].join("\n"),
   // Machine-backed execution (layers 2 and 3) is gated by the `sandbox` slot
   // above and nothing else: configure one and Maple can build boxes, leave it


### PR DESCRIPTION
## What

Deletes one line from Maple's `instructions` array in `examples/demo-bank/src/vendo/server.ts`:

> "For a recurring or scheduled payment/task, use vendo_make — describe the schedule in the request; the automation is armed automatically. There is no separate automations tool."

## Why

The line is stale — it denies a tool that is mounted (automations mount by default, `packages/vendo/src/compose-config.ts:100`, and `vendo_automate` stays in the loadout when mounted, `compose-surfaces.ts:193-197`), and it routes schedule-only asks (recurring payments) into `vendo_make`, which builds a pointless app around them.

The shipped tool descriptions already carry the correct routing law Vendo-wide (`packages/apps/src/server/doors/agent-tools.ts:46` and `:70` — "a schedule with nothing to build belongs in vendo_automate instead" / "Use this when there is nothing to build"), so Maple should not override them. Deleting restores platform behavior.

Behavior is covered by the shipped descriptors — no test changes needed for an instruction-string deletion.

## Verification

- [x] `pnpm build && pnpm test:affected && pnpm typecheck && pnpm lint` green (scoped local gate; full suite is CI's job)
- [x] No UI change — instruction-string deletion only, no screenshots needed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes a stale Maple instruction that told users to use `vendo_make` for schedule-only tasks and claimed no automations tool exists. Restores platform behavior so schedules with nothing to build route to `vendo_automate`.

**Review notes**
- Single-line deletion in examples/demo-bank/src/vendo/server.ts.
- No runtime or UI changes; automations mount by default and shipped tool descriptors handle routing.
- No tests or migrations required.

<sup>Written for commit 17e1e984b4dee3fa55ecffd5aa9db3b0ef6f1fb0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

