### PR TITLE
fix(vendo): the approval ask reads like a text, and never teaches a reply that cannot decide it

### DIFF
--- a/.changeset/channel-approval-text-format.md
+++ b/.changeset/channel-approval-text-format.md
@@ -1,0 +1,18 @@
+---
+"@vendoai/vendo": patch
+---
+
+The approval text reads like a text, not like machinery. The channel's ask
+rendered the guard's raw preview — tool identifier and JSON blob included —
+so a live $25.00 send asked for consent as
+`host_transferMoney {"amount":2500,"recipient_name":"Jordan Avery"}`: a
+voice-rule violation (the identifier reached the person) and a genuinely
+dangerous read (2500 cents scans as twenty-five hundred dollars, in the one
+message whose whole job is informed consent). The ask now renders one plain
+line per argument, labelled from the host schema's own property description
+when it has one ("Amount in cents: 2500") and the spaced-out key when it
+does not; values stay verbatim — the ask is the safety boundary, so nothing
+is paraphrased — capped only so one huge argument cannot flood a text. The
+header also stops saying "needs your OK": the decider matches only YES/NO,
+so a header that says OK teaches the one reply that would not decide it —
+it now reads "needs your approval … Reply YES to approve, or NO to cancel."

--- a/packages/vendo/src/channel-turn.ts
+++ b/packages/vendo/src/channel-turn.ts
@@ -92,14 +92,47 @@ export interface ChannelTurnDeps {
   asks: ChannelAskRepository;
 }
 
