### PR TITLE
fix(vendo): init asks where dev runs, and stops asking where you deploy

### DIFF
--- a/.changeset/init-asks-where-dev-runs.md
+++ b/.changeset/init-asks-where-dev-runs.md
@@ -1,0 +1,33 @@
+---
+"@vendoai/vendo": patch
+---
+
+Init asks where the app runs in DEV, and stops asking where it deploys. The dev
+origin is the one Vendo cannot learn: an own-loop tool call, a backend process
+and the MCP door each make a real HTTP request back at the host's own API and
+never see a wire request to read an origin off, so every one of those installs
+met `Cannot execute … set VENDO_BASE_URL` on its first turn — after a run that
+had reported itself finished. Interactive init now asks one question, prefilled
+with the port the host's own `dev` script names, and writes the answer to
+`.env.local` as `VENDO_BASE_URL`. Enter is the whole interaction, and the
+terminal echoes the value it wrote rather than calling an accepted default a
+skip.
+
+A run that cannot ASK still writes nothing: the prefill is an answer only when a
+person accepts it, and a guessed origin is worse than an absent one — unset, dev
+learns the request's own origin and production fails loud, both unchanged.
+`--base-url` is that same answer as a flag (dev origin, `.env.local`), and it
+travels in `--agent` mode's question list like every other decision a person owns.
+
+"Where will this deploy?" is gone, with the `.env.example` rewrite that went with
+it. Production is told at deploy time, not asked at init: `.env.example`'s
+`VENDO_BASE_URL` block is now an instruction — dev is already in `.env.local`, and
+the real value goes in the hosting platform's own environment settings, never in a
+committed file and never in `.env.local`, where a public URL would repoint local
+dev's discovery, callbacks and credential forwarding at the deployed origin. The
+MCP arm reads the dev answer for the client URL it prints, so the address a user
+pastes into Claude is the app they are actually running, and its first step now
+points at deploy time for the public one.
+
+No platform variable is ever consulted: nothing infers an origin from `VERCEL_URL`
+or any sibling. The URL is set by the person who knows it, or it is loudly unset.

--- a/.changeset/the-door-doctor-grades-is-the-door-init-wrote.md
+++ b/.changeset/the-door-doctor-grades-is-the-door-init-wrote.md
@@ -1,0 +1,19 @@
+---
+"@vendoai/vendo": patch
+---
+
+E-MCP-009 grades the door init actually wrote. The composition moved into its own
+module (`lib/vendo.ts`, `src/lib/vendo.ts` under a src layout) and doctor's MCP
+path list never followed, so on every host init scaffolded since then the check
+found no composition at all and said NOTHING — no failure, no check, nothing to
+notice — which is the precise outcome a hard FAIL exists to prevent: a door whose
+discovery advertises the wrong origin, surfacing hours later in someone else's
+terminal as "Claude can't find my server". The list now leads with the current
+module and keeps every legacy location (the route's sibling `vendo.ts`, the inline
+route, the Express and runtime-neutral modules), in the same order
+`doctor-wiring-checks.ts` reads them, so older installs grade exactly as they did.
+
+Expect the intended failure to reappear: an MCP-wired host with neither
+`VENDO_BASE_URL` nor `mcp: { baseUrl }` fails E-MCP-009 and exits 1, where it had
+been silently green. Interactive `vendo init` now answers it in dev by writing the
+dev origin to `.env.local`; production sets the variable where it deploys.

--- a/docs-site/agents/index.mdx
+++ b/docs-site/agents/index.mdx
@@ -143,14 +143,17 @@ surface as any other install: do the install below, then [MCP door](#mcp-door).
    pick, and the flag that answers it. Put all of them to your human in your
    very next message, in your own words, in one turn. Keep init's order and
    keep its recommendation first: "recommended" in the label is not enough if
-   the cursor lands on the other choice. Usually there are three. How will
+   the cursor lands on the other choice. Usually there are four. How will
    people use your agent: embedded in their app (most apps, and the
    recommended pick), through their own agent loop, or from outside AI apps
    over MCP. Should the assistant act as their signed-in user, on the provider
-   init detected ([which preset?](/production/auth)). And where the model comes
+   init detected ([which preset?](/production/auth)). Where the model comes
    from: a free Vendo Cloud key is one browser click and needs no provider
-   account, or they bring their own Anthropic or OpenAI key. Say what each
-   option gets their users, not what it configures.
+   account, or they bring their own Anthropic or OpenAI key. And where their
+   app runs in dev — init prefills the port their `dev` script names, so this
+   one is usually a yes, and the answer lands in `.env.local` as
+   `VENDO_BASE_URL`. Say what each option gets their users, not what it
+   configures.
 
    Take the model answer first, before you re-run anything. It is the one
    answer that has no flag: the Vendo Cloud pick is a login you run now, and
@@ -328,7 +331,7 @@ MCP**) and init writes 1 and 2 below for you — the composition with
 route:
 
 ```bash
-npx vendo init --agent --use-case mcp --auth authJs --base-url https://app.example.com
+npx vendo init --agent --use-case mcp --auth authJs --base-url http://localhost:3000
 ```
 
 That path needs Next.js and one of the four zero-arg presets,
@@ -406,19 +409,22 @@ sets up a service key (`--service-key`). Answer both as flags on the next run;
    at the origin root as well (`app.use("/.well-known", mountVendo())`),
    registered after the app's own well-known routes.
 
-3. **`VENDO_BASE_URL`.** Set it to the deployment's FULL public URL, path
-   prefix included. The issuer, every advertised endpoint, the
+3. **`VENDO_BASE_URL`.** It names the origin the door actually answers on: the
+   dev origin while your human is local, the deployment's FULL public URL (path
+   prefix included) in production. The issuer, every advertised endpoint, the
    protected-resource identifier, and the RFC 8707 audience all derive from it;
    left unset they come from the request URL — behind any proxy the
    proxy-internal origin, so discovery advertises endpoints no client can reach.
    Forwarded headers are never consulted.
 
-   ```bash
-   VENDO_BASE_URL=https://app.example.com
+   ```bash .env.local
+   VENDO_BASE_URL=http://localhost:3000
    ```
 
-   `--base-url` only writes it into `.env.example`; setting it where the host
-   deploys stays your human's. Doctor FAILS
+   Init's dev-URL question already wrote that line (`--base-url` is the same
+   answer as a flag). Production is set where the host DEPLOYS — in the
+   platform's own environment settings, never in a committed file — and that one
+   stays your human's. Doctor FAILS
    [`E-MCP-009`](/production/troubleshooting/e-mcp-009) on an MCP-wired project with neither
    this variable nor `mcp: { baseUrl }`.
 

--- a/docs-site/backend/quickstart.mdx
+++ b/docs-site/backend/quickstart.mdx
@@ -50,20 +50,26 @@ export const support = agent({
 ```
 
 <Note>
-  **Set `VENDO_BASE_URL` before the first turn.** `api()` tools are not
-  in-process calls — each one is a real HTTP request back at your own API, and
-  `api()` reads this variable to know where to send it. There is no Vendo route
-  mounted on this path for it to learn the origin from, so unset means the first
-  tool call throws `Cannot execute … set VENDO_BASE_URL, or pass baseUrl`.
+  **`VENDO_BASE_URL` has to be set before the first turn — init asked you for
+  it.** `api()` tools are not in-process calls — each one is a real HTTP request
+  back at your own API, and `api()` reads this variable to know where to send
+  it. There is no Vendo route mounted on this path for it to learn the origin
+  from, so unset means the first tool call throws `Cannot execute … set
+  VENDO_BASE_URL, or pass baseUrl`.
+
+  An interactive `vendo init` asks where your app runs in dev and writes the
+  answer for you, so the line is usually already there:
 
   ```bash .env.local
   VENDO_BASE_URL=http://localhost:3000
   ```
 
-  Use the port your own server listens on. In production it is the deployment's
-  full public URL, path prefix included; `api({ baseUrl })` overrides it, and
-  `VENDO_HOST_API_URL` is the answer when your API answers on another origin
-  ([environment variables](/reference/environment-variables)).
+  Add it by hand (with the port your own server listens on) if init ran
+  unattended — a `--yes` or piped run never guesses an origin. In production
+  you set the same variable in your hosting platform's environment settings, to
+  the deployment's full public URL, path prefix included; `api({ baseUrl })`
+  overrides it, and `VENDO_HOST_API_URL` is the answer when your API answers on
+  another origin ([environment variables](/reference/environment-variables)).
 </Note>
 
 Skipping `vendo login`? Then nothing resolves a model for you, and the first

--- a/docs-site/existing-agent/quickstart.mdx
+++ b/docs-site/existing-agent/quickstart.mdx
@@ -196,21 +196,23 @@ One component covers all three, so you never branch on the envelope yourself.
 Run your own chat and ask for something behind your API. The answer comes back as a working card, inside your own bubble.
 
 <Note>
-  **Set `VENDO_BASE_URL` in development.** A `vendo_*` tool call is a real HTTP
-  request back at your own API, so something has to name the origin to send it
-  to. Vendo learns that origin from requests that reach the wire route init
-  wrote — but on this path the tool runs in *your* chat route, which is not one
-  of them, so name it yourself:
+  **`VENDO_BASE_URL` in development — init already asked you for it.** A
+  `vendo_*` tool call is a real HTTP request back at your own API, so something
+  has to name the origin to send it to. Vendo learns that origin from requests
+  that reach the wire route init wrote — but on this path the tool runs in
+  *your* chat route, which is not one of them, so the variable is what names it:
 
   ```bash .env.local
   VENDO_BASE_URL=http://localhost:3000
   ```
 
