### PR TITLE
feat(vendo,automations): the permissions an automation needs can be allowed from the phone that armed it

### DIFF
--- a/.changeset/channel-grant-set-ask.md
+++ b/.changeset/channel-grant-set-ask.md
@@ -1,0 +1,38 @@
+---
+"@vendoai/vendo": minor
+"@vendoai/automations": patch
+---
+
+An automation armed from a phone can now be allowed to run from that phone. On
+2026-08-18 a user set up "check my checking balance every 15 minutes and text
+me" entirely over iMessage. The arming approval worked — the card went out as a
+text, their YES decided it — but arming also minted four pending standing-grant
+captures, and those asks are approval ROWS the engine writes during
+`vendo_automate`, never stream parts, so the mid-turn card watcher could not see
+them and their only surface was the host app's web approvals feed. A person who
+only texts can never reach it: every firing then ran without the Text me
+permission, and the agent could only report that "there are still some
+permissions pending approval" with nothing the person could do about it.
+
+After a channel turn finishes, one automation's outstanding permissions now go
+out as ONE more text — the automation named the way every other surface names it,
+one line per thing to allow, each line the descriptor's own human title:
+
+    check my checking balance and text me — needs your permission to run on its own:
+    - Text me
+    - Look it up in the docs
+    Reply YES to allow all of these, or NO to cancel it.
+
+YES decides the whole set in one batch call on the same guard door the web feed
+uses — all-or-none, never a half-granted set — and each approval settles into its
+standing grant through the automations engine's own decision subscriber. NO is
+the bare no it has always been: nothing is minted and the automation is turned
+off, and the reply says which of the two happened. The consent model is
+unchanged — the same captures, the same grants, the same one decision that
+settles them; only the delivery is new.
+
+One question at a time, the discipline the cards already keep: nothing goes out
+while the conversation is holding a card or a set ask it has not answered, the
+row is written only after the text lands, and a set is never asked twice. The
+store's pending feed is the source of truth rather than "did this turn arm
+something", so a set minted from the web is asked on the next texted turn too.

--- a/packages/automations/src/index.ts
+++ b/packages/automations/src/index.ts
@@ -39,6 +39,11 @@ export { automationsInternals, type AutomationsInternals } from "./engine.js";
  *  reached across the package boundary the dependency guard allows. */
 export { base64url, signedWebhookBytes, verifySignature } from "./webhook-signature.js";
 export type { ReconcileAutomations } from "./create-surface.js";
+/** What to CALL a record in a sentence a person reads. Exported because the text
+ *  channel names automations at someone too (`channel-turn.ts`), and design §3's
+ *  voice law only holds if every surface says the same name — a second spelling
+ *  is how one of them starts printing a tool identifier. */
+export { automationName } from "./messages.js";
 export { UNATTENDED_IRREVERSIBILITY_RULE, unattendedIrreversibilityCheck } from "./law.js";
 
 /** 07 §1 — createAutomations config. */

