### PR TITLE
fix(core,store): a proposed table is an answer, not a swallowed 409

### DIFF
--- a/.changeset/a-proposed-table-is-an-answer.md
+++ b/.changeset/a-proposed-table-is-an-answer.md
@@ -1,0 +1,30 @@
+---
+"@vendoai/core": patch
+"@vendoai/store": patch
+"@vendoai/vendo": patch
+---
+
+A store that asks for a table gets one. Vendo Cloud's typed data plane answers
+the first write to an undeclared table with `409 {error: "schema-proposal",
+proposal}` — the DDL that would make the write legal — and the SDK could not
+read it: the body's `error` is a string, the wire envelope requires an object,
+so the parse failed, the bare status took over, and the caller got "conflict —
+store wire request failed with HTTP 409" with the server's proposal erased. Every
+app's first row write to a new collection failed, on Cloud, with nothing in the
+error to say why.
+
+The store client now declares what it can read on every request
+(`x-vendo-store-capabilities: schema-proposal`, scoped to store traffic — no
+other wire grows a header), confirms a proposal on the mount's schema door and
+replays the write under the SAME idempotency key, so one logical mutation stays
+one. It loops for the multi-step case (create_table, then add_column) and stops
+after three rounds; a proposal on an operation that names no app is never
+confirmed against a guessed one. Both readings of a store failure recognize the
+proposal, so the StoreAdapter façade — the surface an app's own writes take —
+heals exactly like the op client.
+
+Independently: `parseStoreWireError` stops discarding bodies it cannot parse. An
+unrecognized error body now rides a bounded snippet in the message, and a schema
+proposal reads as the new `schema-proposal` error code with the proposal intact
+on `detail` — so the next protocol skew is diagnosable from the error alone
+instead of from a live repro.

