### PR TITLE
fix(harnesses,vendo): a turn sets up in parallel, and the estimate stops billing tools it never sends

### DIFF
--- a/.changeset/knowledge-sick-engine-cool-off.md
+++ b/.changeset/knowledge-sick-engine-cool-off.md
@@ -1,0 +1,12 @@
+---
+"@vendoai/knowledge": patch
+---
+
+A hanging knowledge engine no longer taxes every turn. The prompt index asks the
+adapter for `status()` when the sync state moves, and the wire client aborts that
+call at its own 30s timeout — so an engine that was UP but not answering charged
+30 seconds to every single turn before the prompt could be built, forever. A
+status check that fails SLOWLY now leaves the engine alone for a minute; the turns
+inside that window serve exactly what the failed check would have served, minus the
+wait. A check that fails FAST — a refused connection, microseconds — is unchanged
+and still retried on the very next turn, so a recovered engine is picked up at once.

--- a/.changeset/turn-startup-parallel.md
+++ b/.changeset/turn-startup-parallel.md
@@ -1,0 +1,24 @@
+---
+"@vendoai/harnesses": patch
+"@vendoai/vendo": patch
+---
+
+A turn stops doing its setup one thing at a time. The system prompt is now
+assembled BESIDE the turn's opening store reads instead of after them, and the
+two independent waits inside it — the guard's directions and the knowledge index
+— run together rather than in sequence; the assembled bytes are unchanged,
+because section order comes from the assembler and not from which read settles
+first. The runtime no longer re-validates the composed turn's transcript against
+itself: composition hands it the very array it just read and validated, and one
+array cannot differ from itself, so an O(n) double stringify per turn was
+spent proving a tautology. `vendo()` projects the host's catalog once to set a
+turn up instead of twice, and re-projects it after a tool call only when that
+call could actually change what is reachable — the connector door — rather than
+after every call.
+
+Fixes a compaction accounting bug in the same pass: the prompt estimate billed
+every equipped tool while the call only ever carries the active loadout, so a
+curated surface was charged for a catalog it never sent — the trigger fired on
+tokens that were never there, and the shed floor was handed a figure the prompt
+had never reached. The estimate bills the active set now. The characters-per-token
+ratio is unchanged.

