### PR TITLE
docs: Users & orgs section

### DIFF
--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -197,6 +197,18 @@
                 ]
               }
             ]
+          },
+          {
+            "group": "Users & orgs",
+            "pages": [
+              "users-orgs/your-users",
+              "users-orgs/orgs-and-memberships",
+              "users-orgs/sharing",
+              "users-orgs/org-workspace",
+              "users-orgs/org-policy",
+              "users-orgs/limits",
+              "users-orgs/erasing-a-user"
+            ]
           }
         ]
       },

--- a/docs-site/production/persistence.mdx
+++ b/docs-site/production/persistence.mdx
@@ -92,9 +92,12 @@ than as a silent no-op.
 
 ## Erasing a user
 
-`eraseStore` is the deletion path for right-to-erasure requests, for tearing
-down a test app, and for purging old runs. It cascades across every store
-table.
+Erasure is the deletion path for right-to-erasure requests, for tearing down a
+test app, and for purging old runs. It cascades across every store table, and
+which call you make depends on which store this deployment composed.
+
+A LOCAL store — the default, or your own Postgres — runs the SQL cascade through
+`eraseStore`, which takes the `files` adapter so rows and objects go together:
 
 ```ts highlight={4}
 import { eraseStore } from "@vendoai/vendo/server";
@@ -106,11 +109,25 @@ const report = await eraseStore(vendo.store, { files }).bySubject(subjectId);
 const byApp = await eraseStore(vendo.store, { files }).byApp(appId);
 ```
 
-Each call returns per-table deleted counts, so you can log the cascade or
-assert on it.
+The HOSTED store carries its own erase door with the same two methods and no
+`files` — the console cascades its own storage server-side. `eraseStore` cannot
+be handed that store: it throws `Unknown VendoStore handle` before any request
+goes out.
+
+```ts highlight={3}
+import type { HostedStore } from "@vendoai/vendo/server";
+
+const hosted = (vendo.store as HostedStore).erase;
+const report = await hosted.bySubject(subjectId);
+const byApp = await hosted.byApp(appId);
+```
+
+Either way the call returns per-table deleted counts, so you can log the cascade
+or assert on it. [Erasing a user](/users-orgs/erasing-a-user) has the one branch
+that serves both postures — the branch the Maple demo ships.
 
 <Warning>
-  Against Vendo Cloud, `eraseStore` needs an **admin-scoped** `VENDO_API_KEY`.
+  Against Vendo Cloud, the erase door needs an **admin-scoped** `VENDO_API_KEY`.
   A runtime-scoped key is refused with HTTP 403 and the `blocked` code before
   the request body is read.
 

--- a/docs-site/production/persistence.mdx
+++ b/docs-site/production/persistence.mdx
@@ -100,10 +100,10 @@ table.
 import { eraseStore } from "@vendoai/vendo/server";
 
 // Everything this subject owns, across every table.
-const report = await eraseStore(vendo.store).bySubject(subjectId);
+const report = await eraseStore(vendo.store, { files }).bySubject(subjectId);
 
 // Everything one app owns.
-const byApp = await eraseStore(vendo.store).byApp(appId);
+const byApp = await eraseStore(vendo.store, { files }).byApp(appId);
 ```
 
 Each call returns per-table deleted counts, so you can log the cascade or

--- a/docs-site/reference/handler-options.mdx
+++ b/docs-site/reference/handler-options.mdx
@@ -31,7 +31,7 @@ One key is required, an identity, as either `principal` or an `auth` preset. `oa
 | `actAs` | Escape hatch supplying scoped auth material for away host API execution. Mutually exclusive with `auth` |
 | `serverActions` | The map `vendo sync` emits, keyed `"<module>#<exportName>"`. A missing key fails closed at execution |
 | `guard` | The deployment's choke point as one value. See [below](#guard) |