--- a/packages/core/src/cloud-console.ts
+++ b/packages/core/src/cloud-console.ts
@@ -89,6 +89,11 @@ export function consoleSender(options: {
   timeoutMs: number;
   fetchImpl: typeof fetch;
   raise: (response: Response) => Promise<never>;
+  /** Headers this ONE wire adds to every request — the store wire's capability
+   * list, and nothing at all on the wires that declare none. Scoped here rather
+   * than folded into the identity headers because those ride every Cloud door
+   * alike, and a capability is a statement about one protocol. */
+  headers?: Record<string, string>;
 }): (path: string, init?: RequestInit) => Promise<Response> {
   return async (path, init = {}) => {
     const response = await options.fetchImpl(`${options.base}${options.mountPath}${path}`, {
@@ -97,6 +102,7 @@ export function consoleSender(options: {
         authorization: `Bearer ${options.apiKey}`,
         accept: "application/json",
         ...(await deploymentIdentityHeaders()),
+        ...options.headers,
         ...init.headers,
       },
       signal: AbortSignal.timeout(options.timeoutMs),

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -19,7 +19,14 @@ export type VendoErrorCode =
       than treating it as a business refusal. Wire-mapped to HTTP 503.
       Distinct from `sandbox-unavailable`, which names one specific capability
       rather than "something downstream broke". */
-  | "unavailable";
+  | "unavailable"
+  /** A typed store refused a write to a table it has not been told about and
+      answered the DDL that would make the write legal — the proposal, carried
+      here on `detail`. The store client confirms it and replays the write
+      (hostedStore's `mutate`), so a caller only ever sees this code when that
+      handshake was exhausted or the proposal named no app to confirm it
+      against. Wire-mapped to HTTP 409. */
+  | "schema-proposal";
 
 /** 01-core §15 */
 export const vendoErrorCodeSchema = z.enum([
@@ -32,6 +39,7 @@ export const vendoErrorCodeSchema = z.enum([
   "conflict",
   "forbidden",
   "unavailable",
+  "schema-proposal",
 ]) satisfies z.ZodType<VendoErrorCode>;
 
 /** 01-core §15 */

--- a/packages/core/src/knowledge-wire.ts
+++ b/packages/core/src/knowledge-wire.ts
@@ -148,6 +148,9 @@ export const KNOWLEDGE_WIRE_STATUS_BY_CODE: Record<VendoErrorCode, number> = {
   // untouched — a bare 5xx/429 here still degrades to "not-implemented",
   // unchanged by this slice.
   unavailable: 503,
+  // Table entry only, on the same rule: a schema proposal is a typed STORE's
+  // answer, and no knowledge mount has a table to propose.
+  "schema-proposal": 409,
 };
 
 /** 404 is deliberately absent: only an ENVELOPED `not-found` may become the

--- a/packages/core/src/store-wire.ts
+++ b/packages/core/src/store-wire.ts
@@ -703,6 +703,42 @@ export const storeWireErrorSchema = z.object({
   }).passthrough(),
 }).passthrough() satisfies z.ZodType<StoreWireError>;
 
+/** What a client can do with an answer, declared on EVERY request it sends so a
+    mount never sends a shape the client cannot read. Comma-separated and
+    ADDITIVE — a mount reads it as a set and ignores names it does not know, a
+    client omits names it does not implement — which is what lets a mount grow an
+    answer shape without a version bump. Scoped to the store wire: the other
+    Cloud wires declare nothing, and managed inference does not carry Vendo
+    headers at all. */
+export const STORE_WIRE_CAPABILITIES_HEADER = "x-vendo-store-capabilities";
+
+/** The capabilities THIS build implements — today, only the schema-proposal
+    handshake below. */
+export const STORE_WIRE_CAPABILITIES = "schema-proposal";
+
+/** A typed mount's answer to a write against a table it has not been told
+    about: HTTP 409 carrying the DDL that would make the write legal, instead of
+    applying the write. `error` is the literal STRING "schema-proposal" — that is
+    what discriminates this body from {@link StoreWireError}, whose `error` is an
+    object, and the two have to be told apart by shape because they share a
+    status.
+
+    The proposal is passed through UNTOUCHED: the client forwards it verbatim to
+    the mount's schema door, so only the two fields it reads to explain itself
+    are typed here and every other field crosses on unread. */
+export interface StoreWireSchemaProposal {
+  error: "schema-proposal";
+  proposal: { op: string; table: string };
+}
+
+export const storeWireSchemaProposalSchema = z.object({
+  error: z.literal("schema-proposal"),
+  proposal: z.object({
+    op: z.string(),
+    table: z.string(),
+  }).passthrough(),
+}).passthrough() satisfies z.ZodType<StoreWireSchemaProposal>;
+
 /** Mirrors the umbrella wire's STATUS_BY_CODE — core cannot import it
     (layering: core depends on nothing). */
 export const STORE_WIRE_STATUS_BY_CODE: Record<VendoErrorCode, number> = {
@@ -715,6 +751,10 @@ export const STORE_WIRE_STATUS_BY_CODE: Record<VendoErrorCode, number> = {
   "sandbox-unavailable": 501,
   "not-implemented": 501,
   unavailable: 503,
+  // The proposal's own status. A mount that serves the handshake sends the
+  // PROPOSAL body rather than this envelope; the entry exists so an exhausted
+  // handshake re-crossing a wire keeps the status it arrived on.
+  "schema-proposal": 409,
 };
 
 /** 404 is deliberately absent: only an ENVELOPED `not-found` may become the
@@ -753,18 +793,53 @@ export function storeWireErrorBody(error: VendoError): { status: number; body: S
   };
 }
 
+/** How much of an unreadable body rides the message: enough to name the shape
+    that arrived (a JSON key, an HTML title), short enough that a proxy's error
+    page can never become the error message. */
+const ERROR_BODY_SNIPPET = 200;
+
+/** The body this parser could not read, bounded, for the message. A body thrown
+    away here is the next protocol skew nobody can diagnose — field 2026-08-17:
+    a console 409 carrying a schema proposal reached the caller as a bare
+    "store wire request failed with HTTP 409" and the proposal was simply gone,
+    so the live repro was the only way to learn what the server had said. */
+function bodySnippet(body: unknown): string {
+  let text: string;
+  if (typeof body === "string") {
+    text = body;
+  } else {
+    try {
+      text = (JSON.stringify(body) as string | undefined) ?? "";
+    } catch {
+      return "";
+    }
+  }
+  if (text === "") return "";
+  return ` — body: ${text.length > ERROR_BODY_SNIPPET ? `${text.slice(0, ERROR_BODY_SNIPPET)}…` : text}`;
+}
+
 /** Client half: a non-2xx response → VendoError. An enveloped wire-legal
-    code wins over the bare status; recognized statuses map through
-    STATUS_TO_CODE (429/5xx → "unavailable", retryable); anything else
-    degrades to "not-implemented". */
+    code wins over the bare status; a schema proposal is recognized as ITSELF,
+    carrying the proposal on `detail` for the client that confirms it; recognized
+    statuses map through STATUS_TO_CODE (429/5xx → "unavailable", retryable);
+    anything else degrades to "not-implemented" — and says what it could not
+    read, because a silently discarded body is an undiagnosable skew. */
 export function parseStoreWireError(status: number, body: unknown): VendoError {
   const parsed = storeWireErrorSchema.safeParse(body);
   if (parsed.success) {
     return new VendoError(parsed.data.error.code, parsed.data.error.message, parsed.data.error.detail as Json);
   }
-  const code = STATUS_TO_CODE[status];
-  if (code !== undefined) {
-    return new VendoError(code, `store wire request failed with HTTP ${status}`);
+  const proposed = storeWireSchemaProposalSchema.safeParse(body);
+  if (proposed.success) {
+    const { op, table } = proposed.data.proposal;
+    return new VendoError(
+      "schema-proposal",
+      `the store proposed a schema change before this write: ${op} ${table}`,
+      proposed.data.proposal as Json,
+    );
   }
-  return new VendoError("not-implemented", `store wire request failed with HTTP ${status}`);
+  return new VendoError(
+    STATUS_TO_CODE[status] ?? "not-implemented",
+    `store wire request failed with HTTP ${status}${bodySnippet(body)}`,
+  );
 }

--- a/packages/core/tests/contract-coverage.e2e.test.ts
+++ b/packages/core/tests/contract-coverage.e2e.test.ts
@@ -397,7 +397,7 @@ describe("§12/§13/§14 — store, host-seam, and theme schemas", () => {
 });
 
 describe("§15 — VendoErrorCode taxonomy is a closed enum", () => {
-  it("vendoErrorCodeSchema accepts exactly the nine codes and rejects cut/unknown ones", () => {
+  it("vendoErrorCodeSchema accepts exactly the ten codes and rejects cut/unknown ones", () => {
     for (const code of [
       "validation", "blocked", "not-implemented", "sandbox-unavailable",
       "cloud-required", "not-found", "conflict", "forbidden",
@@ -405,6 +405,10 @@ describe("§15 — VendoErrorCode taxonomy is a closed enum", () => {
       // connection, an upstream 5xx/429) — see store-wire.test.ts for its
       // STATUS_TO_CODE pin.
       "unavailable",
+      // 2026-08-17: a typed store's answer to a write against a table it has
+      // not been told about — the DDL rides on `detail`, and the store client
+      // confirms it and replays before any caller sees this.
+      "schema-proposal",
     ]) {
       expect(vendoErrorCodeSchema.safeParse(code).success).toBe(true);
     }

--- a/packages/core/tests/store-wire.test.ts
+++ b/packages/core/tests/store-wire.test.ts
@@ -450,6 +450,47 @@ describe("vendo/store-wire@1", () => {
     expect(parseStoreWireError(404, undefined).code).toBe("not-implemented");
   });
 
+  /** Field 2026-08-17: a typed console answered the first write to an
+      undeclared table with `{error: "schema-proposal", proposal}` on a 409 —
+      `error` a STRING, so the envelope schema refused it, the bare status took
+      over, and the caller got "conflict / store wire request failed with HTTP
+      409" with the DDL the server had just handed it simply gone. */
+  it("reads the schema proposal as itself, proposal intact on detail", () => {
+    const proposal = {
+      op: "create_table",
+      table: "notes",
+      scope: "private",
+      columns: [{ name: "text", type: "text" }],
+    };
+    const error = parseStoreWireError(409, { error: "schema-proposal", proposal });
+    expect(error.code).toBe("schema-proposal");
+    expect(error.message).toContain("create_table notes");
+    // Verbatim — the client forwards this straight back to the schema door, so
+    // a field this build does not know must survive the round trip.
+    expect(error.detail).toEqual(proposal);
+    expect(STORE_WIRE_STATUS_BY_CODE["schema-proposal"]).toBe(409);
+    // The envelope still wins where both could match: an `error` OBJECT is the
+    // wire's own refusal, whatever it says.
+    expect(parseStoreWireError(409, { error: { code: "conflict", message: "id taken" } }).code).toBe("conflict");
+    // A proposal missing the fields the client explains itself with is not one.
+    expect(parseStoreWireError(409, { error: "schema-proposal" }).code).toBe("conflict");
+  });
+
+  it("an unreadable body rides the message, bounded — never silently erased", () => {
+    // The next protocol skew has to be diagnosable from the error alone.
+    expect(parseStoreWireError(409, { error: "unknown-protocol", hint: "upgrade" }).message)
+      .toContain(`{"error":"unknown-protocol","hint":"upgrade"}`);
+    expect(parseStoreWireError(504, "<html><title>504 Gateway Time-out</title></html>").message)
+      .toContain("504 Gateway Time-out");
+    // A megabyte of proxy error page cannot become the error message.
+    const flood = parseStoreWireError(500, "x".repeat(10_000)).message;
+    expect(flood.length).toBeLessThan(400);
+    expect(flood).toContain("…");
+    // Nothing to say about nothing.
+    expect(parseStoreWireError(500, undefined).message).toBe("store wire request failed with HTTP 500");
+    expect(parseStoreWireError(500, "").message).toBe("store wire request failed with HTTP 500");
+  });
+
   it("the reverse status table round-trips through the forward table", () => {
     for (const [status, code] of Object.entries({ 400: "validation", 402: "cloud-required", 403: "blocked", 409: "conflict" } as const)) {
       expect(STORE_WIRE_STATUS_BY_CODE[code]).toBe(Number(status));

--- a/packages/store/src/hosted-store.test-util.ts
+++ b/packages/store/src/hosted-store.test-util.ts
@@ -1,4 +1,5 @@
 import {
+  STORE_WIRE_CAPABILITIES_HEADER,
   STORE_WIRE_PATHS,
   isVendoError,
   VendoError,
@@ -26,6 +27,7 @@ export interface RecordedRequest {
   contentType: string | null;
   deploymentHost: string | null;
   deploymentName: string | null;
+  capabilities: string | null;
   json?: unknown;
   bytes?: Uint8Array;
 }
@@ -353,6 +355,66 @@ async function appDataOp(
   }
 }
 
+/** The console's typed data plane, as much of it as this seam needs. An app's
+ *  tables — and each table's columns — are DECLARED before rows may land in
+ *  them, and a write to something undeclared answers 409 carrying the DDL that
+ *  would make it legal instead of applying the write.
+ *
+ *  A `create_table` declares the table with NO data columns (its id and owner
+ *  belong to the mount, not the app), so the first write into a new table costs
+ *  two rounds — create_table, then add_column — which is why the client's
+ *  handshake is a loop and not a single retry. Nothing here is a stub of the
+ *  client's expectations: rows land through the same appData door as every other
+ *  write and come back out through the same read. */
+function appSchemas() {
+  // `<appId> <table>` → declared column names; neither half carries a space.
+  const tables = new Map<string, Set<string>>();
+  const key = (appId: string, table: string): string => `${appId} ${table}`;
+  const columnsOf = (operation: Body): string[] =>
+    ((operation.columns ?? []) as { name: string }[]).map((column) => column.name);
+  return {
+    /** The DDL this write needs first, or undefined when it may land. */
+    proposalFor(appId: string, table: string, data: unknown): Body | undefined {
+      const declared = tables.get(key(appId, table));
+      if (declared === undefined) return { op: "create_table", table, scope: "private", columns: [] };
+      const missing = Object.keys((data ?? {}) as object).filter((name) => !declared.has(name));
+      if (missing.length === 0) return undefined;
+      return {
+        op: "add_column",
+        table,
+        scope: "private",
+        columns: missing.map((name) => ({ name, type: "text" })),
+      };
+    },
+    /** The schema door: an in-order DdlOperation array, applied as given, and
+     *  the app's tables afterwards. `add_column` against a table that was never
+     *  created is refused — a client that dropped an operation from the middle
+     *  of the array must not read as a success. */
+    apply(appId: string, operations: Body[]): string[] {
+      for (const operation of operations) {
+        const table = operation.table as string;
+        const declared = tables.get(key(appId, table));
+        if (declared === undefined && operation.op !== "create_table") {
+          throw new VendoError("validation", `no table ${JSON.stringify(table)} in app ${appId}`);
+        }
+        const columns = declared ?? new Set<string>();
+        for (const name of columnsOf(operation)) columns.add(name);
+        tables.set(key(appId, table), columns);
+      }
+      return [...tables.keys()]
+        .filter((held) => held.startsWith(`${appId} `))
+        .map((held) => held.slice(appId.length + 1));
+    },
+  };
+}
+
+/** The capability the proposal above rides on. A client that does not declare
+ *  it cannot read a proposal, so the mount refuses the undeclared table the old
+ *  way instead — which is what makes the header load-bearing here: a client that
+ *  stopped sending it fails against this fake rather than degrading in silence. */
+const declares = (header: string | null, capability: string): boolean =>
+  (header ?? "").split(",").some((name) => name.trim() === capability);
+
 /** Everything the handler learns from the request before routing: the recorded
  *  shape the caller asserts against, with the body parsed into it. */
 async function record(request: Request): Promise<RecordedRequest> {
@@ -363,6 +425,7 @@ async function record(request: Request): Promise<RecordedRequest> {
     contentType: request.headers.get("content-type"),
     deploymentHost: request.headers.get("x-vendo-deployment-host"),
     deploymentName: request.headers.get("x-vendo-deployment-name"),
+    capabilities: request.headers.get(STORE_WIRE_CAPABILITIES_HEADER),
   };
   const raw = new Uint8Array(await request.arrayBuffer());
   if (recorded.contentType === "application/json") {
@@ -385,6 +448,7 @@ export function fakeConsole() {
   const requests: RecordedRequest[] = [];
   const eraseCalls: unknown[] = [];
   const vault = new Map<string, string>();
+  const schemas = appSchemas();
   // The drawers this mount has opened. The reference adapter hands out a
   // RecordStore per name and never lists the names back, so `footprint` measures
   // the ones that came through these doors — which is every drawer this fake can
@@ -452,8 +516,27 @@ export function fakeConsole() {
       assertEngineCollection(collection);
       return recordsOp(records(collection), engineOp, body, miss);
     }
+    // The schema door, beside the wire ops: one app's DDL, in order.
+    if (rest[0] === "schema" && rest.length === 2 && post) {
+      return json({ tables: schemas.apply(rest[1]!, (body.operations ?? []) as Body[]) });
+    }
     const appDataOpName = post ? APP_DATA_ROUTES.get(path) : undefined;
     if (appDataOpName !== undefined) {
+      // Rows are typed; files are not. A row write into a table this app has
+      // not declared answers the proposal rather than landing.
+      if (appDataOpName === "put") {
+        const target = body.target as AppDataTarget;
+        const proposal = schemas.proposalFor(
+          target.appId,
+          target.collection,
+          (body.record as { data?: unknown }).data,
+        );
+        if (proposal !== undefined) {
+          return declares(recorded.capabilities, "schema-proposal")
+            ? json({ error: "schema-proposal", proposal }, 409)
+            : envelope("validation", `no table ${JSON.stringify(target.collection)} in app ${target.appId}`);
+        }
+      }
       return appDataOp(records, (n) => adapter.blobs(n), appDataOpName, body, miss);
     }
     // The audit drawer's own read, and the vault — both over the same backing

--- a/packages/store/src/hosted-store.ts
+++ b/packages/store/src/hosted-store.ts
@@ -11,11 +11,14 @@ import {
   type RecordInput,
   type RecordQuery,
   type RecordStore,
+  STORE_WIRE_CAPABILITIES,
+  STORE_WIRE_CAPABILITIES_HEADER,
   STORE_WIRE_PATHS,
   STORE_WIRE_TURN_OPS,
   type StoreOps,
   type StoreOpsWithAppData,
   storeWireErrorSchema,
+  storeWireSchemaProposalSchema,
   type StoreWireStatus,
   storeWireStatusSchema,
   storeWireTurnCommitResponseSchema,
@@ -40,6 +43,20 @@ import type { VendoStore } from "./store.js";
 /** The console mounts the hosted-store surface here
  * (apps/console/app/api/v1/store/*). */
 const CONSOLE_STORE_PATH = "/api/v1/store";
+
+/** The console's schema door, beside the wire mount: an in-order DdlOperation
+ * array for ONE app, answering the tables it serves afterwards. Deliberately
+ * not in STORE_WIRE_PATHS — that manifest's order IS the mount's capability
+ * level, so only ops belong in it, and this is a door the handshake uses rather
+ * than an op any caller may send. */
+const CONSOLE_SCHEMA_PATH = "/schema";
+
+/** What this client can read, declared on every store request
+ * ({@link STORE_WIRE_CAPABILITIES}): the mount only sends the proposal below to
+ * a client that says it can confirm one. */
+const CAPABILITY_HEADERS: Record<string, string> = {
+  [STORE_WIRE_CAPABILITIES_HEADER]: STORE_WIRE_CAPABILITIES,
+};
 
 /** Store calls are row/blob CRUD, not machine boots: generous enough for a
  * large blob transfer on a slow link, small enough that a hung console
@@ -108,10 +125,28 @@ const invalidResponse = (what: string): never => {
  * upstream 5xx rides its status → unavailable. What is left — a code no table
  * knows — is carried on a plain Error with the server's code attached, the
  * packages/apps cloud client's posture. */
-const raiseStoreError = (response: Response): Promise<never> =>
-  raiseCloudError(response, "store", (code, message) => {
+const raiseStoreError = async (response: Response): Promise<never> => {
+  const proposal = await schemaProposalError(response);
+  if (proposal !== undefined) throw proposal;
+  return raiseCloudError(response, "store", (code, message) => {
     throw Object.assign(new Error(message), { code: code ?? "unavailable" });
   });
+};
+
+/** A typed mount answers a write to a table it has not been told about with
+ * `{error: "schema-proposal", proposal}` on a 409 — a body that is neither the
+ * wire envelope nor anything raiseCloudError can read (its `error` is a STRING,
+ * so the console reading finds no code and no message and lands on the unknown
+ * tail). BOTH readings of a store failure have to recognize it, or the handshake
+ * in `mutate` never fires for the StoreAdapter façade — which is the surface an
+ * app's own row writes actually take. */
+const schemaProposalError = async (response: Response): Promise<VendoError | undefined> => {
+  if (response.status !== 409) return undefined;
+  const body: unknown = await response.clone().json().catch(() => undefined);
+  return storeWireSchemaProposalSchema.safeParse(body).success
+    ? parseStoreWireError(response.status, body)
+    : undefined;
+};
 
 function parseRecord(value: unknown): VendoRecord {
   const parsed = vendoRecordSchema.safeParse(value);
@@ -158,6 +193,7 @@ export function hostedStore(options: HostedStoreOptions): HostedStore {
     apiKey: options.apiKey,
     timeoutMs,
     fetchImpl,
+    headers: CAPABILITY_HEADERS,
     raise: raiseStoreError,
   });
 
@@ -328,6 +364,10 @@ const traceOutcome = (error: unknown): string => {
  * already did it"; a fresh key per attempt would double-apply the write. */
 const newIdempotencyKey = (): string => `idm_${globalThis.crypto.randomUUID()}`;
 
+/** How many schema proposals ONE mutation may confirm before it gives up and
+ * surfaces the proposal it could not satisfy. */
+const SCHEMA_PROPOSAL_CYCLES = 3;
+
 /** Both meter reads bound their window the same way, and a Date is not a wire
  * type: the instants cross as the ISO datetimes the request schemas validate. */
 const bounds = (query: { since: Date; until?: Date }): { since: string; until?: string } => ({
@@ -380,11 +420,15 @@ const retryAfterMs = (response: Response): number | undefined => {
  * and `meter-exhausted` are not wire codes, so a 401/402 that DOES carry a
  * recognized envelope came from the service's protocol half and keeps it. */
 const raiseWireError = async (response: Response): Promise<never> => {
+  const text = await response.text();
   let payload: unknown;
   try {
-    payload = JSON.parse(await response.text());
+    payload = JSON.parse(text);
   } catch {
-    payload = undefined;
+    // Not JSON at all — an edge proxy's HTML, a gateway's plain sentence. The
+    // TEXT crosses on rather than `undefined`, so parseStoreWireError can put a
+    // bounded snippet of it in the message instead of erasing what arrived.
+    payload = text;
   }
   if (storeWireErrorSchema.safeParse(payload).success) throw parseStoreWireError(response.status, payload);
   throw cloudStandingError(response.status, payload, `Vendo Cloud store request failed with ${response.status}`)
@@ -431,6 +475,7 @@ function storeWireClient(
     apiKey: options.apiKey,
     timeoutMs: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
     fetchImpl: options.fetch ?? defaultFetch,
+    headers: CAPABILITY_HEADERS,
     // The Response is gone by the time the retry below sees the error, so the
     // wait the console asked for rides on it.
     raise: (response) => raise(response).catch((error: unknown) => {
@@ -538,9 +583,60 @@ function storeWireClient(
       body: JSON.stringify(body),
     }));
 
-  /** Every mutation gets its key here, at the logical operation's one call. */
-  const mutate = (op: StoreWireOp, path: string, body: unknown, idempotencyKey = newIdempotencyKey()): Promise<unknown> =>
-    post(op, path, body, idempotencyKey);
+  /** The app a proposal would be confirmed against. App-data ops carry it in
+      their target, which is the ONLY place an appId exists on this wire —
+      Vendo's own engine drawers belong to no app and the mount declares them
+      itself. A proposal on an op without one gets no handshake: an appId
+      guessed from anywhere else declares a table in some other app's schema. */
+  const appIdOf = (body: unknown): string | undefined => {
+    const appId = (body as { target?: { appId?: unknown } } | null | undefined)?.target?.appId;
+    return typeof appId === "string" ? appId : undefined;
+  };
+
+  /** Accept one proposal, verbatim, on the mount's schema door. A refusal here
+      surfaces as itself — the write is not sent again on a schema that was
+      never applied. */
+  const confirmSchema = async (appId: string, proposal: unknown): Promise<void> => {
+    await send(`${CONSOLE_SCHEMA_PATH}/${encodeURIComponent(appId)}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ operations: [proposal] }),
+    });
+  };
+
+  /** Every mutation gets its key here, at the logical operation's one call —
+      and KEEPS it across the schema handshake, because a confirmed proposal is
+      a precondition of the same logical mutation, not a second one: a fresh key
+      on the replay is how a write lands twice.
+
+      A typed mount answers the first write to a table it has not been told
+      about with the DDL that would make the write legal, so the client confirms
+      it and sends the write again. One write can need more than one round —
+      create_table, then add_column for the fields the new table has no columns
+      for — so this loops, and it is capped: a mount that keeps proposing is
+      broken, and the caller has to hear that rather than watch a write spin.
+      The handshake lives at THIS call, the one place a mutation is issued, so
+      every writer — agents, automations, an interactive session — heals the
+      same way. */
+  const mutate = async (
+    op: StoreWireOp,
+    path: string,
+    body: unknown,
+    idempotencyKey = newIdempotencyKey(),
+  ): Promise<unknown> => {
+    for (let cycle = 0; ; cycle += 1) {
+      try {
+        return await post(op, path, body, idempotencyKey);
+      } catch (error) {
+        const appId = appIdOf(body);
+        if (
+          !isVendoError(error) || error.code !== "schema-proposal"
+          || appId === undefined || cycle === SCHEMA_PROPOSAL_CYCLES
+        ) throw error;
+        await confirmSchema(appId, error.detail);
+      }
+    }
+  };
 
   const field = <T>(payload: unknown, name: string, what: string, ok: (value: unknown) => boolean): T => {
     const value = (payload as Record<string, unknown> | null | undefined)?.[name];

--- a/packages/store/tests/hosted-store.test.ts
+++ b/packages/store/tests/hosted-store.test.ts
@@ -45,7 +45,7 @@ import {
 import { storeAdapterConformance } from "@vendoai/core/conformance";
 import { createStore, secretStore, storeSecrets, type VendoStore } from "../src/index.js";
 import { hostedStore, hostedStoreOps, type HostedStore } from "../src/hosted-store.js";
-import { fakeConsole } from "../src/hosted-store.test-util.js";
+import { fakeConsole, type RecordedRequest } from "../src/hosted-store.test-util.js";
 
 const encoder = new TextEncoder();
 
@@ -440,6 +440,179 @@ describe("hostedStore error mapping", () => {
       .rejects.toThrow(/invalid erase/);
     await expect(adapterFor(vi.fn(async () => Response.json({ keys: [1] }))).blobs("files").list())
       .rejects.toThrow(/invalid blob list/);
+  });
+});
+
+describe("store schema handshake", () => {
+  /** The two surfaces over the one wire, both driven against the SAME fake
+   *  console: the StoreAdapter façade (the console's error reading) and the op
+   *  client (the protocol's). They read a refusal differently, so a proposal
+   *  that only one of them recognized would heal on one surface and erase
+   *  itself on the other — which is exactly how this shipped broken. */
+  const surfaces = (console_: ReturnType<typeof fakeConsole>) => ({
+    facade: hostedStore({
+      apiKey: "vnd_secret",
+      baseUrl: "https://cloud.test",
+      owner: "user_1",
+      fetch: console_.handler as unknown as typeof fetch,
+    }),
+    ops: hostedStoreOps({
+      apiKey: "vnd_secret",
+      baseUrl: "https://cloud.test",
+      fetch: console_.handler as unknown as typeof fetch,
+    }),
+  });
+
+  const routeOf = (request: RecordedRequest): string => new URL(request.url).pathname;
+
+  it("declares what it can read on every store request, mutations included", async () => {
+    const console_ = fakeConsole();
+    const store = surfaces(console_).facade;
+    await store.records("app:x:notes").put({ id: "n_1", data: { text: "hi" } });
+    await store.records("app:x:notes").get("n_1");
+    await store.erase.bySubject("user_1");
+
+    // The write (with its two schema confirmations), the read, and the erase
+    // door that sits outside the op families — all of them.
+    expect(console_.requests.length).toBeGreaterThan(3);
+    for (const request of console_.requests) {
+      expect(request.capabilities).toBe("schema-proposal");
+    }
+  });
+
+  it("confirms the proposal and lands the write, on both surfaces", async () => {
+    const console_ = fakeConsole();
+    const { facade, ops } = surfaces(console_);
+
+    // A brand-new table: the mount proposes create_table, then — since a new
+    // table carries no data columns — add_column for the field this row has.
+    const put = await facade.records("app:x:notes").put({ id: "n_1", data: { text: "hi" } });
+    expect(put.id).toBe("n_1");
+    expect(console_.requests.map(routeOf)).toEqual([
+      "/api/v1/store/app-data/put",
+      "/api/v1/store/schema/x",
+      "/api/v1/store/app-data/put",
+      "/api/v1/store/schema/x",
+      "/api/v1/store/app-data/put",
+    ]);
+    expect(console_.requests[1]!.json).toEqual({
+      operations: [{ op: "create_table", table: "notes", scope: "private", columns: [] }],
+    });
+    expect(console_.requests[3]!.json).toEqual({
+      operations: [{ op: "add_column", table: "notes", scope: "private", columns: [{ name: "text", type: "text" }] }],
+    });
+    // Read back through the REAL read path — the row landed once, not twice.
+    expect((await facade.records("app:x:notes").get("n_1"))?.data).toEqual({ text: "hi" });
+    expect((await facade.records("app:x:notes").list()).records).toHaveLength(1);
+
+    // The declared table needs no second handshake, and the op surface — which
+    // reads a refusal through parseStoreWireError rather than the console's
+    // mapping — heals identically on a table of its own.
+    const before = console_.requests.length;
+    await facade.records("app:x:notes").put({ id: "n_2", data: { text: "again" } });
+    expect(console_.requests.slice(before).map(routeOf)).toEqual(["/api/v1/store/app-data/put"]);
+
+    const target = { appId: "x", collection: "invoices", owner: "user_1" };
+    await ops.appData!.put(target, { id: "inv_1", data: { total: 5 } });
+    expect((await ops.appData!.get(target, "inv_1"))?.data).toEqual({ total: 5 });
+  });
+
+  it("replays the SAME idempotency key across the handshake — one logical mutation", async () => {
+    const console_ = fakeConsole();
+    const keys: (string | null)[] = [];
+    const handler = (async (input: string, init: RequestInit = {}) => {
+      keys.push(new Headers(init.headers).get("idempotency-key"));
+      return console_.handler(input, init);
+    }) as unknown as typeof fetch;
+    await hostedStore({ apiKey: "vnd_secret", baseUrl: "https://cloud.test", owner: "user_1", fetch: handler })
+      .records("app:x:notes").put({ id: "n_1", data: { text: "hi" } });
+
+    // Three writes, one key: the server can still tell "do it again" from
+    // "you already did it". The schema confirmations carry none — they are a
+    // precondition, not the mutation.
+    const written = keys.filter((key) => key !== null);
+    expect(written).toHaveLength(3);
+    expect(new Set(written).size).toBe(1);
+  });
+
+  it("gives up after three proposals and surfaces the last one, proposal intact", async () => {
+    // A mount that proposes forever — a broken typed plane, which is the only
+    // thing the cap defends against.
+    let attempts = 0;
+    const proposal = { op: "create_table", table: "notes", scope: "private", columns: [] };
+    const looping = hostedStoreOps({
+      apiKey: "vnd_secret",
+      baseUrl: "https://cloud.test",
+      fetch: (async (url: string) => {
+        if (new URL(url).pathname.startsWith("/api/v1/store/schema/")) return Response.json({ tables: ["notes"] });
+        attempts += 1;
+        return Response.json({ error: "schema-proposal", proposal }, { status: 409 });
+      }) as unknown as typeof fetch,
+    });
+
+    const failure = await looping.appData!
+      .put({ appId: "x", collection: "notes", owner: "user_1" }, { id: "n_1", data: {} })
+      .then(() => undefined, (error: unknown) => error);
+    expect(failure).toBeInstanceOf(VendoError);
+    expect(failure).toMatchObject({ code: "schema-proposal", detail: proposal });
+    expect((failure as VendoError).message).toContain("create_table notes");
+    // The first send plus three confirmed retries, and then it stops.
+    expect(attempts).toBe(4);
+  });
+
+  it("never guesses an app: a proposal on an op that names none surfaces as itself", async () => {
+    let attempts = 0;
+    const ops = hostedStoreOps({
+      apiKey: "vnd_secret",
+      baseUrl: "https://cloud.test",
+      fetch: (async () => {
+        attempts += 1;
+        return Response.json(
+          { error: "schema-proposal", proposal: { op: "create_table", table: "vendo_threads" } },
+          { status: 409 },
+        );
+      }) as unknown as typeof fetch,
+    });
+    await expect(ops.engine.put("vendo_threads", { id: "thr_1", data: {} }))
+      .rejects.toMatchObject({ code: "schema-proposal" });
+    // No appId on an engine write, so nothing was confirmed against a guess.
+    expect(attempts).toBe(1);
+  });
+
+  it("a client that declares nothing is refused, not proposed to", async () => {
+    // The header is the whole reason the mount may answer a proposal at all; a
+    // client that cannot read one must still get an honest refusal.
+    const console_ = fakeConsole();
+    const response = await console_.handler("https://cloud.test/api/v1/store/app-data/put", {
+      method: "POST",
+      headers: { authorization: "Bearer vnd_secret", "content-type": "application/json" },
+      body: JSON.stringify({
+        target: { appId: "x", collection: "notes", owner: "user_1" },
+        record: { id: "n_1", data: { text: "hi" } },
+      }),
+    });
+    expect(response.status).toBe(400);
+    expect(parseStoreWireError(response.status, await response.json())).toMatchObject({ code: "validation" });
+  });
+
+  it("says what it could not read, instead of erasing the body", async () => {
+    const unreadable = (body: string, status: number) => hostedStoreOps({
+      apiKey: "vnd_secret",
+      baseUrl: "https://cloud.test",
+      fetch: (async () => new Response(body, { status })) as unknown as typeof fetch,
+    });
+    // The incident's shape: a 409 the envelope cannot parse used to reach the
+    // caller as a bare "HTTP 409" with the server's own words gone.
+    await expect(unreadable(JSON.stringify({ error: "unknown-protocol", hint: "upgrade" }), 409)
+      .engine.put("vendo_threads", { id: "thr_1", data: {} }))
+      .rejects.toMatchObject({
+        code: "conflict",
+        message: expect.stringContaining(`{"error":"unknown-protocol","hint":"upgrade"}`),
+      });
+    // Not JSON at all — an edge proxy's page still names itself.
+    await expect(unreadable("<html><title>504 Gateway Time-out</title></html>", 504)
+      .engine.get("vendo_threads", "thr_1"))
+      .rejects.toMatchObject({ code: "unavailable", message: expect.stringContaining("504 Gateway Time-out") });
   });
 });
 

--- a/packages/vendo/src/wire/shared.ts
+++ b/packages/vendo/src/wire/shared.ts
@@ -57,6 +57,9 @@ const STATUS_BY_CODE: Record<VendoErrorCode, number> = {
   // parses a status code back into one, so there is no STATUS_TO_CODE here
   // to extend.
   unavailable: 503,
+  // Same: a schema proposal is a typed store's answer to its own client, and
+  // this wire has no table to propose.
+  "schema-proposal": 409,
 };
 
 export interface WireDeps {


### PR DESCRIPTION
## The incident

Vendo Cloud's console now routes app-data traffic to a typed data plane. The
first write to an undeclared table answers

```
409 {"error": "schema-proposal", "proposal": {"op": "create_table", "table": "...", ...}}
```

The SDK could not read it. `storeWireErrorSchema` requires `error` to be an
**object** with `code` + `message`; a string `error` fails the parse, falls
through to `STATUS_TO_CODE`, and mints a bare
`VendoError("conflict", "store wire request failed with HTTP 409")`. The
proposal — the server telling us exactly what to do next — was silently erased.
Verified by live repro against production: every app's first row write into a
new collection failed on Cloud, with nothing in the error to say why.

## The contract

Frozen, and implemented verbatim by the parallel console PR.

**Capability declaration.** The store client sends
`x-vendo-store-capabilities: schema-proposal` on every store-wire request —
additive, comma-separated, read by the mount as a set. It is scoped to store
traffic: `consoleSender` gained an optional per-wire `headers` slot, and only
`hostedStore`/`storeWireClient` fill it, so sandbox, connections, apps and the
CLI cloud client are unchanged and managed inference (which never carries Vendo
headers) is untouched.

**The handshake.** On a `409` whose body is `{error: "schema-proposal",
proposal}` — discriminated on `error` being the literal string — the client
POSTs `{operations: [proposal]}` to `/api/v1/store/schema/{appId}` and sends the
original mutation again. It loops while the retry yields another proposal
(`create_table`, then `add_column`), capped at 3 cycles, then surfaces the
proposal it could not satisfy.

**The appId.** Taken from the op's own `target.appId` — the only place an appId
exists on this wire. A proposal arriving on an op that names none (an engine
write, a transcript) is surfaced, never confirmed against a guess.

## Retry semantics

The handshake lives in `mutate` in `packages/store/src/hosted-store.ts` — the
one place a logical mutation is issued — so every writer (agents, automations,
interactive) heals identically.

The **idempotency key is minted once and replayed verbatim** across every
retry: a confirmed proposal is a precondition of the *same* logical mutation,
not a new one, so the server can still tell "do it again" from "you already did
it". The schema confirmations themselves carry no key — they are not the
mutation. This is the existing `wire` retry's rule, kept.

Both readings of a store failure recognize the proposal. `raiseWireError` (the
protocol client) gets it through `parseStoreWireError`; `raiseStoreError` (the
console reading used by the StoreAdapter façade — which is the surface an app's
own row writes actually take) checks the 409 body before falling through to
`raiseCloudError`, whose `error`-as-object assumption would otherwise drop it on
the unknown-code tail. Without both, the fix heals one surface and erases itself
on the other.

## Independently: the parser stops erasing bodies

`parseStoreWireError` now:

- recognizes the proposal as its own `schema-proposal` VendoError code, with the
  proposal intact on `detail` (passed through untouched — the client forwards it
  verbatim, so fields this build does not know must survive);
- puts a **bounded snippet** (200 chars) of any body it could not parse into the
  message, so the next protocol skew is diagnosable from the error alone instead
  of from a live repro. `raiseWireError` now passes the raw text through when the
  body is not JSON at all, so an edge proxy's HTML names itself too.

`schema-proposal` is additive to the `VendoErrorCode` enum (the contract test
already declares new codes additive); it is 409 in the three
`Record<VendoErrorCode, number>` status tables that the compiler requires be
exhaustive.

## Test proof

Per the repo's seam law, the server half is real: `fakeConsole`
(`packages/store/src/hosted-store.test-util.ts`) gained the typed data plane
itself — an app's tables and columns are declared before rows land, an
undeclared write answers the proposal, and `/schema/{appId}` applies an in-order
DDL array. Rows land through the same appData door as every other write and come
back out through the same read. Neither side stubs the other.

New in `packages/store/tests/hosted-store.test.ts`:

1. the capability header rides every store request, mutations included;
2. proposal → confirm → retried write **lands and reads back**, on both the
   façade and the op surface, with the exact route sequence
   (`app-data/put` → `schema/x` → `app-data/put` → `schema/x` → `app-data/put`)
   and both DDL bodies pinned;
3. one idempotency key across all three writes;
4. the 3-cycle cap against a mount that proposes forever — 4 attempts, then the
   proposal surfaces intact;
5. a proposal on an op with no appId is surfaced, not guessed at (1 attempt);
6. a client declaring nothing gets an honest refusal, not a proposal;
7. an unreadable body surfaces its snippet.

New in `packages/core/tests/store-wire.test.ts`: proposal recognition (envelope
still wins where both could match), and the bounded snippet including the
10k-body truncation and the empty-body cases.

**Proved they can fail** — three separate reverts, each restored:

| reverted | red |
|---|---|
| the handshake loop in `mutate` | 5 tests |
| `headers: CAPABILITY_HEADERS` on both senders | 4 tests |
| the body snippet in `parseStoreWireError` | 1 test |

Note the pre-existing "an app-scoped collection rides the appData door" test
goes red under the first two reverts: with the fake now typed, that test's write
only lands because the handshake works.

## Gate

`pnpm build && pnpm test:affected && pnpm typecheck && pnpm lint`, green.

Not merged, not released.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes typed-store 409s by treating a schema proposal as an actionable answer. Previously, a 409 with `{error: "schema-proposal", proposal}` was parsed as a generic conflict and the proposal was lost; first writes to new collections failed with no guidance. Now the store client declares support, confirms the proposal, and retries the write with the same idempotency key. Both the façade and op clients handle this path.

- Adds `x-vendo-store-capabilities: schema-proposal` on the store wire only via a new per-wire `headers` option in `consoleSender`.
- Implements the handshake in `packages/store/src/hosted-store.ts` `mutate`: on a 409 proposal, POST `{operations:[proposal]}` to `/api/v1/store/schema/{appId}`, then retry; loop up to 3; never guess `appId` (surface the proposal if absent).
- Updates `packages/core/src/store-wire.ts` error parsing: recognize `{error:"schema-proposal"}`, return `VendoError` with code `schema-proposal` and `detail`=proposal; include a bounded body snippet when the body is unrecognized; `raiseWireError` forwards raw text for non-JSON.
- Adds `schema-proposal` to `VendoErrorCode` and status maps across `@vendoai/core`, the knowledge wire, and `@vendoai/vendo`; both console-based and protocol-based error paths recognize proposals.
- Reuses the same idempotency key across retries; schema confirmations carry no key.

**Rollout**
- Backward compatible; only the store wire sends the new header; no API changes for apps.
- Custom clients must send the capability header to receive proposals; otherwise the mount returns a validation error.

<sup>Written for commit 71da2d93fb5858e52a5cb6bff70def3cd26c8a31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