-  Use the port your dev server actually prints. Without it, the first tool call
-  comes back with `Cannot execute … set VENDO_BASE_URL, or pass baseUrl`, and
-  forwarding the caller's own credentials is refused. Deployments set it to the
-  public URL, path prefix included ([environment
-  variables](/reference/environment-variables)).
+  An interactive `vendo init` writes that line from your answer, prefilled with
+  the port your `dev` script names. If init ran unattended it wrote nothing —
+  add the line with the port your dev server actually prints. Without it, the
+  first tool call comes back with `Cannot execute … set VENDO_BASE_URL, or pass
+  baseUrl`, and forwarding the caller's own credentials is refused. Deployments
+  set the same variable in the hosting platform, to the public URL, path prefix
+  included ([environment variables](/reference/environment-variables)).
 </Note>
 
 <Frame>

--- a/docs-site/reference/environment-variables.mdx
+++ b/docs-site/reference/environment-variables.mdx
@@ -13,7 +13,7 @@ Every variable a host developer sets. Keys are credentials; config selects.
 | Variable | What it does | Set where |
 | --- | --- | --- |
 | `VENDO_API_KEY` | Authenticates Vendo Cloud; fills any adapter slot you left unset. | `.env.local`, written by init |
-| `VENDO_BASE_URL` | This deployment's full public URL, path prefix included. | deploy platform · init seeds `.env.example` |
+| `VENDO_BASE_URL` | The origin this process answers on: the dev origin locally, the deployment's full public URL, path prefix included, in production. | deploy platform · `.env.local` in dev, written by init from its dev-URL question |
 | `VENDO_MCP_BROKER_URL` | Your tenant's broker endpoint; setting it turns on broker mode. | deploy platform |
 | `VENDO_MCP_FEDERATION_SECRET` | Secret a broker signs its login-federation handshake with. | deploy platform |
 | `VENDO_CLOUD_URL` | Overrides the Vendo Cloud base URL for runtime and CLI. Default `https://console.vendo.run`. | deploy platform |

--- a/docs-site/reference/uninstall.mdx
+++ b/docs-site/reference/uninstall.mdx
@@ -51,7 +51,7 @@ Init may have bumped `zod`. Leave that alone: it is a version floor, not a Vendo
 
 | File | Remove |
 | --- | --- |
