### PR TITLE
feat(core,harnesses,vendo): a slow turn says WHERE it went, and the step count stops lying

### DIFF
--- a/.changeset/agent-run-latency-breakdown.md
+++ b/.changeset/agent-run-latency-breakdown.md
@@ -1,0 +1,15 @@
+---
+"@vendoai/core": patch
+"@vendoai/harnesses": patch
+"@vendoai/vendo": patch
+---
+
+A slow turn now says WHERE it was slow. `agent_run` carried one wall-clock
+number and a `steps` field hardcoded to `0`, so the only honest answer to "why
+did that take nine seconds" was to guess. It now carries `ttftMs` — how long
+the person waited for the first word — plus the five phase marks the wall time
+splits into (`storeMs`, `promptMs`, `modelMs`, `toolsMs`, `guardMs`), and
+`steps` is the turn's real model-call count. `durationMs` starts at the top of
+the turn rather than after the opening store reads, which is why a slow store
+used to be invisible in it. Durations and counts only: a breakdown says how
+long, never what was read, prompted, thought, called or judged.

--- a/packages/core/src/sdk-events.ts
+++ b/packages/core/src/sdk-events.ts
@@ -20,10 +20,22 @@ export type VendoUsageEvent =
    *  itself. */
   | { name: "deployment_boot"; adapters: string[]; blocks: string[]; framework: string | null }
   /** One agent turn ended. `tools` are NAMES; `modelFamily` is the model id the
-   *  thinking seat resolved to, never a key or a URL. */
+   *  thinking seat resolved to, never a key or a URL.
+   *
+   * The breakdown is DURATIONS, and durations are the whole of it: `ttftMs` is
+   * how long the person waited for the first word, and the five phase marks say
+   * where the turn's wall time went — never what was read, prompted, thought,
+   * called or judged. `modelMs` is what the other four leave over, so the split
+   * always adds up to `durationMs`. */
   | {
       name: "agent_run";
       durationMs: number;
+      ttftMs: number;
+      storeMs: number;
+      promptMs: number;
+      modelMs: number;
+      toolsMs: number;
+      guardMs: number;
       steps: number;
       toolCalls: number;
       tools: string[];

--- a/packages/harnesses/src/index.ts
+++ b/packages/harnesses/src/index.ts
@@ -22,10 +22,13 @@ export { assertHarnessComposable, type ComposedAdapters } from "./compose.js";
 export {
   addUsage,
   createHarnessRuntime,
+  createTurnTimings,
   type HarnessRuntime,
   type HarnessRuntimeDeps,
   type TranscriptStore,
   type TurnRunInput,
+  type TurnTimingKey,
+  type TurnTimings,
   type UsageTotals,
 } from "./runtime.js";
 // `vendo()` itself stays on the ROOT barrel: `harness: vendo()` is the

--- a/packages/harnesses/src/runtime.ts
+++ b/packages/harnesses/src/runtime.ts
@@ -73,6 +73,44 @@ function deepFreeze<T>(value: T): T {
   return value;
 }
 
+/** Which phase of a turn a duration belongs to — `agent_run`'s flat breakdown,
+ *  and the whole vocabulary. */
+export type TurnTimingKey = "ttft" | "store" | "prompt" | "tools" | "guard";
+
+/**
+ * ONE turn's measurements, collected by whoever is standing where the time is
+ * spent: composition marks its store reads and its prompt assembly, the runtime
+ * marks the first output and the steps, the guard and the tool bridge mark
+ * theirs. DURATIONS AND COUNTS ONLY — a mark can never carry a prompt, an
+ * argument, or a name.
+ *
+ * `add` accumulates, because tool time and guard time are many calls and one
+ * number each. `elapsed` is ms since the turn began, which is what the
+ * time-to-first-output mark and the run's own `durationMs` are read from.
+ */
+export interface TurnTimings {
+  add(key: TurnTimingKey, ms: number): void;
+  /** One more model call. */
+  step(): void;
+  elapsed(): number;
+  readonly ms: Readonly<Partial<Record<TurnTimingKey, number>>>;
+  readonly steps: number;
+}
+
+/** A collector for the turn starting NOW. */
+export function createTurnTimings(): TurnTimings {
+  const startedAt = Date.now();
+  const ms: Partial<Record<TurnTimingKey, number>> = {};
+  let steps = 0;
+  return {
+    ms,
+    get steps() { return steps; },
+    add: (key, value) => { ms[key] = (ms[key] ?? 0) + value; },
+    step: () => { steps += 1; },
+    elapsed: () => Date.now() - startedAt,
+  };
+}
+
 /** Build contract §6 — lane D's `threadMessageStore(store)` return value. Typed
  *  structurally so this package never imports @vendoai/store: the store handle
  *  arrives as a composed value. */
@@ -144,6 +182,10 @@ export interface HarnessRuntimeDeps {
      */
     steer: (text: string, messageId: string) => Promise<boolean>;
   }) => () => void;