--- a/packages/harnesses/src/runtime.ts
+++ b/packages/harnesses/src/runtime.ts
@@ -302,21 +302,33 @@ export function createHarnessRuntime(deps: HarnessRuntimeDeps): HarnessRuntime {
       let carried: string | undefined;
       try {
         before = await deps.transcript.list(input.ctx.principal, input.threadId);
-        // A client-sourced history is not trusted history. The shipped rule
-        // (`validateUpsert`) is the one that decides what a caller may change:
-        // fresh USER messages, and answering a pending approval. Anything else —
-        // an assistant message the client authored, a rewritten past turn — is a
-        // history-forging attempt and must not reach the model or the store.
-        const persisted = [...before];
-        for (const message of input.messages) {
-          validateUpsert(persisted, message);
-          const at = persisted.findIndex((candidate) => candidate.id === message.id);
-          if (at === -1) persisted.push(message);
-          else persisted[at] = message;
+        // The composed path RE-STATES its own transcript: `harness-turn.ts`
+        // answers `list` with the very array it passes as `messages`, having
+        // already applied the upsert rule to the one message the client
+        // contributed. One array cannot differ from itself, so both passes below
+        // are decided before they start — every upsert matches and the history is
+        // an append — and running them spends an O(n) double stringify per turn
+        // proving a tautology. Identity is the whole condition, which is what
+        // keeps the skip provable: any caller whose stored history is a
+        // different array still takes both checks in full.
+        const restated = before === input.messages;
+        if (!restated) {
+          // A client-sourced history is not trusted history. The shipped rule
+          // (`validateUpsert`) is the one that decides what a caller may change:
+          // fresh USER messages, and answering a pending approval. Anything else —
+          // an assistant message the client authored, a rewritten past turn — is a
+          // history-forging attempt and must not reach the model or the store.
+          const persisted = [...before];
+          for (const message of input.messages) {
+            validateUpsert(persisted, message);
+            const at = persisted.findIndex((candidate) => candidate.id === message.id);
+            if (at === -1) persisted.push(message);
+            else persisted[at] = message;
+          }
         }
         // Classified BEFORE our own flip below, or the runtime's housekeeping
         // would read as the user rewriting history and clear the session.
-        if (classifyHistory(before, input.messages) !== "arbitrary-edit") {
+        if (restated || classifyHistory(before, input.messages) !== "arbitrary-edit") {
           carried = await harnessState.get(input.threadId, input.harness.name);
         } else {
           // §1.3: the harness's session no longer describes our conversation.

--- a/packages/harnesses/src/vendo/loop.ts
+++ b/packages/harnesses/src/vendo/loop.ts
@@ -597,12 +597,23 @@ export async function startTurn(options: TurnLoopOptions): Promise<TurnLoop> {
   /** The step the loop is on and when it began — the workbench's only state. */
   let step = 0;
   let stepStartedAt = Date.now();
+  const { activeTools } = options;
+  // What the model may pick this turn, read ONCE: the prompt about to be built
+  // and the call about to be made have to agree about the same moment, and
+  // `prepareStep` re-reads it per step for the steps after this one anyway.
+  const active = activeTools?.();
   const { messages: modelMessages, compacted } = await turnModelMessages({
     messages: options.messages,
     system: options.system,
-    // The live toolset, because the trigger has to count what the prompt
-    // actually carries and the tools block is most of it on a curated surface.
-    tools: options.tools,
+    // The tools the prompt actually CARRIES, because the trigger has to count
+    // what is sent and the tools block is most of it on a curated surface. That
+    // is the ACTIVE set, not the equipped one: `activeTools` is what reaches the
+    // provider, so a tool the loadout withholds costs the window nothing.
+    // Billing the whole catalog charged a curated surface for tools it never
+    // sent, and the shed floor was then handed a figure the prompt never reached.
+    tools: active === undefined
+      ? options.tools
+      : Object.fromEntries(Object.entries(options.tools).filter(([name]) => active.includes(name))),
     historyWindow: options.context?.historyWindow,
     tokenBudget: options.context?.contextTokenBudget,
     ...(options.compaction === undefined ? {} : { compaction: options.compaction }),
@@ -611,7 +622,6 @@ export async function startTurn(options: TurnLoopOptions): Promise<TurnLoop> {
     ...(options.signal === undefined ? {} : { signal: options.signal }),
     workbench: debug,
   });
-  const { activeTools } = options;
   const result = streamText({
     model: turnModel(options),
     messages: modelMessages,
@@ -625,7 +635,7 @@ export async function startTurn(options: TurnLoopOptions): Promise<TurnLoop> {
     // equips mid-turn (e.g. via vendo()'s `find_tools` hand) becomes choosable
     // on the very next step. This gates the model's CHOICE only — every tool
     // still executes through the guard-bound registry; there is no unguarded path.
-    ...(activeTools === undefined ? {} : { activeTools: activeTools() }),
+    ...(active === undefined ? {} : { activeTools: active }),
     // One hook, two rails. `prepareStep` used to be built only when a loadout
     // existed, which is why a step's growing tool results were never cached —
     // the turn with the most to cache had no hook at all. It is returned on

--- a/packages/harnesses/src/vendo/vendo.ts
+++ b/packages/harnesses/src/vendo/vendo.ts
@@ -17,7 +17,14 @@
  *   business — that is the dividing line, and orchestration is thinking.
  */
 import { z } from "zod";
-import { modelToolDescription, type Harness, type Json, type Turn } from "@vendoai/core";
+import {
+  CONNECTOR_DISCOVERY_TOOLS,
+  modelToolDescription,
+  type Harness,
+  type Json,
+  type ToolListing,
+  type Turn,
+} from "@vendoai/core";
 import { readCompactionState, writeCompactionState, type CompactionState } from "./compaction.js";
 import { startTurn, type TurnCompaction, type TurnContext } from "./loop.js";
 import { contextWindowTokens, rememberResolvedModelId, resolvedModelId } from "./model-windows.js";
@@ -198,9 +205,24 @@ export interface HarnessHand {
 const NO_INPUT_SCHEMA = { type: "object", properties: {}, additionalProperties: false };
 
 /**
+ * The calls that can change what `turn.tools.list()` answers.
+ *
+ * Only the connector door can: connecting an outside service, or using one, is
+ * what brings that service's tools within reach of the next projection. A host
+ * tool cannot add a tool to the registry — the descriptor set behind
+ * `descriptors()` is fixed once its source has loaded — so re-projecting the
+ * whole catalog after EVERY call spent the projection once per tool call to
+ * learn nothing. `find_tools`, the other thing that genuinely changes the set,
+ * never rode this rail: it is the harness's own hand and re-lists inside its own
+ * `execute`, below.
+ */
+const SURFACE_CHANGING_CALLS = new Set<string>(CONNECTOR_DISCOVERY_TOOLS);
+
+/**
  * Refresh the live toolset from `turn.tools.list()` — the ONE discovery surface
- * (contract §1.1: "currently-equipped tools, post-curation"). Returns the names
- * the model may pick this step.
+ * (contract §1.1: "currently-equipped tools, post-curation"). Returns the listing
+ * it projected, so a caller that needs the same surface again reads it from here
+ * instead of asking the registry to build it a second time.
  *
  * Two things make this the whole discovery rail. The set is re-read rather than
  * captured once, so a tool searched in mid-turn through `find_tools` is offered on
@@ -211,11 +233,12 @@ const NO_INPUT_SCHEMA = { type: "object", properties: {}, additionalProperties: 
 async function refreshEquipped(
   turn: Turn<unknown>,
   tools: ToolSet,
-  /** Re-read the listing after every call. A `find_tools` call is what changes
-   *  the equipped set, and `prepareStep` reads the snapshot synchronously, so the
-   *  re-read has to happen while we are still inside the call that changed it. */
+  /** Re-read the listing after a call that can CHANGE it
+   *  ({@link SURFACE_CHANGING_CALLS}). `prepareStep` reads the snapshot
+   *  synchronously, so the re-read has to happen while we are still inside the
+   *  call that changed it. */
   afterCall: () => Promise<void>,
-): Promise<string[]> {
+): Promise<ToolListing[]> {
   const listings = await turn.tools.list();
   for (const listing of listings) {
     tools[listing.name] ??= tool({
@@ -229,12 +252,12 @@ async function refreshEquipped(
       // `call()`.
       execute: async (input: unknown) => {
         const result = await turn.tools.call(listing.name, input as Json);
-        await afterCall();
+        if (SURFACE_CHANGING_CALLS.has(listing.name)) await afterCall();
         return result;
       },
     });
   }
-  return listings.map((listing) => listing.name);
+  return listings;
 }
 
 /**
@@ -526,15 +549,19 @@ export function vendo(deps: VendoHarnessDeps = {}): Harness<VendoHarnessOptions>
         });
       };
       if (deps.tools === undefined) {
+        let listings: ToolListing[] = [];
         const refresh = async (): Promise<void> => {
-          equipped = await refreshEquipped(turn, residentTools, refresh);
+          listings = await refreshEquipped(turn, residentTools, refresh);
+          equipped = listings.map((listing) => listing.name);
         };
         await refresh();
         residentTools[HIRE_SUBAGENT] = hireSubagent;
         if (searchCfg !== undefined) {
-          // The starting toolbelt, computed once per turn over the projected
-          // listing; everything past it stays reachable through `find_tools`.
-          const initial = computeInitialLoadout(await turn.tools.list(), searchCfg);
+          // The starting toolbelt, computed once per turn over the listing the
+          // wrappers were just built from; everything past it stays reachable
+          // through `find_tools`. Re-listing here asked the registry to project
+          // the whole catalog a second time to answer the same question.
+          const initial = computeInitialLoadout(listings, searchCfg);
           residentTools[FIND_TOOLS_TOOL_NAME] = tool({
             description: FIND_TOOLS_DESCRIPTION,
             inputSchema: z.object({

--- a/packages/harnesses/tests/transcript-restated.test.ts
+++ b/packages/harnesses/tests/transcript-restated.test.ts
@@ -1,0 +1,130 @@
+/**
+ * The two transcript passes a composed turn cannot fail, and no longer runs.
+ *
+ * `run()` opens by re-validating every incoming message against the stored
+ * history (`validateUpsert`, a double stringify of each message's parts) and then
+ * re-classifying the two histories against each other (`classifyHistory`). On the
+ * composed chat path both are decided before they start: `harness-turn.ts` answers
+ * `transcript.list` with the very array it passes as `messages`, having already
+ * validated the one message the client contributed. One array cannot differ from
+ * itself — so every upsert matches, the history is "append", and the whole O(n)
+ * pass per turn is spent proving a tautology.
+ *
+ * The skip is keyed on that identity and nothing else, which is what keeps it
+ * PROVABLE: any caller whose stored history is a different array — a client-posted
+ * transcript, the away runner, a host's own runtime — still takes both checks in
+ * full. The last test here is that guarantee.
+ */
+import { defineHarness } from "../src/define.js";
+import type { Harness, ThreadId } from "@vendoai/core";
+import type { UIMessage } from "ai";
+import { describe, expect, it } from "vitest";
+import { createHarnessRuntime } from "../src/runtime.js";
+import { memoryHarnessStateStore } from "../src/harness-state.js";
+import {
+  boundRegistry,
+  ctx,
+  readSse,
+  testGuard,
+  testSkills,
+  testWorkspace,
+  unusedModels,
+} from "../src/test-doubles.test-util.js";
+
+const THREAD = "thr_restated" as ThreadId;
+
+/** A message that counts every read of its `parts` — the field both passes walk,
+ *  and the only way to see from outside whether they walked it. */
+function countingMessage(id: string, text: string, reads: { count: number }): UIMessage {
+  const parts = [{ type: "text", text }];
+  return Object.defineProperty({ id, role: "user" } as UIMessage, "parts", {
+    enumerable: true,
+    get() {
+      reads.count += 1;
+      return parts;
+    },
+  });
+}
+
+const scripted = (): Harness => defineHarness({
+  name: "scripted",
+  async *run() {
+    yield { type: "text", delta: "ok" };
+  },
+});
+
+/** One turn over `messages`, with the stored history the caller chooses. */
+async function turn(
+  messages: UIMessage[],
+  stored: (messages: UIMessage[]) => UIMessage[],
+): Promise<void> {
+  const guard = testGuard();
+  const runtime = createHarnessRuntime({
+    tools: boundRegistry({}, guard),
+    guard,
+    skills: testSkills([]),
+    transcript: {
+      upsert: async () => {},
+      list: async () => stored(messages),
+    },
+    harnessState: memoryHarnessStateStore(),
+  });
+  await readSse(await runtime.run({
+    harness: scripted(),
+    threadId: THREAD,
+    messages,
+    ctx: ctx(),
+    workspace: testWorkspace(),
+    models: unusedModels(),
+    interactive: true,
+  }));
+}
+
+describe("the composed turn's restated transcript", () => {
+  it("walks the messages FEWER times when the stored history is the turn's own array", async () => {
+    // The history a real thread carries by the time the passes cost anything:
+    // the composed path re-states all of it every turn.
+    const history = (reads: { count: number }): UIMessage[] =>
+      Array.from({ length: 6 }, (_, index) => countingMessage(`m${index}`, `line ${index}`, reads));
+
+    // What the composed path used to hand the runtime: its own deep copy, so
+    // both passes compare every message against a structurally equal twin.
+    const copied = { count: 0 };
+    await turn(history(copied), (messages) => messages.map((message) => structuredClone(message)));
+
+    // What it hands the runtime now: the same array it is running.
+    const same = { count: 0 };
+    await turn(history(same), (messages) => messages);
+
+    expect(same.count).toBeLessThan(copied.count);
+  });
+
+  it("still validates and classifies in full when the stored history is a DIFFERENT array", async () => {
+    // A client replaying a known id with different parts is the forgery the
+    // upsert rule exists to refuse. The stored copy is its own array here, so
+    // the fast path cannot apply and the rule has to fire.
+    const guard = testGuard();
+    const stored: UIMessage[] = [
+      { id: "m1", role: "user", parts: [{ type: "text", text: "the real ask" }] } as UIMessage,
+    ];
+    const runtime = createHarnessRuntime({
+      tools: boundRegistry({}, guard),
+      guard,
+      skills: testSkills([]),
+      transcript: { upsert: async () => {}, list: async () => stored.map((m) => structuredClone(m)) },
+      harnessState: memoryHarnessStateStore(),
+    });
+
+    await expect(runtime.run({
+      harness: scripted(),
+      threadId: THREAD,
+      messages: [
+        { id: "m1", role: "user", parts: [{ type: "text", text: "a rewritten ask" }] } as UIMessage,
+      ],
+      ctx: ctx(),
+      workspace: testWorkspace(),
+      models: unusedModels(),
+      interactive: true,
+    })).rejects.toThrow(/existing user message cannot be rewritten/);
+  });
+});

--- a/packages/harnesses/tests/vendo/compaction-active-tools.test.ts
+++ b/packages/harnesses/tests/vendo/compaction-active-tools.test.ts
@@ -1,0 +1,100 @@
+/**
+ * The compaction estimate must bill the tools the prompt actually CARRIES.
+ *
+ * `activeTools` gates which tools reach the provider — `streamText` receives the
+ * gated list, and `prepareStep` re-applies it on every step — so a tool outside
+ * the loadout costs the window nothing. The estimate was reading
+ * `options.tools`, the whole equipped set, so a curated surface with a small
+ * loadout behind a large catalog was charged for the catalog: the trigger fired
+ * on tokens that were never sent, and the shed floor then charged the messages
+ * against a figure the prompt had never reached.
+ *
+ * The 2-chars-per-token ratio is not what is under test here and is unchanged —
+ * this is about WHICH tools go into the count, not what a character is worth.
+ */
+import type { TurnId } from "@vendoai/core";
+import { tool } from "ai";
+import { MockLanguageModelV3, simulateReadableStream } from "ai/test";
+import { afterEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+import { startTurn } from "../../src/vendo/loop.js";
+import { openWorkbench, type WorkbenchEvent } from "../../src/workbench.js";
+
+/** A tool whose SCHEMA is the bulk, as a real host tool's is. ~40k characters
+ *  is ~20k tokens at the loop's own conversion, so a tool that is billed and
+ *  should not be is impossible to miss. */
+const fatTool = (name: string) => tool({
+  description: `${name}. ${"d".repeat(20_000)}`,
+  inputSchema: z.object({ value: z.string().describe("x".repeat(20_000)) }),
+  execute: async () => ({}),
+});
+
+const quietModel = () => new MockLanguageModelV3({
+  doStream: async () => ({
+    stream: simulateReadableStream({ chunks: [
+      { type: "text-start", id: "t1" },
+      { type: "text-delta", id: "t1", delta: "ok" },
+      { type: "text-end", id: "t1" },
+      {
+        type: "finish",
+        usage: {
+          inputTokens: { total: 10, noCache: 10, cacheRead: 0, cacheWrite: 0 },
+          outputTokens: { total: 1, text: 1, reasoning: 0 },
+        },
+        finishReason: { unified: "stop", raw: undefined },
+      },
+    ] }),
+  }),
+});
+
+const closers: Array<() => void> = [];
+afterEach(() => {
+  for (const close of closers.splice(0)) close();
+  delete process.env["VENDO_WORKBENCH"];
+});
+
+/** The estimate this turn tripped on, read off the workbench's `context` fact —
+ *  the loop's own report of what it thinks its prompt costs. */
+async function estimateWith(label: string, activeTools?: () => string[]): Promise<number> {
+  process.env["VENDO_WORKBENCH"] = "1";
+  const turnId = `trn_${label}` as TurnId;
+  const events: WorkbenchEvent[] = [];
+  closers.push(openWorkbench(turnId, (part) => { events.push(part.event); }));
+  const model = quietModel();
+  const loop = await startTurn({
+    model,
+    system: "system",
+    messages: [{ id: "m1", role: "user", parts: [{ type: "text", text: "hello" }] }],
+    tools: { alpha: fatTool("alpha"), beta: fatTool("beta") },
+    turnId,
+    // A window large enough that nothing actually compacts — the `context` fact
+    // is emitted whatever the trigger decides, and the estimate is the subject.
+    compaction: { model, contextWindowTokens: 1_000_000 },
+    ...(activeTools === undefined ? {} : { activeTools }),
+  });
+  await loop.result.consumeStream();
+  const context = events.find((event): event is Extract<WorkbenchEvent, { kind: "context" }> =>
+    event.kind === "context");
+  expect(context, "the loop reported no context estimate").toBeDefined();
+  return context!.estTokens;
+}
+
+describe("the compaction estimate", () => {
+  it("bills only the tools the loadout lets the model pick", async () => {
+    const gated = await estimateWith("gated", () => ["alpha"]);
+    const ungated = await estimateWith("ungated");
+
+    // One whole fat tool's worth of schema is the difference, and it is the
+    // difference the provider sees too: `beta` is not on the wire for the gated
+    // turn. Billed identically, this is 0.
+    expect(ungated - gated).toBeGreaterThan(15_000);
+  });
+
+  it("bills the whole equipped set when there is no loadout to gate it", async () => {
+    // No `activeTools` means every equipped tool really is sent, so the estimate
+    // charging all of them is correct — the fix must not shrink this case.
+    const all = await estimateWith("all-a");
+    const both = await estimateWith("both", () => ["alpha", "beta"]);
+    expect(Math.abs(all - both)).toBeLessThan(50);
+  });
+});

--- a/packages/harnesses/tests/vendo/turn-catalog-reads.test.ts
+++ b/packages/harnesses/tests/vendo/turn-catalog-reads.test.ts
@@ -1,0 +1,114 @@
+/**
+ * How many times one turn projects the host's catalog.
+ *
+ * `turn.tools.list()` is `registry.descriptors(ctx)` plus the projection over it
+ * (turn-tools.ts) — the guard's per-run withholding, a connector's expansion, the
+ * whole surface. `vendo()` was asking for it twice before the model saw a token
+ * (once to build the wrappers, once to compute the starting loadout), and then
+ * again after EVERY tool call, on a rail whose own comment says the only thing
+ * that changes the equipped set is a search.
+ *
+ * The refresh that remains is the one that can matter: the connector-discovery
+ * tools, which are the calls that can bring a service's tools into reach.
+ * `find_tools` never rode this rail at all — it is the harness's own hand and
+ * re-lists inside its own `execute`, which is what makes a found tool callable on
+ * the very next step.
+ */
+import type { ThreadId } from "@vendoai/core";
+import { describe, expect, it } from "vitest";
+import { vendo } from "../../src/vendo/vendo.js";
+import { createHarnessRuntime } from "../../src/runtime.js";
+import {
+  boundRegistry,
+  ctx,
+  readSse,
+  readTool,
+  scriptedModel,
+  seats,
+  testGuard,
+  testSkills,
+  testTranscript,
+  testWorkspace,
+  textTurn,
+  toolCallTurn,
+  userMessage,
+  type ScriptedModel,
+} from "../../src/test-doubles.test-util.js";
+
+const THREAD = "thr_catalog_reads" as ThreadId;
+
+const CATALOG = {
+  host_aaa: { descriptor: readTool("host_aaa"), execute: () => ({ ok: 1 }) },
+  host_bbb: { descriptor: readTool("host_bbb"), execute: () => ({ ok: 1 }) },
+  request_connection: { descriptor: readTool("request_connection"), execute: () => ({}) },
+};
+
+/** One turn, with every catalog projection counted. */
+function rig(model: ScriptedModel) {
+  const guard = testGuard();
+  const registry = boundRegistry(CATALOG, guard);
+  let projections = 0;
+  const counted = {
+    ...registry,
+    descriptors: async (...args: Parameters<typeof registry.descriptors>) => {
+      projections += 1;
+      return registry.descriptors(...args);
+    },
+  };
+  const runtime = createHarnessRuntime({
+    tools: counted as typeof registry,
+    guard,
+    skills: testSkills(),
+    transcript: testTranscript(),
+  });
+  const run = async (): Promise<void> => {
+    await readSse(await runtime.run({
+      harness: vendo({ toolSearch: { maxInitialTools: 5 } }),
+      threadId: THREAD,
+      messages: [userMessage("m1", "go")],
+      ctx: ctx(),
+      workspace: testWorkspace(),
+      models: seats(model),
+      interactive: true,
+    }));
+  };
+  return { run, projections: () => projections, registry };
+}
+
+describe("one turn's catalog projections", () => {
+  it("projects the catalog ONCE to set the turn up, not twice", async () => {
+    const { run, projections } = rig(scriptedModel([textTurn("nothing to do")]));
+    await run();
+    // A turn that calls no tool needs the surface exactly once: to build the
+    // wrappers AND to compute the starting loadout, which are two readings of
+    // one listing, not two listings.
+    expect(projections()).toBe(1);
+  });
+
+  // The guarded-call path looks its own descriptor up (`descriptorFor`,
+  // turn-tools.ts) on every call, whatever the tool. That read belongs to the
+  // guard, not to this rail, so it is the baseline both cases below carry and the
+  // DIFFERENCE between them is the refresh under test.
+  it("does NOT re-project the catalog after a host tool call — a host tool cannot change the surface", async () => {
+    const { run, projections, registry } = rig(scriptedModel([
+      toolCallTurn("host_aaa", {}),
+      textTurn("done"),
+    ]));
+    await run();
+    expect(registry.invocations["host_aaa"]).toBe(1);
+    // The turn's one setup projection, plus the guard's own descriptor lookup.
+    expect(projections()).toBe(2);
+  });
+
+  it("DOES re-project after a connector call — that is the call that can bring new tools into reach", async () => {
+    const { run, projections, registry } = rig(scriptedModel([
+      toolCallTurn("request_connection", { toolkit: "gmail", reason: "to send it" }),
+      textTurn("asked"),
+    ]));
+    await run();
+    expect(registry.invocations["request_connection"]).toBe(1);
+    // The same two, and one more: the refresh that makes a newly reachable tool
+    // callable on the very next step.
+    expect(projections()).toBe(3);
+  });
+});

--- a/packages/knowledge/src/prompt-note.ts
+++ b/packages/knowledge/src/prompt-note.ts
@@ -72,16 +72,30 @@ export interface KnowledgeIndexReaders {
       at reboot, the documented boot posture.
     - A failed status() keeps serving the last good bytes (a sick engine must
       not strip guidance mid-session); with nothing cached yet the block is
-      simply absent and the next turn retries. */
+      simply absent and the next turn retries. A failure that arrived SLOWLY is
+      the exception — see SLOW_FAILURE_MS. */
+/** A refused connection fails in microseconds and is retried on the very next
+    turn (a recovered engine must be picked up at once). An engine that is UP but
+    HANGING is the expensive kind: the wire client aborts at its own 30s timeout,
+    and every turn pays that before the prompt can be built. Past this bound a
+    failure counts as slow and the engine is left alone for the cool-off — which
+    costs only recovery latency, since a turn inside it serves exactly what the
+    failure itself would have returned. */
+const SLOW_FAILURE_MS = 1_000;
+const SLOW_FAILURE_COOL_OFF_MS = 60_000;
+
 export function knowledgeIndexResolver(
   adapter: KnowledgeAdapter,
   readers: KnowledgeIndexReaders,
 ): () => Promise<string | undefined> {
   let cached: { fingerprint: string | undefined; text: string } | undefined;
   let flight: Promise<string | undefined> | undefined;
+  let coolOffUntil = 0;
   return () => {
     const fingerprint = readers.readManifest();
     if (cached !== undefined && cached.fingerprint === fingerprint) return Promise.resolve(cached.text);
+    if (Date.now() < coolOffUntil) return Promise.resolve(cached?.text);
+    const startedAt = Date.now();
     flight ??= adapter.status().then(
       (status) => {
         cached = { fingerprint, text: knowledgeIndexSummary(status, parseKnowledgeConfig(readers.readConfig())) };
@@ -90,6 +104,7 @@ export function knowledgeIndexResolver(
       },
       () => {
         flight = undefined;
+        if (Date.now() - startedAt >= SLOW_FAILURE_MS) coolOffUntil = Date.now() + SLOW_FAILURE_COOL_OFF_MS;
         return cached?.text;
       },
     );

--- a/packages/knowledge/tests/prompt-note-sick-engine.test.ts
+++ b/packages/knowledge/tests/prompt-note-sick-engine.test.ts
@@ -1,0 +1,44 @@
+import { memoryKnowledgeAdapter } from "@vendoai/core/conformance";
+import type { KnowledgeAdapter } from "@vendoai/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { knowledgeIndexResolver } from "../src/prompt-note.js";
+
+const readers = { readConfig: () => undefined, readManifest: () => "v1" };
+
+/** The wire client aborts a status() at its own 30s timeout (`wire.ts`
+    DEFAULT_TIMEOUT_MS), so an engine that is UP but hanging bills 30s to every
+    turn before the prompt can be built. The clock is faked rather than slept:
+    a real sleep here would be a second, invisible speed limit on the test. */
+describe("knowledgeIndexResolver (an engine that fails SLOWLY is not re-probed every turn)", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("asks a TIMING-OUT engine once per cool-off, not once per turn, and retries after it", async () => {
+    vi.useFakeTimers();
+    let statusCalls = 0;
+    const base = memoryKnowledgeAdapter();
+    const hanging: KnowledgeAdapter = {
+      ...base,
+      posture: base.posture,
+      status: async () => {
+        statusCalls += 1;
+        vi.setSystemTime(Date.now() + 30_000);
+        throw new Error("knowledge engine unreachable");
+      },
+    };
+    const resolve = knowledgeIndexResolver(hanging, readers);
+
+    expect(await resolve()).toBeUndefined();
+    expect(statusCalls).toBe(1);
+
+    // Later turns inside the cool-off pay nothing and still see no index.
+    expect(await resolve()).toBeUndefined();
+    expect(await resolve()).toBeUndefined();
+    expect(statusCalls).toBe(1);
+
+    vi.setSystemTime(Date.now() + 61_000);
+    expect(await resolve()).toBeUndefined();
+    expect(statusCalls).toBe(2);
+  });
+});

--- a/packages/vendo/src/harness-turn.ts
+++ b/packages/vendo/src/harness-turn.ts
@@ -406,6 +406,25 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
       // costs no read, no write and no model call.
       const verdict = await config.limiter?.gate("message", input.ctx);
       if (verdict?.allow === false) return limitResponse(verdict);
+      // Assembled once, per turn, for WHOEVER thinks. The venue gate and the guard's
+      // directions live in here, which is why it is composition's job and not the
+      // harness's. Which discovery section it may promise is decided by what is
+      // actually on the listing: a curated surface has `find_tools`, an uncurated one
+      // has the connector pair (and only with connectors configured), or neither.
+      //
+      // STARTED HERE and awaited after the store phase. It needs only the
+      // request's ctx and the rail this harness carries — neither of which the
+      // store below can change — so assembling it after the reads meant the turn
+      // paid the store's wait and the guard's `directions` wait end to end.
+      // Started after the limiter gate, not before: a refused message must still
+      // cost nothing.
+      const rail = config.harness.toolSurface?.curated !== false
+        ? "find-tools" as const
+        : config.connectorDiscovery === true ? "connectors" as const : false;
+      const systemRead = config.system(input.ctx, { discovery: rail });
+      // A rejection is delivered where the prompt is awaited below; this only
+      // keeps a store-phase throw from turning it into an unhandled one.
+      void systemRead.catch(() => {});
       // The turn's opening reads, in ONE call where the store serves it: the
       // thread row, the workspace index, and the harness slot. Each part is
       // exactly what its own op answers, so the doors below decide on the same
@@ -592,7 +611,14 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
           ...transcript,
           list: async (principal, threadId) =>
             threadId === thread.id && principal.subject === thread.subject
-              ? structuredClone(thread.messages)
+              // The ARRAY the turn is running, not a copy of it. The runtime
+              // takes its own deep copies of both the canonical transcript and
+              // the pristine one it diffs persistence against, so it never
+              // writes through this — and handing it the same array is what
+              // lets it SEE that its stored history and its incoming history
+              // are one thing, and skip re-validating the transcript against
+              // itself (runtime.ts).
+              ? thread.messages
               : transcript.list(principal, threadId),
         },
         harnessState: {
@@ -667,16 +693,14 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
         }),
       });
 
-      // Assembled once, per turn, for WHOEVER thinks. The venue gate and the guard's
-      // directions live in here, which is why it is composition's job and not the
-      // harness's. Which discovery section it may promise is decided by what is
-      // actually on the listing: a curated surface has `find_tools`, an uncurated one
-      // has the connector pair (and only with connectors configured), or neither.
+      // What the prompt still COSTS the turn, now that it was assembled beside
+      // the store phase: the wait left over once the reads are done. The phase
+      // split has to keep summing to the wall clock (`modelMs` is the
+      // remainder), so an overlapped span must be billed once, to whichever
+      // phase was still waiting — and a prompt that finished first is honestly
+      // worth ~0ms to this turn.
       const promptAt = Date.now();
-      const rail = config.harness.toolSurface?.curated !== false
-        ? "find-tools" as const
-        : config.connectorDiscovery === true ? "connectors" as const : false;
-      const system = await config.system(input.ctx, { discovery: rail });
+      const system = await systemRead;
       // Spec 2026-08-05 §2, relocated (sub-1s shipment): the screen snapshot is
       // delivered BESIDE the stable prompt, not inside it — it changes every
       // message, and volatile bytes ahead of stable ones are what kept the

--- a/packages/vendo/src/prompt.ts
+++ b/packages/vendo/src/prompt.ts
@@ -188,7 +188,19 @@ export async function assembleSystemPrompt(
   const user = userPromptBlock(ctx.user);
   if (user !== undefined) sections.push(user);
 
-  const directions = (await guard.directions(ctx))
+  // The assembler's two waits, started TOGETHER: the guard's directions and the
+  // knowledge index ask different questions of different backends and neither
+  // reads the other, so awaiting them in turn made a turn pay the sum. `Promise.all`
+  // rather than two loose promises because the first rejection must not leave the
+  // other one unhandled — `directions` fails closed, and a host's own resolver may
+  // reject too. The BYTES cannot move: the section order is the `push` order below,
+  // not the order these settle in.
+  const [directionsRead, knowledgeRead] = await Promise.all([
+    guard.directions(ctx),
+    typeof system?.knowledge === "function" ? system.knowledge() : system?.knowledge,
+  ]);
+
+  const directions = directionsRead
     .map((direction) => direction.trim())
     .filter(Boolean);
   if (directions.length > 0) {
@@ -204,7 +216,7 @@ export async function assembleSystemPrompt(
   // Knowledge k8 (ENG-368): the static index + usage guidance rides only the
   // venues whose turns go through this assembler with a knowledge-capable
   // surface (chat + app); automation and MCP rely on the tool descriptor.
-  const knowledge = (await (typeof system?.knowledge === "function" ? system.knowledge() : system?.knowledge))?.trim();
+  const knowledge = knowledgeRead?.trim();
   if (knowledge && TREE_VENUES.has(ctx.venue)) sections.push(knowledge);
 
   const instructions = system?.instructions?.trim();

--- a/packages/vendo/tests/prompt-assembly-parallel.test.ts
+++ b/packages/vendo/tests/prompt-assembly-parallel.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Prompt assembly's two independent waits, and the bytes they must not change.
+ *
+ * `guard.directions()` and the knowledge resolver answer different questions of
+ * different backends; the assembler used to await them one after the other, so a
+ * turn paid the sum. They run together now — and because the section ORDER is
+ * fixed by the `sections.push` sequence rather than by which promise settled
+ * first, the assembled string is the byte-for-byte one it always was. The second
+ * test is the guardrail for that: it pins the whole prompt, not a substring, so a
+ * reordering shows up as a diff rather than as a passing test.
+ */
+import type { Guard, RunContext } from "@vendoai/core";
+import { describe, expect, it } from "vitest";
+import { assembleSystemPrompt } from "../src/prompt.js";
+
+const ctx = (): RunContext => ({
+  principal: { kind: "user", subject: "user_prompt_parallel" },
+  venue: "chat",
+}) as RunContext;
+
+const guardWith = (directions: () => Promise<string[]>): Guard =>
+  ({ directions }) as unknown as Guard;
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe("assembleSystemPrompt", () => {
+  it("waits for the guard's directions and the knowledge index AT THE SAME TIME", async () => {
+    // Each side is slow enough that a sequential assembler could not finish
+    // under the sum, and the assertion is against the SUM rather than a fixed
+    // number — a busy machine slows both waits equally, so the margin holds
+    // without a wall-clock budget of its own.
+    const delayMs = 150;
+    const guard = guardWith(async () => {
+      await sleep(delayMs);
+      return ["Never move money without asking."];
+    });
+    const knowledge = async (): Promise<string> => {
+      await sleep(delayMs);
+      return "Knowledge\nThe host has a product knowledge base of 3 documents.";
+    };
+
+    const startedAt = Date.now();
+    const prompt = await assembleSystemPrompt(guard, ctx(), { knowledge });
+    const elapsed = Date.now() - startedAt;
+
+    // Both waits are in the prompt, so neither was skipped to win the race.
+    expect(prompt).toContain("Never move money without asking.");
+    expect(prompt).toContain("The host has a product knowledge base of 3 documents.");
+    expect(elapsed).toBeLessThan(delayMs * 2);
+  });
+
+  it("assembles the SAME BYTES as the sequential assembler, with every section present", async () => {
+    // The sequential reference: the two independent reads resolved by hand, in
+    // the order the old assembler awaited them, then handed to the assembler as
+    // already-settled values. If parallelising ever moved a section, or let a
+    // resolver's settle order pick the order, this diverges.
+    const directions = ["Never move money without asking.", "Escalate refunds over $500."];
+    const knowledgeText = "Knowledge\nThe host has a product knowledge base of 3 documents.";
+    const sequential = await assembleSystemPrompt(
+      guardWith(async () => directions),
+      ctx(),
+      {
+        product: "Maple is a bank.",
+        theme: "Theme\nMaple is green.",
+        knowledge: knowledgeText,
+        instructions: "Host instructions\nBe brief.",
+      },
+      true,
+      "find-tools",
+    );
+
+    // The same inputs, but every one of them slow and resolving out of order:
+    // knowledge settles FIRST here and the directions last, the reverse of the
+    // await order the sections are pushed in.
+    const parallel = await assembleSystemPrompt(
+      guardWith(async () => {
+        await sleep(80);
+        return directions;
+      }),
+      ctx(),
+      {
+        product: "Maple is a bank.",
+        theme: "Theme\nMaple is green.",
+        knowledge: async () => {
+          await sleep(10);
+          return knowledgeText;
+        },
+        instructions: "Host instructions\nBe brief.",
+      },
+      true,
+      "find-tools",
+    );
+
+    expect(parallel).toBe(sequential);
+    // The order the guardrail actually protects, stated so a failure names the
+    // section that moved.
+    const order = ["You are Vendo's agent.", "How you work", "Presentation",
+      "When the user's ask cannot be fulfilled:", "Discovery budget", "Product",
+      "Directions", "Theme", "Knowledge", "Host instructions"];
+    expect(order.map((section) => parallel.indexOf(section)))
+      .toEqual([...order.map((section) => parallel.indexOf(section))].sort((a, b) => a - b));
+    expect(order.every((section) => parallel.includes(section))).toBe(true);
+  });
+});

--- a/packages/vendo/tests/turn-startup-overlap.test.ts
+++ b/packages/vendo/tests/turn-startup-overlap.test.ts
@@ -1,0 +1,137 @@
+/**
+ * The turn's prompt is assembled BESIDE its store phase, not after it.
+ *
+ * `config.system(...)` needs only the request's ctx and which discovery rail the
+ * harness carries — neither of which the opening reads can change — so a turn
+ * that assembled it after them paid the store's wait and the guard's
+ * `directions` wait end to end.
+ *
+ * The proof is an ORDER, not a stopwatch: the guard's `directions()` is the first
+ * thing prompt assembly awaits, so the moment it is called is the moment the
+ * prompt started. If that moment lands INSIDE the store phase's own span
+ * (`storeMs`, marked by composition), the two overlapped. Assembled afterwards,
+ * the call could not arrive before `storeMs` had already elapsed.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Principal, ToolDescriptor, ToolRegistry, RunContext, VendoUsageEvent } from "@vendoai/core";
+import { setUsageSink } from "@vendoai/core";
+import { createGuard, type VendoGuard } from "@vendoai/guard";
+import { defineHarness } from "@vendoai/harnesses";
+import { memoryStoreAdapter } from "@vendoai/core/conformance";
+import { createStore } from "@vendoai/store";
+import type { LanguageModel, UIMessage } from "ai";
+import { afterEach, expect, it } from "vitest";
+import { createVendo } from "../src/server.js";
+
+type AgentRun = Extract<VendoUsageEvent, { name: "agent_run" }>;
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  setUsageSink(undefined);
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+const principal: Principal = { kind: "user", subject: "user_overlap" };
+
+const hostTools: ToolRegistry = {
+  async descriptors(): Promise<ToolDescriptor[]> {
+    return [{
+      name: "maple_invoices_list",
+      title: "List invoices",
+      description: "The host's invoice list",
+      inputSchema: { type: "object", properties: {}, additionalProperties: false },
+      risk: "read",
+    }];
+  },
+  async execute() {
+    return { status: "ok", output: { invoices: [] } };
+  },
+};
+
+/**
+ * A real guard with ONE method watched. A Proxy rather than a subclass because
+ * `VendoGuard` keeps private fields, so every other method has to run with the
+ * real instance as its receiver.
+ */
+function watchDirections(real: VendoGuard, onCall: () => void): VendoGuard {
+  return new Proxy(real, {
+    get: (target, prop) => {
+      if (prop === "directions") {
+        return async (ctx: RunContext) => {
+          onCall();
+          return await real.directions(ctx);
+        };
+      }
+      const value = Reflect.get(target, prop, target) as unknown;
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  }) as VendoGuard;
+}
+
+it("starts assembling the prompt inside the store phase, not after it", async () => {
+  const dataDir = await mkdtemp(join(tmpdir(), "vendo-overlap-"));
+  const store = createStore({ dataDir });
+  cleanups.push(async () => {
+    await store.close();
+    await rm(dataDir, { recursive: true, force: true });
+  });
+
+  /** When prompt assembly reached the guard, relative to the turn's own start. */
+  let directionsAt: number | undefined;
+  let turnStartedAt = 0;
+
+  const vendo = createVendo({
+    models: { default: {} as LanguageModel },
+    principal: async () => principal,
+    store,
+    guard: watchDirections(
+      createGuard({ store: memoryStoreAdapter(), policy: {} }),
+      () => { directionsAt ??= Date.now() - turnStartedAt; },
+    ),
+    harness: defineHarness({
+      name: "scripted",
+      run: async function* () {
+        yield { type: "text", delta: "done" };
+      },
+    }) as never,
+  } as Parameters<typeof createVendo>[0]);
+  vendo.actions.add(hostTools);
+
+  const posted: VendoUsageEvent[] = [];
+  const post = (threadId: string): Request =>
+    new Request("https://host.test/api/vendo/threads", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        threadId,
+        message: { id: "m1", role: "user", parts: [{ type: "text", text: "hello" }] } as UIMessage,
+      }),
+    });
+
+  // One turn to pay for the deployment's own boot — opening the embedded
+  // database and ensuring its schema happens on the first request and dwarfs
+  // everything this test is looking at. The measured turn is the second one, so
+  // the clock below starts where `stream()` does.
+  await (await vendo.handler(post("thr_warm"))).text();
+  setUsageSink((event) => { posted.push(event); });
+  directionsAt = undefined;
+
+  turnStartedAt = Date.now();
+  const turn = await vendo.handler(post("thr_overlap"));
+  expect(await turn.text()).toContain("done");
+
+  const run = posted.find((event): event is AgentRun => event.name === "agent_run");
+  expect(run).toBeDefined();
+  expect(directionsAt).toBeDefined();
+  // The store phase is a real span on this turn — without one there is nothing
+  // for the prompt to have overlapped and the assertion below would be vacuous.
+  expect(run!.storeMs).toBeGreaterThan(0);
+  // THE assertion: prompt assembly began before the store phase had finished.
+  expect(directionsAt!).toBeLessThan(run!.storeMs);
+  // S1's split still adds up — an overlapped span is billed once, to whichever
+  // phase was still waiting, so the four marks can never over-claim the turn.
+  expect(run!.storeMs + run!.promptMs + run!.modelMs + run!.toolsMs + run!.guardMs)
+    .toBeLessThanOrEqual(run!.durationMs);
+});


### PR DESCRIPTION
Lane C of the latency build. Stacks on #1461 (`yousefh409/latency-telemetry`).

A turn did its setup one thing at a time. The system prompt was assembled only
after the opening store reads had finished, and inside the assembler the guard's
directions and the knowledge index — two waits on two different backends, neither
of which reads the other — were awaited one after the other. So a turn paid the
sum of three waits that had no reason to be in a line.

The prompt now starts with the turn and is awaited after the store phase, and the
assembler's two reads run together. **The assembled bytes are unchanged and
pinned**: section order comes from the `sections.push` sequence, never from which
read settles first, and `prompt-assembly-parallel.test.ts` assembles the whole
prompt with every section present and asserts exact equality against the
sequential form. The prompt-cache breakpoint layout in `loop.ts` is untouched
(`cache-breakpoints.test.ts` still green).

`promptMs` stays honest across the overlap. The phase split has to keep summing
to the wall clock, since `modelMs` is whatever the other four leave over — so an
overlapped span is billed once, to whichever phase was still waiting. `storeMs`
is still the store phase's own wall time; `promptMs` is now what the prompt still
cost the turn once the reads were done, which for a prompt that finished first is
honestly ~0. #1461's `TurnTimings` collector, its ttft mark and its
`durationMs`-from-the-top are all unchanged.

Three more places the turn was paying for nothing:

- The runtime re-validated the composed turn's transcript **against itself**.
  Composition hands it the very array it just read and validated, and one array
  cannot differ from itself, so `validateUpsert`'s double stringify per message
  and the history classification behind it were an O(n) pass per turn proving a
  tautology. The skip is keyed on that identity and nothing else — a
  client-posted transcript, the away runner, or a host's own runtime still takes
  both checks in full, which `transcript-restated.test.ts` pins.
- `vendo()` projected the host's catalog twice to set a turn up and again after
  every single tool call. It projects once now, and re-projects after a call only
  when that call can change what is reachable — the connector door.

And one real accounting bug: the compaction estimate billed every equipped tool
while the call only ever carries the active loadout, so a curated surface was
charged for a catalog it never sent. The trigger fired on tokens that were never
there and the shed floor was handed a figure the prompt had never reached. The
estimate bills the active set now. The characters-per-token ratio is unchanged.

## Not done in this PR (parked, with evidence)

- **Caching the knowledge manifest read / a failed `status()` with a TTL.** Both
  halves collide with shipped acceptance criteria.
  `packages/knowledge/tests/prompt-note.test.ts:153-179` asserts that the call
  immediately after a failed `status()` MUST retry, or a recovered engine is
  never picked up — the exact opposite of "the second turn makes no network
  call". And a TTL on the manifest read breaks `:106-120` and `:133-146`, which
  flip the manifest and require the very next resolve to see it. The read itself
  measures **21µs/turn** on a realistic 15KB manifest. Left untouched rather than
  reinterpreting either criterion.
- **Hoisting `residentTools` to per-process.** Every wrapper's `execute` closes
  over *this* turn's `turn`, and the object is mutated per turn by
  `refreshEquipped` and `find_tools` — sharing it across turns in one process
  would call a dead turn's guard and let one user's discovery equip another
  user's model. Measured value: 0.31 ms/turn at 50 tools. The two safe halves of
  that bullet (duplicated projection, per-call refresh) shipped.

## Gate

Scoped packages + typecheck, run locally on an idle box, output read back from files:

| command | result |
|---|---|
| `npx vitest run` (harnesses: runtime, transcript-restated, harness-state, vendo/) | 21 files, **253 passed**, 4 skipped |
| `npx vitest run` (vendo: 7 touched-surface files) | 7 files, **41 passed** |
| `pnpm typecheck` | 42/42 tasks successful |
| `pnpm build` | 21/21 tasks successful |
| `pnpm lint` | 0 errors |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Turns set up in parallel and compaction estimates bill only tools the turn actually sends. Old: the prompt assembled after store reads and awaited guard directions then knowledge in sequence, and the estimate charged all equipped tools. New: the prompt assembles beside the store phase with directions+knowledge awaited together and deterministic section order; the estimate counts only the active loadout; slow knowledge failures cool off instead of taxing every turn.

- `@vendoai/vendo`: start system prompt assembly before store reads finish; await guard directions and knowledge together with `Promise.all`; section order is pinned by push order; `promptMs` now measures only post-store wait (phase totals still ≤ wall clock).
- `@vendoai/harnesses`: skip `validateUpsert` and history classification when `transcript.list()` returns the same array as `messages`; compute wrappers and the initial loadout from one listing; re-project the catalog only after connector‑discovery calls; compaction estimate uses `activeTools` when present, otherwise all equipped tools.
- `@vendoai/knowledge`: treat a slow `status()` failure as a 1‑minute cool‑off and serve the last good/empty index during it; fast failures are retried next turn.

<sup>Written for commit bb972a636f349ed9d716dda63adf8b13164e206b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1467?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

