### PR TITLE
feat(vendo,core): the channel can text you first, and it stops talking itself out of the job

### DIFF
--- a/.changeset/the-channel-can-text-you-back.md
+++ b/.changeset/the-channel-can-text-you-back.md
@@ -1,0 +1,48 @@
+---
+"@vendoai/vendo": minor
+"@vendoai/core": patch
+---
+
+The channel can text you first, and it stops talking itself out of the job.
+
+One sentence of hidden grounding rode on every inbound text: "you cannot send
+scheduled, recurring or unprompted texts, and you cannot set any of that up from
+here — say so plainly if asked, point to the app, and say it is coming soon." It
+was written about delivery. Next to a user's actual ask it read as a
+channel-wide restriction, and on 2026-08-18 the agent refused four separate
+transfer requests over text — "isn't something I'm able to do from here… do that
+directly in the Maple app" — without ever searching its tool catalog, on a
+prompt carrying three copies of the search-first instruction. The web surface,
+which has no such note, moves the same money without a blink. The note itself
+taught the refusal. It was also false about automations, which a texted user can
+set up perfectly well.
+
+The channel now states the one limit it actually has, and names the way around
+it: "To text the user later, set up an automation for it — the Text me action is
+how an automation reaches this phone, and its grant is part of arming. You cannot
+otherwise send scheduled, recurring or unprompted texts. That is this channel's
+only limit: anything else your tools can do, you can do right here in this
+conversation."
+
+That last clause is only true because the action it points at now exists.
+`vendo_text_me` sends one text to the person the run is FOR, from any surface — a
+web chat, an app, an automation firing at 6am while they are asleep. It composes
+exactly when the text channel does, so a deployment that never asked for texts
+is not offered a tool whose every call could only refuse.
+
+Its input is `{ text }` and nothing else. There is no number to pass, so no model
+output can aim a text at a phone that is not the current user's own: the
+destination is read from that subject's link row, which only exists because the
+signed-in user asked for a code and texted it back. Consent is the machinery that
+was already there — a `write` descriptor on the one registry, so a live turn
+parks whatever card the host's policy calls for, and an away firing needs the
+standing grant that arming mints. "Text me when the rent clears" is allowed once,
+on the screen where it is armed, and delivered from then on.
+
+Nothing is claimed that did not happen. A user with no phone linked gets a
+result carrying the connect link itself, minted fresh, so the agent can offer it
+instead of apologising; a phone the router can no longer reach gets a result that
+says the text did not go through and that reconnecting will fix it. The link row
+remembers the conversation the person's own messages arrive on, which is the only
+address the channel has — the deployment never learns the router's addressing,
+and never sends to a bare number.