--- a/packages/vendo/src/channel-links.ts
+++ b/packages/vendo/src/channel-links.ts
@@ -14,6 +14,7 @@
 import {
   VendoError,
   type ApprovalId,
+  type AutomationId,
   type IsoDateTime,
   type StoreAdapter,
   type VendoRecord,
@@ -34,6 +35,10 @@ const ASK_COLLECTION = "vendo_channel_asks";
 /** An approval id IS the row id, and the guard mints them `apr_<uuid>`
  *  (guard.ts:205) — so a row that is not one was not written by this file. */
 const ASK_ID_PATTERN = /^apr_[0-9a-f-]+$/;
+/** How a grant-SET ask row is told apart from a card row in the one collection.
+ *  The prefix is what keeps `ids()` — which admits approval ids only — from ever
+ *  handing a set row to the card decider. */
+const SET_ID_PREFIX = "set_";
 
 /** Unambiguous alphabet: no O/0, no I/1/L. A person retypes this code from one
  *  message into another, on a phone keyboard. */
@@ -300,9 +305,67 @@ export class ChannelAskRepository {
     await this.records().delete(approvalId);
   }
 
+  /** Remember that this conversation was asked about one automation's whole set
+   *  of outstanding permissions, and which approvals that one text covers.
+   *
+   *  Keyed by the AUTOMATION, not by the engine's own `gset_` id: the engine
+   *  mints exactly one grant set per record — arming reuses the record's still
+   *  pending set and a fire-time miss joins it (automations `consent.ts`,
+   *  `captureGrants` and `needsPermission`) — so the automation names the same
+   *  set without this file reading the engine's private capture rows. The row
+   *  lives from the moment the text lands until a YES or NO settles it, which
+   *  makes it both what a bare reply routes to and the memory that stops a later
+   *  turn asking the same set twice. */
+  async addSet(
+    subject: string,
+    conversationId: string,
+    automationId: AutomationId,
+    approvals: readonly ApprovalId[],
+  ): Promise<void> {
+    await this.records().put({
+      id: `${SET_ID_PREFIX}${automationId}`,
+      data: { subject, conversationId, automationId, approvals: [...approvals] },
+      refs: { subject, conversation: conversationId },
+    });
+  }
+
+  /** The grant set ask this conversation is holding, if any. One at a time, like
+   *  the cards: whichever row the store lists first is the open question, and
+   *  nothing new goes out while one is here. */
+  async setAsk(conversationId: string): Promise<ChannelGrantSetAsk | null> {
+    let cursor: string | undefined;
+    do {
+      const page = await this.records().list({
+        refs: { conversation: conversationId },
+        ...(cursor === undefined ? {} : { cursor }),
+      });
+      for (const record of page.records) {
+        if (!record.id.startsWith(SET_ID_PREFIX)) continue;
+        const data = record.data as Partial<ChannelGrantSetAsk> | null;
+        if (typeof data?.automationId === "string" && Array.isArray(data.approvals)) {
+          return { automationId: data.automationId as AutomationId, approvals: data.approvals };
+        }
+      }
+      cursor = page.cursor;
+    } while (cursor !== undefined);
+    return null;
+  }
+
+  /** Spend the set row: its question has been answered, or answered elsewhere. */
+  async consumeSet(automationId: AutomationId): Promise<void> {
+    await this.records().delete(`${SET_ID_PREFIX}${automationId}`);
+  }
+
   private records(): ReturnType<StoreAdapter["records"]> {
     return this.store.records(ASK_COLLECTION);
   }
+}
+
+/** One automation's outstanding permissions, as this conversation was asked
+ *  about them. */
+export interface ChannelGrantSetAsk {
+  automationId: AutomationId;
+  approvals: readonly ApprovalId[];
 }
 
 /** The row id for a delivery: a digest, because the id is the vendor's string

--- a/packages/vendo/src/channel-turn.ts
+++ b/packages/vendo/src/channel-turn.ts
@@ -8,16 +8,23 @@
  * `venue: "chat"`, `presence: "present"`, the subject from the link, and the
  * delivery's `eventId` as the conversation the guard scopes its cards by.
  */
+import { automationName, type AutomationsEngine } from "@vendoai/automations";
 import {
   AGENT_CONTEXT_MARK,
   type ApprovalRequest,
+  type AutomationId,
   type Principal,
   type RunContext,
 } from "@vendoai/core";
 import type { VendoGuard } from "@vendoai/guard";
 import { THREAD_ID_HEADER } from "@vendoai/harnesses";
 import type { UIMessage } from "ai";
-import type { ChannelAskRepository, ChannelLink, ChannelLinkRepository } from "./channel-links.js";
+import type {
+  ChannelAskRepository,
+  ChannelGrantSetAsk,
+  ChannelLink,
+  ChannelLinkRepository,
+} from "./channel-links.js";
 import type { ChannelsService, InboundTextEvent } from "./channels.js";
 import type { HarnessTurns } from "./harness-turn.js";
 
