### PR TITLE
fix(vendo): a "no tool for that" verdict is earned by the search, not the belt

### DIFF
--- a/.changeset/miss-report-requires-search.md
+++ b/.changeset/miss-report-requires-search.md
@@ -1,0 +1,12 @@
+---
+"@vendoai/vendo": patch
+---
+
+A "no tool for that" conclusion now requires the search. The capability-miss
+prompt told the agent to report a no-matching-tool miss "before replying", and
+the discovery section told it to search find_tools "before concluding you
+can't" — two instructions, one situation, and the model may satisfy either. On
+a live text-channel transfer ask it satisfied the first: filed the miss off its
+equipped read tools alone and told the customer it couldn't send money, while
+"Send money" sat one find_tools call away. The miss bullet now names the search
+as the only way to establish "no available tool" on a surface that has one.

--- a/packages/vendo/src/prompt.ts
+++ b/packages/vendo/src/prompt.ts
@@ -61,8 +61,17 @@ Verifying
 // perform it", so reporting a miss and replying in prose read as compliance with
 // this section while the connect etiquette below was asking for the opposite. Two
 // instructions, one situation, and the model may satisfy either.
+//
+// Same defect, different pair (maple text channel 2026-08-18): a transfer ask
+// was reported as no-matching-tool off the equipped reads alone — with
+// host_transferMoney one find_tools call away — because this bullet offered a
+// compliant exit that never required the search the discovery section asks
+// for. The bullet now makes the search the only way to establish "no
+// available tool" on a surface that has one — in the same tool-name-free
+// voice as HOW_YOU_WORK's discovery bullet, because this section rides every
+// surface and must not promise a rail the turn does not carry.
 const CAPABILITY_MISS_PROMPT = `When the user's ask cannot be fulfilled:
-- If no available tool can perform it, call vendo_report_capability_miss with kind "no-matching-tool" before replying.
+- If no available tool can perform it, call vendo_report_capability_miss with kind "no-matching-tool" before replying — and when this surface offers discovery tools, only a search can establish that: never conclude no tool exists from your equipped set alone.
 - An outside service this user has not connected is not a capability miss: ask for it with request_connection instead of reporting one.
 - If you explicitly give up after trying available approaches, call vendo_report_capability_miss with kind "agent-give-up" before replying.
 - List only tool names you actually considered. Do not call the reporter for a pending approval or a policy-blocked call.


### PR DESCRIPTION
## What broke

A live text-channel turn on Maple: "send $25 to Dana Whitfield" → the agent called `host_listPayees`, filed `vendo_report_capability_miss` with kind `no-matching-tool` (toolsConsidered: the two payee reads), and told the customer it cannot send money — while `host_transferMoney` ("Send money", destructive, ask-gated, built for exactly this flow) sat one `find_tools` call away. A retry an hour later refused again with zero tool calls.

## Why

The system prompt held two instructions that both fit that situation, with no order between them:

- Discovery budget: "search find_tools before concluding you can't"
- Capability miss: "If no available tool can perform it, call vendo_report_capability_miss … before replying"

The model satisfied the second and skipped the first — fully compliant by its own lights. The comment above the miss section already documents this defect class from uiaudit 2026-08-06: "Two instructions, one situation, and the model may satisfy either." This is the same shape with a different pair (search vs. miss-report instead of connect-ask vs. miss-report).

## Fix

One bullet. The miss prompt's `no-matching-tool` exit now names the search as the only way to establish "no available tool":

> …before replying — **and when this surface offers discovery tools, only a search can establish that: never conclude no tool exists from your equipped set alone.**

Worded tool-name-free ("discovery tools", HOW_YOU_WORK's own term) because the miss section rides every surface, and `harness-system-prompt.test.ts`'s discovery-rail case rightly rejects a prompt that names `find_tools` on a surface that doesn't carry it — the first draft of this change failed exactly that test.

No mechanism changes: the belt, its safest-first sort, and the miss reporter are untouched.

## Gate

`pnpm build && pnpm test:affected && pnpm typecheck && pnpm lint` green locally (vendo: 2415 passed after the reword; the discovery-rail case failed on the tool-named draft and passes on this one).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require a search before reporting a "no-matching-tool" capability miss on surfaces with discovery tools. Previously the agent could conclude “no tool” from its equipped set and report a miss; now it must run discovery first, preventing false negatives like skipping a transfer tool.

- Prompt-only change in `CAPABILITY_MISS_PROMPT`; belt ordering and the miss reporter are unchanged.
- Tool-name-free wording applies across surfaces; surfaces without discovery tools keep prior behavior.
- Ships as a patch via changeset to `@vendoai/vendo`.

<sup>Written for commit 722cf34552161125da01ec0bcdfd3d4ccccfc3bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