-| `.env.local` | the `VENDO_API_KEY` line, then [revoke the key](#the-cloud-side) |
+| `.env.local` | the `VENDO_BASE_URL` line, and the `VENDO_API_KEY` line — then [revoke the key](#the-cloud-side) |
 | `.env.example` | the appended Vendo block: `VENDO_BASE_URL` plus the commented `VENDO_HOST_API_URL`, `VENDO_LOGIN_URL`, and `ANTHROPIC_API_KEY` lines |
 | deployed environments | `VENDO_BASE_URL`, `VENDO_API_KEY`, and any other `VENDO_*` variables you set |
 

--- a/docs-site/reference/vendo-init.mdx
+++ b/docs-site/reference/vendo-init.mdx
@@ -23,7 +23,8 @@ Init never writes to a file you authored. Every file it creates is new and Vendo
 | `.vendo/overrides.json` `.vendo/policy.json` `.vendo/brief.md` | all | stubs you own |
 | `.vendo/theme.json` `.vendo/theme.extracted.json` | all | the extracted theme, and the scan output it was merged from |
 | `.vendo/data/` | all | the local database, with its own `.gitignore` |
-| `.env.example` | all | `VENDO_BASE_URL`, plus commented `VENDO_HOST_API_URL`, `VENDO_LOGIN_URL`, and `ANTHROPIC_API_KEY` lines. The append is idempotent |
+| `.env.example` | all | the `VENDO_BASE_URL` block — the dev shape for reference, and the instruction to set the real value in your hosting platform when you deploy — plus commented `VENDO_HOST_API_URL`, `VENDO_LOGIN_URL`, and `ANTHROPIC_API_KEY` lines. The append is idempotent |
+| `.env.local` | all | `VENDO_BASE_URL`, from the dev-URL question, on interactive runs and with `--base-url`. Never a deployed URL |
 | `.claude/skills/vendo-setup/` | all | the setup skill, when a `.claude/` directory exists and the skill does not |
 
 It also adds idempotent `predev` and `prebuild` hooks to `package.json`:
@@ -105,6 +106,7 @@ Init never fails on a Cloud error. `vendo cloud login <email>` is the email-OTP 
 There is no interview. An interactive run stops only for Enter-to-accept decisions:
 
 - the detected auth preset
+- where the app runs in dev, prefilled from your `dev` script's port — Enter accepts it, and the answer lands in `.env.local` as `VENDO_BASE_URL`
 - the Vendo Cloud key offer
 - consent for the AI judgment pass
 - one aggregated review, if that pass proposes a loosening
@@ -138,7 +140,7 @@ The `status` field tells the two runs apart, so an agent never has to guess whet
 | `questions` | `detected` (framework and any auth preset), and `questions`: each one a chat-ready `prompt` with its `options` |
 | `written` | `wrote` (every file of the install), `pasteEdits` (the mount and any other paste), `tools`, `riskRecommendations`, and `judgment`, whose `checklist` names the four calls only a reader of the code can make |
 
-The answer flags are the ones init already has: `--use-case`, `--auth`, `--cloud-key` or `--byo`, and on the MCP path `--posture` and `--service-key`. Nothing else is asked. `--base-url`, the `zod` bump, uncertain theme slots, and the closing live check never surface in agent mode. They take exactly the defaults `--yes` takes.
+The answer flags are the ones init already has: `--use-case`, `--auth`, `--cloud-key` or `--byo`, `--base-url`, and on the MCP path `--posture` and `--service-key`. Nothing else is asked. The `zod` bump, uncertain theme slots, and the closing live check never surface in agent mode. They take exactly the defaults `--yes` takes.
 
 ## Every flag
 
@@ -151,7 +153,7 @@ The answer flags are the ones init already has: `--use-case`, `--auth`, `--cloud
 | `--cloud-key <key>` | a `vnd_` key | writes an existing Vendo Cloud key to `.env.local` |
 | `--byo` | | declines the Cloud key offer |
 | `--ai` / `--no-ai` | | force the AI judgment and theme pass on or off |
-| `--base-url <url>` | a full `http(s)` URL | where this deploys |
+| `--base-url <url>` | a full `http(s)` URL | where the app runs in dev |
 | `--theme <slot=value>` | repeatable | answers an uncertain theme slot |
 | `--framework <name>` | `next`, `express`, `custom` | overrides framework detection |
 | `--engine <name>` | `claude`, `codex`, `npx` | pins the AI-pass engine instead of first-available |
@@ -167,7 +169,7 @@ The answer flags are the ones init already has: `--use-case`, `--auth`, `--cloud
 `--posture` or `--service-key` without `--use-case mcp` exits `1` rather than being silently ignored. `--ai-polish` is the older spelling of `--ai`.
 
 <Warning>
-  `--base-url` is written to `.env.example` only, replacing init's own localhost placeholder. It never touches `.env.local`, where a production URL would repoint local dev's discovery, callbacks, and credential forwarding at the deployed origin.
+  `--base-url` is a DEV URL: it lands in `.env.local` as `VENDO_BASE_URL`, which is what your own agent loop, any backend process, and the MCP door need before their first tool call. Production is never set here — set `VENDO_BASE_URL` in your hosting platform's environment settings when you deploy. A deployed URL in `.env.local` would repoint local dev's discovery, callbacks, and credential forwarding at the deployed origin.
 </Warning>
 
 Init rejects an option it does not recognize and exits `1` before doing anything. A flag an older CLI does not support can never be silently dropped.

--- a/packages/vendo/src/cli.ts
+++ b/packages/vendo/src/cli.ts
@@ -39,7 +39,7 @@ Options:
   --wait <seconds>           Login only: bound this call's polling to N seconds (agents loop re-runs; each resumes the same request), then exit resumably
   --byo                      Init only: decline the Vendo Cloud offer (bring your own model key)
   --use-case <name>          Init only: how people will use the agent (embedded, agent-loop, mcp)
-  --base-url <url>           Init only: this deployment's public URL — written to .env.example, never .env.local
+  --base-url <url>           Init only: where the app runs in dev — written to .env.local as VENDO_BASE_URL (production is set where you deploy)
   --posture <name>           Init only, --use-case mcp: how outside agents sign in (local, broker)
   --service-key              Init only, --use-case mcp: set up a machine-to-machine service key
   --check / --no-check       Init only: run vendo doctor at the end (offered only when no paste is outstanding)
@@ -199,7 +199,7 @@ async function initCommand(args: string[]): Promise<number> {
   }
   const baseUrl = option(args, "--base-url");
   if (baseUrl !== undefined && !/^https?:\/\/\S+$/.test(baseUrl)) {
-    problems.push(`--base-url must be this deployment's full public URL (example: vendo init --base-url https://app.acme.com), got ${JSON.stringify(baseUrl)}`);
+    problems.push(`--base-url must be the full origin this app answers on in dev, scheme included (example: vendo init --base-url http://localhost:3000), got ${JSON.stringify(baseUrl)}`);
   }
   const posture = option(args, "--posture");
   if (posture !== undefined && !INIT_POSTURE_VALUES.includes(posture)) {

--- a/packages/vendo/src/cli/doctor-mcp-checks.ts
+++ b/packages/vendo/src/cli/doctor-mcp-checks.ts
@@ -3,12 +3,19 @@ import type { DoctorRun } from "./doctor-report.js";
 import { validateRegistryServer } from "./mcp/registry.js";
 import { readOptional } from "./shared.js";
 
-/** Where a Vendo composition lives: the two shapes init writes (the MCP path's
-    split `vendo.ts`, the ordinary inline route) and the runtime-neutral /
-    Express module, under both root layouts. A host that opened the door
-    somewhere else entirely is not named here on purpose — E-MCP-009 is a hard
-    FAIL, so it fires on evidence, never on a guess. */
+/** Where a Vendo composition lives: the composition module init writes today
+    (`lib/vendo.ts`, under `src/` when the app directory is), the two earlier
+    shapes still in the field (the MCP path's split `vendo.ts` beside the route,
+    the ordinary inline route) and the runtime-neutral / Express module, under
+    both root layouts. The current shape leads and every legacy one stays, the
+    same order `compositionOf` reads them in (doctor-wiring-checks.ts) — a list
+    that knows only the old locations goes SILENT on a correctly wired host,
+    which is exactly what this check exists to catch. A host that opened the
+    door somewhere else entirely is not named here on purpose — E-MCP-009 is a
+    hard FAIL, so it fires on evidence, never on a guess. */
 const COMPOSITION_PATHS: readonly string[][] = [
+  ["lib", "vendo.ts"],
+  ["src", "lib", "vendo.ts"],
   ["app", "api", "vendo", "[...vendo]", "vendo.ts"],
   ["src", "app", "api", "vendo", "[...vendo]", "vendo.ts"],
   ["app", "api", "vendo", "[...vendo]", "route.ts"],

--- a/packages/vendo/src/cli/init-mcp.ts
+++ b/packages/vendo/src/cli/init-mcp.ts
@@ -59,8 +59,9 @@ export interface McpPlanInput {
   /** Did the user say yes to "will your own backend call these tools
       machine-to-machine?" */
   serviceKey: boolean;
-  /** The public origin captured earlier this run, or null when the user skipped
-      the question. */
+  /** The origin captured earlier this run — the DEV one, which is what a client
+      config and doctor both want while the developer is still local. Null when
+      the run could not ask. */
   baseUrl: string | null;
   /** The provider key init found in the environment. This path's composition
       module is the ONLY place it may land: the thin route composes nothing, so
@@ -206,8 +207,8 @@ export function planMcp(input: McpPlanInput): McpPlan {
   // indents the detail lines, so a step never wraps mid-phrase into a wall.
   const steps = [
     baseUrl === null
-      ? "Set `VENDO_BASE_URL` in your deploy platform to this deployment's public origin\nwithout it, discovery points at the wrong origin and clients cannot find your server"
-      : `Set \`VENDO_BASE_URL\` in your deploy platform\n\`${baseUrl}\` — captured earlier, already in .env.example`,
+      ? "Set `VENDO_BASE_URL` to the origin this app answers on — .env.local in dev, your deploy platform in production\nwithout it, discovery points at the wrong origin and clients cannot find your server"
+      : `When you deploy, set \`VENDO_BASE_URL\` in your platform to the public origin\ndev is answered — \`${baseUrl}\` is in .env.local, and every discovery URL hangs off it`,
     `Point any MCP client at \`${clientBase}${MCP_MOUNT}\`\nyour users' setup page ships free at \`${MCP_MOUNT}/connect\` — copy for Claude · ChatGPT · Cursor included`,
     "Claude Code: `/plugin marketplace add runvendo/vendo` then `/plugin install vendo@vendo`",
   ];

--- a/packages/vendo/src/cli/init-questions.ts
+++ b/packages/vendo/src/cli/init-questions.ts
@@ -7,9 +7,9 @@
  * as flags on a re-run, and that run writes. No new flags exist for any of it:
  * every option below names one of the six init already validates.
  *
- * Only what a PERSON must decide appears here. The base URL, the zod floor, the
- * theme slots and the live check are mechanical, so they default exactly as
- * `--yes` leaves them and show up in the diff instead of in someone's chat.
+ * Only what a PERSON must decide appears here. The zod floor, the theme slots
+ * and the live check are mechanical, so they default exactly as `--yes` leaves
+ * them and show up in the diff instead of in someone's chat.
  *
  * PURE apart from reading the host's dependencies for auth: every prompt is
  * decided from the answers already on the command line, so the whole set is
@@ -60,6 +60,20 @@ const MODELS: InitQuestion = {
     { label: "Own key", flag: "--byo", note: "put the key in .env.local first, it never enters the chat" },
   ],
 };
+
+/** The dev URL. A QUESTION and not a mechanical default, because the answer is
+    WRITTEN (.env.local) and only the person running init knows which origin
+    their app answers on — a guessed origin fails the first tool call with the
+    developer believing it was configured. The prefill is the port their own
+    `dev` script names, so the recommended option is the whole answer. */
+const devUrlQuestion = (port: number): InitQuestion => ({
+  id: "dev-url",
+  prompt: `Where does this app run in dev? Vendo writes it to .env.local as VENDO_BASE_URL: your own agent loop, any backend process and the MCP door all send real HTTP requests back at your API, so without it the first tool call fails. Your dev script says http://localhost:${port}.`,
+  options: [
+    { label: `http://localhost:${port}`, flag: `--base-url http://localhost:${port}`, recommended: true },
+    { label: "Another origin", flag: "--base-url <url>", note: "replace the placeholder with the origin the dev server actually prints" },
+  ],
+});
 
 const SERVICE_KEY_PROMPT = "Will your own backend call these tools machine to machine, like a nightly job? If yes I'll set up a service key.";
 
@@ -144,6 +158,9 @@ export async function initQuestions(input: {
   /** A Vendo Cloud key specifically — the only thing a broker posture can run
       on, so it decides whether the MCP sign-in question exists at all. */
   cloudKey: boolean;
+  /** The port the host's `dev` script names — the dev-URL question's prefill.
+      Passed in rather than read here so the whole set stays assertable. */
+  devPort: number;
 }): Promise<InitQuestions | null> {
   const { options } = input;
   // `wired`, never `matches[0]`: two families matching is AMBIGUOUS, and
@@ -154,6 +171,7 @@ export async function initQuestions(input: {
   if (options.useCase === undefined) questions.push(USE_CASE);
   if (options.auth === undefined) questions.push(authQuestion(detected));
   if (!input.modelKey && options.byo !== true && options.cloudKey === undefined) questions.push(MODELS);
+  if (options.baseUrl === undefined) questions.push(devUrlQuestion(input.devPort));
   // ONE gate for the MCP extras: they travel in the same relay, so `--posture`
   // on the way back is what says they were answered. A bare `--service-key` has
   // no "no" spelling, so gating on it would ask forever.

--- a/packages/vendo/src/cli/init-scaffolds.ts
+++ b/packages/vendo/src/cli/init-scaffolds.ts
@@ -582,17 +582,25 @@ export async function devPort(root: string): Promise<number> {
   }
 }
 
-/** The line `vendo init` writes and `captureBaseUrl` later replaces with the
-    deployed URL — one spelling, so the replacement can never miss. */
-export const baseUrlLine = (port: number): string => `VENDO_BASE_URL=http://localhost:${port}`;
+/** Where the host answers in dev: the value the dev-URL question prefills, and
+    the illustrative line `.env.example` carries. One spelling for both. */
+export const devBaseUrl = (port: number): string => `http://localhost:${port}`;
+
+export const baseUrlLine = (port: number): string => `VENDO_BASE_URL=${devBaseUrl(port)}`;
 
 export const vendoEnvExample = (port: number): string =>
   "# This deployment's FULL public URL — path prefix included. Nothing strips its\n" +
   "# path: every URL Vendo builds (host tool calls, login redirects, box callbacks)\n" +
-  "# hangs off it. Dev trusts the request's own origin automatically, EXCEPT for\n" +
-  "# your own agent loop and any backend process — they never see a wire request,\n" +
-  "# so they need this set even in dev; production fails loud without it (a\n" +
-  "# credential-forwarding call errors instead of silently running unauthenticated).\n" +
+  "# hangs off it.\n" +
+  "#\n" +
+  "# Dev is already done: `vendo init` asked where this app runs and wrote your\n" +
+  "# answer to .env.local. When you DEPLOY, set VENDO_BASE_URL in your hosting\n" +
+  "# platform's environment settings to the public URL — a production URL belongs\n" +
+  "# in neither a committed file nor .env.local. Production fails loud without it\n" +
+  "# (a credential-forwarding call errors instead of silently running\n" +
+  "# unauthenticated).\n" +
+  "#\n" +
+  "# For reference, the dev shape:\n" +
   `${baseUrlLine(port)}\n` +
   "# Optional — the host API on another origin (default: the public URL above).\n" +
   "# VENDO_HOST_API_URL=\n" +

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -26,11 +26,11 @@ import {
 } from "./init-auth.js";
 import { aiBelowPeerFloor, ensureProviderDeps, ensureVendoPackage, ensureZodFloor, type InstallRunner } from "./provider-deps.js";
 import {
-  baseUrlLine,
   compositionModulePath,
   compositionModuleSource,
   compositionSpecifier,
   customServerSource,
+  devBaseUrl,
   devPort,
   disabledTools,
   expressServerSource,
@@ -186,9 +186,10 @@ export interface InitOptions {
   /** --use-case: answer the first question without asking. Unattended runs
       take "embedded" — today's behaviour, so no existing script changes. */
   useCase?: InitUseCase;
-  /** --base-url: answer "where will this deploy?" without asking. Written to
-      .env.example ONLY, by replacing init's own localhost placeholder — never
-      .env.local, where a production URL would repoint local dev's discovery,
+  /** --base-url: answer "where does this app run in dev?" without asking —
+      written to .env.local as VENDO_BASE_URL. A DEPLOYED URL does not belong
+      here: production reads the variable from the hosting platform's own env,
+      and a public URL in .env.local would repoint local dev's discovery,
       callbacks and credential forwarding at the deployed origin. */
   baseUrl?: string;
   /** --posture: how outside agents sign in (MCP use case only). */
@@ -246,8 +247,10 @@ export interface InitOptions {
   /** Test seam: the use-case question, and the MCP posture select that hangs
       off it. Mirrors the auth picker's shape. */
   selectUseCase?: (question: string, options: SelectOption[]) => Promise<string>;
-  /** Test seam: the free-text asks (the base URL). "" is a decline. */
-  askText?: (question: string, hint?: string) => Promise<string>;
+  /** Test seam: the free-text asks (the dev base URL). "" is "nobody was
+      asked" — the prompt itself turns a bare Enter into the prefilled default,
+      so a seam that answers "" stands for a run that never got to ask. */
+  askText?: (question: string, hint?: string, defaultValue?: string) => Promise<string>;
   /** Test seam: the doctor-check offer. Mirrors the auth confirm's shape. */
   confirmCheck?: (question: string, defaultYes: boolean) => Promise<boolean>;
   /** Test seam: the check itself (default: `vendo doctor`). */
@@ -746,12 +749,21 @@ async function resolveUseCase(input: {
   return (INIT_USE_CASES as readonly string[]).includes(picked) ? picked as InitUseCase : "embedded";
 }
 
-/** "Where will this deploy?" — one Enter to decline, and the answer replaces
-    init's OWN placeholder in .env.example. Nowhere else: a production URL in
-    .env.local would repoint local dev's discovery, callbacks and credential
-    forwarding at the deployed origin, and dev already trusts the request's
-    own origin. Returns the captured URL, or null when skipped. */
-export async function captureBaseUrl(input: {
+/** "Where does this app run in dev?" — prefilled with the port the host's own
+    `dev` script names, so Enter is the whole interaction, and the answer lands
+    in .env.local as VENDO_BASE_URL. Own-agent-loop tools, backend processes and
+    the MCP door never see a wire request, so without it the first tool call
+    meets "Cannot execute … set VENDO_BASE_URL" instead of working.
+ *
+ *  A run that cannot ASK writes NOTHING: the prefill is only an answer when a
+ *  person accepts it, and a guessed origin is worse than an absent one — unset
+ *  in dev still learns the request's own origin, and production fails loud.
+ *  Production is told at deploy time, never asked here: a public URL in
+ *  .env.local would repoint local dev's discovery, callbacks and credential
+ *  forwarding at the deployed origin.
+ *
+ *  Returns the answer, or null when the run could not ask. */
+export async function captureDevBaseUrl(input: {
   root: string;
   options: InitOptions;
   output: Output;
@@ -760,22 +772,24 @@ export async function captureBaseUrl(input: {
 }): Promise<string | null> {
   const { root, options, output, pretty, interactive } = input;
   // plainText carries plainSelect's guard — a non-TTY input or output returns
-  // the fallback and never prompts — so a piped run stays byte-identical while
-  // a NO_COLOR terminal still gets the question. Making this pretty-only would
-  // silently delete the feature for anyone who sets NO_COLOR.
+  // "" and never prompts — so a piped run stays byte-identical while a NO_COLOR
+  // terminal still gets the question. Making this pretty-only would silently
+  // delete the feature for anyone who sets NO_COLOR.
+  // The seam sits INSIDE the interactivity gate, like the auth confirm's: a
+  // stubbed prompt must not make an unattended run ask a question the real one
+  // never reaches.
   const ask = options.baseUrl !== undefined
     ? async () => options.baseUrl!
-    : options.askText
-      ?? (options.yes === true || !interactive ? undefined : (pretty === null ? plainText : pretty.text));
+    : options.yes === true || !interactive
+      ? undefined
+      : options.askText ?? (pretty === null ? plainText : pretty.text);
   if (ask === undefined) return null;
-  const url = (await ask("Where will this deploy?", "e.g. https://app.acme.com — Enter to skip")).trim();
+  const prefill = devBaseUrl(await devPort(root));
+  const url = (await ask("Where does this app run in dev?", `Enter to accept ${prefill}`, prefill)).trim();
   if (url === "") return null;
-  const path = join(root, ".env.example");
-  const current = await readOptional(path);
-  const placeholder = baseUrlLine(await devPort(root));
-  if (current === null || !current.includes(placeholder)) return url;
-  await writeText(path, current.replace(placeholder, `VENDO_BASE_URL=${url}`));
-  output.log("written to .env.example — set it in your deploy platform's env");
+  await upsertEnvLocal(root, "VENDO_BASE_URL", url);
+  output.log(`Wrote VENDO_BASE_URL=${url} to .env.local`);
+  await ensureEnvLocalIgnored(root, output);
   return url;
 }
 
@@ -916,7 +930,9 @@ async function planMcpScaffold(input: {
     models: scaffoldModel(root, options),
     // Not optional: a null base URL is an ANSWER the plan reads, and it is
     // what makes steps[] lead with the recoverable version of E-MCP-009's
-    // failure instead of assuming an origin.
+    // failure instead of assuming an origin. Set, it is the DEV origin — which
+    // is the right one for a client config and for doctor, both of which run
+    // against the app the developer is looking at.
     baseUrl,
   });
   if (mcp.blocked !== undefined) {
@@ -1850,10 +1866,10 @@ async function finishRun(input: {
     wrote, risks,
   } = input;
 
-  // Where will this deploy? — every path but MCP, which needed the answer
-  // before it wrote. One Enter declines and the placeholder stands. The answer
-  // is written to .env.example inside, so there is nothing to read back here.
-  if (useCase !== "mcp") await captureBaseUrl({ root, options, output, pretty, interactive });
+  // Where does this app run in dev? — every path but MCP, which needed the
+  // answer before it wrote. The answer lands in .env.local inside, so there is
+  // nothing to read back here.
+  if (useCase !== "mcp") await captureDevBaseUrl({ root, options, output, pretty, interactive });
 
   // Variant B: the wired route stays (it serves apps and approvals to the
   // embeds) — what is added is the one snippet for their own loop.
@@ -1998,6 +2014,7 @@ const explainedPlanFailure = (error: unknown): boolean => {
       framework: await resolveFramework(root, options),
       modelKey: cloudKey || scaffoldModel(root, options) !== null,
       cloudKey,
+      devPort: await devPort(root),
     });
     if (questions !== null) {
       output.log(JSON.stringify(questions, null, 2));
@@ -2061,10 +2078,10 @@ const explainedPlanFailure = (error: unknown): boolean => {
     // The MCP door derives every discovery URL from VENDO_BASE_URL and both
     // extra answers change the composition's own source, so that path needs
     // all three BEFORE it writes. Every other path asks the URL at the end,
-    // where it is one Enter to decline.
+    // where it is one Enter.
     let mcp: ReturnType<typeof planMcp> | null = null;
     if (useCase === "mcp") {
-      const baseUrl = await captureBaseUrl({ root, options, output, pretty, interactive });
+      const baseUrl = await captureDevBaseUrl({ root, options, output, pretty, interactive });
       mcp = await planMcpScaffold({
         root, options, output, pretty, interactive, changes, baseUrl,
         framework: plan.framework, authWired, cloudKey: cloud.keyValid,

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -750,10 +750,10 @@ async function resolveUseCase(input: {
 }
 
 /** "Where does this app run in dev?" — prefilled with the port the host's own
-    `dev` script names, so Enter is the whole interaction, and the answer lands
-    in .env.local as VENDO_BASE_URL. Own-agent-loop tools, backend processes and
-    the MCP door never see a wire request, so without it the first tool call
-    meets "Cannot execute … set VENDO_BASE_URL" instead of working.
+ *  `dev` script names, so Enter is the whole interaction, and the answer lands
+ *  in .env.local as VENDO_BASE_URL. Own-agent-loop tools, backend processes and
+ *  the MCP door never see a wire request, so without it the first tool call
+ *  meets "Cannot execute … set VENDO_BASE_URL" instead of working.
  *
  *  A run that cannot ASK writes NOTHING: the prefill is only an answer when a
  *  person accepts it, and a guessed origin is worse than an absent one — unset
@@ -774,10 +774,9 @@ export async function captureDevBaseUrl(input: {
   // plainText carries plainSelect's guard — a non-TTY input or output returns
   // "" and never prompts — so a piped run stays byte-identical while a NO_COLOR
   // terminal still gets the question. Making this pretty-only would silently
-  // delete the feature for anyone who sets NO_COLOR.
-  // The seam sits INSIDE the interactivity gate, like the auth confirm's: a
-  // stubbed prompt must not make an unattended run ask a question the real one
-  // never reaches.
+  // delete the feature for anyone who sets NO_COLOR. The test seam sits INSIDE
+  // the interactivity gate, like the auth confirm's: a stubbed prompt must not
+  // make an unattended run ask what the real one never reaches.
   const ask = options.baseUrl !== undefined
     ? async () => options.baseUrl!
     : options.yes === true || !interactive

--- a/packages/vendo/src/cli/pretty.ts
+++ b/packages/vendo/src/cli/pretty.ts
@@ -76,9 +76,11 @@ export interface PrettyOutput extends Output {
       1-9 only: keep lists at nine options or fewer (a longer list stays
       arrow-navigable, but two-digit entry is deliberately not built). */
   select(question: string, options: SelectOption[], defaultIndex?: number): Promise<string>;
-  /** A free-text answer; Enter returns "" and the caller decides what a skip
-      means. Non-TTY stdin never prompts — "" stands. */
-  text(question: string, hint?: string): Promise<string>;
+  /** A free-text answer; Enter returns `defaultValue` where one is given, else
+      "" and the caller decides what a skip means. The echoed receipt shows what
+      the answer actually WAS, so an accepted default never reads as "skipped".
+      Non-TTY stdin never prompts — "" stands. */
+  text(question: string, hint?: string, defaultValue?: string): Promise<string>;
   /** A secret: the typing is not echoed and only a masked receipt reaches the
       transcript. The value itself is NEVER written to the terminal. */
   secret(question: string, hint?: string): Promise<string>;
@@ -399,10 +401,13 @@ export async function plainSelect(
 }
 
 /** The plain-terminal free-text prompt — plainSelect's sibling, same non-TTY
-    guard: a piped run never prompts and answers "". */
+    guard: a piped run never prompts and answers "". Enter takes `defaultValue`
+    where one is given, so "" always means "nobody was asked", never "the person
+    accepted the default". */
 export async function plainText(
   question: string,
   hint?: string,
+  defaultValue?: string,
   input: NodeJS.ReadableStream & { isTTY?: boolean } = stdin,
   output: NodeJS.WritableStream & { isTTY?: boolean } = stdout,
 ): Promise<string> {
@@ -411,7 +416,8 @@ export async function plainText(
   if (hint !== undefined) output.write(`  ${hint}\n`);
   const prompt = createInterface({ input, output });
   try {
-    return (await prompt.question("> ")).trim();
+    const typed = (await prompt.question("> ")).trim();
+    return typed === "" ? defaultValue ?? "" : typed;
   } finally {
     prompt.close();
   }
@@ -953,7 +959,7 @@ export function createPrettyOutput(options: PrettyOptions = {}): PrettyOutput {
         prompt.close();
       }
     },
-    async text(question, hint) {
+    async text(question, hint, defaultValue) {
       // Same stdin guard as confirm: no keypress source → no question, and ""
       // is the skip the caller already has to handle.
       if (input.isTTY !== true) return "";
@@ -965,7 +971,8 @@ export function createPrettyOutput(options: PrettyOptions = {}): PrettyOutput {
         output: promptOutput,
       });
       try {
-        const answer = (await prompt.question(`${BAR}  ${dim("›")} `)).trim();
+        const typed = (await prompt.question(`${BAR}  ${dim("›")} `)).trim();
+        const answer = typed === "" ? defaultValue ?? "" : typed;
         line(`${BAR}  ${lilac("●")} ${answer === "" ? dim("skipped") : answer}`);
         return answer;
       } finally {

--- a/packages/vendo/tests/cli.test.ts
+++ b/packages/vendo/tests/cli.test.ts
@@ -150,7 +150,7 @@ describe("vendo CLI commands", () => {
     expect(error.mock.calls.flat().join("\n")).toContain("--use-case must be one of embedded, agent-loop, mcp");
 
     expect(await main(["init", root, "--base-url", "app.acme.com"])).toBe(1);
-    expect(error.mock.calls.flat().join("\n")).toContain("--base-url must be this deployment's full public URL");
+    expect(error.mock.calls.flat().join("\n")).toContain("--base-url must be the full origin this app answers on in dev");
 
     expect(await main(["init", root, "--use-case", "mcp", "--posture", "hybrid"])).toBe(1);
     expect(error.mock.calls.flat().join("\n")).toContain("--posture must be local or broker");

--- a/packages/vendo/tests/cli/doctor.test.ts
+++ b/packages/vendo/tests/cli/doctor.test.ts
@@ -1430,6 +1430,19 @@ describe("vendo doctor error codes + fix_refs", () => {
       await writeFile(join(root, "app", "api", "vendo", "[...vendo]", "vendo.ts"), composition);
       return root;
     }
+    /** The shape init writes TODAY: the composition in its own module, with the
+        wire route a thin handler over it. */
+    async function libHost(composition: string, base = ""): Promise<string> {
+      const root = await healthy();
+      await mkdir(join(root, base, "lib"), { recursive: true });
+      await writeFile(join(root, base, "lib", "vendo.ts"), composition);
+      // The `@/` specifier init writes wherever the host maps the alias — and
+      // the one shape of it that is not an escaping relative path spelled
+      // inline, which the dependency guard reads as a real import.
+      await writeFile(join(root, "app", "api", "vendo", "[...vendo]", "route.ts"),
+        'import { nextVendoHandler } from "@vendoai/vendo/server";\nimport { vendo } from "@/lib/vendo";\n\nexport const { GET, POST } = nextVendoHandler(vendo);\n');
+      return root;
+    }
     const wired = 'import { createVendo } from "@vendoai/vendo/server";\nexport const vendo = createVendo({ mcp: true });\n';
 
     it("fails, and exits 1", async () => {
@@ -1449,6 +1462,28 @@ describe("vendo doctor error codes + fix_refs", () => {
       });
       expect(report.checks.find((entry) => entry.id === "mcp/base-url")).toMatchObject({ status: "ok" });
     });
+
+    /** The composition moved into `lib/vendo.ts` and this check's path list did
+        not follow, so the door it was written to catch became invisible: an
+        init-scaffolded MCP host with no base URL graded SILENT — no failure, no
+        check, nothing to notice — while the legacy shapes kept failing. Both
+        layouts, because the module follows the app directory under `src/`. */
+    it.each([["root", ""], ["src", "src"]] as const)(
+      "fires on the composition module init writes (%s layout), and passes once the variable is set",
+      async (_label, base) => {
+        const { exit, report } = await jsonChecks({ targetDir: await libHost(wired, base) });
+        expect(exit).toBe(1);
+        const check = report.checks.find((entry) => entry.id === "mcp/base-url");
+        expect(check).toMatchObject({ status: "broken", error_code: "E-MCP-009" });
+        expect(check?.message).toContain("VENDO_BASE_URL is not set");
+
+        const { report: set } = await jsonChecks({
+          targetDir: await libHost(wired, base),
+          env: { VENDO_BASE_URL: "http://localhost:3000" },
+        });
+        expect(set.checks.find((entry) => entry.id === "mcp/base-url")).toMatchObject({ status: "ok" });
+      },
+    );
 
     // Host config beats the environment default, so a composition that names
     // its own public origin needs no variable.

--- a/packages/vendo/tests/cli/init-mcp.test.ts
+++ b/packages/vendo/tests/cli/init-mcp.test.ts
@@ -118,14 +118,20 @@ describe("planMcp — the service key", () => {
 
 describe("planMcp — the two steps that stay the user's", () => {
   it("puts the base URL FIRST, always", () => {
-    expect(plan().steps[0]).toContain("Set `VENDO_BASE_URL`");
+    expect(plan().steps[0]).toContain("`VENDO_BASE_URL`");
     expect(plan({ baseUrl: null }).steps[0]).toContain("Set `VENDO_BASE_URL`");
-    expect(plan({ posture: "broker", serviceKey: true }).steps[0]).toContain("Set `VENDO_BASE_URL`");
+    expect(plan({ posture: "broker", serviceKey: true }).steps[0]).toContain("`VENDO_BASE_URL`");
   });
 
-  it("names the captured origin when there is one, and the risk when there is not", () => {
-    expect(plan().steps[0]).toContain("`https://app.acme.com` — captured earlier, already in .env.example");
+  /** The captured origin is the DEV one now (init writes it to .env.local), so
+      the step points at deploy time for production instead of claiming the
+      answer already covers it. */
+  it("names the captured origin as dev-and-done, and the risk when there is none", () => {
+    expect(plan().steps[0]).toContain("When you deploy, set `VENDO_BASE_URL` in your platform to the public origin");
+    expect(plan().steps[0]).toContain("`https://app.acme.com` is in .env.local");
+    expect(plan().steps[0]).not.toContain(".env.example");
     expect(plan({ baseUrl: null }).steps[0]).toContain("points at the wrong origin");
+    expect(plan({ baseUrl: null }).steps[0]).toContain(".env.local in dev, your deploy platform in production");
   });
 
   it("points clients at the same URL in BOTH postures — it derives from the base URL, never the broker", () => {

--- a/packages/vendo/tests/cli/init-scaffolds.test.ts
+++ b/packages/vendo/tests/cli/init-scaffolds.test.ts
@@ -151,11 +151,15 @@ describe("the .env.example base URL", () => {
     expect(devScriptPort("PORT=5050 node server.js")).toBe(5050);
   });
 
-  it("names that port, and names the exception to dev's own-origin trust", () => {
+  it("names that port, and reads as an instruction rather than a value to fill in", () => {
     expect(vendoEnvExample(4000)).toContain("VENDO_BASE_URL=http://localhost:4000\n");
-    // The clause that used to be missing: an agent loop and any backend process
-    // never see a wire request, so the origin trust never reaches them.
-    expect(vendoEnvExample(3000)).toContain("your own agent loop and any backend process");
+    // Dev was answered into .env.local by init's own question; production is
+    // set where the app deploys, and belongs in neither file here.
+    const example = vendoEnvExample(3000);
+    expect(example).toContain("Dev is already done");
+    expect(example).toContain("platform's environment settings to the public URL");
+    expect(example).toContain("in neither a committed file nor .env.local");
+    expect(example).toContain("Production fails loud without it");
   });
 });
 

--- a/packages/vendo/tests/cli/init.test.ts
+++ b/packages/vendo/tests/cli/init.test.ts
@@ -6,12 +6,12 @@ import type { RunContext, ToolDescriptor } from "@vendoai/core";
 import { createGuard } from "@vendoai/guard";
 import { createStore } from "@vendoai/store";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { runDoctor } from "../../src/cli/doctor.js";
 import type { ExtractionHarness } from "../../src/cli/extract/harness.js";
 import { NEXT_SERVER_EXTERNALS, NEXT_SERVER_EXTERNALS_LINE } from "../../src/cli/framework.js";
 import { firstSentence, prettyThemeReview, runInit, type InitReceipt } from "../../src/cli/init.js";
 import type { InitQuestions } from "../../src/cli/init-questions.js";
 import { CLI_VERSION, type Output } from "../../src/cli/shared.js";
-import { readEnvFiles } from "../../src/cli/sync-flow.js";
 
 const cleanup: string[] = [];
 
@@ -2742,13 +2742,13 @@ describe("the five questions", () => {
     expect(await readFile(join(answered, ".env.local"), "utf8")).toContain("VENDO_BASE_URL=http://localhost:5173");
   });
 
-  /** The MCP arm's own question, answered from the same prompt — and then read
-      back through the OTHER side of the seam: `readEnvFiles` is the CLI's one
-      env reader, the same call doctor makes before grading E-MCP-009, so the
-      file init writes is the file doctor sees. Nothing is stubbed on either end.
-      Local posture in dev is the point: the door's client URL and its discovery
-      both want the origin the developer is looking at. */
-  it("MCP: the dev answer opens the door locally, and the CLI's env reader sees it", async () => {
+  /** The MCP arm's own question, answered from the same prompt — and then graded
+      by the OTHER side of the seam: a REAL `vendo doctor` run over the repo init
+      just wrote, with no env override, so E-MCP-009 reads the same .env.local
+      init produced. Nothing is stubbed on either end. Local posture in dev is
+      the point: the door's client URL and its discovery both want the origin the
+      developer is looking at. */
+  it("MCP: the dev answer opens the door locally, and a real doctor run greens E-MCP-009", async () => {
     const root = await mkdtemp(join(tmpdir(), "vendo-init-mcp-dev-url-"));
     cleanup.push(root);
     await mkdir(join(root, "app"), { recursive: true });
@@ -2776,9 +2776,19 @@ describe("the five questions", () => {
     // The client URL a user pastes into Claude is the dev origin, not a guess.
     expect(sink.logs.join("\n")).toContain("Point any MCP client at `http://localhost:4300/api/vendo/mcp`");
 
-    // The read-back, through the reader doctor itself uses — no env override,
-    // no stub: whatever this returns is what E-MCP-009 grades.
-    expect((await readEnvFiles(root))["VENDO_BASE_URL"]).toBe("http://localhost:4300");
+    // The read-back: doctor over the repo init just wrote. No env override, so
+    // it loads .env.local itself — the file this run produced. (Only this check
+    // is this test's business; the fixture owes other things doctor grades.)
+    const doctorLogs: string[] = [];
+    await runDoctor({
+      targetDir: root,
+      json: true,
+      output: { log: (message) => doctorLogs.push(message), error: () => {} },
+      telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
+    });
+    const report = JSON.parse(doctorLogs[0]!) as { checks: Array<{ id: string; status: string; message: string }> };
+    expect(report.checks.find((check) => check.id === "mcp/base-url"))
+      .toMatchObject({ status: "ok", message: expect.stringContaining("VENDO_BASE_URL is set") });
   });
 
   it("offers the doctor check only when nothing is left to paste, and never changes the exit code", async () => {

--- a/packages/vendo/tests/cli/init.test.ts
+++ b/packages/vendo/tests/cli/init.test.ts
@@ -11,6 +11,7 @@ import { NEXT_SERVER_EXTERNALS, NEXT_SERVER_EXTERNALS_LINE } from "../../src/cli
 import { firstSentence, prettyThemeReview, runInit, type InitReceipt } from "../../src/cli/init.js";
 import type { InitQuestions } from "../../src/cli/init-questions.js";
 import { CLI_VERSION, type Output } from "../../src/cli/shared.js";
+import { readEnvFiles } from "../../src/cli/sync-flow.js";
 
 const cleanup: string[] = [];
 
@@ -132,7 +133,7 @@ function agentRun(
   sink: { output: Output },
   extra: Partial<Parameters<typeof runInit>[0]> = {},
 ): Promise<number> {
-  return run(root, sink, { agent: true, useCase: "embedded", auth: "none", byo: true, ...extra });
+  return run(root, sink, { agent: true, useCase: "embedded", auth: "none", byo: true, baseUrl: "http://localhost:3000", ...extra });
 }
 
 const receiptOf = (logs: string[]): InitReceipt => JSON.parse(logs.at(-1)!) as InitReceipt;
@@ -243,16 +244,16 @@ describe("vendo init (zero-question)", () => {
       "export default function Layout({ children }) { return <html><body>{children}</body></html>; }\n");
     const sink = output();
     expect(await run(root, sink, {
-      useCase: "mcp", yes: true, auth: "clerk", baseUrl: "https://app.acme.com",
+      useCase: "mcp", yes: true, auth: "clerk", baseUrl: "http://localhost:3000",
     })).toBe(0);
     const logs = sink.logs.join("\n");
     expect(logs).toContain(
-      "  Set `VENDO_BASE_URL` in your deploy platform\n"
-      + "    `https://app.acme.com` — captured earlier, already in .env.example",
+      "  When you deploy, set `VENDO_BASE_URL` in your platform to the public origin\n"
+      + "    dev is answered — `http://localhost:3000` is in .env.local, and every discovery URL hangs off it",
     );
     // The headline of a step is never indented past two spaces, so a reader
     // (and a grep) can still tell a step from its detail.
-    expect(logs).toContain("  Point any MCP client at `https://app.acme.com/api/vendo/mcp`\n    your users' setup page");
+    expect(logs).toContain("  Point any MCP client at `http://localhost:3000/api/vendo/mcp`\n    your users' setup page");
   });
 
   it("is idempotent: a re-run changes nothing and says so", async () => {
@@ -1196,21 +1197,25 @@ describe("vendo init (zero-question)", () => {
     const example = await readFile(join(root, ".env.example"), "utf8");
     expect(example).toContain("HOST_FLAG=1");
     expect(example).toContain("VENDO_BASE_URL=http://localhost:3000");
-    // Post server-wiring semantics: dev trusts its own origin; production
-    // fails loud without the variable — no silent credential drop. Plus the
-    // clause that used to be missing: an agent loop and any backend process
-    // never see a wire request, so the origin trust never reaches them.
-    expect(example).toContain("Dev trusts the request's own");
-    expect(example).toContain("your own agent loop and any backend process");
-    expect(example).toContain("production fails loud without it");
+    // The line is an INSTRUCTION now, not a value to fill in at init: dev was
+    // answered into .env.local, production is set where the app deploys, and a
+    // public URL belongs in neither this file nor .env.local. The security
+    // phrasing is unchanged — the behaviour it describes did not change.
+    expect(example).toContain("Dev is already done");
+    expect(example).toContain("wrote your");
+    expect(example).toContain("platform's environment settings to the public URL");
+    expect(example).toContain("in neither a committed file nor .env.local");
+    expect(example).toContain("Production fails loud without it");
     expect(example).not.toContain("disabled without it");
     expect(await run(root, output())).toBe(0);
-    expect((await readFile(join(root, ".env.example"), "utf8")).match(/VENDO_BASE_URL/g)).toHaveLength(1);
+    // The ASSIGNMENT, not the name: the block's comment names the variable too,
+    // and what must never double is the line.
+    expect((await readFile(join(root, ".env.example"), "utf8")).match(/^VENDO_BASE_URL=/gm)).toHaveLength(1);
   });
 
-  /** The placeholder used to name :3000 on every host, so a dev on another port
-      copied a base URL that pointed at nothing. */
-  it("names the host's OWN dev port in the placeholder, and the deploy answer still replaces it", async () => {
+  /** The illustrative line used to name :3000 on every host, so a dev on
+      another port read a base URL that pointed at nothing. */
+  it("names the host's OWN dev port in .env.example, and no answer ever rewrites that file", async () => {
     const root = await fixture();
     await writeFile(join(root, "package.json"), JSON.stringify({
       name: "host",
@@ -1220,11 +1225,11 @@ describe("vendo init (zero-question)", () => {
     expect(await run(root, output())).toBe(0);
     expect(await readFile(join(root, ".env.example"), "utf8")).toContain("VENDO_BASE_URL=http://localhost:4000");
 
-    // captureBaseUrl replaces THAT line — one spelling, so it can never miss.
-    expect(await run(root, output(), { baseUrl: "https://app.acme.com" })).toBe(0);
-    const answered = await readFile(join(root, ".env.example"), "utf8");
-    expect(answered).toContain("VENDO_BASE_URL=https://app.acme.com");
-    expect(answered).not.toContain("localhost:4000");
+    // The dev answer lands in .env.local. .env.example is documentation now, so
+    // a run that captures an answer leaves it byte for byte.
+    expect(await run(root, output(), { baseUrl: "http://localhost:4100" })).toBe(0);
+    expect(await readFile(join(root, ".env.example"), "utf8")).toContain("VENDO_BASE_URL=http://localhost:4000");
+    expect(await readFile(join(root, ".env.local"), "utf8")).toContain("VENDO_BASE_URL=http://localhost:4100");
   });
 
   it("merges the sync hooks into existing scripts without clobbering them", async () => {
@@ -1873,17 +1878,21 @@ describe("vendo init --agent (ask first, then write)", () => {
     const asked = questionsOf(sink.logs);
     expect(asked.status).toBe("questions");
     expect(asked.detected.framework).toBe("next");
-    expect(asked.questions.map((question) => question.id)).toEqual(["use-case", "auth", "models"]);
+    expect(asked.questions.map((question) => question.id)).toEqual(["use-case", "auth", "models", "dev-url"]);
     // The prompts are chat copy, relayed verbatim: each option carries the
     // literal thing the agent does to pick it.
     expect(asked.questions[0]?.prompt).toContain("real working screens from your data");
     expect(asked.questions[0]?.options[0]).toMatchObject({ flag: "--use-case embedded", recommended: true });
     expect(asked.questions[2]?.options[0]?.command).toBe("npx vendo login --wait 90");
     expect(asked.questions[2]?.options[1]?.flag).toBe("--byo");
+    // The dev URL travels like the rest: the recommended option carries the
+    // host's own dev port, so relaying it costs the reader one word.
+    expect(asked.questions[3]?.prompt).toContain("Vendo writes it to .env.local as VENDO_BASE_URL");
+    expect(asked.questions[3]?.options[0])
+      .toMatchObject({ flag: "--base-url http://localhost:3000", recommended: true });
     // The mechanical answers never surface: they default like --yes and show
     // up in the diff.
     const ids = asked.questions.map((question) => question.id).join(" ");
-    expect(ids).not.toContain("base-url");
     expect(ids).not.toContain("theme");
     expect(ids).not.toContain("check");
     expect(await tree(root)).toEqual(before); // the ask pass wrote nothing
@@ -1937,11 +1946,15 @@ describe("vendo init --agent (ask first, then write)", () => {
     const sink = output();
     expect(await run(root, sink, { agent: true, useCase: "mcp", auth: "clerk" })).toBe(0);
     const asked = questionsOf(sink.logs);
-    expect(asked.questions.map((question) => question.id)).toEqual(["posture", "service-key"]);
-    expect(asked.questions[0]?.prompt).toContain("yourcompany.mcp.vendo.run");
-    expect(asked.questions[0]?.options[0]?.flag).toBe("--posture broker");
-    expect(asked.questions[1]?.prompt).toContain("machine to machine");
-    expect(asked.questions[1]?.options[0]?.flag).toBe("--service-key");
+    // The dev URL rides along on every path, MCP included — the door's own
+    // discovery derives from it.
+    expect(asked.questions.map((question) => question.id)).toEqual(["dev-url", "posture", "service-key"]);
+    const byId = (id: string): InitQuestions["questions"][number] | undefined =>
+      asked.questions.find((question) => question.id === id);
+    expect(byId("posture")?.prompt).toContain("yourcompany.mcp.vendo.run");
+    expect(byId("posture")?.options[0]?.flag).toBe("--posture broker");
+    expect(byId("service-key")?.prompt).toContain("machine to machine");
+    expect(byId("service-key")?.options[0]?.flag).toBe("--service-key");
   });
 
   /** A keyless run cannot reach a broker, so posture is not a decision — the
@@ -1952,10 +1965,10 @@ describe("vendo init --agent (ask first, then write)", () => {
     const sink = output();
     expect(await run(root, sink, { agent: true, useCase: "mcp", auth: "clerk", byo: true })).toBe(0);
     const asked = questionsOf(sink.logs);
-    expect(asked.questions.map((question) => question.id)).toEqual(["service-key"]);
+    expect(asked.questions.map((question) => question.id)).toEqual(["dev-url", "service-key"]);
     expect(JSON.stringify(asked)).not.toContain("broker");
     // Both answers carry the settled posture, so the SAME gate closes.
-    expect(asked.questions[0]?.options.map((option) => option.flag))
+    expect(asked.questions.find((question) => question.id === "service-key")?.options.map((option) => option.flag))
       .toEqual(["--posture local --service-key", "--posture local"]);
   });
 
@@ -1989,7 +2002,7 @@ describe("vendo init --agent (ask first, then write)", () => {
     await writeFile(join(root, ".env.local"), `VENDO_API_KEY=vnd_${"a".repeat(40)}\n`);
     const after = output();
     expect(await run(root, after, { agent: true })).toBe(0);
-    expect(questionsOf(after.logs).questions.map((question) => question.id)).toEqual(["use-case", "auth"]);
+    expect(questionsOf(after.logs).questions.map((question) => question.id)).toEqual(["use-case", "auth", "dev-url"]);
   });
 
   /** `--ai` cannot buy an engine here: the caller IS one. The harness below
@@ -2044,7 +2057,7 @@ describe("vendo init --agent (ask first, then write)", () => {
     expect(await run(root, sink, { agent: true, env: { ANTHROPIC_API_KEY: "sk-ant-test" } })).toBe(0);
     const asked = questionsOf(sink.logs);
     expect(asked.detected.auth).toBe("clerk");
-    expect(asked.questions.map((question) => question.id)).toEqual(["use-case", "auth"]);
+    expect(asked.questions.map((question) => question.id)).toEqual(["use-case", "auth", "dev-url"]);
     expect(asked.questions[1]?.prompt)
       .toBe("It detected Clerk. Should the assistant act as your signed-in Clerk user?");
     expect(asked.questions[1]?.options).toEqual([
@@ -2676,20 +2689,96 @@ describe("the five questions", () => {
     expect(mastraLogs).toContain("VENDO_PRINCIPAL_KEY");
   });
 
-  it("--base-url replaces init's own .env.example placeholder and never touches .env.local", async () => {
+  /** The dev URL is a QUESTION now, and its answer is WRITTEN. An agent loop, a
+      backend process and the MCP door each send real HTTP requests back at the
+      host's own API, and none of them sees a wire request to learn the origin
+      from — so every one of those installs used to meet "Cannot execute … set
+      VENDO_BASE_URL" on its first turn. One Enter now settles it. */
+  it("asks where the app runs in dev, prefilled with the host's own port, and writes the answer to .env.local", async () => {
     const root = await fixture();
-    expect(await run(root, output(), { baseUrl: "https://app.acme.com" })).toBe(0);
-    const example = await readFile(join(root, ".env.example"), "utf8");
-    expect(example).toContain("VENDO_BASE_URL=https://app.acme.com");
-    expect(example).not.toContain("VENDO_BASE_URL=http://localhost:3000");
-    // A production URL in .env.local would repoint local dev's discovery,
-    // callbacks and forwarding at the deployed origin.
+    await writeFile(join(root, "package.json"), JSON.stringify({
+      name: "host",
+      dependencies: { next: "16.0.0" },
+      scripts: { dev: "next dev --port 4000" },
+    }));
+    const asked: Array<{ question: string; hint?: string; prefill?: string }> = [];
+    const sink = output();
+    // A bare Enter is resolved by the prompt itself — the seam stands in for a
+    // terminal, so it answers with the default it was handed.
+    expect(await run(root, sink, {
+      interactive: true,
+      askText: async (question, hint, prefill) => {
+        asked.push({ question, hint, prefill });
+        return prefill ?? "";
+      },
+    })).toBe(0);
+
+    expect(asked).toEqual([{
+      question: "Where does this app run in dev?",
+      hint: "Enter to accept http://localhost:4000",
+      prefill: "http://localhost:4000",
+    }]);
+    expect(await readFile(join(root, ".env.local"), "utf8")).toContain("VENDO_BASE_URL=http://localhost:4000");
+    expect(sink.logs.join("\n")).toContain("Wrote VENDO_BASE_URL=http://localhost:4000 to .env.local");
+    // The question that used to live here is gone: production is told at deploy
+    // time, never asked at init.
+    expect(sink.logs.join("\n")).not.toContain("Where will this deploy?");
+  });
+
+  /** Writing the prefill unasked would be a GUESS wearing an answer's clothes:
+      unset, dev still learns the request's own origin and production fails
+      loud, so silence is the honest outcome. */
+  it("never asks and never writes .env.local on an unattended run", async () => {
+    const root = await fixture();
+    expect(await run(root, output(), {
+      yes: true,
+      askText: async () => { throw new Error("prompted"); },
+    })).toBe(0);
     await expect(readFile(join(root, ".env.local"))).rejects.toMatchObject({ code: "ENOENT" });
 
-    // Enter declines: the placeholder stands, byte for byte.
-    const skipped = await fixture();
-    expect(await run(skipped, output(), { interactive: true, askText: async () => "" })).toBe(0);
-    expect(await readFile(join(skipped, ".env.example"), "utf8")).toContain("VENDO_BASE_URL=http://localhost:3000");
+    // --base-url is the same answer arriving as a flag, and it writes.
+    const answered = await fixture();
+    expect(await run(answered, output(), { yes: true, baseUrl: "http://localhost:5173" })).toBe(0);
+    expect(await readFile(join(answered, ".env.local"), "utf8")).toContain("VENDO_BASE_URL=http://localhost:5173");
+  });
+
+  /** The MCP arm's own question, answered from the same prompt — and then read
+      back through the OTHER side of the seam: `readEnvFiles` is the CLI's one
+      env reader, the same call doctor makes before grading E-MCP-009, so the
+      file init writes is the file doctor sees. Nothing is stubbed on either end.
+      Local posture in dev is the point: the door's client URL and its discovery
+      both want the origin the developer is looking at. */
+  it("MCP: the dev answer opens the door locally, and the CLI's env reader sees it", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vendo-init-mcp-dev-url-"));
+    cleanup.push(root);
+    await mkdir(join(root, "app"), { recursive: true });
+    await writeFile(join(root, "package.json"), JSON.stringify({
+      name: "mcp-host",
+      dependencies: { next: "16.0.0", "@clerk/nextjs": "7.0.0" },
+      scripts: { dev: "next dev -p 4300" },
+    }));
+    await writeFile(join(root, "app", "layout.tsx"),
+      'import { VendoProvider } from "@vendoai/vendo/react";\n'
+      + "export default function Layout({ children }) { return <VendoProvider>{children}<VendoOverlay /></VendoProvider>; }\n");
+    const sink = output();
+    expect(await run(root, sink, {
+      useCase: "mcp",
+      auth: "clerk",
+      interactive: true,
+      askText: async (_question, _hint, prefill) => prefill ?? "",
+      confirmAuth: async () => false,
+      selectUseCase: async () => "local",
+      confirmCheck: async () => false,
+      confirmZodBump: async () => false,
+    })).toBe(0);
+
+    expect(await readFile(join(root, ".env.local"), "utf8")).toContain("VENDO_BASE_URL=http://localhost:4300");
+    // The client URL a user pastes into Claude is the dev origin, not a guess.
+    expect(sink.logs.join("\n")).toContain("Point any MCP client at `http://localhost:4300/api/vendo/mcp`");
+
+    // The read-back, through the reader doctor itself uses — no env override,
+    // no stub: whatever this returns is what E-MCP-009 grades.
+    expect((await readEnvFiles(root))["VENDO_BASE_URL"]).toBe("http://localhost:4300");
   });
 
   it("offers the doctor check only when nothing is left to paste, and never changes the exit code", async () => {

--- a/packages/vendo/tests/cli/pretty.test.ts
+++ b/packages/vendo/tests/cli/pretty.test.ts
@@ -765,6 +765,9 @@ describe("createPrettyOutput (visual system)", () => {
   it("plainText and plainSecret answer the empty skip without prompting when not a TTY", async () => {
     expect(await plainText("Where will this deploy?")).toBe("");
     expect(await plainSecret("Paste your provider key")).toBe("");
+    // A default does NOT leak past the guard: "" still means nobody was asked,
+    // so a piped run can never be handed an answer it never gave.
+    expect(await plainText("Where does this app run in dev?", undefined, "http://localhost:3000")).toBe("");
   });
 
   it("confirm parses y / n / Enter-default / other text through a real readline", async () => {
@@ -825,6 +828,33 @@ describe("createPrettyOutput (visual system)", () => {
     expect(plain).toContain("● skipped");
   });
 
+  /** A prefilled question has no skip: Enter IS the answer, and the receipt has
+      to say so — echoing "skipped" over a value that was just written is how a
+      transcript starts lying about what the run did. */
+  it("text takes a default on Enter and echoes the value, not a skip", async () => {
+    const out = sink();
+    const io = promptStreams();
+    const pretty = createPrettyOutput({
+      write: out.write,
+      input: io.input,
+      promptOutput: io.output,
+      banner: false,
+    });
+
+    const accepted = pretty.text("Where does this app run in dev?", "Enter to accept http://localhost:4000", "http://localhost:4000");
+    io.input.write("\n");
+    expect(await accepted).toBe("http://localhost:4000");
+
+    const typed = pretty.text("Where does this app run in dev?", undefined, "http://localhost:4000");
+    io.input.write("http://localhost:8080\n");
+    expect(await typed).toBe("http://localhost:8080");
+
+    const plain = out.plain();
+    expect(plain).toContain("● http://localhost:4000");
+    expect(plain).toContain("● http://localhost:8080");
+    expect(plain).not.toContain("● skipped");
+  });
+
   it("secret echoes a masked receipt and never the value", async () => {
     const out = sink();
     const io = promptStreams();
@@ -881,11 +911,18 @@ describe("createPrettyOutput (visual system)", () => {
 
   it("plainText and plainSecret drive a real readline, and only plainSecret hides the typing", async () => {
     const asked = promptStreams();
-    const answer = plainText("Where will this deploy?", "Enter to skip", asked.input, asked.output);
+    const answer = plainText("Where will this deploy?", "Enter to skip", undefined, asked.input, asked.output);
     asked.input.write("https://app.acme.com\n");
     expect(await answer).toBe("https://app.acme.com");
     expect(asked.echoed()).toContain("Where will this deploy?");
     expect(asked.echoed()).toContain("  Enter to skip");
+
+    // Enter on a prefilled question answers with the default — the NO_COLOR
+    // path the dev-URL question rides in a plain terminal.
+    const defaulted = promptStreams();
+    const byEnter = plainText("Where does this app run in dev?", undefined, "http://localhost:4000", defaulted.input, defaulted.output);
+    defaulted.input.write("\n");
+    expect(await byEnter).toBe("http://localhost:4000");
 
     const secret = promptStreams();
     (secret.input as PassThrough & { setRawMode?: (mode: boolean) => void }).setRawMode = () => undefined;


### PR DESCRIPTION
## The shape

Init's base-URL question moves from production to dev, because dev is the origin Vendo cannot learn for itself. An own-agent-loop tool call, a backend process and the MCP door each make a real HTTP request back at the host's own API and never see a wire request to read an origin off — so those installs met `Cannot execute … set VENDO_BASE_URL` on their first turn, after a run that had already called itself finished.

- **New question.** Interactive init asks `Where does this app run in dev?`, prefilled with `http://localhost:<port from your dev script>`. Enter accepts it, and the answer is written to `.env.local` as `VENDO_BASE_URL` (the same `upsertEnvLocal` + `ensureEnvLocalIgnored` machinery the models step uses).
- **Certain or loud, never a silent guess.** A run that cannot ASK writes nothing — `--yes`, piped, and non-TTY runs behave exactly as they do today. The prefill is an answer only when a person accepts it; unset, dev still learns the request's own origin and production still fails loud.
- **`--base-url` is that same answer as a flag** (dev origin → `.env.local`), and it now travels in `--agent` mode's question list (`dev-url`) like every other decision a person owns.
- **Honest receipt.** `pretty.text` / `plainText` take an optional default, so Enter resolves to the value and the terminal echoes what it wrote instead of printing `skipped` over a file it just changed.

## What was removed

- **"Where will this deploy?"** — `captureBaseUrl` and the `.env.example` placeholder-rewrite flow, with both call sites (the non-MCP one in `finishRun`, the MCP one before the plan). Production is told at deploy time, not asked at init.
- The MCP arm now reads the **dev** answer: the client URL it prints (`Point any MCP client at http://localhost:3006/api/vendo/mcp`) is the app the developer is actually running, and its first step points at deploy time for the public origin.
- **No inference anywhere.** Nothing reads `VERCEL_URL`, `AUTH_URL` or any platform variable. The optional "this looks like Vercel" suggestion was deliberately skipped — it would have put a platform-specific branch into the credential-forwarding refusal path in `compose-actions.ts`, which is not clean for a DX change.

## Also fixed: E-MCP-009 had gone silent (regression from #1452)

#1452 moved the composition into its own module (`lib/vendo.ts`, `src/lib/vendo.ts` under a src layout). `doctor-wiring-checks.ts`'s `compositionOf` was taught the new location; `doctor-mcp-checks.ts`'s `COMPOSITION_PATHS` was not — so on every host init has scaffolded since, E-MCP-009 found no composition and reported **nothing at all**: no failure, no check, no line to notice, on precisely the misconfiguration a hard FAIL exists to catch.

The path list now leads with the composition module (both layouts) and keeps every legacy location — the route's sibling `vendo.ts`, the inline route, the Express and runtime-neutral modules — in the same order `compositionOf` reads them, so older installs grade exactly as before.

**Heads-up on the behavior flip:** this restores the intended failure. An MCP-wired host with neither `VENDO_BASE_URL` nor `mcp: { baseUrl }` now fails E-MCP-009 and exits 1 where it had been silently green. That is the point of the check, and the dev-URL question above is what makes it green by construction for a fresh interactive install; production sets the variable where it deploys.

## The `.env.example` wording

The `VENDO_BASE_URL` line stays (dev port as illustration), and its comment is now an instruction rather than a value to fill in:

```
# This deployment's FULL public URL — path prefix included. Nothing strips its
# path: every URL Vendo builds (host tool calls, login redirects, box callbacks)
# hangs off it.
#
# Dev is already done: `vendo init` asked where this app runs and wrote your
# answer to .env.local. When you DEPLOY, set VENDO_BASE_URL in your hosting
# platform's environment settings to the public URL — a production URL belongs
# in neither a committed file nor .env.local. Production fails loud without it
# (a credential-forwarding call errors instead of silently running
# unauthenticated).
#
# For reference, the dev shape:
VENDO_BASE_URL=http://localhost:3000
```

## Proof

**Tests** — `packages/vendo`: 227 files passed, 2441 tests passed, 45 skipped. New coverage: the question is asked with its prefill and the answer lands in `.env.local`; nothing is asked or written unattended; the flag writes; the agent-mode `dev-url` question carries the host's port; `.env.example` is never rewritten by an answer; the MCP arm's client URL and step text; `pretty.text` echoes an accepted default; E-MCP-009 fires on an init-shaped host (both layouts) with the variable unset and passes with it set.

The MCP dev-answer test is now a real seam: init writes the repo, then a real `runDoctor` over it — no env override, no stub — grades `mcp/base-url` green off the `.env.local` init produced.

Both headline tests were proven able to fail:
- removed the `upsertEnvLocal` call → the dev-URL test red (`ENOENT … /.env.local`), restored → green.
- removed the two `lib/vendo.ts` path entries → both new E-MCP-009 cases red (`expected +0 to be 1` — doctor exits 0, i.e. silent) **and** the init seam test red, restored → green.

**Built CLI, real TTY** — `pnpm build`, then the built `bin/vendo.mjs` run under `script -q /dev/null` on a scratch Next host whose dev script pins `-p 3006`, answering Enter:

```
◇  Where does this app run in dev?
│  Enter to accept http://localhost:3006
│  ›
│  ● http://localhost:3006
│  Wrote VENDO_BASE_URL=http://localhost:3006 to .env.local
```

`.env.local` → `VENDO_BASE_URL=http://localhost:3006`. Zero occurrences of the deploy question in the transcript. Exit 0.

**Gate** (worktree root): `pnpm build` 21/21 · `pnpm typecheck` 42/42 · `pnpm lint` 4/4 (0 errors; 4 pre-existing demo-bank warnings) · `pnpm test:affected` 31/31 (run before the doctor fix; the full `packages/vendo` suite was rerun green after it, and CI covers the rest).

## Docs

`reference/vendo-init.mdx` (writes table gains `.env.local`, the interactive-question list, the agent-mode flag list, the flag row, the Warning), `reference/environment-variables.mdx`, `reference/uninstall.mdx`, `agents/index.mdx` (playbook question list, the MCP `VENDO_BASE_URL` step, the example command), `backend/quickstart.mdx` and `existing-agent/quickstart.mdx` (init already wrote the line; add it by hand only if init ran unattended). `production/deploying.mdx` was left alone — its only `VENDO_BASE_URL` mention is already deploy-time framing.