@@ -90,6 +97,9 @@ export interface ChannelTurnDeps {
   /** Which cards actually went out over this channel — see
    *  `ChannelAskRepository`, and why it is in the store and not in memory. */
   asks: ChannelAskRepository;
+  /** Read-only, and only to NAME an automation whose grant set is being asked
+   *  about: the asks themselves are read off the guard's pending feed. */
+  automations: Pick<AutomationsEngine, "get">;
 }
 
 /** A schema property description cut down to a label: everything before the
@@ -168,6 +178,119 @@ function approvalText(request: ApprovalRequest): string {
   ].join("\n");
 }
 
+/**
+ * The one text a whole grant set goes out as.
+ *
+ * Arming an automation captures a standing-permission ask per thing it will need
+ * (automations `consent.ts`), and those asks are approval ROWS the engine writes
+ * during the `vendo_automate` call — they never ride the turn's stream, so the
+ * mid-turn card watcher above cannot see them. Until this existed their only
+ * surface was the host app's web approvals feed, which a person who only ever
+ * texts can never reach: live 2026-08-18 a user armed "check my balance every 15
+ * minutes and text me" entirely over iMessage, the arming YES landed, and every
+ * firing then ran without the Text me permission while the agent told them
+ * "there are still some permissions pending approval".
+ *
+ * ONE text for the whole set, because the set exists precisely so one decision
+ * settles everything outstanding. The automation is named the way every other
+ * surface names it, and each line is the descriptor's own human title — never a
+ * tool identifier, which is design §3's voice law and the same rule
+ * `approvalText` follows.
+ */
+function grantSetText(name: string, titles: readonly string[]): string {
+  return [
+    `${name} — needs your permission to run on its own:`,
+    ...titles.map((title) => `- ${title}`),
+    "Reply YES to allow all of these, or NO to cancel it.",
+  ].join("\n");
+}
+
+/** What a decided set is answered with. A set ask has no parked turn behind it to
+ *  speak for itself — unlike a card, where the turn that was blocked delivers its
+ *  own reply — so these two sentences are the whole receipt. The NO wording says
+ *  what a bare no actually DOES: `handleDecision` disarms a consent moment that
+ *  ended with nothing granted (automations `consent.ts`). */
+const SET_ALLOWED = "Done — it can run on its own now.";
+const SET_CANCELLED = "Okay — I turned it off.";
+
+/** The automation grant asks this subject has outstanding, grouped by the
+ *  automation they belong to, oldest first.
+ *
+ *  Read off the guard's own pending feed rather than the engine's capture rows: a
+ *  pending `venue: "automation"` approval carrying an automation id is exactly
+ *  what a capture is the ask for, it is already scoped to this subject, and it
+ *  arrives with the descriptor whose title the text prints. A goal firing's own
+ *  away ask lands here too, and should — it settles into the same standing grant
+ *  through the same subscriber, and it is just as unanswerable over text. */
+function grantSetsByAutomation(pending: readonly ApprovalRequest[]): Map<AutomationId, ApprovalRequest[]> {
+  const sets = new Map<AutomationId, ApprovalRequest[]>();
+  for (const request of [...pending].sort((a, b) => a.createdAt.localeCompare(b.createdAt))) {
+    const automationId = request.ctx.venue === "automation" ? request.ctx.trigger?.automationId : undefined;
+    if (automationId === undefined) continue;
+    const group = sets.get(automationId);
+    if (group === undefined) sets.set(automationId, [request]);
+    else group.push(request);
+  }
+  return sets;
+}
+
+/** The set ask this conversation is still waiting on, or null.
+ *
+ *  A row whose approvals are all decided somewhere else — the web feed, the
+ *  guard's TTL sweep — is SPENT, not outstanding, so it is consumed here: one
+ *  abandoned set must never become a permanent block on every later one. */
+async function outstandingSet(
+  deps: Pick<ChannelTurnDeps, "asks">,
+  conversationId: string,
+  pending: readonly ApprovalRequest[],
+): Promise<ChannelGrantSetAsk | null> {
+  const row = await deps.asks.setAsk(conversationId);
+  if (row === null) return null;
+  const live = row.approvals.filter((id) => pending.some((request) => request.id === id));
+  if (live.length > 0) return { automationId: row.automationId, approvals: live };
+  await deps.asks.consumeSet(row.automationId);
+  return null;
+}
+
+/**
+ * After the turn: one automation's outstanding permissions, asked over the
+ * channel that armed it.
+ *
+ * ONE question at a time, the discipline the cards already keep: nothing goes out
+ * while this conversation is holding a card it has not answered, or a set ask it
+ * has not answered — the next turn picks up whatever is still outstanding then.
+ * And the row is written only AFTER the text lands, for the same reason
+ * `asks.add` is: a set nobody was shown must not be answerable, and a failed
+ * delivery should leave the ask to be made again rather than silently spent.
+ */
+async function offerGrantSet(
+  deps: Pick<ChannelTurnDeps, "asks" | "automations">,
+  input: { ctx: RunContext; conversationId: string; pending: readonly ApprovalRequest[] },
+  send: (text: string) => Promise<void>,
+): Promise<void> {
+  const { ctx, conversationId, pending } = input;
+  const sets = grantSetsByAutomation(pending);
+  if (sets.size === 0) return;
+  // A card this conversation was shown and has not decided — a park from an
+  // earlier turn whose ten-minute waiter is still running. Compared against the
+  // LIVE pending feed, never against the rows alone: a card row outlives its
+  // approval when something other than a reply decided it, and a stale row must
+  // not silence this ask forever.
+  const cards = await deps.asks.ids(conversationId);
+  if (pending.some((request) => cards.includes(request.id))) return;
+  if (await outstandingSet(deps, conversationId, pending) !== null) return;
+  for (const [automationId, asks] of sets) {
+    const record = await deps.automations.get(automationId, ctx);
+    // A record that is gone leaves asks nothing can name; the guard's TTL sweep
+    // is what closes those.
+    if (record === null) continue;
+    const titles = asks.map((ask) => ask.descriptor.title ?? ask.descriptor.name);
+    await send(grantSetText(automationName(record), titles));
+    await deps.asks.addSet(ctx.principal.subject, conversationId, automationId, asks.map((ask) => ask.id));
+    return;
+  }
+}
+
 /** The assistant's words for the turn, read back off the SSE the harness door
  *  answers with. Keepalives are comment frames and never match `data: `. */
 async function assistantText(response: Response): Promise<string> {
@@ -224,14 +347,34 @@ export async function runChannelTurn(
 
   const answer = event.text.trim();
   if (YES.test(answer) || NO.test(answer)) {
+    const pending = await deps.guard.approvals.pending(principal);
     const asked = await deps.asks.ids(event.conversationId);
-    const mine = (await deps.guard.approvals.pending(principal))
+    const mine = pending
       .filter((request) => asked.includes(request.id))
       .sort((a, b) => a.createdAt.localeCompare(b.createdAt))
       .at(-1);
     if (mine !== undefined) {
       await deps.guard.approvals.decide(mine.id, { approve: YES.test(answer) }, principal);
       await deps.asks.consume(mine.id);
+      return;
+    }
+    // No card to answer, but a grant set can be the open question instead. Cards
+    // come first on purpose: a card is a turn blocked right now, and one is never
+    // sent while a set ask is outstanding, so whichever of the two exists is the
+    // last thing this person was shown.
+    const set = await outstandingSet(deps, event.conversationId, pending);
+    if (set !== null) {
+      const approve = YES.test(answer);
+      // ONE batch decide, which is what the web feed sends for a grant set too:
+      // the guard treats a multi-id decide as a set decision — validated and
+      // committed all-or-none, never a half-granted set (guard.ts) — and then
+      // fans out to the automations engine's decision subscriber per approval,
+      // which is the one path that mints each standing grant. There is no
+      // settle-by-set verb on the server: `grantSetId` is a grouping label, and
+      // `handleDecision` reads the capture keyed by ONE approval id.
+      await deps.guard.approvals.decide([...set.approvals], { approve }, principal);
+      await deps.asks.consumeSet(set.automationId);
+      await send(approve ? SET_ALLOWED : SET_CANCELLED);
       return;
     }
   }
@@ -272,6 +415,16 @@ export async function runChannelTurn(
     if (effective !== null) await deps.links.rememberTurn(link, effective, event.conversationId);
     const text = await assistantText(response);
     await send(text === "" ? NOTHING_TO_SAY : text);
+    // AFTER the turn's own words, and only then: the standing-permission asks
+    // arming raises are approval rows, not stream parts, so nothing inside the
+    // turn could have offered them. The pending feed is the source of truth here
+    // rather than "did this turn arm something" — a set minted from the WEB gets
+    // asked on the next texted turn, which is exactly right.
+    await offerGrantSet(
+      deps,
+      { ctx, conversationId: event.conversationId, pending: await deps.guard.approvals.pending(principal) },
+      send,
+    );
   } finally {
     unsubscribe();
   }

--- a/packages/vendo/src/compose-channels.ts
+++ b/packages/vendo/src/compose-channels.ts
@@ -163,6 +163,7 @@ export const composeChannels = (composition: VendoComposition): Pick<VendoCompos
           channel: channels,
           links,
           asks,
+          automations: composition.automations,
         },
         { event, link: known },
       );