+  /** This turn's measurements ({@link TurnTimings}), for whoever reports them.
+   *  The runtime fills the marks only it can see — the first output on the wire
+   *  and the model calls. Unset, nothing is measured. */
+  timings?: TurnTimings;
   /**
    * Land this turn's three closing writes — the messages it produced, the
    * harness state to carry into the next one, and the run's audit row — in ONE
@@ -411,10 +453,25 @@ export function createHarnessRuntime(deps: HarnessRuntimeDeps): HarnessRuntime {
           // here, in the loop, in the guarded-call path — is a map miss.
           const closeWorkbench = openWorkbench(turnId, (part) => writeDebug(writer, part));
           const text = new TextChannel(writer);
+          // The turn's first model call. Every ROUND of tool calls below is one
+          // more: the thinker asks, runs what it asked for, then asks again. A
+          // turn that used no tool still thought once.
+          deps.timings?.step();
+          /** Is the next `call` the start of a new round? True at the turn's
+           *  start (the first call opens one) and again after every result; a
+           *  step's parallel calls are all announced before any of them lands,
+           *  so they stay in the round they belong to. */
+          let newRound = true;
           const mirror = (event: MirrorEvent): void => {
-            // Close the open text part first, so a reply that spans tool calls
-            // renders as prose, tool, prose instead of collapsing into one block.
-            if (event.kind === "call") text.break();
+            if (event.kind === "call") {
+              if (newRound) {
+                newRound = false;
+                deps.timings?.step();
+              }
+              // Close the open text part first, so a reply that spans tool calls
+              // renders as prose, tool, prose instead of collapsing into one block.
+              text.break();
+            } else if (event.kind === "result") newRound = true;
             writeMirror(writer, event);
           };
           const tools = createTurnTools({
@@ -540,6 +597,10 @@ export function createHarnessRuntime(deps: HarnessRuntimeDeps): HarnessRuntime {
               }
               switch (event.type) {
                 case "text":
+                  // Time to first output, marked HERE because here is where the
+                  // user's first word reaches the wire. Once per turn: the mark
+                  // is the FIRST one, and `add` would sum the rest.
+                  if (deps.timings?.ms.ttft === undefined) deps.timings?.add("ttft", deps.timings.elapsed());
                   text.delta(event.delta);
                   break;
                 case "status":

--- a/packages/vendo/src/harness-turn.ts
+++ b/packages/vendo/src/harness-turn.ts
@@ -60,6 +60,7 @@ import {
 } from "@vendoai/store";
 import {
   createHarnessRuntime,
+  createTurnTimings,
   latestUserIntent,
   provideHarnessAdapters,
   THREAD_ID_HEADER,
@@ -396,6 +397,9 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
     },
 
     async stream(input) {
+      // The turn's clock, started at the top: `durationMs` used to begin after
+      // the opening reads, which is why a slow store was invisible in it.
+      const timings = createTurnTimings();
       validateMessage(input?.message);
       // The message choke (limits.ts owns the counting, the policy and the
       // recording): asked BEFORE the thread is resolved, so a refused message
@@ -415,6 +419,10 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
       // without costing a read, which is what it always cost.
       const given = input.threadId as ThreadId | undefined;
       const { subject } = input.ctx.principal;
+      // The store phase: the handshake, the envelope read, the thread resolve,
+      // the opening write and the workspace open — everything before the prompt
+      // is assembled. One span, because it is one wait for the person.
+      const storeAt = Date.now();
       const batched = (given === undefined || isThreadId(given)) && await servesTurn();
       // Minted HERE only when the envelope will ask for it: a turn has to name
       // its thread before it can read it, and a first turn still has a
@@ -531,6 +539,7 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
           ...(index === undefined ? {} : { index }),
         }),
       ]);
