### PR TITLE
fix(store,ui): the release gate stops failing itself — the tsc spawn yields, the store's tables get their own schema

### DIFF
--- a/packages/store/src/backends.test-util.ts
+++ b/packages/store/src/backends.test-util.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -16,36 +17,6 @@ export interface Backend {
   name: "pglite" | "postgres";
   make(): Promise<MadeBackend>;
 }
-
-const TABLES = [
-  "invoices",
-  "vendo_usage",
-  "vendo_quarantine",
-  "vendo_idempotency_ledger",
-  "vendo_app_grants",
-  "vendo_workspace_history",
-  "vendo_workspace_files",
-  "vendo_mcp_grants",
-  "vendo_mcp_clients",
-  "vendo_secrets",
-  "vendo_runs",
-  "vendo_automations",
-  "vendo_audit",
-  "vendo_approvals",
-  "vendo_grants",
-  "vendo_thread_messages",
-  "vendo_effects",
-  "vendo_threads",
-  "vendo_state",
-  "vendo_blobs",
-  "vendo_records",
-  "vendo_apps",
-  "vendo_meta",
-] as const;
-
-const dropTables = async (client: Client): Promise<void> => {
-  await client.query(`DROP TABLE IF EXISTS ${TABLES.join(", ")} CASCADE`);
-};
 
 const pglite: Backend = {
   name: "pglite",
@@ -70,21 +41,49 @@ const pglite: Backend = {
   },
 };
 