--- a/packages/core/src/tools.ts
+++ b/packages/core/src/tools.ts
@@ -124,6 +124,7 @@ export const VENDO_TOOL_TITLES: Readonly<Record<string, string>> = {
   vendo_apps_data_put: "Save an item in the app",
   vendo_apps_data_delete: "Remove an item from the app",
   vendo_knowledge_search: "Look it up in the docs",
+  vendo_text_me: "Text me",
   // The verbs and `ask_user` authored these titles inline first; they moved here
   // verbatim so the CLIENT can say them too — a live browser proof caught a verb
   // narrating its identifier prettified while its descriptor carried a real title.

--- a/packages/vendo/src/channel-links.ts
+++ b/packages/vendo/src/channel-links.ts
@@ -67,6 +67,13 @@ export interface ChannelLink {
    *  and persist the texting style into every later web turn on it. */
   threadId?: string;
   lastTurnAt?: IsoDateTime;
+  /** The router conversation this phone last texted on — the ONLY address the
+   *  channel can send to (`ChannelsService.send` takes a conversation, never a
+   *  number, because the deployment never learns the router's addressing). It is
+   *  what lets `vendo_text_me` reach this person from a web turn or an away
+   *  firing. Absent until they have sent at least one real message: a one-text
+   *  link carries no conversation of its own (`InboundLinkEvent`). */
+  conversationId?: string;
 }
 
 function mintLinkId(): string {
@@ -172,9 +179,10 @@ export class ChannelLinkRepository {
   }
 
   /** Remember which thread this conversation is running in, and when it last
-   *  ran — the two facts `runChannelTurn` rolls the thread on. */
-  async rememberTurn(link: ChannelLink, threadId: string): Promise<void> {
-    const updated: ChannelLink = { ...link, threadId, lastTurnAt: new Date().toISOString() };
+   *  ran — the two facts `runChannelTurn` rolls the thread on — plus the
+   *  conversation itself, which is the address `vendo_text_me` sends to. */
+  async rememberTurn(link: ChannelLink, threadId: string, conversationId: string): Promise<void> {
+    const updated: ChannelLink = { ...link, threadId, lastTurnAt: new Date().toISOString(), conversationId };
     await this.records().put({
       id: link.id,
       data: updated,

--- a/packages/vendo/src/channel-turn.ts
+++ b/packages/vendo/src/channel-turn.ts
@@ -44,18 +44,34 @@ export const CHANNEL_APPROVAL_WAIT_MS = 600_000;
  *  in the host app's history like any web chat. */
 const THREAD_IDLE_MS = 24 * 60 * 60_000;
 
+/** How a text READS, stated once. Shared with the Text me tool's descriptor
+ *  (text-me.ts): a text the agent sends from a web turn or an away firing is
+ *  still a text, and two copies of this sentence would drift. */
+export const PLAIN_TEXT_RULE =
+  "Write like a text: one short paragraph, plain sentences, no markdown, no headings, no bullet lists, "
+  + "no links unless asked.";
+
 /** The house style for this channel, delivered the way every other hidden
  *  grounding is (01-core's AGENT_CONTEXT_MARK): a text part the model reads and
  *  the person never sees. There is no host-facing knob for it — a text is a
  *  text. */
 const TEXT_STYLE = [
   `${AGENT_CONTEXT_MARK} This conversation is happening over text message.`,
-  "Write like a text: one short paragraph, plain sentences, no markdown, no headings, no bullet lists, no links unless asked.",
+  PLAIN_TEXT_RULE,
   "Never mention that you are texting. If you need a yes or no, ask for it in one line.",
-  // Delivery does not exist yet: nothing can send a text on a schedule or of its
-  // own accord. So the channel must not OFFER it either — an agent that promises
-  // Friday's text has already broken a promise the product cannot keep.
-  "You cannot send scheduled, recurring or unprompted texts, and you cannot set any of that up from here — say so plainly if asked, point to the app, and say it is coming soon.",
+  // Live incident 2026-08-18. This sentence rides as hidden context on EVERY
+  // inbound text, so next to "send $25 to Dana" the old wording — "you cannot
+  // send … from here, point to the app" — read as a channel-wide restriction:
+  // the model refused four transfer asks verbatim ("do that directly in the
+  // Maple app") without ever searching its tool catalog, on a prompt carrying
+  // three copies of the search-first instruction. The web surface, which has no
+  // such note, sends money fine — the note itself taught the refusal. It was
+  // also false about automations, which a texted user CAN set up. So the limit
+  // is stated as the ONE thing it actually is, and the escape hatch is named:
+  // `vendo_text_me` (text-me.ts) is how a later text gets sent.
+  "To text the user later, set up an automation for it — the Text me action is how an automation reaches this "
+  + "phone, and its grant is part of arming. You cannot otherwise send scheduled, recurring or unprompted texts. "
+  + "That is this channel's only limit: anything else your tools can do, you can do right here in this conversation.",
 ].join(" ");
 
 /** What a turn says when it produced no words at all — a failure that never
@@ -188,7 +204,7 @@ export async function runChannelTurn(
     // The effective thread, reopened or freshly minted — every door that serves
     // a turn stamps the same header.
     const effective = response.headers.get(THREAD_ID_HEADER);
-    if (effective !== null) await deps.links.rememberTurn(link, effective);
+    if (effective !== null) await deps.links.rememberTurn(link, effective, event.conversationId);
     const text = await assistantText(response);
     await send(text === "" ? NOTHING_TO_SAY : text);
   } finally {

--- a/packages/vendo/src/compose-channels.ts
+++ b/packages/vendo/src/compose-channels.ts
@@ -22,6 +22,7 @@ import {
 } from "./channels.js";
 import { cloudKeyOptions } from "./compose-selection.js";
 import type { VendoComposition } from "./compose-context.js";
+import { textMeRegistry } from "./text-me.js";
 import type { CreateVendoConfig } from "./types.js";
 
 /** The conversation ref a link delivery is logged under. Link events carry no
@@ -167,6 +168,18 @@ export const composeChannels = (composition: VendoComposition): Pick<VendoCompos
       );
     },
   };
+
+  // "No adapter, no tool" (compose-tools.ts, knowledge and the connector pair):
+  // a deployment that never opted into texts must not be offered a tool whose
+  // every call could only refuse. Registered on the SAME registry as everything
+  // else, so the guard, the audit trail and `find_tools` see it like a host tool.
+  if (channels.posture !== false) {
+    composition.actions.add(textMeRegistry({
+      channel: channels,
+      links,
+      invite: (principal) => door.invite(principal),
+    }));
+  }
 
   return { channels, channelDoor: door, channelInboundSecret };
 };

--- a/packages/vendo/src/text-me.ts
+++ b/packages/vendo/src/text-me.ts
@@ -1,0 +1,114 @@
+/**
+ * `vendo_text_me` — one text to the person the run is FOR, from any surface.
+ *
+ * It exists because the text channel could only ever answer: a conversation the
+ * user started, in the turn they started it. Everything that wants to reach them
+ * later — an away automation, a web turn that finishes after they have closed the
+ * tab — had nothing to call, so the channel's own grounding told the model to
+ * point at the app and promise "coming soon" (channel-turn.ts). This is the other
+ * half: the action an automation holds a grant for, so "text me when the rent
+ * clears" is armed once and delivered forever.
+ *
+ * MISUSE RESISTANCE IS THE SHAPE, not a check: the input is `{ text }` and
+ * nothing else. There is no number to pass, so no model output can aim a text at
+ * a phone that is not the current subject's own — the destination is read from
+ * the link row under `ctx.principal`, which only ever exists because that signed-in
+ * user asked for it and texted a code back (channel-links.ts).
+ *
+ * Consent is the existing machinery, untouched: a `write` descriptor on the one
+ * registry, so a present turn parks a card under whatever the host's policy says,
+ * and an away firing needs the standing grant that arming mints (automations
+ * `grants.ts`). No new consent path, no per-tool allowlist.
+ */
+import {
+  VENDO_TOOL_TITLES,
+  type Principal,
+  type RunContext,
+  type ToolDescriptor,
+  type ToolRegistry,
+} from "@vendoai/core";
+import type { ChannelLinkRepository } from "./channel-links.js";
+import { PLAIN_TEXT_RULE } from "./channel-turn.js";
+import type { ChannelsService, TextChannelInvite } from "./channels.js";
+
+export const VENDO_TEXT_ME_TOOL = "vendo_text_me";
+
+export interface TextMeDeps {
+  channel: ChannelsService;
+  links: ChannelLinkRepository;
+  /** The connect flow's own invite — the same `sms:` URL the link page hands
+   *  out, so an agent that finds no phone offers the ONE link that fixes it. */
+  invite: (principal: Principal) => Promise<TextChannelInvite>;
+}
+
+const DESCRIPTOR: ToolDescriptor = {
+  name: VENDO_TEXT_ME_TOOL,
+  title: VENDO_TOOL_TITLES[VENDO_TEXT_ME_TOOL]!,
+  description:
+    "Send this user one text message on the phone they linked to their account. It reaches them from any "
+    + "surface — a web chat, an app, an automation firing while they are away — and it can only ever reach "
+    + "their own phone. In a text conversation, just reply: do not call this to answer the person you are "
+    + "already texting. To text them later or on a schedule, set up an automation that calls this action; "
+    + `the permission is granted once, when they arm it. ${PLAIN_TEXT_RULE}`,
+  inputSchema: {
+    type: "object",
+    properties: { text: { type: "string", minLength: 1 } },
+    required: ["text"],
+    additionalProperties: false,
+  },
+  risk: "write",
+};
+
+/** No phone, no text — and the fix is a link, not an apology. The invite is
+ *  minted rather than described because the code expires (LINK_CODE_TTL_MS) and a
+ *  stale one reads as a broken product. */
+const notLinked = (url: string) =>
+  "No phone is linked to this account, so there is nothing to text. Tell them so plainly and offer them this "
+  + `link to connect one — it opens a prefilled first message: ${url}`;
+
+/** The router had the conversation and could not deliver on it (a lapsed
+ *  iMessage assignment answers 404). Never a fabricated success: the model is
+ *  told, in one sentence, that the text did NOT arrive. */
+const NOT_REACHABLE =
+  "The text did not go through — their phone is not reachable right now and the connection may have lapsed. "
+  + "Say plainly that you could not text them, and that reconnecting their phone will fix it. Do not say you sent it.";
+
+/**
+ * The `vendo_text_me` door as a one-tool registry, composed alongside the others
+ * (compose-channels.ts) and ONLY when a channel adapter is configured — the same
+ * "no adapter, no tool" rule knowledge and the connector pair follow. A
+ * deployment that never asked for texts must not be shown a tool whose every
+ * call would refuse.
+ */
+export function textMeRegistry(deps: TextMeDeps): ToolRegistry {
+  return {
+    async descriptors() {
+      return [DESCRIPTOR];
+    },
+
+    async execute(call, ctx: RunContext) {
+      const args = (call.args ?? {}) as { text?: unknown };
+      const text = typeof args.text === "string" ? args.text.trim() : "";
+      if (text === "") {
+        return { status: "error", error: { code: "validation", message: "Text me needs the message to send" } };
+      }
+      // The destination, read off the subject's own link row. A pending code is
+      // not a link (`bySubject` answers claimed rows only), and a link with no
+      // conversation is a phone the router has never carried a real message for.
+      const link = await deps.links.bySubject(ctx.principal.subject);
+      if (link?.conversationId === undefined) {
+        const invite = await deps.invite(ctx.principal);
+        return { status: "error", error: { code: "not-linked", message: notLinked(invite.url) } };
+      }
+      try {
+        await deps.channel.send({ conversationId: link.conversationId, text });
+      } catch {
+        // Loud, and the model's to explain. Rethrowing would surface as "the
+        // tool is broken", which the agent retries; a result the person can act
+        // on is what gets their phone reconnected.
+        return { status: "error", error: { code: "unavailable", message: NOT_REACHABLE } };
+      }
+      return { status: "ok", output: { sent: true } };
+    },
+  };
+}

--- a/packages/vendo/src/text-me.ts
+++ b/packages/vendo/src/text-me.ts
@@ -59,12 +59,15 @@ const DESCRIPTOR: ToolDescriptor = {
   risk: "write",
 };
 
-/** No phone, no text — and the fix is a link, not an apology. The invite is
- *  minted rather than described because the code expires (LINK_CODE_TTL_MS) and a
- *  stale one reads as a broken product. */
-const notLinked = (url: string) =>
-  "No phone is linked to this account, so there is nothing to text. Tell them so plainly and offer them this "
-  + `link to connect one — it opens a prefilled first message: ${url}`;
+/** No phone this can reach — either nobody linked one, or the link is minutes
+ *  old and the router has not carried a real message on it yet (a one-text link
+ *  relays no conversation of its own). ONE sentence covers both, because the fix
+ *  is the same: the person texts once. The invite is minted rather than described
+ *  because a code expires (LINK_CODE_TTL_MS) and a stale one reads as a broken
+ *  product. */
+const noReachablePhone = (url: string) =>
+  "There is no phone this can reach for this account yet — a phone becomes reachable once its owner has texted "
+  + `here at least once. Tell them so plainly, and offer them this link, which opens a prefilled first message: ${url}`;
 
 /** The router had the conversation and could not deliver on it (a lapsed
  *  iMessage assignment answers 404). Never a fabricated success: the model is
@@ -98,7 +101,7 @@ export function textMeRegistry(deps: TextMeDeps): ToolRegistry {
       const link = await deps.links.bySubject(ctx.principal.subject);
       if (link?.conversationId === undefined) {
         const invite = await deps.invite(ctx.principal);
-        return { status: "error", error: { code: "not-linked", message: notLinked(invite.url) } };
+        return { status: "error", error: { code: "not-linked", message: noReachablePhone(invite.url) } };
       }
       try {
         await deps.channel.send({ conversationId: link.conversationId, text });

--- a/packages/vendo/tests/text-me.e2e.test.ts
+++ b/packages/vendo/tests/text-me.e2e.test.ts
@@ -1,0 +1,283 @@
+import { createServer, type Server } from "node:http";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AddressInfo } from "node:net";
+import { automationsInternals } from "@vendoai/automations";
+import type { Principal, RunContext } from "@vendoai/core";
+import { defineHarness } from "@vendoai/harnesses";
+import { createStore, type VendoStore } from "@vendoai/store";
+import type { LanguageModel } from "ai";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { channelInboundSecret } from "../src/channels.js";
+import { createVendo, guard, type Vendo } from "../src/server.js";
+import { VENDO_TEXT_ME_TOOL } from "../src/text-me.js";
+
+/**
+ * `vendo_text_me` end to end, over the REAL composition: real `createVendo`, real
+ * guard, real automations engine, one real PGlite store, the real
+ * `cloudTextChannel` client — and an HTTP console standing in for the one half
+ * this repo does not own.
+ *
+ * WHY IT IS SHAPED THIS WAY: the thing worth proving is not that a registry
+ * returns a descriptor, it is that an automation somebody armed MONTHS ago puts a
+ * text on a real phone, and that the same automation without that consent puts
+ * nothing anywhere. Producer (the tool) and consumer (the console's send route)
+ * are on opposite sides of a wire here, with no stub between them — the send this
+ * suite asserts on is a request the console actually received.
+ */
+
+const API_KEY = "vk_live_text_me";
+const owner: Principal = { kind: "user", subject: "user_text_me" };
+const PHONE = "+15551239999";
+const CONVERSATION = "conv_text_me";
+
+const cleanups: Array<() => Promise<void>> = [];
+beforeEach(() => {
+  // The ladder reads the key itself; a developer's real key must never decide
+  // what this suite observes.
+  vi.stubEnv("VENDO_API_KEY", "");
+  vi.stubEnv("VENDO_CLOUD_URL", "");
+});
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+  vi.unstubAllEnvs();
+});
+
+/** What the console received, in order — the only witness that says a text
+ *  really went out rather than that a tool said "ok". */
+interface FakeConsole {
+  baseUrl: string;
+  sent: Array<{ conversationId: string; text: string }>;
+  /** On, the router has no live assignment for the conversation: a 404, exactly
+   *  as a lapsed iMessage identity answers. */
+  failSends: boolean;
+}
+
+async function fakeConsole(): Promise<FakeConsole> {
+  const state: FakeConsole = { baseUrl: "", sent: [], failSends: false };
+  const server: Server = createServer((req, res) => {
+    let body = "";
+    req.on("data", (chunk) => (body += String(chunk)));
+    req.on("end", () => {
+      res.setHeader("content-type", "application/json");
+      if (req.url === "/api/v1/channels/text/register") {
+        res.end(JSON.stringify({
+          identityId: "tid_text_me",
+          handle: "maple",
+          number: "+15550000000",
+          connectCommand: "connect @maple",
+        }));
+        return;
+      }
+      if (req.url === "/api/v1/channels/text/send") {
+        if (state.failSends) {
+          res.statusCode = 404;
+          res.end(JSON.stringify({ error: { code: "not-found", message: "no active assignment" } }));
+          return;
+        }
+        state.sent.push(JSON.parse(body) as { conversationId: string; text: string });
+        res.end(JSON.stringify({ ok: true }));
+        return;
+      }
+      res.statusCode = 404;
+      res.end("{}");
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  cleanups.push(async () => new Promise<void>((resolve) => server.close(() => resolve())));
+  const { port } = server.address() as AddressInfo;
+  state.baseUrl = `http://127.0.0.1:${port}`;
+  return state;
+}
+
+async function tempStore(): Promise<VendoStore> {
+  const dataDir = await mkdtemp(join(tmpdir(), "vendo-text-me-"));
+  const store = createStore({ dataDir });
+  cleanups.push(async () => {
+    await store.close();
+    await rm(dataDir, { recursive: true, force: true });
+  });
+  return store;
+}
+
+const replying = defineHarness({
+  name: "text-me-probe",
+  // eslint-disable-next-line require-yield
+  async *run() {
+    yield { type: "text", delta: "Two invoices are due." };
+  },
+});
+
+async function compose(cloud: FakeConsole | undefined, policy?: "ask" | "run"): Promise<Vendo> {
+  if (cloud !== undefined) {
+    vi.stubEnv("VENDO_API_KEY", API_KEY);
+    vi.stubEnv("VENDO_CLOUD_URL", cloud.baseUrl);
+  }
+  vi.stubEnv("VENDO_BASE_URL", "https://maple.test");
+  const vendo = createVendo({
+    models: { default: {} as LanguageModel },
+    principal: async () => owner,
+    store: await tempStore(),
+    harness: replying as never,
+    ...(policy === undefined ? {} : { guard: guard({ policy: { rules: [{ match: { risk: "write" }, action: policy }] } }) }),
+    ...(cloud === undefined ? {} : { channels: { text: true } }),
+  } as Parameters<typeof createVendo>[0]);
+  return vendo;
+}
+
+const inbound = async (vendo: Vendo, eventId: string, text: string): Promise<Response> =>
+  vendo.handler(new Request("https://maple.test/api/vendo/channels/text/inbound", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${await channelInboundSecret(API_KEY)}`,
+    },
+    body: JSON.stringify({
+      eventId,
+      channel: "text",
+      from: PHONE,
+      text,
+      conversationId: CONVERSATION,
+      receivedAt: new Date().toISOString(),
+    }),
+  }));
+
+async function waitFor(check: () => boolean): Promise<void> {
+  while (!check()) await new Promise((resolve) => setTimeout(resolve, 25));
+}
+
+/** A linked, texting user: the code from the link page, then one real message —
+ *  which is what teaches the link row the conversation a later text rides on. */
+async function linkAndText(vendo: Vendo, cloud: FakeConsole): Promise<void> {
+  const page = await (await vendo.handler(
+    new Request("https://maple.test/api/vendo/channels/text/link", { headers: { "user-agent": "Macintosh" } }),
+  )).text();
+  await inbound(vendo, "evt_link", /connect @maple ([23456789A-Z]{6})/.exec(page)![1]!);
+  await waitFor(() => cloud.sent.length === 1);
+  await inbound(vendo, "evt_hello", "how much is due?");
+  await waitFor(() => cloud.sent.length === 2);
+}
+
+const away: RunContext = {
+  principal: owner,
+  venue: "automation",
+  presence: "away",
+  sessionId: "sess_text_me",
+};
+const present: RunContext = {
+  principal: owner,
+  venue: "chat",
+  presence: "present",
+  sessionId: "sess_text_me_web",
+};
+
+describe.sequential("Text me", () => {
+  it("delivers a real text from an armed automation, and nothing at all without its grant", async () => {
+    const cloud = await fakeConsole();
+    const vendo = await compose(cloud);
+    await linkAndText(vendo, cloud);
+
+    const record = await automationsInternals(vendo.automations).create({
+      owner,
+      when: { event: "rent.cleared" },
+      // Step args are JSONata, so a literal message is a quoted string.
+      task: { kind: "steps", steps: [{ id: "tell", tool: VENDO_TEXT_ME_TOOL, args: { text: "'Your rent cleared.'" } }] },
+      authoredBy: "chat",
+    }, away);
+
+    // Armed, holding nothing: the away downgrade forces an ask and the run ends
+    // LOUDLY. No new consent machinery is involved — this is the same standing
+    // grant flow every other tool descriptor goes through.
+    const [refusedId] = await vendo.emit("rent.cleared", {}, owner);
+    expect(await vendo.automations.runs.get(refusedId!, away)).toMatchObject({
+      automationId: record.id,
+      status: "error",
+      error: { code: "needs-permission", tool: VENDO_TEXT_ME_TOOL },
+    });
+    // THE POINT of the negative half: the refusal reached the wire, not just a
+    // status. The console received nothing beyond the two linking texts.
+    expect(cloud.sent).toHaveLength(2);
+
+    // One tap on the real guard — exactly what an arming card sends.
+    const pending = await vendo.guard.approvals.pending(owner);
+    expect(pending.map((ask) => ask.ctx.trigger?.automationId)).toEqual([record.id]);
+    await vendo.guard.approvals.decide([pending[0]!.id], { approve: true }, owner);
+    expect(await vendo.guard.grants.list(owner)).toMatchObject([{
+      subject: owner.subject,
+      tool: VENDO_TEXT_ME_TOOL,
+      automationId: record.id,
+      source: "automation",
+      duration: "standing",
+    }]);
+
+    // The same automation, the same guard — and now the phone rings.
+    const rerunId = await vendo.automations.runs.rerun(refusedId!, away);
+    const run = await vendo.automations.runs.get(rerunId, away);
+    expect(run).toMatchObject({ status: "ok" });
+    // The ledger records the send as a step of that firing.
+    expect(run?.steps).toMatchObject([{ id: "tell", tool: VENDO_TEXT_ME_TOOL, outcome: "ok" }]);
+    // And the console really received it, on the conversation the link row
+    // learned from the person's own message.
+    expect(cloud.sent[2]).toEqual({ conversationId: CONVERSATION, text: "Your rent cleared." });
+  }, 120_000);
+
+  it("parks a live turn's text behind the same card any other write earns", async () => {
+    const cloud = await fakeConsole();
+    const vendo = await compose(cloud, "ask");
+    await linkAndText(vendo, cloud);
+
+    const outcome = await vendo.guardedTools.execute(
+      { id: "call_web", tool: VENDO_TEXT_ME_TOOL, args: { text: "Two invoices are due." } },
+      present,
+    );
+
+    expect(outcome.status).toBe("pending-approval");
+    // Nothing went out while the card is open.
+    expect(cloud.sent).toHaveLength(2);
+  }, 120_000);
+
+  it("answers an unlinked user with the connect link, never a throw", async () => {
+    const cloud = await fakeConsole();
+    const vendo = await compose(cloud, "run");
+
+    const outcome = await vendo.guardedTools.execute(
+      { id: "call_unlinked", tool: VENDO_TEXT_ME_TOOL, args: { text: "Two invoices are due." } },
+      present,
+    );
+
+    if (outcome.status !== "error") throw new Error(`expected a plain error result, got ${outcome.status}`);
+    expect(outcome.error.code).toBe("not-linked");
+    // The SAME link the connect flow hands out, minted for this subject — a
+    // live agent can offer it verbatim, and an away run leaves it in the ledger.
+    expect(outcome.error.message).toMatch(/sms:\+15550000000\?&body=connect%20%40maple%20[23456789A-Z]{6}/);
+    expect(cloud.sent).toHaveLength(0);
+  }, 120_000);
+
+  it("says the phone is unreachable when the router cannot deliver", async () => {
+    const cloud = await fakeConsole();
+    const vendo = await compose(cloud, "run");
+    await linkAndText(vendo, cloud);
+
+    cloud.failSends = true;
+    const outcome = await vendo.guardedTools.execute(
+      { id: "call_lapsed", tool: VENDO_TEXT_ME_TOOL, args: { text: "Two invoices are due." } },
+      present,
+    );
+
+    if (outcome.status !== "error") throw new Error(`expected a plain error result, got ${outcome.status}`);
+    // Never a fabricated success: the model is told the text did NOT arrive.
+    expect(outcome.error.message).toContain("did not go through");
+    expect(outcome.error.message).toContain("reconnecting their phone");
+  }, 120_000);
+
+  it("is absent entirely from a deployment that never asked for texts", async () => {
+    const configured = await compose(await fakeConsole());
+    expect((await configured.actions.descriptors()).map((tool) => tool.name)).toContain(VENDO_TEXT_ME_TOOL);
+
+    // No adapter, no tool: a host that never opted in must not be offered one
+    // whose every call could only refuse.
+    const bare = await compose(undefined);
+    expect((await bare.actions.descriptors()).map((tool) => tool.name)).not.toContain(VENDO_TEXT_ME_TOOL);
+  }, 120_000);
+});


### PR DESCRIPTION
## What broke

One sentence of hidden grounding rode as agent context on **every** inbound text (`packages/vendo/src/channel-turn.ts`, `TEXT_STYLE`):

> You cannot send scheduled, recurring or unprompted texts, and you cannot set any of that up from here — say so plainly if asked, point to the app, and say it is coming soon.

It was written about **delivery**. Sitting next to a user's actual ask — "send $25 to Dana" — the words "you cannot send … from here … point to the app" read as a **channel-wide restriction**. Live incident 2026-08-18: the model refused four separate transfer asks verbatim in that script ("isn't something I'm able to do from here… do that directly in the Maple app") **without ever searching its tool catalog**, on the current prompt, which carries three copies of the search-first instruction. The web surface has no such note and sends money fine — the note itself taught the refusal. It was also simply false about automations, which a texted user *can* set up.

## The disclaimer, as shipped

> To text the user later, set up an automation for it — the Text me action is how an automation reaches this phone, and its grant is part of arming. You cannot otherwise send scheduled, recurring or unprompted texts. That is this channel's only limit: anything else your tools can do, you can do right here in this conversation.

That last clause is only honest because the action it names now exists — which is why both halves are one PR.

## The tool

`vendo_text_me` · title **"Text me"** · risk `write` · input `{ text }` — new file `packages/vendo/src/text-me.ts`, registered on the one actions registry from `compose-channels.ts` **only when a channel adapter composed** (`channels.posture !== false`), the same "no adapter, no tool" rule knowledge and the connector pair follow. A deployment that never asked for texts is not offered a tool whose every call could only refuse.

**Misuse resistance is the shape, not a check.** There is no phone argument, so no model output can aim a text at a number that is not the current subject's own: the destination is read from that subject's link row (`ChannelLinkRepository.bySubject`), which only exists because the signed-in user asked for a code and texted it back.

**One new stored fact.** `ChannelsService.send` takes a *conversation*, never a number — the deployment never learns the router's addressing. So `ChannelLink` now carries `conversationId`, remembered by `rememberTurn` from the person's own inbound messages. That is the only address the channel has, and it is what lets a web turn or an away firing reach the phone.

## Consent model — nothing new

- **Live turn:** a `write` descriptor on the one registry, so it parks whatever card the host's policy calls for, is audited, and is findable by `find_tools`. No privileged side door.
- **Away run:** the existing per-descriptor standing grant flow in `packages/automations` (`grants.ts`, consent at arming). "Text me when the rent clears" is allowed once, on the screen where it is armed, and delivered from then on. Verified by test in both directions.
- The away auth path in `packages/actions` (`hostHeaders`) is host-HTTP-tool-only; contributed registries dispatch straight through `registry.execute`, exactly as `ask_user` does. No new branch was invented.
- **No rate cap in v1** (founder's explicit call).

## Failure paths — never silent, never fabricated

| Situation | Result |
|---|---|
| No phone linked | `error` / `not-linked`, carrying the **connect link itself** — the same freshly-minted `sms:` URL the link flow hands out, so a live agent can offer "connect your phone first"; in an away run it lands in the run ledger. Never throws. |
| Router cannot deliver (404, lapsed iMessage assignment) | `error` / `unavailable` — "the text did not go through … reconnecting their phone will fix it. Do not say you sent it." |
| Empty `text` | `error` / `validation` |

## Tests

New: `packages/vendo/tests/text-me.e2e.test.ts` — 5 cases, all through real `createVendo` + real guard + real automations engine + one real PGlite store + the real `cloudTextChannel` client, against an HTTP console standing in for the one half this repo does not own. No stub between producer and consumer.

1. **The granted-automation seam** — an armed automation holding nothing fails `needs-permission` and the console receives nothing; one real tap on the real guard mints the standing grant; the rerun lands a real send on the console's `/api/v1/channels/text/send` door, on the conversation the link row learned from the person's own message, and the run ledger records the step.
2. **Live turn** — a present `write` call parks a card, nothing goes out while it is open.
3. **Unlinked subject** — the result carries the `sms:` connect link.
4. **Unreachable phone** — the router 404s, the result says the text did not go through.
5. **Unconfigured deployment** — `vendo_text_me` is absent from `actions.descriptors()` entirely; present when channels are configured.

No pre-existing test needed editing — nothing pinned the old wording (only `CHANGELOG.md`, which is history and stays).

**Prove-it-can-fail:** with `deps.channel.send(...)` stubbed out, case 1 goes red on `expected undefined to deeply equal { conversationId, text }` and case 4 on `expected a plain error result, got ok`; restored, all 5 green. Neighbouring suites re-run green: `channels`, `channel-links`, `channel-hosted-store`, `channel-turn-ctx`, `channel-wire.e2e`, `channel-approval.e2e`, `ask-user` (55 tests).

## Gate

`pnpm build` ✅ · `pnpm typecheck` ✅ (42/42) · `pnpm lint` ✅ · `pnpm test:affected` — 3,232 passed, 5 pre-existing failures unrelated to this change: every one is `ENOENT … /Users/yousefh/Desktop/Cool%20Code/…`, a URL-encoded path artifact of this worktree living under a directory with a space in its name. Reproduced with these changes stashed. CI's checkout has no space in its path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lets the channel text the user first and stops a grounding line from causing tool refusals. Previously, inbound texts carried “can’t send from here” and the agent declined valid work; now the note names the one limit and routes later texts through a new action.

- Adds `vendo_text_me` (“Text me”) in `@vendoai/vendo`: sends a single message to the signed-in user’s linked phone from any surface. Input is `{ text }`; destination comes from `ChannelLink.conversationId`. Registered only when the text channel is configured. Risk `write`: live turns park behind the guard; away runs need the standing grant created at arming.
- Revises hidden grounding in `channel-turn` to direct scheduled/later texts to automations via Text me, otherwise “do what your tools allow here.” Shares one plain‑text style rule across the channel and tool.
- Persists `conversationId` on `ChannelLink`; `rememberTurn` stores it and `runChannelTurn` captures it from inbound events, enabling sends from web or automations without exposing bare numbers.
- Clear errors: no reachable phone (unlinked or linked but no conversation yet) returns `not-linked` with a fresh `sms:` connect link that explains “text here once”; router delivery failures return `unavailable` (“did not go through … reconnecting will fix it”); empty messages return `validation`. No fabricated successes.
- End-to-end tests cover guarded live calls, automation grants, no-reachable-phone, unreachable phones, and tool registration gating.
- Updates `@vendoai/core` tool titles to include `vendo_text_me`.

<sup>Written for commit 4d71e1ea28d6cda62dafacbaf63931f32d3708f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1457?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