+      timings.add("store", Date.now() - storeAt);
       // §1.6 — the render seam, built for THIS turn's ctx and handed to the
       // runtime's generic `wrapWorkspace` slot: the runtime owns WHERE the wrap
       // happens and what `emit` writes to; composition owns WHAT wraps.
@@ -539,26 +548,37 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
       // every tool call passes the bridge's `onCall`, and `liveTurn`'s disposer
       // is the runtime's turn end (it retracts the publication in the run's
       // `finally`). Names and counts only — no argument and no result.
-      const startedAt = Date.now();
       const toolNames = new Set<string>();
       let toolCalls = 0;
-      const emitRun = (outcome: "ok" | "error", errorCode: string | null): void => emitUsage({
-        name: "agent_run",
-        durationMs: Date.now() - startedAt,
-        // No rail carries the thinker's step count out of the harness runtime
-        // (the workbench's `step-start` is dev-only, gated on VENDO_WORKBENCH),
-        // so this stays 0 until the runtime publishes one.
-        steps: 0,
-        toolCalls,
-        tools: [...toolNames].sort(),
-        modelFamily: modelFamilyOf(config.models),
-        outcome,
-        errorCode,
-      });
+      const emitRun = (outcome: "ok" | "error", errorCode: string | null): void => {
+        const durationMs = timings.elapsed();
+        const { ttft = 0, store = 0, prompt = 0, tools: toolsMs = 0, guard = 0 } = timings.ms;
+        emitUsage({
+          name: "agent_run",
+          durationMs,
+          ttftMs: ttft,
+          storeMs: store,
+          promptMs: prompt,
+          // Whatever the other four leave over — the thinker's own wall time,
+          // which is what a slow turn is usually made of.
+          modelMs: Math.max(0, durationMs - store - prompt - toolsMs - guard),
+          toolsMs,
+          guardMs: guard,
+          steps: timings.steps,
+          toolCalls,
+          tools: [...toolNames].sort(),
+          modelFamily: modelFamilyOf(config.models),
+          outcome,
+          errorCode,
+        });
+      };
       const bridge = config.bridge?.(input.ctx, thread.id) as ToolBridgeOptions | undefined;
       const runtime = createHarnessRuntime({
         tools: config.tools,
         guard: config.guard,
+        // The same collector the marks above went into: the runtime adds the
+        // ones only it can see (the first output, the model calls).
+        timings,
         // Read off THIS turn's mount, so a skill the host stopped shipping is
         // gone the moment they deploy — no stale copy to invalidate.
         skills: createTurnSkills(workspace),
@@ -652,6 +672,7 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
       // harness's. Which discovery section it may promise is decided by what is
       // actually on the listing: a curated surface has `find_tools`, an uncurated one
       // has the connector pair (and only with connectors configured), or neither.
+      const promptAt = Date.now();
       const rail = config.harness.toolSurface?.curated !== false
         ? "find-tools" as const
         : config.connectorDiscovery === true ? "connectors" as const : false;
@@ -662,6 +683,7 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
       // provider's prompt cache cold. Same block builder, same this-turn-only
       // life: the ctx and `Turn.situation`, never the store.
       const situation = situationPromptBlock(input.ctx.context);
+      timings.add("prompt", Date.now() - promptAt);
       const response = await runtime.run<never>({
         harness: config.harness,
         threadId: thread.id,

--- a/packages/vendo/tests/agent-run-timings.seam.test.ts
+++ b/packages/vendo/tests/agent-run-timings.seam.test.ts
@@ -1,0 +1,126 @@
+/**
+ * `agent_run`'s latency breakdown, END TO END: the composed turn that measures
+ * it, the shipped events pipeline that uploads it, and the batch the console
+ * actually receives.
+ *
+ * The seam is producer/consumer here too. A test that installed its own sink
+ * would read numbers the real pipeline never carried, and a test that called
+ * `emitUsage` by hand would never touch the marks a turn takes. So: ONE real
+ * composed turn through `createVendo`, the SHIPPED `createSdkEvents` pipeline as
+ * its sink, and the assertions read off the POSTed body — the same bytes the
+ * console's allowlist parses. Only the network is stood in for.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Principal, ToolDescriptor, ToolRegistry, VendoUsageEvent } from "@vendoai/core";
+import { setUsageSink } from "@vendoai/core";
+import { defineHarness } from "@vendoai/harnesses";
+import { createStore, type VendoStore } from "@vendoai/store";
+import type { LanguageModel, UIMessage } from "ai";
+import { afterEach, expect, it } from "vitest";
+import { createSdkEvents } from "../src/sdk-events.js";
+import { createVendo } from "../src/server.js";
+
+/** Read back off the wire as the CONTRACT type, so a field this asserts on is a
+ *  field the catalog really carries. */
+type AgentRun = Extract<VendoUsageEvent, { name: "agent_run" }>;
+
+/** How long the scripted thinker takes before its first word — the floor
+ *  `ttftMs` and `modelMs` are asserted against, so a mark that is really zero
+ *  cannot pass. */
+const THINK_MS = 30;
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  setUsageSink(undefined);
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+const descriptor = (name: string): ToolDescriptor => ({
+  name,
+  title: name,
+  description: `The host's ${name}`,
+  inputSchema: { type: "object", properties: {}, additionalProperties: false },
+  risk: "read",
+});
+
+const hostTools: ToolRegistry = {
+  async descriptors() {
+    return [descriptor("maple_invoices_list")];
+  },
+  async execute() {
+    return { status: "ok", output: { invoices: [] } };
+  },
+};
+
+it("reports the turn's time-to-first-output, its per-phase split and its real step count", async () => {
+  const dataDir = await mkdtemp(join(tmpdir(), "vendo-run-timings-"));
+  const store: VendoStore = createStore({ dataDir });
+  cleanups.push(async () => {
+    await store.close();
+    await rm(dataDir, { recursive: true, force: true });
+  });
+
+  const vendo = createVendo({
+    // Never reached: the harness below is scripted, so no provider is involved.
+    models: { default: {} as LanguageModel },
+    principal: async (): Promise<Principal> => ({ kind: "user", subject: "user_timings" }),
+    store,
+    harness: defineHarness({
+      name: "scripted",
+      async *run(turn) {
+        // Two SEQUENTIAL rounds: the thinker asks, the tool answers, it asks
+        // again — three model calls, which is what `steps` has to say.
+        await sleep(THINK_MS);
+        yield { type: "text", delta: "checking" };
+        await turn.tools.call("maple_invoices_list", {});
+        await turn.tools.call("maple_invoices_list", {});
+        yield { type: "text", delta: "done" };
+      },
+    }),
+  });
+  vendo.actions.add(hostTools);
+
+  // AFTER createVendo — composition installs its own sink at boot (undefined
+  // without a Cloud key), so an earlier install would simply be replaced. The
+  // pipeline is the shipped one; `env: {}` keeps the opt-outs out of it.
+  const posted: unknown[] = [];
+  const pipeline = createSdkEvents({
+    cloud: { apiKey: "vnd_test_timings" },
+    env: {},
+    runtime: "node",
+    fetchImpl: async (_input, init) => {
+      posted.push(JSON.parse(String(init?.body)));
+      return Response.json({ accepted: 1 }, { status: 202 });
+    },
+  });
+  setUsageSink(pipeline?.record);
+
+  const turn = await vendo.handler(new Request("https://host.test/api/vendo/threads", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      threadId: "thr_timings",
+      message: { id: "m1", role: "user", parts: [{ type: "text", text: "list my invoices" }] } as UIMessage,
+    }),
+  }));
+  expect(await turn.text()).toContain("done");
+  await pipeline?.flush();
+
+  const events = posted.flatMap((body) => (body as { events: VendoUsageEvent[] }).events);
+  const run = events.find((event): event is AgentRun => event.name === "agent_run");
+  expect(run).toBeDefined();
+  expect(run).toMatchObject({ steps: 3, toolCalls: 2, outcome: "ok" });
+  // Time to the first word the user saw — after the thinking, before the end.
+  expect(run!.ttftMs).toBeGreaterThanOrEqual(THINK_MS);
+  expect(run!.ttftMs).toBeLessThanOrEqual(run!.durationMs);
+  // The store phase really ran (the turn opened a database and wrote a row),
+  // and the split never claims more than the turn took.
+  expect(run!.storeMs).toBeGreaterThan(0);
+  expect(run!.modelMs).toBeGreaterThanOrEqual(THINK_MS);
+  const split = run!.storeMs + run!.promptMs + run!.modelMs + run!.toolsMs + run!.guardMs;
+  expect(split).toBeLessThanOrEqual(run!.durationMs);
+});


### PR DESCRIPTION
`agent_run` reported one wall-clock number and a `steps` field hardcoded to `0` — the comment beside it said no rail carried a step count out of the runtime — so the only honest answer to "why did that turn take nine seconds" was to guess.

## What the event carries now

| Field | What it says |
| --- | --- |
| `ttftMs` | How long the person waited for the **first word**, marked where that word reaches the wire |
| `storeMs` | The turn's opening reads and its opening write |
| `promptMs` | Assembling the system prompt and the situation block |
| `modelMs` | Whatever the other four leave over — the thinker's own wall time |
| `toolsMs` / `guardMs` | Still `0`; the marks exist, the call sites land in the guard/tools slice |
| `steps` | The turn's **real** model-call count |

The split always adds up to `durationMs`, and `durationMs` now starts at the top of the turn rather than after the opening store reads — which is why a slow store used to be invisible in it.

**Durations and counts only**, which is the catalog's standing rule: a mark says how long a phase took, never what was read, prompted, thought, called or judged.

## How `steps` is counted

The runtime is the one place that sees the whole turn, and a step has a visible shape: the thinker asks, runs what it asked for, then asks again. So the first call of every tool **round** is one more model call, and a turn that used no tool still thought once. No new harness event, no dev-only flag.

## The collector

One small `TurnTimings` on the runtime's deps (`add(key, ms)` / `step()` / `elapsed()`), because the marks are taken in three places — composition's store reads, the runtime's first output, the guard and the tool bridge next — and reported in one. Exported from `@vendoai/harnesses` so the guard/tools slice can fill the last two marks without a second rail.

## Verification

- **New seam test** `packages/vendo/tests/agent-run-timings.seam.test.ts`: one real composed turn through `createVendo`, the shipped `createSdkEvents` pipeline as its sink, assertions read off the **POSTed batch body** — the same bytes the console's allowlist parses. Only the network is stood in for. Red first (`steps: 0`, no marks), green after.
- Scoped suites, all green: `@vendoai/core` 787 · `@vendoai/harnesses` 559 · `@vendoai/vendo`.
- Repo-wide `typecheck` 42/42 and `lint` green (the new required fields break no caller).
- Cross-repo: vendo-web's opt-in producer/consumer seam (`VENDO_TELEMETRY_SEAM`) run against this branch — 7 passed.

Paired console change (the door drops any field not on its allowlist, silently): runvendo/vendo-web#572.

## Not done here, deliberately

`docs-site/production/telemetry.mdx` and `TELEMETRY.md` still list the old `agent_run` field set — both are outside this slice's file ownership and need a follow-up so the public transparency doc names the six new marks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Breaks down `agent_run` latency by phase and reports a real step count. Previously we sent one wall‑clock number (starting after store reads) and `steps: 0`; now we include `ttftMs`, `storeMs`, `promptMs`, `modelMs` (remainder), `toolsMs`, `guardMs`, and `steps`. `durationMs` now starts at turn entry.

- `@vendoai/core`: extends `VendoUsageEvent` `"agent_run"` with `ttftMs`, `storeMs`, `promptMs`, `modelMs`, `toolsMs`, `guardMs`. The split always sums to `durationMs`.
- `@vendoai/harnesses`: adds `createTurnTimings` and optional `timings` on `HarnessRuntimeDeps`. Runtime marks time‑to‑first‑text at the writer and counts steps: the first model call and one at the start of each tool round.
- `@vendoai/vendo`: starts the clock at turn start; records `storeMs` and `promptMs`; computes `modelMs` as the remainder; emits the new fields; passes `timings` into the runtime. `toolsMs`/`guardMs` are wired for upcoming call sites and remain 0. Adds an end‑to‑end seam test that asserts the posted batch includes the new fields and a nonzero `steps`.

- No app changes required; events add fields. Existing sinks ignore unknown fields. The console will drop the new fields until its allowlist update lands. Expect `durationMs` to increase because it now includes opening store work.

<sup>Written for commit fa23d2d896b7e597b3bc57aea72ac829c9625119. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1461?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