--- a/packages/vendo/tests/channel-grant-set.e2e.test.ts
+++ b/packages/vendo/tests/channel-grant-set.e2e.test.ts
@@ -1,0 +1,324 @@
+import { createServer, type Server } from "node:http";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AddressInfo } from "node:net";
+import {
+  VENDO_AUTOMATE_TOOL,
+  type AutomationRecord,
+  type Principal,
+  type RunContext,
+  type ToolDescriptor,
+  type ToolRegistry,
+} from "@vendoai/core";
+import { defineHarness } from "@vendoai/harnesses";
+import { createStore, type VendoStore } from "@vendoai/store";
+import type { LanguageModel } from "ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { channelInboundSecret } from "../src/channels.js";
+import { createVendo, guard, type Vendo } from "../src/server.js";
+import { VENDO_TEXT_ME_TOOL } from "../src/text-me.js";
+
+/**
+ * ARMING AN AUTOMATION FROM A PHONE, ALL THE WAY TO A FIRING THAT DELIVERS.
+ *
+ * The gap this pins, live 2026-08-18 on production Maple: a user armed "check my
+ * checking balance every 15 minutes and text me" entirely over iMessage. The
+ * arming approval worked — the card went out as a text and their YES decided it —
+ * but arming ALSO minted four pending standing-grant captures, and those asks are
+ * approval rows the engine writes during `vendo_automate`, not stream parts. They
+ * had exactly one surface: the host app's web approvals feed. A text-only user
+ * could never reach it, so every firing ran without the Text me grant and the
+ * agent could only say "there are still some permissions pending approval".
+ *
+ * Nothing is stubbed between the two halves: real `createVendo`, real guard, real
+ * automations engine, one real PGlite store, the real `cloudTextChannel` client,
+ * and an HTTP console standing in for the one half this repo does not own. The
+ * grants are read back through the path that actually gates a firing — the away
+ * run's own call to `vendo_text_me` reaching the console — because a grant row
+ * that the guard would not honour proves nothing.
+ */
+
+const API_KEY = "vk_live_grant_set";
+const owner: Principal = { kind: "user", subject: "user_grant_set" };
+const PHONE = "+15557770456";
+const CONVERSATION = "conv_grant_set";
+const BALANCE_TOOL = "maple_accounts_balance";
+/** The goal an automation is armed with, and the phrase the probe brain keys the
+ *  firing branch off. */
+const GOAL = "check my checking balance and text me";
+const SET_ASK_HEADER = "needs your permission to run on its own";
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+  vi.unstubAllEnvs();
+});
+
+interface FakeConsole {
+  baseUrl: string;
+  sent: Array<{ conversationId: string; text: string }>;
+}
+
+async function fakeConsole(): Promise<FakeConsole> {
+  const state: FakeConsole = { baseUrl: "", sent: [] };
+  const server: Server = createServer((req, res) => {
+    let body = "";
+    req.on("data", (chunk) => (body += String(chunk)));
+    req.on("end", () => {
+      res.setHeader("content-type", "application/json");
+      if (req.url === "/api/v1/channels/text/register") {
+        res.end(JSON.stringify({
+          identityId: "tid_grant_set",
+          handle: "maple",
+          number: "+15550000000",
+          connectCommand: "connect @maple",
+        }));
+        return;
+      }
+      if (req.url === "/api/v1/channels/text/send") {
+        state.sent.push(JSON.parse(body) as { conversationId: string; text: string });
+        res.end(JSON.stringify({ ok: true }));
+        return;
+      }
+      res.statusCode = 404;
+      res.end("{}");
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  cleanups.push(async () => new Promise<void>((resolve) => server.close(() => resolve())));
+  const { port } = server.address() as AddressInfo;
+  state.baseUrl = `http://127.0.0.1:${port}`;
+  return state;
+}
+
+/** One read the host owns, so the goal's consent surface is more than Vendo's own
+ *  tools — the set ask has to name every one of them. */
+function bankingHost(): ToolRegistry {
+  const descriptor: ToolDescriptor = {
+    name: BALANCE_TOOL,
+    title: "Check an account balance",
+    description: "Read the balance of one of the customer's accounts",
+    inputSchema: { type: "object" },
+    risk: "read",
+  };
+  return {
+    async descriptors() {
+      return [descriptor];
+    },
+    async execute() {
+      return { status: "ok", output: { balance: 41_208 } };
+    },
+  };
+}
+
+/** The brain, on both sides of the same composition: it arms when asked to, it
+ *  texts when a firing hands it the goal, and it just answers otherwise. One
+ *  harness rather than three because the automation has to be armed by the SAME
+ *  deployment whose away run later fires it. */
+const probe = defineHarness({
+  name: "channel-grant-set-probe",
+  async *run(turn) {
+    const said = (turn.messages.at(-1)?.parts ?? [])
+      .map((part) => (part.type === "text" ? part.text : ""))
+      .join(" ");
+    if (said.includes("arm:")) {
+      const armed = await turn.tools.call(VENDO_AUTOMATE_TOOL, { when: { event: "balance.checked" }, task: GOAL });
+      yield { type: "text", delta: armed.status === "ok" ? "Set — I'll keep an eye on it." : "I couldn't set that up." };
+      return;
+    }
+    if (said.includes("checking balance")) {
+      const sent = await turn.tools.call(VENDO_TEXT_ME_TOOL, { text: "Your checking balance is $412.08." });
+      yield { type: "text", delta: sent.status === "ok" ? "Texted them." : "Could not text them." };
+      return;
+    }
+    yield { type: "text", delta: "Nothing else is due this week." };
+  },
+});
+
+async function tempStore(): Promise<VendoStore> {
+  const dataDir = await mkdtemp(join(tmpdir(), "vendo-grant-set-"));
+  const store = createStore({ dataDir });
+  cleanups.push(async () => {
+    await store.close();
+    await rm(dataDir, { recursive: true, force: true });
+  });
+  return store;
+}
+
+async function waitFor(check: () => boolean): Promise<void> {
+  while (!check()) await new Promise((resolve) => setTimeout(resolve, 25));
+}
+
+async function compose(cloud: FakeConsole): Promise<Vendo> {
+  vi.stubEnv("VENDO_API_KEY", API_KEY);
+  vi.stubEnv("VENDO_CLOUD_URL", cloud.baseUrl);
+  vi.stubEnv("VENDO_BASE_URL", "https://maple.test");
+  const vendo: Vendo = createVendo({
+    models: { default: {} as LanguageModel },
+    principal: async () => owner,
+    store: await tempStore(),
+    harness: probe as never,
+    // Arming future unattended behaviour is a write, so `vendo_automate` itself
+    // earns a card — which is the flow the live incident got RIGHT.
+    guard: guard({ policy: { rules: [{ match: { risk: "write" }, action: "ask" }] } }),
+    channels: { text: true },
+  } as Parameters<typeof createVendo>[0]);
+  vendo.actions.add(bankingHost());
+  return vendo;
+}
+
+const inbound = async (vendo: Vendo, eventId: string, text: string): Promise<Response> =>
+  vendo.handler(new Request("https://maple.test/api/vendo/channels/text/inbound", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${await channelInboundSecret(API_KEY)}`,
+    },
+    body: JSON.stringify({
+      eventId,
+      channel: "text",
+      from: PHONE,
+      text,
+      conversationId: CONVERSATION,
+      receivedAt: new Date().toISOString(),
+    }),
+  }));
+
+/** A linked, texting user — the code off the link page, then nothing else. */
+async function link(vendo: Vendo, cloud: FakeConsole): Promise<void> {
+  const page = await (await vendo.handler(
+    new Request("https://maple.test/api/vendo/channels/text/link", { headers: { "user-agent": "Macintosh" } }),
+  )).text();
+  await inbound(vendo, "evt_link", /connect @maple ([23456789A-Z]{6})/.exec(page)![1]!);
+  await waitFor(() => cloud.sent.length === 1);
+}
+
+/** Arm the automation the way the live user did: one text asking for it, the
+ *  arming card, and a YES. Answers the set ask that lands after the turn. */
+async function armOverText(
+  vendo: Vendo,
+  cloud: FakeConsole,
+): Promise<{ record: AutomationRecord; ctx: RunContext; setAsk: string }> {
+  await link(vendo, cloud);
+  await inbound(vendo, "evt_arm", `arm: ${GOAL} every 15 minutes`);
+  // The arming card.
+  await waitFor(() => cloud.sent.length === 2);
+  expect(cloud.sent[1]!.text).toContain("Set this to run on its own — needs your approval");
+
+  await inbound(vendo, "evt_arm_yes", "YES");
+  // The turn's own words, and then the set ask behind them.
+  await waitFor(() => cloud.sent.length === 4);
+
+  const ctx: RunContext = { principal: owner, venue: "chat", presence: "present", sessionId: "sess_grant_set" };
+  const records = await vendo.automations.list({ owner: owner.subject }, ctx);
+  expect(records).toHaveLength(1);
+  return { record: records[0]!, ctx, setAsk: cloud.sent[3]!.text };
+}
+
+describe.sequential("an automation's grant set, asked over text", () => {
+  it("asks for the whole set in ONE text, by title, after the arming turn", async () => {
+    const cloud = await fakeConsole();
+    const vendo = await compose(cloud);
+    const { record, setAsk } = await armOverText(vendo, cloud);
+
+    // Every ask arming raised is still pending — nothing about the set ask
+    // decides anything — and the text names every one of them.
+    const pending = await vendo.guard.approvals.pending(owner);
+    const captures = pending.filter((ask) => ask.ctx.trigger?.automationId === record.id);
+    expect(captures.length).toBeGreaterThan(1);
+
+    expect(setAsk.startsWith(`${GOAL} — ${SET_ASK_HEADER}:`)).toBe(true);
+    for (const ask of captures) {
+      expect(setAsk).toContain(`\n- ${ask.descriptor.title ?? ask.descriptor.name}`);
+    }
+    // The one the live incident lost: without it the automation can never reach
+    // the phone it was armed from.
+    expect(setAsk).toContain("\n- Text me");
+    expect(setAsk).toContain("\n- Check an account balance");
+    expect(setAsk).toContain("Reply YES to allow all of these, or NO to cancel it.");
+    // Design §3's voice law: no identifier, and no machinery, reaches the person.
+    expect(setAsk).not.toContain("vendo_");
+    expect(setAsk).not.toContain(BALANCE_TOOL);
+    expect(setAsk).not.toContain("gset_");
+    expect(setAsk).not.toContain("{");
+
+    // ONE text for the whole set, not one per capture — which is the entire
+    // reason a grant SET exists.
+    expect(cloud.sent.filter((text) => text.text.includes(SET_ASK_HEADER))).toHaveLength(1);
+  }, 120_000);
+
+  it("turns one YES into every standing grant, and the next firing really texts", async () => {
+    const cloud = await fakeConsole();
+    const vendo = await compose(cloud);
+    const { record, ctx } = await armOverText(vendo, cloud);
+    const before = cloud.sent.length;
+
+    await inbound(vendo, "evt_set_yes", "YES");
+    await waitFor(() => cloud.sent.length > before);
+
+    // Every capture in the set settled: no ask of this automation's is left
+    // pending, and each one is now a live standing grant the guard will honour
+    // away.
+    const stillPending = await vendo.guard.approvals.pending(owner);
+    expect(stillPending.filter((ask) => ask.ctx.trigger?.automationId === record.id)).toEqual([]);
+    const grants = await vendo.guard.grants.list(owner);
+    expect(grants.length).toBeGreaterThan(1);
+    for (const grant of grants) {
+      expect(grant).toMatchObject({
+        subject: owner.subject,
+        automationId: record.id,
+        source: "automation",
+        duration: "standing",
+      });
+    }
+    expect(grants.map((grant) => grant.tool)).toContain(VENDO_TEXT_ME_TOOL);
+    expect(cloud.sent.at(-1)!.text).toBe("Done — it can run on its own now.");
+
+    // THE POINT. An away firing of the automation they armed from their phone
+    // now reaches that phone — through the away runner, the guard's away
+    // authority check, the real `vendo_text_me`, and the console's own send
+    // route. A grant row the guard would not honour would leave this silent.
+    const landed = cloud.sent.length;
+    const [runId] = await vendo.emit("balance.checked", {}, owner);
+    expect(await vendo.automations.runs.get(runId!, ctx)).toMatchObject({
+      automationId: record.id,
+      status: "ok",
+    });
+    expect(cloud.sent.slice(landed)).toEqual([
+      { conversationId: CONVERSATION, text: "Your checking balance is $412.08." },
+    ]);
+  }, 120_000);
+
+  it("turns a NO into the disarm a bare no has always meant, and says so", async () => {
+    const cloud = await fakeConsole();
+    const vendo = await compose(cloud);
+    const { record, ctx } = await armOverText(vendo, cloud);
+    expect(record.armed).toBe(true);
+    const before = cloud.sent.length;
+
+    await inbound(vendo, "evt_set_no", "no");
+    await waitFor(() => cloud.sent.length > before);
+
+    // `handleDecision`'s deny half (automations `consent.ts`): a consent moment
+    // that ended with NOTHING granted turns the record off. Nothing is minted,
+    // and the person is told which of the two things happened.
+    expect(await vendo.automations.get(record.id, ctx)).toMatchObject({ armed: false });
+    expect(await vendo.guard.grants.list(owner)).toEqual([]);
+    expect(cloud.sent.at(-1)!.text).toBe("Okay — I turned it off.");
+  }, 120_000);
+
+  it("never asks the same set twice, however many turns go by", async () => {
+    const cloud = await fakeConsole();
+    const vendo = await compose(cloud);
+    await armOverText(vendo, cloud);
+
+    // An ordinary turn about something else entirely. The set is still
+    // outstanding — the person simply has not answered — and re-asking it every
+    // turn is how this feature would become the thing they mute.
+    await inbound(vendo, "evt_later", "what did I spend on food?");
+    await waitFor(() => cloud.sent.at(-1)!.text === "Nothing else is due this week.");
+
+    expect(cloud.sent.filter((text) => text.text.includes(SET_ASK_HEADER))).toHaveLength(1);
+  }, 120_000);
+});


### PR DESCRIPTION
## The gap (live 2026-08-18, production Maple)

A user armed **"check my checking balance every 15 minutes and text me"** entirely over iMessage.

The arming approval worked — `vendo_automate` is a write, so it parked, the card went out as a text, and their YES decided it. But arming *also* minted four pending standing-grant captures (`vendo_text_me`, `vendo_knowledge_search`, `request_connection`, `list_connections` — one grant set, `gset_*`). Those asks are approval **rows** the automations engine writes during the `vendo_automate` call ([`consent.ts` `captureGrants`](https://github.com/runvendo/vendo/blob/main/packages/automations/src/consent.ts)); they never ride the turn's SSE stream, so the mid-turn card watcher in `channel-turn.ts` could not see them, and their only surface was the host app's **web approvals feed**.

A text-only user can never reach that feed. So every firing ran without the Text me grant, and the agent could only tell them *"there are still some permissions pending approval"* — with nothing they could do about it.

## The flow now

After a channel turn finishes, the channel reads the subject's pending automation grant asks and, if this conversation has never been asked about them, sends ONE more text for the whole set:

```
check my checking balance and text me — needs your permission to run on its own:
- Text me
- Look it up in the docs
- Check an account balance
Reply YES to allow all of these, or NO to cancel it.
```

- The automation is named by `automationName()` — the same helper every other surface names a record with (now exported from `@vendoai/automations` so there is one spelling, not two).
- One line per pending capture, each line the **descriptor's own human title**. No tool identifier, no `gset_`, no JSON — design §3's voice law, the same rule `approvalText` follows since #1458.
- **YES** decides the set with one batch `guard.approvals.decide([...ids], { approve: true })` — the same door the web feed's set decision uses. The guard treats a multi-id decide as a set decision: validated and committed all-or-none, never a half-granted set, then it fans out to the automations engine's decision subscriber **per approval**, which is the one path that mints each standing grant. There is no settle-by-set verb on the server — `grantSetId` is a grouping label, and `handleDecision` reads the capture keyed by one approval id — so per-capture fan-out inside one batch call is what settling the set *is*.
- **NO** is the bare no it has always been: nothing is minted, and `handleDecision`'s deny half disarms a consent moment that ended with nothing granted. The reply says which of the two happened (`"Okay — I turned it off."` / `"Done — it can run on its own now."`), because a set ask has no parked turn behind it to speak for itself.

**The consent model is unchanged** — same captures, same grants, same one decision that settles them. Only the delivery is new.

### Discipline

- **One question at a time**, the rule the cards already keep: nothing goes out while the conversation is holding a card it has not decided, or a set ask it has not answered. The card check is made against the guard's **live** pending feed, never the ask rows alone, so a stale row can never silence this ask forever.
- **Idempotent.** The set ask is a row in the existing `vendo_channel_asks` collection, keyed by the automation and prefixed `set_` so `ids()` (approval ids only) can never hand one to the card decider. It lives from the moment the text lands until a YES or NO settles it, which makes it both what a bare reply routes to and the memory that stops a later turn re-asking. A row whose approvals were all decided elsewhere (web feed, TTL sweep) is *spent*, not outstanding — it self-heals, so one abandoned set never blocks every later one.
- **Keyed by the automation, not by `gset_`**, deliberately: the engine mints exactly one grant set per record — `captureGrants` reuses the record's still-pending set and `needsPermission` joins it — so the automation names the same set without this file reading the engine's private capture rows. (The record's own `grantSetId` field is *not* usable for this: it is stamped only when asks are outstanding and never cleared, so it goes stale.)
- **Row after send**, same law as `asks.add`: a set nobody was shown must not be answerable, and a failed delivery leaves the ask to be made again.
- **Scoped to the subject**, from the guard's own pending feed. Which means a set minted from the **web** is asked on the next texted turn — intended, and good.

## Tests

`packages/vendo/tests/channel-grant-set.e2e.test.ts` — real `createVendo`, real guard, real automations engine, one real PGlite store, the real `cloudTextChannel` client, and an HTTP console standing in for the half this repo does not own. Nothing between the producer and the consumer is stubbed.

1. **Arms a goal automation over the channel** (text → `vendo_automate` card → YES) → after the arming turn exactly ONE set-ask text lands, naming every pending capture's title (derived from the guard's own pending feed, not hardcoded), with no identifier, no `gset_`, no JSON.
2. **YES** → every capture in the set becomes a live standing grant scoped to that automation, no ask of its own is left pending — and then `vendo.emit` fires the automation away, the away runner calls the real `vendo_text_me`, and the **console really receives the text**. A grant row the guard would not honour leaves this silent.
3. **NO** → the record is disarmed (what `handleDecision` actually does), no grant is minted, and the person is told.
4. **A later unrelated turn does not re-ask** the still-outstanding set.

**Prove-it-can-fail:** stubbed out the set's `guard.approvals.decide` in `channel-turn.ts` and re-ran test 2 — red (`expected [ …18 items ] to deeply equal []`: every capture stayed pending, no grant, no text). Restored, green.

## Gate

`pnpm build && pnpm test:affected && pnpm typecheck && pnpm lint` on the touched scope: build, typecheck and lint green; tests green except three pre-existing `ENOENT … Cool%20Code …` failures (`your-agent-docs.docs.test.ts` ×2, `cli/init-mcp.test.ts` ×1) — the worktree-path-with-a-space artifact. Reproduced identically with this branch's changes stashed. `@vendoai/automations` 104/104, `@vendoai/vendo` 2449 passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow granting an automation’s standing permissions from the same phone that armed it. Previously, standing-grant asks only surfaced on the web approvals feed; now the channel sends one follow‑up text per automation after a turn. YES approves the whole set in one batch; NO cancels and disarms. Consent model is unchanged.

- Consistent naming: exports `automationName` from `@vendoai/automations`; the set-ask text uses the automation’s name and each capture’s human title.
- One question at a time: no set ask is sent while a card or another set ask is outstanding; a single extra text may follow a turn.
- Channel logic: `channel-turn.ts` groups pending approvals by automation, sends a single set-ask text, records an idempotent ask row, and handles YES/NO with a multi-id `guard.approvals.decide` (all-or-none), then replies with a short receipt.
- Store plumbing: `channel-links.ts` adds `set_`-prefixed rows (`addSet`, `setAsk`, `consumeSet`) so card handling is unaffected and stale rows self-heal when approvals resolve elsewhere.
- Wiring and tests: `compose-channels.ts` provides `automations` to the channel; `channel-grant-set.e2e.test.ts` covers arm over text, YES minting standing grants and triggering `vendo_text_me`, NO disarming, and no re-ask on later turns.

<sup>Written for commit 0d75fa61f775d018c4e049a17aac17cb1a98434d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1469?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

