### PR TITLE
feat(ui): the workspace flips — the conversation docks left, the built view renders right

### DIFF
--- a/.changeset/the-workspace-reads-left-to-right.md
+++ b/.changeset/the-workspace-reads-left-to-right.md
@@ -1,0 +1,11 @@
+---
+"@vendoai/ui": minor
+---
+
+The expanded workspace reads left to right now: the conversation docks as the
+left rail and the featured view renders large on the right stage — the canvas
+convention, where you talk on the left and the built thing appears beside your
+words. The header cluster (history, expand, new conversation, close) stays the
+chat column's furniture, gliding to the rail's edge on the same spring the
+panes ride, and the embed's shared-element flight lands on the stage's new
+side. Dock and mobile takeover are unchanged — neither ever shows the stage.

--- a/packages/ui/src/chrome/chrome-css.ts
+++ b/packages/ui/src/chrome/chrome-css.ts
@@ -933,7 +933,8 @@ export const CHROME_CSS = ONEST_FONT_CSS + `/* @vendoai/ui chrome — the S1 des
   transform-origin: center; animation: fl-overlay-stretch .5s cubic-bezier(.22, 1.2, .36, 1) both; }
 .fl-overlay-close { position: absolute; top: 12px; right: 12px; z-index: 5; width: 28px; height: 28px;
   border-radius: 9px; display: grid; place-items: center; border: 0; background: transparent;
-  color: var(--vendo-fg-muted); cursor: pointer; transition: background .12s, color .12s; }
+  color: var(--vendo-fg-muted); cursor: pointer;
+  transition: background .12s, color .12s, right .45s cubic-bezier(.22, 1, .36, 1); }
 .fl-overlay-close:hover { background: var(--vendo-accent-soft); color: var(--vendo-fg); }
 /* ENG-221: new-conversation sits just left of the close X — same quiet header
    treatment (it shares .fl-overlay-close), only the horizontal offset differs.
@@ -957,27 +958,40 @@ export const CHROME_CSS = ONEST_FONT_CSS + `/* @vendoai/ui chrome — the S1 des
   to   { transform: translate(-50%, -50%) scaleX(1) scaleY(1); opacity: 1; } }
 /* ---------- split-view workspace (2026-07 demo feedback) ---------- */
 /* The overlay's expandable workspace: the panel grows near-fullscreen, the
-   featured microapp renders LARGE on a left stage (the leftover ~2/3) and the
-   conversation docks as the right rail. One animated property does the pane
-   work — the rail's flex-basis walks 100% ⇄ max(360px, 33.5%), so the stage
-   (flex 1 1 0) grows exactly as the rail shrinks; the panel's own width/height
-   ride the existing .45s spring. The thread's DOM slot is identical in both
-   states (no remount — the ENG-221 invariant). */
+   conversation docks as the left rail and the featured microapp renders LARGE
+   on a right stage (the leftover ~2/3) — the canvas convention: you talk on
+   the left, the built thing renders on the right. One animated property does
+   the pane work — the rail's flex-basis walks 100% ⇄ var(--vendo-rail-w), so
+   the stage (flex 1 1 0) grows exactly as the rail shrinks; the panel's own
+   width/height ride the existing .45s spring. The thread's DOM slot is
+   identical in both states (no remount — the ENG-221 invariant). */
 .fl-split { flex: 1; min-height: 0; display: flex; align-items: stretch; }
 .fl-split-stage { flex: 1 1 0; min-width: 0; overflow: hidden; display: flex; flex-direction: column;
   background: var(--vendo-bg); opacity: 0;
-  border-right: 0 solid var(--vendo-border);
-  transition: opacity .28s ease .1s, border-right-width 0s .45s; }
+  border-left: 0 solid var(--vendo-border);
+  transition: opacity .28s ease .1s, border-left-width 0s .45s; }
 .fl-split-rail { flex: 0 0 100%; min-width: 0; display: flex; flex-direction: column;
   transition: flex-basis .45s cubic-bezier(.22, 1, .36, 1), filter .22s ease; }
 /* The signed-out panel (H2-E): one centered quiet line where the thread would
    be — same ground, no chrome, nothing that looks broken. */
 .fl-signedout { flex: 1; display: flex; align-items: center; justify-content: center; padding: 24px; }
 .fl-signedout-line { margin: 0; font-size: 15px; color: var(--vendo-muted-foreground, #6b7280); text-align: center; }
-.fl-overlay-panel[data-vendo-expanded] { width: min(1500px, 96vw); height: min(940px, 94vh); }
-.fl-overlay-panel[data-vendo-expanded] .fl-split-rail { flex-basis: max(360px, 33.5%); }
-.fl-overlay-panel[data-vendo-expanded] .fl-split-stage { opacity: 1; border-right-width: 1px;
-  transition: opacity .28s ease .1s, border-right-width 0s; }
+.fl-overlay-panel[data-vendo-expanded] { width: min(1500px, 96vw); height: min(940px, 94vh);
+  --vendo-rail-w: max(360px, 33.5%); }
+.fl-overlay-panel[data-vendo-expanded] .fl-split-rail { flex-basis: var(--vendo-rail-w); }
+.fl-overlay-panel[data-vendo-expanded] .fl-split-stage { opacity: 1; border-left-width: 1px;
+  transition: opacity .28s ease .1s, border-left-width 0s; }
+/* The header cluster (close/new/expand/history) belongs to the CHAT column in
+   both postures, so when the rail docks left the whole ladder rides to the
+   rail's top-right edge — same offsets, now measured from the divider. Its
+   .45s right-glide (on .fl-overlay-close) tracks the rail's flex-basis walk
+   exactly: both interpolate linearly against the same animating panel width.
+   Docked never expands, but the guard keeps a stale attribute harmless. */
+.fl-overlay-panel[data-vendo-expanded]:not(.fl-dock) .fl-overlay-close { right: calc(100% - var(--vendo-rail-w) + 12px); }
+.fl-overlay-panel[data-vendo-expanded]:not(.fl-dock) .fl-overlay-new { right: calc(100% - var(--vendo-rail-w) + 46px); }
+.fl-overlay-panel[data-vendo-expanded]:not(.fl-dock) .fl-overlay-expand { right: calc(100% - var(--vendo-rail-w) + 80px); }
+.fl-overlay-panel[data-vendo-expanded]:not(.fl-dock) .fl-overlay-history { right: calc(100% - var(--vendo-rail-w) + 114px); }
+.fl-overlay-panel[data-vendo-expanded]:not(.fl-dock) .fl-history { right: calc(100% - var(--vendo-rail-w) + 12px); }
 /* The stage: a quiet porcelain workspace — hairline-framed content, generous
    air, the same app-boundary vocabulary as the in-thread card. */
 .fl-stage { flex: 1; min-height: 0; display: flex; flex-direction: column; animation: fl-fade-in .22s ease both; }
@@ -1002,6 +1016,7 @@ export const CHROME_CSS = ONEST_FONT_CSS + `/* @vendoai/ui chrome — the S1 des
    conversation; the rail keeps rendering beneath it. */
 .fl-history { position: absolute; top: 48px; right: 12px; z-index: 6;
   width: min(320px, calc(100% - 24px)); max-height: min(60%, 420px);
+  transition: right .45s cubic-bezier(.22, 1, .36, 1);
   display: flex; flex-direction: column; overflow: hidden;
   background: var(--vendo-surface); color: var(--vendo-fg);
   border: 1px solid color-mix(in srgb, var(--vendo-fg) 12%, transparent);

--- a/packages/ui/src/chrome/split-view.tsx
+++ b/packages/ui/src/chrome/split-view.tsx
@@ -3,9 +3,9 @@
  * The centered overlay modal is a fine conversation surface but a cramped one
  * for microapps: the generated view competes with the transcript inside one
  * ~620px column. Expanding animates the modal into a near-fullscreen
- * workspace — the FEATURED microapp renders large in a left stage (~2/3
- * width) while the conversation docks as a right-hand rail (~1/3, min
- * 360px) with the composer at its bottom. Collapse animates back; the
+ * workspace — the conversation docks as a left-hand rail (~1/3, min 360px)
+ * with the composer at its bottom while the FEATURED microapp renders large
+ * in a right stage (~2/3 width). Collapse animates back; the
  * conversation NEVER remounts across the flip (same rule as close/reopen —
  * the DOM hierarchy around the thread is identical in both states, only CSS
  * changes).
@@ -182,7 +182,7 @@ export interface MorphRect {
 /** MUST mirror the chrome-css split-view constants — update together:
  *  `.fl-overlay-panel[data-vendo-expanded] { width: min(1500px, 96vw);
  *  height: min(940px, 94vh); }` (centered fixed panel, 1px border) and
- *  `.fl-split-rail { flex-basis: max(360px, 33.5%); }`. */
+ *  `--vendo-rail-w: max(360px, 33.5%);`. */
 const EXPANDED = {
   panelMaxW: 1500,
   panelVw: 0.96,
@@ -197,7 +197,8 @@ const EXPANDED = {
  *  target rect for the embed's FLIP ghost. Computed (not measured) because a
  *  CSS transition interpolates: at flight time the DOM still reports the
  *  compact layout, and suppressing the transitions to measure would kill the
- *  panel spring the ghost rides alongside. */
+ *  panel spring the ghost rides alongside. The stage is the RIGHT pane, so
+ *  its left edge sits past the rail. */
 export function expandedStageRect(viewport: { width: number; height: number }): MorphRect {
   const panelWidth = Math.min(EXPANDED.panelMaxW, viewport.width * EXPANDED.panelVw);
   const panelHeight = Math.min(EXPANDED.panelMaxH, viewport.height * EXPANDED.panelVh);
@@ -205,7 +206,7 @@ export function expandedStageRect(viewport: { width: number; height: number }): 
   const railWidth = Math.max(EXPANDED.railMin, contentWidth * EXPANDED.railFraction);
   return {
     top: (viewport.height - panelHeight) / 2 + EXPANDED.border,
-    left: (viewport.width - panelWidth) / 2 + EXPANDED.border,
+    left: (viewport.width - panelWidth) / 2 + EXPANDED.border + railWidth,
     width: contentWidth - railWidth,
     height: panelHeight - 2 * EXPANDED.border,
   };

--- a/packages/ui/src/chrome/vendo-overlay.tsx
+++ b/packages/ui/src/chrome/vendo-overlay.tsx
@@ -485,7 +485,7 @@ function embedFlight(
   return { mode: "out", from, target, clipTo, clone: makeClone(stageEl, from.width) };
 }
 
-/** The workspace's left pane: the featured app rendered large, with the build's
+/** The workspace's right pane: the featured app rendered large, with the build's
     own beat rail under it. Stays mounted through expanded → collapsing →
     collapsed (`mounted`) so the featured app does not blink out before the panes
     finish sliding. */
@@ -1102,6 +1102,17 @@ export function VendoOverlay({
             stage pane is width-0 and empty; the rail IS the whole panel. */}
         <SplitViewContext.Provider value={splitContextValue}>
           <div className="fl-split">
+            <div className="fl-split-rail" key="rail">
+              <RailBody signedOut={signedOut} notice={signedOutNotice} prefillScope={prefillScope.current}>
+                <Thread
+                  key={`${conversationKey ?? 0}:${conversationEpoch}:${resumeThreadId ?? "new"}`}
+                  {...resumeThreadProps(resumeThreadId)}
+                  discoverability={dial}
+                  firstRunGreeting={greeting}
+                  onThreadId={adoptThreadId}
+                />
+              </RailBody>
+            </div>
             <WorkspaceStage
               key="stage"
               mounted={stagePhase !== "collapsed"}
@@ -1115,17 +1126,6 @@ export function VendoOverlay({
                 setOpen(false);
               }}
             />
-            <div className="fl-split-rail" key="rail">
-              <RailBody signedOut={signedOut} notice={signedOutNotice} prefillScope={prefillScope.current}>
-                <Thread
-                  key={`${conversationKey ?? 0}:${conversationEpoch}:${resumeThreadId ?? "new"}`}
-                  {...resumeThreadProps(resumeThreadId)}
-                  discoverability={dial}
-                  firstRunGreeting={greeting}
-                  onThreadId={adoptThreadId}
-                />
-              </RailBody>
-            </div>
           </div>
         </SplitViewContext.Provider>
       </div>

--- a/packages/ui/test/chrome/split-view.test.tsx
+++ b/packages/ui/test/chrome/split-view.test.tsx
@@ -111,22 +111,24 @@ describe("splitViewReducer (state machine)", () => {
 
   it("expandedStageRect mirrors the chrome-css split-view constants (the FLIP ghost's target)", async () => {
     // 1440×1100 viewport: panel = min(1500, .96·1440)=1382.4 × min(940, .94·1100)=940,
-    // centered; rail = max(360, .335·(1382.4−2)); stage pane = the rest inside the border.
+    // centered; rail = max(360, .335·(1382.4−2)) on the LEFT; stage pane = the
+    // rest inside the border, starting past the rail.
     const rect = expandedStageRect({ width: 1440, height: 1100 });
     const panelW = Math.min(1500, 1440 * 0.96);
     const panelH = Math.min(940, 1100 * 0.94);
     const rail = Math.max(360, (panelW - 2) * 0.335);
-    expect(rect.left).toBeCloseTo((1440 - panelW) / 2 + 1, 5);
+    expect(rect.left).toBeCloseTo((1440 - panelW) / 2 + 1 + rail, 5);
     expect(rect.top).toBeCloseTo((1100 - panelH) / 2 + 1, 5);
     expect(rect.width).toBeCloseTo(panelW - 2 - rail, 5);
     expect(rect.height).toBeCloseTo(panelH - 2, 5);
     // Small viewport: the 360px rail floor holds.
     const small = expandedStageRect({ width: 900, height: 700 });
     expect(small.width).toBeCloseTo(900 * 0.96 - 2 - 360, 5);
+    expect(small.left).toBeCloseTo((900 - 900 * 0.96) / 2 + 1 + 360, 5);
     // And the constants the math mirrors are still the ones the stylesheet ships.
     const { CHROME_CSS } = await import("../../src/chrome/chrome-css.js");
     expect(CHROME_CSS).toContain("width: min(1500px, 96vw); height: min(940px, 94vh);");
-    expect(CHROME_CSS).toContain("flex-basis: max(360px, 33.5%);");
+    expect(CHROME_CSS).toContain("--vendo-rail-w: max(360px, 33.5%);");
   });
 
   it("the plan hint's auto-stage shot is recorded ONCE per BUILD, open or not (G1)", () => {


### PR DESCRIPTION
## What

In the expanded overlay workspace, the two panes swap sides: the **conversation is now the left rail** and the **featured view renders large on the right stage** — the canvas convention (ChatGPT canvas / Claude artifacts): you talk on the left, the built thing appears beside your words.

```
before                                   after
┌──────────────────┬─────────┐           ┌─────────┬──────────────────┐
│                  │  CHAT   │           │  CHAT   │                  │
│    APP STAGE     │  ▸ ⌕ + ✕│           │  ▸ ⌕ + ✕│    APP STAGE     │
│                  │ [input] │           │ [input] │                  │
└──────────────────┴─────────┘           └─────────┴──────────────────┘
```

## How

- `vendo-overlay.tsx`: the rail renders before the stage in `.fl-split` (also puts the conversation first in tab order).
- `chrome-css.ts`: the stage's divider becomes `border-left`; the rail width gets a single source (`--vendo-rail-w`); the header cluster (history/expand/new/close) and the history card stay the chat column's furniture — when expanded they ride to the rail's right edge on a `.45s` right-glide that tracks the rail's flex-basis walk exactly (both interpolate linearly against the same animating panel width, so the buttons stay pinned to the divider mid-flight).
- `split-view.tsx`: `expandedStageRect` (the FLIP ghost's computed target) moves the stage's left edge past the rail.
- Test update, stated out loud: `split-view.test.tsx` asserted the old stage-left rect and the old `flex-basis` literal — both assertions now mirror the new geometry/CSS (plus a new `small.left` assertion for the rail-floor case). The contract changed; the test follows it.

Dock and mobile takeover are untouched — neither ever shows the stage (`stageHidden`), and the button-shift rules are scoped `[data-vendo-expanded]:not(.fl-dock)`.

## Verified

- Real browser (fresh worktree, dev server, Maple): expanded rail 25→410, stage 410→1175 on a 1200px viewport; button ladder inset 12/46/80/114 from the divider; collapsed modal unchanged (centered, close 12px inset). `expandedStageRect` predicts 410.25 for that viewport — the ghost lands on the pane.
- Local gate green on touched scope: `pnpm build && pnpm test:affected && pnpm typecheck && pnpm lint` (2416 tests).
- Local browser specs (CI skips them): smoke / extreme-content / screenshots / accessibility — 33 passed. One pre-existing failure unrelated to this change: `thread-citations` axe color-contrast fails identically on the unmodified tree.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Flips the expanded overlay workspace: previously the stage was left and the conversation rail was right; now the conversation docks on the left and the stage renders on the right. This aligns with canvas-style apps and keeps header controls with the chat column.

- Render order: in `.fl-split`, the rail renders before the stage, placing the conversation first in tab order.
- CSS: the divider moves to `border-left`; introduce `--vendo-rail-w` as the single rail-width source; header cluster elements glide to the rail’s right edge via animated `right` offsets, guarded by `[data-vendo-expanded]:not(.fl-dock)`.
- FLIP target: `expandedStageRect` now offsets the stage’s left by the rail width, since the stage is the right pane.
- Tests and modes: geometry and constants assertions updated (including small-viewport rail floor); dock and mobile takeover remain unchanged (stage stays hidden; no conversation remount).

<sup>Written for commit 6ff6772a360524719ee7528bd53476efc572d2fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1453?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

