### PR TITLE
fix(vendo,apps): the ask words its schedule, and a verb-phrase title survives the header

### DIFF
--- a/.changeset/approval-ask-prose.md
+++ b/.changeset/approval-ask-prose.md
@@ -1,0 +1,15 @@
+---
+"@vendoai/vendo": patch
+"@vendoai/apps": patch
+---
+
+The approval ask words its schedule and survives a verb-phrase title. Live
+2026-08-18, arming a balance check over text asked as "Set this to run on its
+own needs your approval: - when: */15 * * * *" — a sentence collision for a
+header and a cron expression as the one thing the person must understand
+before saying yes. The header gains an em dash ("Set this to run on its own —
+needs your approval:"), a schedule-shaped value is worded beside its verbatim
+self ("every 15 minutes (*/15 * * * *)" — beside, never instead: the ask is
+the consent boundary), argument labels cut at the first comma as well as the
+first period, and the automate tool's `when` property leads with the label
+consent surfaces show ("When it runs") while keeping its format teaching.

--- a/packages/apps/src/server/doors/agent-tools.ts
+++ b/packages/apps/src/server/doors/agent-tools.ts
@@ -73,7 +73,10 @@ const descriptors = [
       type: "object",
       properties: {
         when: {
-          description: "A 5-field cron string, or one of {every}, {at}, {event}, {webhook}.",
+          // The first sentence is the human LABEL consent surfaces show for this
+          // argument (they cut at the first period) — the format teaching stays
+          // in the second sentence and in the tool description above.
+          description: "When it runs. A 5-field cron string, or one of {every}, {at}, {event}, {webhook}.",
           oneOf: [
             { type: "string", minLength: 1 },
             {

--- a/packages/vendo/src/channel-turn.ts
+++ b/packages/vendo/src/channel-turn.ts
@@ -103,8 +103,36 @@ function argLabel(key: string, schema: ApprovalRequest["descriptor"]["inputSchem
   const description = typeof property === "object" && property !== null
     && typeof (property as Record<string, unknown>)["description"] === "string"
     ? (property as Record<string, unknown>)["description"] as string : undefined;
-  const label = description?.split(/[.(]|, e\.g\./)[0]?.trim();
+  const label = description?.split(/[.(,]/)[0]?.trim();
   return label && label.length <= 60 ? label : key.replace(/[_-]+/g, " ");
+}
+
+/** The common cron shapes an agent actually mints, in words — anything else
+ *  stays raw. Used beside the raw expression, never instead of it: the ask is
+ *  the consent boundary, so the verbatim value always shows. */
+export function cronProse(cron: string): string | undefined {
+  const fields = cron.trim().split(/\s+/);
+  if (fields.length !== 5) return undefined;
+  const [minute, hour, dayOfMonth, month, dayOfWeek] = fields as [string, string, string, string, string];
+  if (dayOfMonth !== "*" || month !== "*") return undefined;
+  const at = (h: string, m: string) => `${h}:${m.padStart(2, "0")}`;
+  if (dayOfWeek !== "*") {
+    const days = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+    return /^[0-6]$/.test(dayOfWeek) && /^\d+$/.test(minute) && /^\d+$/.test(hour)
+      ? `every ${days[Number(dayOfWeek)]} at ${at(hour, minute)}` : undefined;
+  }
+  const everyN = (field: string) => /^\*\/\d+$/.test(field) ? field.slice(2) : undefined;
+  if (hour === "*") {
+    if (minute === "*") return "every minute";
+    const n = everyN(minute);
+    if (n !== undefined) return `every ${n} minutes`;
+    if (/^\d+$/.test(minute)) return minute === "0" ? "every hour" : `every hour at :${minute.padStart(2, "0")}`;
+    return undefined;
+  }
+  if (!/^\d+$/.test(minute)) return undefined;
+  const nHours = everyN(hour);
+  if (nHours !== undefined) return `every ${nHours} hours`;
+  return /^\d+$/.test(hour) ? `daily at ${at(hour, minute)}` : undefined;
 }
 
 const ARG_VALUE_CAP = 200;
@@ -122,15 +150,19 @@ function approvalText(request: ApprovalRequest): string {
   const lines = input && typeof input === "object" && !Array.isArray(input)
     ? Object.entries(input).map(([key, value]) => {
       const raw = typeof value === "string" ? value : JSON.stringify(value);
-      const shown = raw.length > ARG_VALUE_CAP ? `${raw.slice(0, ARG_VALUE_CAP)}… (truncated)` : raw;
+      const prose = typeof value === "string" ? cronProse(value) : undefined;
+      const shown = prose !== undefined ? `${prose} (${raw})`
+        : raw.length > ARG_VALUE_CAP ? `${raw.slice(0, ARG_VALUE_CAP)}… (truncated)` : raw;
       return `- ${argLabel(key, request.descriptor.inputSchema)}: ${shown}`;
     })
     : [];
   const detail = lines.length > 0 ? lines : [request.inputPreview.trim()].filter(Boolean);
   return [
     // "approval", never "OK" — the decider matches only YES/NO, and a header
-    // that says OK teaches the one reply that will NOT decide it.
-    `${what} needs your approval${detail.length === 0 ? "" : ":"}`,
+    // that says OK teaches the one reply that will NOT decide it. The em dash
+    // keeps verb-phrase titles from reading as a sentence collision ("Set this
+    // to run on its own needs your approval").
+    `${what} — needs your approval${detail.length === 0 ? "" : ":"}`,
     ...detail,
     "Reply YES to approve, or NO to cancel.",
   ].join("\n");

--- a/packages/vendo/tests/channel-approval.e2e.test.ts
+++ b/packages/vendo/tests/channel-approval.e2e.test.ts
@@ -195,7 +195,7 @@ describe.sequential("consent over text", () => {
     // rendered as `host_transferMoney {"amount":2500…}` for a $25.00 send).
     // "approval", not "OK": the decider only matches YES/NO, so the header
     // must never advertise a reply word that would not decide it.
-    expect(ask.text).toContain("Pay a bill needs your approval:");
+    expect(ask.text).toContain("Pay a bill — needs your approval:");
     expect(ask.text).not.toMatch(/\bOK\b/);
     expect(ask.text).toContain("- billId: bill_9");
     expect(ask.text).toContain("- Amount in cents: 4200");

--- a/packages/vendo/tests/channel-turn-ctx.test.ts
+++ b/packages/vendo/tests/channel-turn-ctx.test.ts
@@ -1,7 +1,26 @@
 import type { RunContext } from "@vendoai/core";
 import { describe, expect, it, vi } from "vitest";
 import type { ChannelLink } from "../src/channel-links.js";
-import { runChannelTurn } from "../src/channel-turn.js";
+import { cronProse, runChannelTurn } from "../src/channel-turn.js";
+
+describe("cronProse", () => {
+  it("words the shapes an agent actually mints, beside the raw value", () => {
+    expect(cronProse("*/15 * * * *")).toBe("every 15 minutes");
+    expect(cronProse("* * * * *")).toBe("every minute");
+    expect(cronProse("0 * * * *")).toBe("every hour");
+    expect(cronProse("30 * * * *")).toBe("every hour at :30");
+    expect(cronProse("0 */6 * * *")).toBe("every 6 hours");
+    expect(cronProse("30 9 * * *")).toBe("daily at 9:30");
+    expect(cronProse("0 8 * * 1")).toBe("every Monday at 8:00");
+  });
+  it("stays silent on anything it cannot word honestly", () => {
+    expect(cronProse("0 9 1 * *")).toBeUndefined(); // monthly — not covered
+    expect(cronProse("0 9 * 2 *")).toBeUndefined(); // month-bound
+    expect(cronProse("1,31 * * * *")).toBeUndefined(); // lists
+    expect(cronProse("not a cron")).toBeUndefined();
+    expect(cronProse("check my balance")).toBeUndefined();
+  });
+});
 
 /**
  * WHAT A TEXTED TURN TELLS THE REST OF THE SYSTEM ABOUT ITSELF.


### PR DESCRIPTION
## What broke (live, 2026-08-18, minutes after #1458)

Arming a balance check over text asked:

    Set this to run on its own needs your approval:
    - when: */15 * * * *
    - What to do on every firing, in plain language: Check the balance…

Three warts: a verb-phrase title collides with the header into a broken sentence; a raw cron is the one thing the person must understand before consenting; and the label machinery let a long clause through.

## Fix

    Set this to run on its own — needs your approval:
    - When it runs: every 15 minutes (*/15 * * * *)
    - What to do on every firing: Check the balance…
    Reply YES to approve, or NO to cancel.

- Header gains an em dash, so any title shape reads.
- `cronProse` words the shapes agents actually mint (every-N-minutes/hours, minute, hourly, hourly-at, daily-at, weekly-at) BESIDE the verbatim expression, never instead of it — the ask stays the consent boundary. Anything it cannot word honestly (monthly, month-bound, lists, non-crons) stays raw.
- Labels cut at the first comma as well as the first period/parenthesis.
- The automate tool's `when` property leads with the label consent surfaces show ("When it runs.") and keeps its format teaching in the second sentence.

## Tests

New `cronProse` unit block (worded shapes + honest silences) in `channel-turn-ctx.test.ts`; `channel-approval.e2e.test.ts` header assertion updated to the em-dash form. Local gate green: build, test:affected, typecheck, lint.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies approval asks in `@vendoai/vendo` and `@vendoai/apps` and prevents header/title collisions. Previously the ask header produced a broken sentence and showed only a raw cron; now it uses an em dash and shows a human-readable schedule beside the cron without changing consent semantics.

- Header now reads “… — needs your approval:”; YES/NO flow is unchanged.
- Schedules: `cronProse` renders common shapes (every-N-minutes/hours, every minute, hourly, hourly-at, daily-at, weekly-at) beside the verbatim cron; it leaves unsupported shapes (monthly, month-bound, lists, non-crons) raw.
- Argument labels now stop at the first comma as well as the first period/parenthesis to avoid long clauses.
- Tool schema: the automate tool’s `when` description starts with “When it runs.” so consent surfaces show the label first; adds unit tests for `cronProse` and updates the e2e header assertion to the em-dash form.

<sup>Written for commit 360cf0c6fc3b5750a9b98a6a14c70a36c83c4246. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1462?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