-| `limits` | Per-user limits in your own logic. See [below](#limits) |
+| `limits` | Per-user and per-org limits in your own logic. See [below](#limits) and [Limits](/users-orgs/limits) |
 | `secrets` | `{ get(name) }`. Default is environment-backed lookup |
 | `logger` | One structured event per line Vendo would have written to the console. Unset keeps those console lines |
 | `telemetry` | `boolean`. Wires the telemetry client. Unset is off |
@@ -105,6 +105,8 @@ createVendo({
 Return `false`, or `{ allow: false, message }` to say why in your own words, and the action is refused and never counted. Anything else allows it and the meter records it.
 
 A policy against a store with no usage meter is refused at composition. A callback that throws denies and logs `limits.callback_error`.
+
+[Limits](/users-orgs/limits) walks the per-user cap, the per-org pool, windows, and what a blocked user sees.
 
 ## `mcp`
 
@@ -229,4 +231,6 @@ createVendo({ principal: async () => ({ kind: "user", subject: "dev" }) });
 
 If you want logged-out visitors served, resolve them to a principal of your own choosing. Marking it `ephemeral: true` keeps it out of org membership and blocks it from connecting external accounts.
 
-The preset seams `facts`, `pools`, and `memberships` run once per context resolution. `facts` becomes the prompt's `[User]` block, `pools` feeds the limits policy, and `memberships` answers `can()`.
+The preset seams `facts`, `pools`, and `memberships` run once per context resolution. `facts` becomes the prompt's `[User]` block, `pools` feeds the limits policy, and `memberships` answers `can()`. Every asserted membership is already a pool named `org:<orgId>`, so an org cap needs no `pools` seam of its own.
+
+See [Your users](/users-orgs/your-users) for `facts` and [Orgs & memberships](/users-orgs/orgs-and-memberships) for `memberships`.

--- a/docs-site/users-orgs/erasing-a-user.mdx
+++ b/docs-site/users-orgs/erasing-a-user.mdx
@@ -20,6 +20,10 @@ const report = await erase.bySubject(subjectId);
 with a real bucket erases every row and quietly keeps the objects. Pass the same
 adapter you wired as `files`, or `storeFiles(store)` when blobs ride the store.
 
+That is the call for a local or BYO Postgres store. On Vendo Cloud the hosted store
+answers through its own door instead — see [On Vendo Cloud](#on-vendo-cloud) — and
+handing `eraseStore` a hosted handle throws `Unknown VendoStore handle`.
+
 The report is per-table deleted counts — every table present, zeroes included — plus
 `workspace_content_objects`, a count of workspace content objects removed rather than
 bytes. Log it or assert on it.

--- a/docs-site/users-orgs/erasing-a-user.mdx
+++ b/docs-site/users-orgs/erasing-a-user.mdx
@@ -1,0 +1,141 @@
+---
+title: "Erasing a user"
+sidebarTitle: "Erasing a user"
+description: "One call that removes everything a person owns, across every store table, with per-table counts you can log — and a clear account of what it deliberately leaves standing."
+---
+
+A right-to-erasure request arrives with one subject in it, and one call answers it.
+
+## One call, one subject
+
+```ts app/api/account/delete/route.ts highlight={3,5}
+import { eraseStore, storeFiles } from "@vendoai/store";
+
+const erase = eraseStore(vendo.store, { files: storeFiles(vendo.store) });
+
+const report = await erase.bySubject(subjectId);
+```
+
+`files` is required, and deliberately not defaulted: a silent default is how a host
+with a real bucket erases every row and quietly keeps the objects. Pass the same
+adapter you wired as `files`, or `storeFiles(store)` when blobs ride the store.
+
+The report is per-table deleted counts — every table present, zeroes included — plus
+`workspace_content_objects`, a count of workspace content objects removed rather than
+bytes. Log it or assert on it.
+
+This is also the only sanctioned way to delete rows from the append-only audit
+table; the ordinary store door refuses that.
+
+---
+
+## What it removes
+
+Apps the subject owns go first, to close the write gate, and each one takes its own
+data with it: records, the version history, blob namespaces, state, that app's
+grants, and quarantine rows.
+
+Then everything keyed to the subject: threads and their messages, automations and
+the runs those fired, permission grants, effects, approvals, audit rows, records
+that reference them, usage, MCP clients and grants, knowledge docs and chunks, and
+their workspace files and history.
+
+Workspace content is deleted **through the files adapter**, not just as rows — the
+cascade reads each row's blob reference before deleting it, because that reference
+is the object's only pointer.
+
+<Note>
+  It is deliberately not one transaction, because blob deletion is external work.
+  A failure part-way leaves less data, never a half-deleted row and orphaned object.
+</Note>
+
+---
+
+## What it leaves
+
+This is the part worth reading twice.
+
+- **Org-owned apps stand.** The selector is the subject, and an app the org holds
+  carries the *org* id, so erasing a member never reaches it. The org outlives the
+  person. What does go is that person's own access: their `user:` grant rows.
+- **Team and org grants stand.** They name no person, so they describe an
+  arrangement the departure does not change.
+- **Grants the person wrote are redacted, not deleted.** Their name comes off the
+  `createdBy` field and the row survives — deleting it would revoke a team's access
+  because whoever set it up left. The redaction is intentionally absent from the
+  report, which counts rows destroyed.
+- **Your own tables are untouched.** Vendo erases Vendo's store. Your user row,
+  your billing, your audit log are yours to handle.
+- **Connected accounts live broker-side** and are not part of this cascade.
+
+<Warning>
+  One table is out of reach by construction: the idempotency ledger is keyed by
+  operation rather than by subject, and a recorded response body there can carry
+  caller data. No subject selector reaches it.
+</Warning>
+
+---
+
+## Erasing one app instead
+
+```ts
+const report = await erase.byApp(appId);
+```
+
+The app's row, its record collections, blob namespaces, state, app-scoped grants,
+and audit rows. Useful for tearing down a test build.
+
+---
+
+## On Vendo Cloud
+
+`eraseStore` runs the SQL cascade against a local or BYO Postgres store. The hosted
+store carries **its own erase door** with the same two methods, so the cascade runs
+server-side with the same behavior:
+
+```ts highlight={2}
+const door = typeof (vendo.store as Partial<HostedStore>).erase?.bySubject === "function"
+  ? (vendo.store as HostedStore).erase
+  : eraseStore(vendo.store, { files: storeFiles(vendo.store) });
+
+await door.bySubject(subjectId);
+```
+
+That is exactly the branch the Maple demo ships, so one route works against either
+store.
+
+Erasure against Vendo Cloud needs an admin-scoped `VENDO_API_KEY` — see
+[Persistence](/production/persistence) for the scope and how to mint one.
+
+---
+
+## Wiring it to your own deletion flow
+
+There is no CLI command for this, on purpose. Erasure is programmatic, so it runs
+inside the delete-account path your product already owns — after your own
+confirmation, alongside your own tables, in one flow you can audit.
+
+Call it with the subject your resolver mints for that person. If your subjects are
+not stable, this is where you find out.
+
+---
+
+## Where to go next
+
+<CardGroup cols={3}>
+  <Card title="Your users" href="/users-orgs/your-users">
+    The subject this call takes, and why it has to be stable.
+
+    `principal.subject`
+  </Card>
+  <Card title="Persistence" href="/production/persistence">
+    Every table the cascade walks, and the admin key Cloud wants.
+
+    `vendo_threads`
+  </Card>
+  <Card title="Sharing" href="/users-orgs/sharing">
+    The grants that go, the ones that stay, and the one that gets redacted.
+
+    `appAccess(store).revoke`
+  </Card>
+</CardGroup>

--- a/docs-site/users-orgs/limits.mdx
+++ b/docs-site/users-orgs/limits.mdx
@@ -67,6 +67,13 @@ an org cap needs — see [Orgs & memberships](/users-orgs/orgs-and-memberships).
   sharing principal and the meter. An org is spelled one way everywhere.
 </Note>
 
+<Warning>
+  A `pools` entry of your own wins on a name collision, so you can meter an org by
+  your own key — but if you do, do it for every member of that org. Half an org on
+  `org:acme` and half on your key is one allowance split across two meters, and
+  each one under-counts.
+</Warning>
+
 The Maple demo in `examples/demo-bank` wires exactly this: one `memberships`
 seam, one org cap, and a refusal worded in Maple's own voice.
 

--- a/docs-site/users-orgs/limits.mdx
+++ b/docs-site/users-orgs/limits.mdx
@@ -1,0 +1,234 @@
+---
+title: "Limits"
+sidebarTitle: "Limits"
+description: "Cap what one user spends, cap what a whole org spends, in your own logic. Vendo counts; your policy decides."
+---
+
+One callback is asked once before each metered action, and its answer is
+honored.
+
+Two things are metered. A `message` is one user turn; a `generation` is one app
+the agent built. Both are things a person does — never tokens, never calls — so
+you write the policy in the units you sell in.
+
+## Cap one user
+
+```ts app/api/vendo/[...vendo]/route.ts highlight={6,7,8,9}
+import { authJs } from "@vendoai/vendo/auth/auth-js";
+import { createVendo } from "@vendoai/vendo/server";
+
+export const vendo = createVendo({
+  auth: authJs(),
+  limits: async ({ action, count }) => {
+    if (action !== "message") return true;
+    return (await count("message", { days: 30 })) < 500;
+  },
+});
+```
+
+Five hundred messages a rolling month, per person. That is the whole feature for
+most hosts.
+
+`count(action, window?)` is already bound to the user this request resolved to. A
+policy never names a subject, so it can never read another person's usage by
+accident.
+
+Return `true` and the action runs and is counted. Return `false` and it is
+refused and never counted.
+
+---
+
+## Cap a whole org
+
+Every org your host asserts for a request is already a shared meter, named
+`org:<orgId>`. There is nothing to wire.
+
+```ts app/api/vendo/[...vendo]/route.ts highlight={4}
+export const vendo = createVendo({
+  auth: authJs({ memberships }),
+  limits: async ({ user, action, count }) => {
+    const org = user.pools?.find((pool) => pool.startsWith("org:"));
+    if (org === undefined) return true;
+    return (await count(action, { days: 30, pool: org })) < 5_000;
+  },
+});
+```
+
+`pool` counts the whole bucket instead of the one person, so five members
+spending a thousand messages each reach a five-thousand-message org cap
+together.
+
+`user.pools` lists the pools this caller draws from. One `org:<orgId>` entry
+arrives for every org your `memberships` seam asserted, which is the only wiring
+an org cap needs — see [Orgs & memberships](/users-orgs/orgs-and-memberships).
+
+<Note>
+  The pool name is the same string a grant uses for that org — `org:acme` is the
+  sharing principal and the meter. An org is spelled one way everywhere.
+</Note>
+
+The Maple demo in `examples/demo-bank` wires exactly this: one `memberships`
+seam, one org cap, and a refusal worded in Maple's own voice.
+
+---
+
+## Both at once
+
+Per-user and per-org are one callback, and the first `false` ends it, so the
+tighter cap wins.
+
+```ts limits highlight={4,13}
+limits: async ({ user, action, count }) => {
+  if (action !== "message") return true;
+
+  if ((await count("message", { days: 1 })) >= 50) {
+    return {
+      allow: false,
+      message: "You've used today's 50 messages. They reset at midnight UTC.",
+    };
+  }
+
+  const org = user.pools?.find((pool) => pool.startsWith("org:"));
+  if (org !== undefined) {
+    if ((await count("message", { days: 30, pool: org })) >= 5_000) {
+      return {
+        allow: false,
+        message: "Your workspace used this month's 5,000 messages — ask an admin.",
+      };
+    }
+  }
+
+  return true;
+},
+```
+
+Each `count` is one live read of the meter, which is why it is a callback and
+not a number handed to you: most policies read one window, and pre-computing
+every window a policy might ask about would be a query per action per call.
+Order the cheap branch first and a policy that returns early does less work.
+
+Tiers are a branch on your own data. `user.facts` is the bag your auth preset
+asserted — plan, role, seat count, tenure — so a Pro user and a Free user read
+different numbers out of the same policy.
+
+```ts limits highlight={2,3}
+limits: async ({ user, action, count }) => {
+  const cap = user.facts?.plan === "pro" ? 5_000 : 200;
+  return (await count(action, { days: 30 })) < cap;
+},
+```
+
+---
+
+## Windows
+
+The three durations are summed into one lookback. `since` names an instant floor
+instead. Omit all four and the count is all-time.
+
+| Window | What it counts |
+| --- | --- |
+| `{ days: 30 }` | The last 30 days, rolling |
+| `{ hours: 12, minutes: 30 }` | The last twelve and a half hours |
+| `{ since: periodStart }` | Everything since that instant — a billing period, not a rolling window |
+| omitted | All time |
+| `{ days: 30, pool: "org:acme" }` | The org's last 30 days, not this user's |
+
+A billing period is the `since` case, and the date is yours:
+
+```ts limits highlight={2,3}
+limits: async ({ user, action, count }) => {
+  const since = new Date(user.facts?.periodStart as string);
+  return (await count(action, { since })) < 2_000;
+},
+```
+
+<Warning>
+  Set a duration and a `since` together and the duration wins. Pass one or the
+  other, never both.
+</Warning>
+
+---
+
+## What a blocked user sees
+
+A refused message never reaches the model. The check runs before the thread is
+even read, so a refused turn costs no read, no write, and no model call — and
+the surface renders one notice in the thread, where the answer would have been.
+
+Return the object form to write that sentence yourself:
+
+```ts limits highlight={1,2,3,4}
+return {
+  allow: false,
+  message: "You've used this month's 500 messages. Upgrade to Pro for 5,000.",
+};
+```
+
+| You return | The card reads |
+| --- | --- |
+| `{ allow: false, message }` | **You’ve reached your limit** — your sentence, verbatim |
+| `false` | **You’ve reached your limit** — "This request wasn’t run — nothing was changed." |
+| the meter could not be read | **Couldn’t check your limit** — "Vendo Cloud is busy right now, so this limit could not be checked — this is temporary, not a cap." |
+
+A reached cap is a status, not a failure, so the notice carries no alert mark.
+
+There is deliberately no `{ allow: true }`. Allowing has nothing to say.
+
+A refused _generation_ reads differently on purpose: the turn carries on, because
+the agent can talk about a build that did not happen. It is told the facts — that
+nothing was built, your sentence when you wrote one, and that calling again gets
+the same answer.
+
+---
+
+## The fail-closed rule
+
+A policy that throws denies.
+
+A limits system that fails open stops limiting silently: you keep believing you
+have a cap while every user is unlimited. A turn that was refused and said so is
+strictly better. Every such denial logs `limits.callback_error`.
+
+- Counting a `pool` this user is not in throws, and therefore denies. Answering
+  `0` for a meter that was never resolved would silently under-count every limit
+  written against it. The error names the pools the user does have.
+- A meter that cannot be read _right now_ still denies, but never dressed as a
+  cap they reached — nothing was counted, so the notice says the check failed and
+  that it is temporary.
+- A store with no usage meter is refused at composition, not at request time.
+  `createVendo({ limits })` throws naming the gap, because every count would read
+  `0` and no limit would ever be reached.
+
+---
+
+## What is not metered
+
+Automation firings. A schedule fire or a webhook delivery is nobody's request and
+has no per-user meter to spend, so an app built inside one is not gated by your
+policy.
+
+What a person does in front of the product is: the message they send, and the app
+the agent builds for them. Those are the two chokes, and there is nothing to
+configure — setting `limits` arms both.
+
+---
+
+## Where to go next
+
+<CardGroup cols={3}>
+  <Card title="Orgs & memberships" href="/users-orgs/orgs-and-memberships">
+    The one seam an org cap needs, and the three other things it unlocks.
+
+    `memberships`
+  </Card>
+  <Card title="Your users" href="/users-orgs/your-users">
+    Where `facts` comes from, and what a tier branch may read.
+
+    `user.facts`
+  </Card>
+  <Card title="Handler options" href="/reference/handler-options">
+    Every `createVendo` key, including this one in one table row.
+
+    `limits`
+  </Card>
+</CardGroup>

--- a/docs-site/users-orgs/org-policy.mdx
+++ b/docs-site/users-orgs/org-policy.mdx
@@ -1,0 +1,146 @@
+---
+title: "Org policy"
+sidebarTitle: "Org policy"
+description: "Rules an org's own admin sets, applied on top of the guardrails your deployment already ships — the file, the tighten-only rule, and how it fails."
+---
+
+Your deployment's guard is the floor: what the product will never let anyone do.
+An org's own admin can raise it for their own people, and the two are layered,
+never traded.
+
+## Two layers, one verdict
+
+Your policy decides first. Then the strictest matching rule from the orgs this
+request asserted may tighten that decision, and only tighten it.
+
+Strictness is a rank — run, then ask, then block — and an org rule moves a
+verdict up it or leaves it alone. It can never turn your `ask` into a `run`.
+
+When an org rule blocks, its `note` becomes the reason the person is shown.
+
+<Warning>
+  One documented hole: a one-time approval that has already been tapped skips the
+  org layer entirely, `block` included. A standing grant stays clamped. An org
+  rule adopted between a park and its approval is not applied to that one call.
+</Warning>
+
+---
+
+## The file
+
+One file per org, inside the org's own [workspace](/users-orgs/org-workspace):
+
+```json /orgs/acme/policy.json highlight={2}
+{
+  "format": "vendo/org-policy@1",
+  "rules": [
+    { "match": { "risk": "destructive" }, "action": "ask", "note": "Ask Priya in #ops first." },
+    { "match": { "tool": "refunds_*", "venue": "automation" }, "action": "block" }
+  ]
+}
+```
+
+`format` and `rules` are both required, and both objects are strict — an unknown
+key is a parse failure, not a warning.
+
+A rule is a match and an action.
+
+| Field | What it takes |
+| --- | --- |
+| `match.tool` | A tool name, `*` glob allowed |
+| `match.risk` | `read`, `write`, `destructive`, or `ungraded` |
+| `match.venue` | `chat`, `app`, `automation`, or `mcp` |
+| `match.presence` | `present` or `away` |
+| `action` | `ask` or `block` |
+| `note` | The sentence a blocked member reads |
+
+Every `match` field is optional and they are ANDed. An omitted field matches
+anything, so `{}` matches every call.
+
+This is not your deployment's `.vendo/policy.json` with a field removed: an org
+file has no `directions`, and its `rules` array is mandatory.
+
+---
+
+## Why there is no "run"
+
+Tighten-only is the whole design, and it is enforced three times.
+
+- The schema has no permissive action, so a console that sends `run` is told at
+  the moment the mistake is made rather than having its rule silently ignored on
+  every call.
+- Within the org layer, the strictest matching rule wins.
+- At the seam where the layer applies, the clamp is monotone: it raises the rank
+  or does nothing.
+
+An org can therefore only ever be stricter than you are. Nothing an org writes can
+widen what your deployment allows.
+
+---
+
+## Who may edit it
+
+Every member of the org may read the file. Only a member your `memberships` seam
+asserted with `admin: true` may write it.
+
+That is a workspace rule, not a policy one, and nothing in the runtime writes the
+file — today it is managed from the console.
+
+---
+
+## Freshness and failure
+
+The file is re-read per request behind a 30-second cache, so an admin's edit binds
+within half a minute. The cache holds the file body, keyed on org id; the rules are
+re-parsed on each check.
+
+Failure is per-org and never widens anything:
+
+- A missing file means that org simply has no rules, and that answer is cached like
+  any other.
+- A file that cannot be read or does not parse drops **that one org's** rules. Every
+  other org in the request still binds. A read failure is deliberately not cached,
+  so a blip cannot disarm an org for the whole window.
+- Every drop is reported, never silently swallowed: a console warning naming the org
+  and the path, and an audit row with reason `org-policy-unavailable`. A resolver that
+  fails outright logs `guard.org-policy-unavailable`.
+
+Because org rules can only raise strictness, a dropped file leaves your own verdict
+standing. There is no failure mode in which losing an org's rules loosens anything.
+
+<Note>
+  A keyed deployment with no local workspace can read no org policy at all. It says
+  so once, loudly, rather than pretending the layer is armed.
+</Note>
+
+---
+
+## What a member sees
+
+The same approval or refusal your own guard produces, because the org layer moves
+the verdict rather than replacing the experience.
+
+A call an org tightened to `ask` parks for approval. A call an org blocked is
+refused with the rule's `note`, which is where an admin gets to say who to ask.
+
+---
+
+## Where to go next
+
+<CardGroup cols={3}>
+  <Card title="Orgs & memberships" href="/users-orgs/orgs-and-memberships">
+    The seam that decides whose rules load, and who counts as an admin.
+
+    `admin: true`
+  </Card>
+  <Card title="The org workspace" href="/users-orgs/org-workspace">
+    The mount the file lives in, and the rest of the tree around it.
+
+    `/orgs/<orgId>/**`
+  </Card>
+  <Card title="Handler options" href="/reference/handler-options">
+    Your deployment's own guard — the floor an org builds on.
+
+    `guard`
+  </Card>
+</CardGroup>

--- a/docs-site/users-orgs/org-workspace.mdx
+++ b/docs-site/users-orgs/org-workspace.mdx
@@ -1,0 +1,151 @@
+---
+title: "The org workspace"
+sidebarTitle: "The org workspace"
+description: "A file tree the org owns instead of a person, so work outlives whoever made it — what gets mounted, who may write where, and what happens when two people commit at once."
+---
+
+Everything a person builds lives in a workspace, and by default that workspace is
+theirs. Every org your host asserts is mounted beside it.
+
+## What gets mounted
+
+Three mounts, and no others.
+
+| Mount | Whose it is |
+| --- | --- |
+| `/user` | The caller's private area. Nobody else reaches it |
+| `/orgs/<orgId>` | One per asserted membership, owned by the org |
+| `/host` | What your deployment projects in for the turn, read-only for everyone |
+
+All of a caller's orgs are mounted **at once**. There is no active org and nothing
+to switch — `/orgs` lists exactly what this request's `memberships` seam
+asserted, and it is absent entirely for a caller who belongs to nothing.
+
+A `scratch` directory inside `/user` or any org mount is working space that is
+never committed.
+
+---
+
+## Ownership is the path
+
+The owner of a path is read off the path itself: the first segment under `/orgs`
+is the org id, and everything else belongs to the caller.
+
+Nothing is transferred and no row moves when someone leaves, because there was
+never a pointer to their subject to update. That is what makes the tree survive
+people.
+
+<Note>
+  The org id is one path segment, so an id containing `/` is unaddressable. Keep
+  the `org` string you assert free of slashes.
+</Note>
+
+---
+
+## Who may read and write where
+
+An asserted membership for that org is the precondition. Without one, the answer
+is no — a path naming an org you are not in is refused before any rule below is
+consulted.
+
+Past that, three rules decide:
+
+- **An app's subtree defers to that app's grants.** Under
+  `/orgs/<orgId>/apps/<appId>`, access is whatever [Sharing](/users-orgs/sharing)
+  says it is, root row included.
+- **`policy.json` is members-read, admin-write.** Every member of the org may read
+  `/orgs/<orgId>/policy.json`; only a member you asserted with `admin: true` may
+  write it. See [Org policy](/users-orgs/org-policy).
+- **The rest of the mount belongs to the membership.** Outside app subtrees and
+  outside `policy.json`, any asserted member of the org may read and write it.
+
+<Warning>
+  That last rule is not admin-gated. An ordinary member can write anywhere in the
+  org mount that is not an app subtree or `policy.json` — `admin` buys implicit
+  app ownership and the policy file, not write control over the tree.
+</Warning>
+
+Access is checked twice: once when the turn opens, to decide what the agent may
+even see, and again at commit against live rows. A membership or grant you revoke
+mid-session therefore bites at the commit, while reads already served stand.
+
+---
+
+## Members only
+
+An outsider is not told an org exists. Reading a path in an org you have no
+membership for fails the same way a path that was never written fails:
+
+```text highlight={1}
+ENOENT: no such file or directory, open '/orgs/acme/notes.md'
+```
+
+A write refusal names your own mounts rather than theirs, so "no such org" and
+"no orgs at all" read differently to you and identically to an outsider:
+
+```text
+EACCES: permission denied, open '/orgs/acme/notes.md' (the workspace holds /host, /orgs, /user)
+```
+
+A refused commit picks its code on the same principle: a caller who cannot even
+read the path gets not-found, and only a caller proven to be a viewer gets
+forbidden. A `forbidden` to an outsider would be an existence oracle for every
+org app id.
+
+---
+
+## Two people, one file
+
+Org paths commit under **compare-and-swap**. The turn remembers the revision it
+opened each file at, and the commit lands only if that revision is still current.
+
+A conflict is a returned status, not a thrown error:
+
+```ts highlight={2}
+const result = await workspace.commit();
+if (result.status === "conflict") {
+  // result.paths — the files someone else moved under you
+}
+```
+
+Nothing in a conflicted batch lands, deletions included, so a partial commit can
+never silently drop data. Re-read the paths and apply your change again.
+
+Commits are batched per owner, so a conflict in an org mount does not take the
+same turn's `/user` writes down with it. `/user` itself is last-write-wins — a
+private file has no second writer to race.
+
+The shipped surface says this in plain words when a generated app loses the race:
+"The save did not land — someone else changed this app. Save again."
+
+---
+
+## When someone leaves
+
+Drop them from your own roster and their mount is gone on their very next
+request. There is nothing to propagate.
+
+Erasing that person leaves the org's tree standing, because none of it was ever
+theirs — see [Erasing a user](/users-orgs/erasing-a-user).
+
+---
+
+## Where to go next
+
+<CardGroup cols={3}>
+  <Card title="Sharing" href="/users-orgs/sharing">
+    The grants an app subtree defers to, and the three principals they name.
+
+    `appAccess(store).grant`
+  </Card>
+  <Card title="Org policy" href="/users-orgs/org-policy">
+    The one file in the mount an ordinary member may read but not write.
+
+    `/orgs/<orgId>/policy.json`
+  </Card>
+  <Card title="Persistence" href="/production/persistence">
+    Where these files actually land, and what the store refuses.
+
+    `vendo_apps`
+  </Card>
+</CardGroup>

--- a/docs-site/users-orgs/orgs-and-memberships.mdx
+++ b/docs-site/users-orgs/orgs-and-memberships.mdx
@@ -1,0 +1,163 @@
+---
+title: "Orgs & memberships"
+sidebarTitle: "Orgs & memberships"
+description: "Vendo keeps no roster. Your host answers who this caller works with, once per request, and that one answer unlocks sharing, the org workspace, org policy, and org limits."
+---
+
+Vendo has no org chart. There is no roster to sync, no invite table, no
+membership row of ours to keep in step with yours.
+
+On every request your host answers one question — which orgs is this caller in? —
+and Vendo believes the answer for exactly that request.
+
+## The seam
+
+```ts app/api/vendo/[...vendo]/route.ts highlight={3,4,5,6,7,8,9,10,11,12,13,14}
+export const vendo = createVendo({
+  auth: authJs({
+    memberships: async ({ subject }) => {
+      const rows = await db.membership.findMany({
+        where: { userId: subject },
+        include: { org: true },
+      });
+      return rows.map((row) => ({
+        org: row.orgId,
+        display: row.org.name,
+        teams: row.teamIds,
+        admin: row.role === "admin",
+      }));
+    },
+  }),
+});
+```
+
+One query against your own tables. It is keyed on the resolved principal rather
+than the request, which is what makes it answerable for an away run: a schedule
+firing has no session, and this callback is your server code in the same
+deployment.
+
+```ts Membership
+interface Membership {
+  org: string;
+  display?: string;
+  teams?: string[];
+  admin?: boolean;
+}
+```
+
+| Field | What it is |
+| --- | --- |
+| `org` | Your own org id, verbatim, and never empty. It becomes the owner of the workspace at `/orgs/<org>/**` and the row subject of an org-owned app, so it has to be stable in your tables |
+| `display` | The org's name in your product's voice, so a surface says "Acme" instead of `org_7f3` |
+| `teams` | Your team ids inside this org. A grant to `team:<org>/<id>` matches a member holding that id |
+| `admin` | `true` makes this member an implicit owner of every app the org holds |
+
+Return `[]` for a caller who belongs to nothing. Leave the seam off entirely and
+nothing is asserted: sharing degenerates to plain ownership, no org owns a
+workspace, and there are no org pools to count.
+
+---
+
+## Asserted, never stored
+
+This is the whole model, and the rules that fall out of it:
+
+- Resolved **once per request** and read by every door downstream, so one request
+  can never see two different answers.
+- **Never persisted.** There is no orgs table and no members table in the store.
+  Removing someone from an org in your tables removes them from Vendo on their
+  very next request — nothing to propagate, no cache to invalidate.
+- An **ephemeral visitor is not even asked.** A principal you marked
+  `ephemeral: true` belongs to no org by construction — your host issued them
+  nothing.
+- Your resolver mints **user principals only.** Org context is derived from
+  membership, so a resolver returning `kind: "org"`, or a subject in the reserved
+  `vendo:` namespace, is rejected at the wire.
+
+<Note>
+  Because the answer is asserted per request, your identity system stays the
+  single source of truth for who is in what. Vendo never disagrees with it,
+  because Vendo never has a second copy.
+</Note>
+
+---
+
+## One name, everywhere
+
+An org is spelled the same way wherever it appears. That string is the grant
+principal and it is the limits pool.
+
+| Principal | Matches |
+| --- | --- |
+| `user:<subject>` | That one person |
+| `team:<org>/<teamId>` | A member whose asserted `teams` includes that id |
+| `org:<org>` | Any member of that org |
+
+A grant is matched against the memberships this request asserted, so one row
+covers the whole org and never needs a per-user fan-out.
+
+---
+
+## What a membership unlocks
+
+Four things, all out of that one array.
+
+<CardGroup cols={2}>
+  <Card title="Sharing" href="/users-orgs/sharing">
+    A grant whose principal is `org:<org>` or `team:<org>/<id>` matches every
+    member you asserted. Share an app once, the org has it.
+
+    `org:acme`
+  </Card>
+  <Card title="The org workspace" href="/users-orgs/org-workspace">
+    Paths under `/orgs/<org>/**` are owned by the org, not the person who made
+    them. An `admin` member is an implicit owner of every app it holds.
+
+    `/orgs/acme/apps/…`
+  </Card>
+  <Card title="Org policy" href="/users-orgs/org-policy">
+    Guard rules that ride on top of your deployment's own policy for the members
+    of one org.
+
+    `vendo/org-policy@1`
+  </Card>
+  <Card title="Limits" href="/users-orgs/limits">
+    Every asserted org is automatically a shared meter named `org:<org>`, so one
+    line caps an org's spend.
+
+    `count(action, { pool })`
+  </Card>
+</CardGroup>
+
+---
+
+## Verify it
+
+`vendo doctor` reads files on disk, so it cannot see this seam. Run your app and
+make one real call as a member of an org.
+
+An org-shared app that a member cannot open means the seam returned no membership
+for them — log what your callback returned for that subject and compare the `org`
+string against the grant's.
+
+---
+
+## Where to go next
+
+<CardGroup cols={3}>
+  <Card title="Auth" href="/production/auth">
+    The preset this seam rides, and the principal it is keyed on.
+
+    `auth: authJs()`
+  </Card>
+  <Card title="Limits" href="/users-orgs/limits">
+    The org cap that needs nothing but the seam above.
+
+    `pool: "org:acme"`
+  </Card>
+  <Card title="Handler options" href="/reference/handler-options">
+    Where `memberships`, `facts`, and `pools` sit among every other key.
+
+    `createVendo`
+  </Card>
+</CardGroup>

--- a/docs-site/users-orgs/sharing.mdx
+++ b/docs-site/users-orgs/sharing.mdx
@@ -1,0 +1,167 @@
+---
+title: "Sharing"
+sidebarTitle: "Sharing"
+description: "Give one person, one team, or a whole org access to an app — a grant row written from your own server code, matched against the memberships your host asserted."
+---
+
+<Note>
+  Sharing is a **server-side call** today. There is no HTTP route, no MCP tool,
+  and no CLI command for it — the Share dialog that used to front it was removed,
+  and the grant seam it wrote through stayed. You mount your own UI, or share from
+  your own backend logic.
+</Note>
+
+## A share is a grant
+
+One row: who may reach an app, and how far.
+
+| Level | What it allows |
+| --- | --- |
+| `viewer` | Open and run the app |
+| `editor` | Change it |
+| `owner` | Everything, including sharing it further |
+
+They are ranked, `viewer` < `editor` < `owner`, so a check for `editor` is
+satisfied by an owner.
+
+---
+
+## The three principals
+
+The "who" is a string, and there are exactly three shapes:
+
+| Principal | Matches |
+| --- | --- |
+| `user:<subject>` | That one person, by the subject your resolver minted |
+| `team:<orgId>/<teamId>` | A member whose asserted `teams` includes that id |
+| `org:<orgId>` | Any member of that org |
+
+`user:` is compared against the caller's subject. `team:` and `org:` are matched
+only against the memberships [your host asserted](/users-orgs/orgs-and-memberships)
+on that request — Vendo consults no org chart of its own.
+
+So one `org:` row covers everybody in the org, today and after the next hire, with
+no fan-out and nothing to re-run when your roster changes. Take someone out of the
+org in your own tables and the row stops matching them on their next request.
+
+---
+
+## Granting from your own code
+
+`appAccess` ships on `@vendoai/store`, which a host installs directly — it is not
+re-exported by the umbrella.
+
+```bash
+npm install @vendoai/store
+```
+
+```ts app/api/share/route.ts highlight={5}
+import { appAccess } from "@vendoai/store";
+
+const access = appAccess(vendo.store);
+
+await access.grant(ctx, appId, "org:acme", "viewer");
+```
+
+`ctx` is the `RunContext` of the person doing the sharing, and only an `owner` may
+grant or revoke. A caller who holds viewer or editor is told they need owner; a
+caller who cannot see the app at all gets not-found instead, which is the same
+answer a nonexistent app gives.
+
+Two refusals are worth knowing before you build a share UI, because both are about
+where the app lives rather than who you named:
+
+- **An `org:` or `team:` grant naming a different org than the app's** is refused.
+  Move the app into that org first.
+- **A still-personal app shared with anyone but its holder** is refused. Move it
+  into a team first, or fork a copy for them.
+
+A principal string that does not parse is refused too, naming the three shapes.
+
+---
+
+## Reading access back
+
+```ts highlight={1,2}
+const level = await access.levelFor(ctx, appId);   // "viewer" | "editor" | "owner" | null
+const allowed = await access.can(ctx, "editor", { app: appId });
+const rows = await access.list(ctx, appId);        // needs viewer
+```
+
+When a caller matches several grants, **the strongest one wins** — a personal
+viewer row plus a team editor row is editor.
+
+`can` also answers for a workspace path, `{ path }`, which is how the
+[org workspace](/users-orgs/org-workspace) defers to an app's grants inside that
+app's subtree.
+
+---
+
+## The admin shortcut
+
+A member you asserted with `admin: true` reads as **owner of every app that org
+holds**, with no grant row at all.
+
+That is what makes an org's apps administrable without Vendo keeping a role system
+of its own: you already know who your admins are, and you say so per request.
+
+Membership alone is not access. An ordinary member of the org reaches an org-held
+app only through a grant.
+
+---
+
+## Revoking
+
+```ts
+await access.revoke(ctx, appId, "org:acme");
+```
+
+The row is deleted outright — no tombstone. Granting a principal that already has
+a row updates that row in place instead of adding a second one, so a downgrade is
+a real downgrade.
+
+The other way to revoke is to change nothing here at all: drop the person from the
+org in your own tables and the `org:` row stops matching them on their next
+request.
+
+Access is re-checked at commit time against live rows, so a revoke lands mid-session
+rather than at the next sign-in.
+
+---
+
+## Not this: `share` and `publish`
+
+`AppsRuntime.share` and `AppsRuntime.publish` are a **different verb**, and the
+names invite exactly the wrong reach.
+
+| | What it does |
+| --- | --- |
+| `appAccess(...).grant` | Gives a principal access to **the live app**, in your deployment |
+| `AppsRuntime.share` | Sends a **frozen copy** of the document to Vendo Cloud and returns a snapshot |
+| `AppsRuntime.publish` | Sends a copy to the Cloud **registry** as a published version |
+
+Both copy-outs require an owner and a `VENDO_API_KEY`, and both refuse with
+cloud-required without one. Neither writes a grant, names a principal, or consults
+a membership.
+
+---
+
+## Where to go next
+
+<CardGroup cols={3}>
+  <Card title="Orgs & memberships" href="/users-orgs/orgs-and-memberships">
+    The asserted array every `team:` and `org:` grant is matched against.
+
+    `memberships`
+  </Card>
+  <Card title="The org workspace" href="/users-orgs/org-workspace">
+    Where an org's apps live, and the subtree that defers to these grants.
+
+    `/orgs/<orgId>/apps/…`
+  </Card>
+  <Card title="Erasing a user" href="/users-orgs/erasing-a-user">
+    What happens to a leaver's grants, and to the ones they wrote.
+
+    `bySubject`
+  </Card>
+</CardGroup>

--- a/docs-site/users-orgs/your-users.mdx
+++ b/docs-site/users-orgs/your-users.mdx
@@ -1,0 +1,143 @@
+---
+title: "Your users"
+sidebarTitle: "Your users"
+description: "Who Vendo thinks a person is, where that comes from, and what you can tell it about them — the subject everything hangs off, and the facts you assert beside it."
+---
+
+Vendo mints no identity of its own. A user here is one string, and everything
+else is derived from it.
+
+## A user is a subject
+
+A principal is four fields, and only two of them are yours to fill:
+
+```ts
+interface Principal {
+  kind: "user" | "org";
+  subject: string;
+  display?: string;
+  ephemeral?: boolean;
+}
+```
+
+`subject` is the whole model. Threads, apps, records, grants, approvals,
+activity, and runs all hang off that one string, and a row never crosses
+subjects.
+
+So it has to be **stable**. Use the immutable id from your own tables, never an
+email or username someone can change — a subject that moves is a user who lost
+everything they built.
+
+Your resolver may only mint `kind: "user"`. Returning `kind: "org"` is rejected
+at the wire, because org context is derived from membership rather than
+resolved; so is any subject in the reserved `vendo:` namespace.
+
+[Auth](/production/auth) is where the resolver itself lives — the presets, the
+session decode, and away runs. This page is only about what rides on top of it.
+
+---
+
+## Telling Vendo about them
+
+`facts` is the profile you assert. It is not part of the principal; it is a
+second seam, resolved from the same request, and it is a flat bag of JSON.
+
+```ts app/api/vendo/[...vendo]/route.ts highlight={6,7,8,9,10}
+export const vendo = createVendo({
+  auth: authJs({
+    user: async (subject) => {
+      const user = await db.user.findUnique({ where: { id: subject } });
+      if (!user) return null;
+      return {
+        display: user.name,
+        facts: { plan: user.plan, role: user.role, seats: user.seatCount },
+      };
+    },
+  }),
+});
+```
+
+Re-asserted on every request, so a plan change binds on the user's next turn.
+There is nothing to invalidate.
+
+<Note>
+  `facts` is a preset seam. A hand-wired `principal(request)` has no facts
+  channel — pass an `auth` preset if you want one.
+</Note>
+
+---
+
+## What the model sees
+
+Facts become the prompt's `[User]` block, one `key: value` line per fact,
+rebuilt every turn. Assert nothing and the block does not exist at all.
+
+```text [User]
+name: Priya Raman
+plan: pro
+role: org admin
+```
+
+This is data the agent may reason about out loud. **Never put a secret in it** —
+no tokens, no keys, no internal flags you would not want quoted back to the
+person. Secrets belong in `secrets`, and tool credentials in `actAs`.
+
+---
+
+## What your own code sees
+
+The same facts reach your own choke points, where they are the tier branch:
+
+| Where | Reads it as |
+| --- | --- |
+| The limits policy | `user.facts` — see [Limits](/users-orgs/limits) |
+| A guard check | `ctx.user` |
+| A tool's `execute` | `ctx.user` |
+
+`ctx.context` is the sibling bag for things the model must not see. It is passed
+to guards and tools and is never rendered into the prompt.
+
+---
+
+## Signed-out and ephemeral visitors
+
+A resolver that answers `null` refuses the request — the host owns sign-in, so
+that is correct. [Auth](/production/auth) covers what the chrome does next.
+
+To serve logged-out visitors, resolve them to a principal of your own and mark
+it `ephemeral: true`. That subject still chats and still builds, but four doors
+close:
+
+- The `memberships` seam is **not even asked**, so an ephemeral visitor belongs
+  to no org by construction.
+- Connecting an external account is refused — that needs a signed-in user.
+- The MCP door will not open a session for them.
+- They cannot mint an in-client approval.
+
+<Warning>
+  Every visitor you resolve to the same ephemeral subject **is** the same user,
+  and shares one set of threads and apps. Key the subject off something of your
+  own if that is not what you want.
+</Warning>
+
+---
+
+## Where to go next
+
+<CardGroup cols={3}>
+  <Card title="Auth" href="/production/auth">
+    The resolver that mints the subject, and the presets that fill it.
+
+    `auth: authJs()`
+  </Card>
+  <Card title="Orgs & memberships" href="/users-orgs/orgs-and-memberships">
+    Who this person works with, asserted the same way and just as fresh.
+
+    `memberships`
+  </Card>
+  <Card title="Erasing a user" href="/users-orgs/erasing-a-user">
+    The other end of the lifecycle — one call, every table.
+
+    `eraseStore(...).bySubject`
+  </Card>
+</CardGroup>


### PR DESCRIPTION
Seven pages for machinery that already ships but had no page teaching it. Before this, `limits`, `memberships`, and `pools` existed **only** as rows in the handler-options reference — nothing in the Docs tab taught any of them.

Stacked on `yousefh409/org-pools` (PR 1), which makes every asserted membership a pool named `org:<orgId>`.

## Pages

New group **Users & orgs**, slotted after Production in `docs.json`, in `docs-site/users-orgs/`:

| Page | What it covers |
| --- | --- |
| `your-users` | The subject everything hangs off, the `facts` seam beside it, the `[User]` prompt block, and what `ephemeral: true` takes away. Links to Auth for the resolver rather than restating it |
| `orgs-and-memberships` | Host-asserts-per-request, the `Membership` shape, "never stored" (there is no orgs table), and the `org:<orgId>` one-name-everywhere convention |
| `sharing` | Grants, the three principals, `viewer` < `editor` < `owner`, the org-admin shortcut, strongest-match-wins, and existence masking |
| `org-workspace` | The `/orgs/<orgId>` mounts beside `/user`, all orgs mounted at once with no active org, who may write where, and CAS conflicts |
| `org-policy` | `/orgs/<orgId>/policy.json`, `vendo/org-policy@1`, `ask`/`block` only, the three-layer tighten-only enforcement, and the 30s resolver TTL |
| `limits` | The centerpiece: per-user caps, the automatic org pool, both at once, windows, the blocked-user card's real shipped wording, and the fail-closed rule |
| `erasing-a-user` | `eraseStore(store, { files }).bySubject(id)`, what it cascades through, and what it deliberately leaves standing |

## Also in this PR

- **Fixes a wrong signature in `production/persistence.mdx`.** It showed `eraseStore(vendo.store)` with no second argument — `files` is required by design, so the published example did not typecheck. Both call sites in that block now pass `{ files }`, matching the already-correct example in `reference/server-api.mdx`.
- **Cross-links `reference/handler-options.mdx`** into the new section: the `limits` row and section, and the closing seam sentence for `facts` / `pools` / `memberships`, which also gains the clause that every asserted membership is already an `org:<orgId>` pool. The Composition table's key column is untouched, so it stays 1:1 with `CreateVendoConfig`.

No changeset — `docs-site/` is not a published package, matching every past docs-only commit.

## Notes on accuracy

Every claim was verified against source, not against docs or comments. Three things the draft got wrong and this PR does not:

- The blocked-user strings use curly apostrophes (`You’ve reached your limit`, `This request wasn’t run — nothing was changed.`, `Couldn’t check your limit`). Transcribed verbatim from `packages/ui`.
- `facts` is **not** a field on `Principal` — it is a separate preset seam that lands on the run context. The principal is `kind`, `subject`, `display?`, `ephemeral?`.
- The composition-time limits error does not name the store adapter, so the page says it "throws naming the gap" rather than naming the store.

Two places the pages state a truth a rosier draft would have skipped: org policy's tighten-only guarantee has one documented hole (an already-tapped one-time approval skips the org layer, `block` included), and an ordinary org member — not just an admin — can write anywhere in the org mount outside app subtrees and `policy.json`.

Sharing is stated plainly as a server-side call: there is no HTTP route, MCP tool, or CLI command for it today, and it is a different verb from `AppsRuntime.share`/`publish` (the Cloud snapshot copy-out). The page also notes `appAccess` ships on `@vendoai/store` and is not re-exported by the umbrella.

## Verification

Docs are UI, so this was checked in a real browser (Mintlify dev server, Chromium), not just by tests:

- All 7 new pages plus the 2 edited pages render, every `h2` section present through the bottom "Where to go next" cards.
- Nav: **Users & orgs** sits directly after Production, with all 7 pages in the intended order.
- Every internal link on the new pages resolves 200 (the only 404 anywhere is Mintlify's own `/llms.txt` footer link, which 404s on pre-existing pages too).
- Zero zero-size/blank icon elements, so no bad FontAwesome name. Zero page errors. Code blocks, tables, `<Note>`/`<Warning>` callouts, and `<CardGroup>`s all render; `<subject>`-style placeholders survive MDX.

Local gate green on the touched scope: `pnpm build && pnpm test:affected && pnpm typecheck && pnpm lint`. Because `docs-site/` is not a workspace package, `test:affected` executes 0 tasks, so the five docs-rot suites were run explicitly — 61/61 pass, including the gate that every `docs.json` nav entry has a file and the one keeping the Composition table 1:1 with `CreateVendoConfig`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new “Users & orgs” docs section (seven guides) and corrects erasure docs to distinguish LOCAL vs HOSTED stores. This consolidates how users, orgs, sharing, limits, and policy work, and fixes the `eraseStore` example to prevent orphaned files and misuses on Vendo Cloud.

- Navigation: new “Users & orgs” group (after Production) with pages: Your users, Orgs & memberships, Sharing, The org workspace, Org policy, Limits, Erasing a user.
- Reference updates (`reference/handler-options.mdx`): `limits` is per-user and per-org; each asserted membership is also a pool named `org:<orgId>`; links to the new guides.
- Limits guide: clarifies org-level metering and warns that overriding an org pool’s key via `pools` must be done for every member or the allowance splits across meters.
- Persistence updates: `eraseStore` now documented as LOCAL/BYO Postgres only and requires `{ files }`; hosted stores expose their own `erase` door on `HostedStore` (admin-scoped `VENDO_API_KEY` required). The new Erasing a user guide shows a branch that works against either posture.
- No runtime or package changes; `docs-site/` is not published.

**Migration**
- If you copied the old example, call `eraseStore(vendo.store, { files })` from `@vendoai/vendo/server` to avoid orphaned blobs.
- On Vendo Cloud (hosted store), switch to `vendo.store.erase.bySubject()`/`.byApp()` (type `HostedStore`) with an admin-scoped `VENDO_API_KEY`; `eraseStore` throws `Unknown VendoStore handle` on hosted stores.

<sup>Written for commit 16ccc5641fecda4176bb250e1f5ab7e476cf49af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1470?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