+/** A private schema per made backend, never the shared `public` one.
+ *
+ *  The whole monorepo's `pnpm test` can point at ONE Postgres — the release gate
+ *  does exactly that (release.yml sets a single `vendo_test` for every package,
+ *  at turbo concurrency 4) — and this backend used to give itself a clean slate
+ *  by DROPping a hand-kept list of tables in `public`. That nuked the tables
+ *  `fixtures/integration`'s J9 durability journey was reading mid-flight
+ *  (`relation "vendo_apps" does not exist`), which took out a release run and
+ *  v0.26.0's. So: carve a schema, point `search_path` at it, drop it whole.
+ *
+ *  `search_path` rides the connection string, so the store under test builds its
+ *  own pool and advisory-lock client from it and lands every statement — the same
+ *  unqualified SQL it ships — inside the schema. Same mechanic as
+ *  `fixtures/mcp-e2e`'s token-claim race. Dropping the schema also cannot drift
+ *  the way the list did: it had fallen two tables behind the DDL, so every run
+ *  leaked `vendo_knowledge_docs`/`_chunks` into `public`. And the schema is empty
+ *  by construction, so the clean slate the DROP used to buy comes free. */
 const postgres = (url: string): Backend => ({
   name: "postgres",
   async make() {
-    const client = new Client({ connectionString: url });
+    const schema = `vendo_store_${randomUUID().replaceAll("-", "")}`;
+    const scoped = new URL(url);
+    const priorOptions = scoped.searchParams.get("options");
+    scoped.searchParams.set(
+      "options",
+      [priorOptions, `-c search_path=${schema}`].filter(Boolean).join(" "),
+    );
+    const scopedUrl = scoped.toString();
+
+    // Connected before the schema exists, which is fine: `search_path` is
+    // resolved per statement, and CREATE/DROP SCHEMA name it absolutely.
+    const client = new Client({ connectionString: scopedUrl });
     try {
       await client.connect();
-      await dropTables(client);
+      await client.query(`CREATE SCHEMA ${schema}`);
     } catch (error) {
       await client.end().catch(() => undefined);
       throw error;
     }
     let cleaned = false;
     const result: MadeBackend = {
-      store: createStore({ url }),
-      url,
+      store: createStore({ url: scopedUrl }),
+      url: scopedUrl,
       async sql(text, params = []) {
         return (await client.query(text, params)).rows as Record<string, unknown>[];
       },
@@ -92,7 +91,7 @@ const postgres = (url: string): Backend => ({
         if (cleaned) return;
         cleaned = true;
         await result.store.close();
-        await dropTables(client);
+        await client.query(`DROP SCHEMA ${schema} CASCADE`);
         await client.end();
       },
     };
@@ -100,7 +99,7 @@ const postgres = (url: string): Backend => ({
   },
 });
 
-/** One shared schema on both supported backends. */
+/** One shared table shape on both supported backends. */
 export function backends(): Backend[] {
   const url = process.env.POSTGRES_URL;
   if (!url) {

--- a/packages/store/tests/effects-erase.test.ts
+++ b/packages/store/tests/effects-erase.test.ts
@@ -34,13 +34,13 @@ for (const backend of backends()) {
     it("has a NOT NULL subject column and an index on it", async () => {
       const columns = await made.sql(
         `SELECT column_name, is_nullable FROM information_schema.columns
-         WHERE table_name = 'vendo_effects' AND column_name = 'subject'`,
+         WHERE table_schema = current_schema() AND table_name = 'vendo_effects' AND column_name = 'subject'`,
       );
       expect(columns).toHaveLength(1);
       expect(columns[0]!["is_nullable"]).toBe("NO");
 
       const indexes = await made.sql(
-        "SELECT indexdef FROM pg_indexes WHERE schemaname = 'public' AND tablename = 'vendo_effects'",
+        "SELECT indexdef FROM pg_indexes WHERE schemaname = current_schema() AND tablename = 'vendo_effects'",
       );
       expect(indexes.some((row) => /\(subject\)/.test(String(row["indexdef"])))).toBe(true);
     });

--- a/packages/store/tests/schema.test.ts
+++ b/packages/store/tests/schema.test.ts
@@ -83,7 +83,7 @@ for (const backend of backends()) {
       expect((await made.sql("SELECT value FROM vendo_meta WHERE key = 'schema_version'"))[0]?.value).toBe(11);
       const rows = await made.sql(
         `SELECT table_name FROM information_schema.tables
-         WHERE table_schema = 'public' AND table_name IN ('vendo_mcp_clients', 'vendo_mcp_grants')
+         WHERE table_schema = current_schema() AND table_name IN ('vendo_mcp_clients', 'vendo_mcp_grants')
          ORDER BY table_name`,
       );
       expect(rows).toEqual([
@@ -114,7 +114,7 @@ for (const backend of backends()) {
 
     it("creates all 24 contract tables with every contracted key column", async () => {
       const rows = await made.sql(
-        "SELECT table_name, column_name FROM information_schema.columns WHERE table_schema = 'public' AND table_name LIKE 'vendo_%'",
+        "SELECT table_name, column_name FROM information_schema.columns WHERE table_schema = current_schema() AND table_name LIKE 'vendo_%'",
       );
       const actual = new Map<string, Set<string>>();
       for (const row of rows) {
@@ -167,7 +167,7 @@ for (const backend of backends()) {
         ["vendo_quarantine", "data"],
       ];
       const rows = await made.sql(
-        "SELECT table_name, column_name, data_type FROM information_schema.columns WHERE table_schema = 'public' AND table_name LIKE 'vendo_%'",
+        "SELECT table_name, column_name, data_type FROM information_schema.columns WHERE table_schema = current_schema() AND table_name LIKE 'vendo_%'",
       );
       const typeOf = new Map(rows.map((row) => [`${row.table_name}.${row.column_name}`, String(row.data_type)]));
       for (const [table, column] of jsonbColumns) {
@@ -182,7 +182,7 @@ for (const backend of backends()) {
     for (const table of ["vendo_records", "vendo_mcp_clients", "vendo_mcp_grants", "vendo_knowledge_docs", "vendo_knowledge_chunks"] as const) {
       it(`creates a GIN index on ${table}.refs`, async () => {
         const rows = await made.sql(
-          "SELECT indexdef FROM pg_indexes WHERE schemaname = 'public' AND tablename = $1",
+          "SELECT indexdef FROM pg_indexes WHERE schemaname = current_schema() AND tablename = $1",
           [table],
         );
         expect(rows.some((row) => /USING gin \(refs/.test(String(row.indexdef)))).toBe(true);
@@ -195,7 +195,7 @@ for (const backend of backends()) {
       // for the user. Without this index each of those is a seq scan of every
       // grant row in the deployment, on the hot list path.
       const rows = await made.sql(
-        "SELECT indexdef FROM pg_indexes WHERE schemaname = 'public' AND tablename = 'vendo_app_grants'",
+        "SELECT indexdef FROM pg_indexes WHERE schemaname = current_schema() AND tablename = 'vendo_app_grants'",
       );
       expect(rows.some((row) => /\(principal\)/.test(String(row.indexdef)))).toBe(true);
     });
@@ -210,7 +210,7 @@ for (const backend of backends()) {
 
       const rows = await made.sql(
         `SELECT table_name FROM information_schema.tables
-         WHERE table_schema = 'public' AND table_name = 'vendo_sessions'`,
+         WHERE table_schema = current_schema() AND table_name = 'vendo_sessions'`,
       );
       expect(rows).toEqual([]);
     });
@@ -221,7 +221,7 @@ for (const backend of backends()) {
 
       const rows = await made.sql(
         `SELECT table_name FROM information_schema.tables
-         WHERE table_schema = 'public' AND table_name = 'vendo_sessions'`,
+         WHERE table_schema = current_schema() AND table_name = 'vendo_sessions'`,
       );
       expect(rows).toEqual([]);
     });
@@ -237,7 +237,7 @@ for (const backend of backends()) {
 
       const rows = await made.sql(
         `SELECT column_name FROM information_schema.columns
-         WHERE table_name = 'vendo_apps' AND column_name LIKE 'trigger%'`,
+         WHERE table_schema = current_schema() AND table_name = 'vendo_apps' AND column_name LIKE 'trigger%'`,
       );
       expect(rows).toEqual([]);
     });

--- a/packages/store/tests/thread-messages.test.ts
+++ b/packages/store/tests/thread-messages.test.ts
@@ -234,7 +234,7 @@ for (const backend of backends()) {
       expect(threads[0]!["n"]).toBe(2);
       // vendo_threads lost `messages` (build contract §6).
       const columns = await made.sql(
-        `SELECT column_name FROM information_schema.columns WHERE table_name = 'vendo_threads'`,
+        `SELECT column_name FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'vendo_threads'`,
       );
       expect(columns.map((c) => c["column_name"])).not.toContain("messages");
     });

--- a/packages/ui/test/chrome/export-surface.test.ts
+++ b/packages/ui/test/chrome/export-surface.test.ts
@@ -1,7 +1,8 @@
-import { execFileSync } from "node:child_process";
+import { execFile } from "node:child_process";
 import { rmSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { join } from "node:path";
+import { promisify } from "node:util";
 import { afterEach, describe, expect, it } from "vitest";
 import * as chrome from "../../src/chrome/index.js";
 
@@ -149,23 +150,31 @@ afterEach(() => {
   for (const path of fixtures.splice(0)) rmSync(path, { force: true });
 });
 
+// AWAITED, never sync: each tsc spawn below takes ~30s, and `execFileSync` spent
+// that time blocking the vitest worker's event loop. birpc hard-codes a 60s RPC
+// timeout (DEFAULT_TIMEOUT = 6e4, no config knob), so two blocking spawns in one
+// worker starved the `onTaskUpdate` heartbeat past it and the whole run exited 1
+// with `Timeout calling "onTaskUpdate"` while all 1370 tests passed. The
+// duration is unchanged — the event loop staying free is the fix.
+const execFileAsync = promisify(execFile);
+
 /** Type-check a fixture that `import type`s `names` from the chrome entry.
  *  Returns tsc's combined output on failure, or null when it exits clean. */
-function typecheckImports(names: string[]): string | null {
+async function typecheckImports(names: string[]): Promise<string | null> {
   const fixturePath = join(packageDir, `.chrome-surface.${process.pid}.${Math.random().toString(36).slice(2)}.ts`);
   fixtures.push(fixturePath);
   writeFileSync(fixturePath, `import type { ${names.join(", ")} } from "./src/chrome/index.js";\n`);
   try {
-    execFileSync(
+    await execFileAsync(
       process.execPath,
       [tsc, fixturePath, "--noEmit", "--strict", "--target", "ES2022", "--module", "ESNext",
         "--moduleResolution", "Bundler", "--skipLibCheck", "--esModuleInterop", "--jsx", "react-jsx"],
-      { cwd: packageDir, stdio: "pipe" },
+      { cwd: packageDir },
     );
     return null;
   } catch (error) {
-    const err = error as { stdout?: Buffer; stderr?: Buffer };
-    return `${err.stdout?.toString() ?? ""}${err.stderr?.toString() ?? ""}`;
+    const err = error as { stdout?: string; stderr?: string };
+    return `${err.stdout ?? ""}${err.stderr ?? ""}`;
   }
 }
 
@@ -180,13 +189,13 @@ describe("@vendoai/ui/chrome export surface", () => {
     expect(Object.keys(chrome).sort()).toEqual([...VALUE_EXPORTS].sort());
   });
 
-  it("re-exports every chrome type from the source entry", () => {
-    const failure = typecheckImports(TYPE_EXPORTS);
+  it("re-exports every chrome type from the source entry", async () => {
+    const failure = await typecheckImports(TYPE_EXPORTS);
     expect(failure, failure ?? "").toBeNull();
   }, 120_000);
 
-  it("has teeth: a missing type re-export fails the tsc gate with TS2305", () => {
-    const failure = typecheckImports(["__DefinitelyNotAChromeExport"]);
+  it("has teeth: a missing type re-export fails the tsc gate with TS2305", async () => {
+    const failure = await typecheckImports(["__DefinitelyNotAChromeExport"]);
     expect(failure).not.toBeNull();
     expect(failure).toContain("TS2305");
   }, 120_000);


### PR DESCRIPTION
Two mechanisms made the Release workflow fail on work that was green. Both are test infrastructure; no product code is touched, and no package changes behaviour, so there is no changeset.

## 1. The 60-second wall in `packages/ui/test/chrome/export-surface.test.ts`

The type-surface guard shells out to a real `tsc --noEmit`, and it did so through `execFileSync` — so the ~34s compile ran with the vitest worker's event loop fully blocked, twice back to back (~68s). birpc hard-codes its RPC timeout at 60s (`DEFAULT_TIMEOUT = 6e4` in vitest 3.2.7's rpc chunk; there is no config knob), so the `onTaskUpdate` heartbeat starved past the deadline and the run exited 1 with `Timeout calling "onTaskUpdate"` while all 1370 tests passed. The spawn is now a promisified `execFile` that both tests `await`: same binary, same args, same pass/fail semantics (including the negative control that *expects* a nonzero tsc exit), same duration — only the blocking is gone.

**History: 5 of the last 12 release failures.** Every release run where this file exceeded 60s failed; every run under it passed; zero exceptions. #1368 raised the per-test timeouts to 120s, which made it worse by giving tsc more room to run — those timeouts are kept here (they still catch a genuinely hung compiler), and the block itself is what changed.

Measured directly, running the same tsc command both ways:

```
execFileSync  (the old shape):
    tsc wall 2835ms | heartbeats serviced 2  | LONGEST GAP BETWEEN HEARTBEATS 2835ms
await execFile (the new shape):
    tsc wall 2534ms | heartbeats serviced 50 | LONGEST GAP BETWEEN HEARTBEATS 52ms
```

The sync shape goes silent for the entire compile — whatever that compile costs. The async shape holds a ~50ms heartbeat no matter how slow tsc gets, which is what takes the 60s wall off the table instead of moving it.

## 2. The shared-database collision in `packages/store/src/backends.test-util.ts`

The Release workflow points the whole monorepo's `pnpm test` at ONE Postgres (`release.yml:71-72`, turbo concurrency 4), and the store's Postgres backend gave itself a clean slate by DROPping its table list in `public` at every `make()` and `cleanup()` — while `fixtures/integration`'s J9 durability journey was reading those same tables. The Postgres leg now carves a private schema per made backend (`CREATE SCHEMA vendo_store_<uuid>`), threads `search_path` through the connection string so the store's own pool and advisory-lock client land every statement inside it, and `DROP SCHEMA … CASCADE`s on cleanup. `public` is never touched. CI was immune only because `ci.yml` hands integration a separate `vendo_integration` database.

**History: this killed the current release run and v0.26.0's.**

The store's shipped SQL is unchanged and still genuinely exercised — the schema swap is confined to the test-util's connection bootstrap. What did need changing is the store's own test assertions that pinned `schemaname = 'public'` / `table_schema = 'public'`; those now use `current_schema()`, which is the idiom already in `tests/schema.indexes.test.ts:93` and resolves to `public` on the PGlite leg, so both backends keep working. Three unqualified `information_schema` probes were qualified the same way — one of them asserts `toHaveLength(1)` and would have started failing the moment a sibling schema held the same table.

Dropping the schema also fixes a drift bug: the hand-kept table list had fallen two tables behind the DDL, so every run was leaking `vendo_knowledge_docs`/`vendo_knowledge_chunks` into `public`.

### Proof — the race reproduced, then killed

Real Postgres 18.4, one shared database, the store's Postgres suite in one shell and the J9 durability journey looping in another. **Before**, on iteration 5:

```
iteration 1: J9 green
iteration 2: J9 green
iteration 3: J9 green
iteration 4: J9 green
=== SHELL B FAILED on iteration 5 ===
[vendo] render seam: source did not reach the store {
  appId: 'app_4cecda21-e7d7-4773-9f12-24ace5d90321',
  error: 'relation "vendo_apps" does not exist'
}
[vendo] harness runtime: transcript persist failed — this turn was NOT saved {
  threadId: 'thr_j9', subject: 'user_ada', attempts: 3,
  error: 'relation "vendo_threads" does not exist'
}
 FAIL  tests/postgres-durability.e2e.test.ts > J9 …
error: relation "vendo_apps" does not exist
```

**After**, the same pair, twice — J9 stayed green for every iteration the full 65-file / 1403-test store suite took to run:

```
run 1: === store suite finished, J9 survived 24 iterations ===
       Test Files  65 passed (65)   Tests  1403 passed | 4 skipped (1407)
run 2: === store suite finished, J9 survived 25 iterations ===
       Test Files  65 passed (65)   Tests  1403 passed | 4 skipped (1407)
```

The isolation is verified directly, not just inferred from green — if `options=-c search_path=…` were silently ignored the tables would land in `public` and the suite would still pass. After a full store run against the shared database:

```
public tables            : 0
leftover vendo_store_*   : 0
```

## Gate

`pnpm build`, `pnpm typecheck`, `pnpm lint` green from the worktree root; `packages/store` full suite green against real Postgres; `packages/ui/test/chrome/export-surface.test.ts` green. The full suite stays CI's job.

`packages/ui/test/eject-templates.test.ts:161,167` has two more `execFileSync` calls (`pnpm pack`, then `tar`), **left alone deliberately.** They are not the same shape — side-effect-only, no return value read and no `stdout`/`stderr` capture to preserve — and the margin is not close: the whole `pack-and-inspect` test measures **741ms** against a 60s wall. Scaling by the same factor the tsc spawn shows between this laptop (2.7s) and the release runner (~34s) still lands under 10s. Worth revisiting only if that test starts growing.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops release gate flakiness by unblocking the vitest worker during `tsc` runs and isolating `store` tests in per-run Postgres schemas. Tests only; no product code or runtime behavior changes.

- `packages/ui/test/chrome/export-surface.test.ts`: Replaced `execFileSync` with awaited `execFile` for `tsc --noEmit`. Old behavior blocked the event loop (~68s across two runs) and triggered birpc’s 60s RPC timeout; new behavior preserves args, pass/fail semantics, and duration while keeping heartbeats flowing.
- `packages/store/src/backends.test-util.ts`: Each made backend now creates a private schema (`vendo_store_<uuid>`), sets `search_path` via the connection string, and `DROP SCHEMA … CASCADE`s on cleanup. Old behavior dropped a hand-kept table list in `public`, which collided with other test suites sharing one database. Updated tests to use `current_schema()` instead of hard-coding `'public'`, and qualified a few `information_schema` probes to avoid cross-schema false positives.

- Rollout: No migration or env changes. Run `pnpm test` as before.

<sup>Written for commit 269fd7fff8e1d707735b78d865f01eebac628109. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