+/** A schema property description cut down to a label: everything before the
+ *  first example or parenthetical ("Amount to send in cents (positive whole
+ *  number), e.g. …" → "Amount to send in cents"). Falls back to the key name
+ *  spaced out of its snake_case. */
+function argLabel(key: string, schema: ApprovalRequest["descriptor"]["inputSchema"]): string {
+  const properties = schema["properties"];
+  const property = typeof properties === "object" && properties !== null
+    ? (properties as Record<string, unknown>)[key] : undefined;
+  const description = typeof property === "object" && property !== null
+    && typeof (property as Record<string, unknown>)["description"] === "string"
+    ? (property as Record<string, unknown>)["description"] as string : undefined;
+  const label = description?.split(/[.(]|, e\.g\./)[0]?.trim();
+  return label && label.length <= 60 ? label : key.replace(/[_-]+/g, " ");
+}
+
+const ARG_VALUE_CAP = 200;
+
 /** What the person is told when a call parks: the exact action and its exact
- *  arguments, because a yes over text is consent given without a screen. */
+ *  arguments, because a yes over text is consent given without a screen. One
+ *  plain line per argument, labelled from the host's own schema — never the
+ *  tool identifier and never a JSON blob, which is what this used to read as
+ *  ("host_transferMoney {\"amount\":2500…}" for a $25.00 send, live
+ *  2026-08-18). Values stay verbatim — the ask is the safety boundary, so no
+ *  model paraphrase — capped only so one huge argument cannot flood a text. */
 function approvalText(request: ApprovalRequest): string {
   const what = request.descriptor.title ?? request.descriptor.name;
-  const detail = request.inputPreview.trim();
+  const input = request.call.args;
+  const lines = input && typeof input === "object" && !Array.isArray(input)
+    ? Object.entries(input).map(([key, value]) => {
+      const raw = typeof value === "string" ? value : JSON.stringify(value);
+      const shown = raw.length > ARG_VALUE_CAP ? `${raw.slice(0, ARG_VALUE_CAP)}… (truncated)` : raw;
+      return `- ${argLabel(key, request.descriptor.inputSchema)}: ${shown}`;
+    })
+    : [];
+  const detail = lines.length > 0 ? lines : [request.inputPreview.trim()].filter(Boolean);
   return [
-    `${what} needs your OK${detail === "" ? "" : `: ${detail}`}`,
-    "Reply YES to go ahead, or NO to cancel.",
+    // "approval", never "OK" — the decider matches only YES/NO, and a header
+    // that says OK teaches the one reply that will NOT decide it.
+    `${what} needs your approval${detail.length === 0 ? "" : ":"}`,
+    ...detail,
+    "Reply YES to approve, or NO to cancel.",
   ].join("\n");
 }
 

--- a/packages/vendo/tests/channel-approval.e2e.test.ts
+++ b/packages/vendo/tests/channel-approval.e2e.test.ts
@@ -96,7 +96,10 @@ function payingHost(): { tools: ToolRegistry; paid: Array<{ billId: string; amou
     description: "Pay one of the customer's bills",
     inputSchema: {
       type: "object",
-      properties: { billId: { type: "string" }, amount: { type: "number" } },
+      properties: {
+        billId: { type: "string" },
+        amount: { type: "number", description: "Amount in cents (whole number), e.g. 4200 = $42.00" },
+      },
       required: ["billId", "amount"],
     },
     risk: "write",
@@ -186,9 +189,18 @@ describe.sequential("consent over text", () => {
     expect(ask.conversationId).toBe("conv_approval");
     // The exact action and the exact arguments — a yes given over text is
     // consent given without a screen, so the text has to carry what a card would.
-    expect(ask.text).toContain("Pay a bill");
-    expect(ask.text).toContain("bill_9");
-    expect(ask.text).toContain("4200");
+    // And it reads like a text, never like machinery: one labelled line per
+    // argument (label from the schema's own description when it has one), and
+    // the tool identifier never reaches the person (live 2026-08-18: the ask
+    // rendered as `host_transferMoney {"amount":2500…}` for a $25.00 send).
+    // "approval", not "OK": the decider only matches YES/NO, so the header
+    // must never advertise a reply word that would not decide it.
+    expect(ask.text).toContain("Pay a bill needs your approval:");
+    expect(ask.text).not.toMatch(/\bOK\b/);
+    expect(ask.text).toContain("- billId: bill_9");
+    expect(ask.text).toContain("- Amount in cents: 4200");
+    expect(ask.text).not.toContain(PAY_TOOL);
+    expect(ask.text).not.toContain("{");
     expect(ask.text).toContain("Reply YES");
     // Nothing has happened yet: the gate is holding the write.
     expect(host.paid).toEqual([]);


### PR DESCRIPTION
## What broke (live, 2026-08-18)

The text channel's approval ask rendered the guard's raw preview. A real $25.00 send asked for consent as:

    Send money needs your OK: host_transferMoney {"amount":2500,"recipient_name":"Jordan Avery"}

Three defects in one line:
- the tool identifier reached a customer (the voice rule forbids it anywhere a person reads),
- `2500` — cents — scans as twenty-five hundred dollars, in the one message whose whole job is informed consent,
- "needs your OK" advertises a reply the decider does not accept: it matches only YES/NO, so replying "OK" starts a new turn instead of approving.

## Fix

`approvalText` renders one plain line per argument from the call's structured args, labelled from the host schema's own property description when it has one ("Amount to send in cents") and the spaced-out key when it does not. Values stay verbatim — the ask is the safety boundary, so nothing is model-paraphrased — capped at 200 chars per value so one huge argument cannot flood a text. The header says "needs your approval … Reply YES to approve, or NO to cancel": every word shown is a word that works.

    Send money needs your approval:
    - Amount to send in cents: 2500
    - Who the money goes to: Jordan Avery
    Reply YES to approve, or NO to cancel.

## Tests

`channel-approval.e2e.test.ts` (existing seam test, assertions strengthened + a schema description added to its fixture): pins the labelled lines, the schema-derived label, the absence of the tool identifier, of any JSON brace, and of the word "OK". Red-green proven: with the renderer change stashed the case fails (1 failed | 3 passed), restored it passes.

Local gate green: build, test:affected, typecheck, lint.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the text-channel approval prompt so it reads like a normal message and teaches a reply that actually decides it. Previously the prompt leaked the tool identifier with a JSON blob, displayed cents like “2500” (easy to misread as $2,500), and said “needs your OK” while the decider only accepted YES/NO; now it renders labeled argument lines and clear YES/NO instructions.

- Formats the approval text as: “<title> needs your approval:” followed by one line per argument (“- <label>: <value>”), with labels sourced from the input schema’s property description or a spaced-out key; values are verbatim and capped at 200 chars; falls back to the existing preview if args are unavailable.
- Removes any tool identifier and JSON from the message; clarifies the footer to “Reply YES to approve, or NO to cancel.”
- Strengthens `channel-approval.e2e.test.ts` to pin the labels, header wording, and the absence of the identifier, braces, and the word “OK.”
- Package `@vendoai/vendo` patch bump; no migration required (payloads and decider behavior are unchanged).

<sup>Written for commit 4b1a13b42cf313983885e2f1ce2b2d2ca62b18af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1458?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

