### PR TITLE
feat(vendo,core): org memberships derive org usage pools

### DIFF
--- a/.changeset/org-membership-pools.md
+++ b/.changeset/org-membership-pools.md
@@ -25,5 +25,7 @@ name collision, so metering an org by the host's own key keeps working — overr
 it for every member of that org, because half an org on `org:<orgId>` and half on
 your own key is one allowance split across two meters that each under-count. A
 policy naming an org nobody asserted still fails closed rather than reading zero.
-Maple demonstrates it: the branch shares 200 messages a month, on top of a
-per-person daily cap.
+An inbound text asks the same seam for the linked subject — it is keyed on the
+principal, not a request — so a member who texts draws on the org's allowance
+instead of quietly outside it. Maple demonstrates it: the branch shares 200
+messages a month, on top of a per-person daily cap.

--- a/.changeset/org-membership-pools.md
+++ b/.changeset/org-membership-pools.md
@@ -10,14 +10,20 @@ by core's own principal encoding, so a limits policy can cap a whole team the
 day it can name one:
 
 ```ts
-limits: async ({ count }) =>
-  (await count("message", { days: 30, pool: "org:maple" })) < 200,
+limits: async ({ user, count }) => {
+  // Guard on `user.pools`: an identity with no asserted membership — a signed-out
+  // guest, an inbound text — is in no org pool, and counting one denies the turn.
+  if (!user.pools?.includes("org:maple")) return true;
+  return (await count("message", { days: 30, pool: "org:maple" })) < 200;
+},
 ```
 
 One grammar, not two: the string a policy counts is the string a grant names
 that org by. Teams stay out of it — a team is a slice of an org's allowance, not
 a bucket the host asked to meter. A pool the host asserts itself still wins on a
-name collision, so metering an org by the host's own key keeps working, and a
-policy naming an org nobody asserted still fails closed rather than reading
-zero. Maple demonstrates it: the branch shares 200 messages a month, on top of a
+name collision, so metering an org by the host's own key keeps working — override
+it for every member of that org, because half an org on `org:<orgId>` and half on
+your own key is one allowance split across two meters that each under-count. A
+policy naming an org nobody asserted still fails closed rather than reading zero.
+Maple demonstrates it: the branch shares 200 messages a month, on top of a
 per-person daily cap.

--- a/.changeset/org-membership-pools.md
+++ b/.changeset/org-membership-pools.md
@@ -1,0 +1,23 @@
+---
+"@vendoai/vendo": minor
+"@vendoai/core": patch
+---
+
+An org the host already asserts is a usage pool, with nothing wired for it. A
+host that answers `memberships` for a request — the same assertion app grants
+are matched against — now gets one pool per org, named and keyed `org:<orgId>`
+by core's own principal encoding, so a limits policy can cap a whole team the
+day it can name one:
+
+```ts
+limits: async ({ count }) =>
+  (await count("message", { days: 30, pool: "org:maple" })) < 200,
+```
+
+One grammar, not two: the string a policy counts is the string a grant names
+that org by. Teams stay out of it — a team is a slice of an org's allowance, not
+a bucket the host asked to meter. A pool the host asserts itself still wins on a
+name collision, so metering an org by the host's own key keeps working, and a
+policy naming an org nobody asserted still fails closed rather than reading
+zero. Maple demonstrates it: the branch shares 200 messages a month, on top of a
+per-person daily cap.

--- a/examples/demo-bank/src/vendo/server.ts
+++ b/examples/demo-bank/src/vendo/server.ts
@@ -1,6 +1,6 @@
 import { anthropic } from "@ai-sdk/anthropic";
 import { composioConnector } from "@vendoai/actions";
-import type { Principal } from "@vendoai/core";
+import type { LimitsCallback, Principal } from "@vendoai/core";
 import { memoryKnowledgeAdapter } from "@vendoai/core/conformance";
 import { vendoAutoJudge } from "@vendoai/guard";
 import { createStore } from "@vendoai/store";
@@ -40,9 +40,9 @@ const mapleAuthJs = authJs({
   // Build contract §9.1 — Maple's OWN identity tables answer "which orgs?".
   // One query against what the host already knows; Vendo stores nothing about
   // it. Keyed on the Principal, not the request, so an unattended automation
-  // fire resolves the same orgs an attended click does. Both seeded staff are
-  // in `maple`; Yousef is the org admin (implicit owner of every org app),
-  // Mia is an ordinary member who reaches an app only through a grant.
+  // fire resolves the same orgs an attended click does. All four seeded staff
+  // are in `maple`; Yousef is the org admin (implicit owner of every org app),
+  // and the rest are ordinary members who reach an app only through a grant.
   memberships: async (principal) => {
     const user = resolveMapleSubject(principal.subject);
     if (!user) return [];
@@ -67,6 +67,32 @@ const MAPLE_GUEST: Principal = { kind: "user", subject: "maple_guest", ephemeral
 export const mapleAuth: HostAuthPreset = {
   ...mapleAuthJs,
   principal: async (request) => (await mapleAuthJs.principal(request)) ?? MAPLE_GUEST,
+};
+
+// Vendo counts, Maple decides. All four seeded staff are members of `maple`, so
+// the `org:maple` pool exists without Maple wiring one: the branch shares one
+// rolling monthly allowance, and no single person can spend it all.
+//
+// Guarded on `user.pools`: Maple serves identities it asserts no membership for —
+// the signed-out guest, an inbound text, a deployment with no password env — and
+// counting a pool they are not in is an error, so an unguarded count would refuse
+// every one of those turns instead of falling through to the per-person cap.
+export const mapleLimits: LimitsCallback = async ({ user, action, count }) => {
+  if (action !== "message") return true;
+  if (user.pools?.includes("org:maple")
+    && await count("message", { days: 30, pool: "org:maple" }) >= 200) {
+    return {
+      allow: false,
+      message: "Maple Bank has used its 200 shared messages for this month. They free up as the last 30 days roll past.",
+    };
+  }
+  if (await count("message", { days: 1 }) >= 50) {
+    return {
+      allow: false,
+      message: "That's your 50 messages for today. The branch's allowance is shared, so this picks back up tomorrow.",
+    };
+  }
+  return true;
 };
 
 export const vendo = createVendo({
@@ -151,25 +177,7 @@ export const vendo = createVendo({
     policy: { file: ".vendo/policy.json" },
     judge: vendoAutoJudge({ model: vendoModel("vendo-judge") }),
   }),
-  // Vendo counts, Maple decides. Both seeded staff are members of `maple`, so
-  // the `org:maple` pool exists without Maple wiring one: the branch shares one
-  // rolling monthly allowance, and no single person can spend it all.
-  limits: async ({ action, count }) => {
-    if (action !== "message") return true;
-    if (await count("message", { days: 30, pool: "org:maple" }) >= 200) {
-      return {
-        allow: false,
-        message: "Maple Bank has used its 200 shared messages for this month. They free up as the last 30 days roll past.",
-      };
-    }
-    if (await count("message", { days: 1 }) >= 50) {
-      return {
-        allow: false,
-        message: "That's your 50 messages for today. The branch's allowance is shared, so this picks back up tomorrow.",
-      };
-    }
-    return true;
-  },
+  limits: mapleLimits,
   mcp: mapleMcpConfig(),
   // Maple's customers can text the assistant: they link their phone from the
   // "Text with Maple" card on /settings (components/settings/text-channel-card.tsx

--- a/examples/demo-bank/src/vendo/server.ts
+++ b/examples/demo-bank/src/vendo/server.ts
@@ -151,6 +151,25 @@ export const vendo = createVendo({
     policy: { file: ".vendo/policy.json" },
     judge: vendoAutoJudge({ model: vendoModel("vendo-judge") }),
   }),
+  // Vendo counts, Maple decides. Both seeded staff are members of `maple`, so
+  // the `org:maple` pool exists without Maple wiring one: the branch shares one
+  // rolling monthly allowance, and no single person can spend it all.
+  limits: async ({ action, count }) => {
+    if (action !== "message") return true;
+    if (await count("message", { days: 30, pool: "org:maple" }) >= 200) {
+      return {
+        allow: false,
+        message: "Maple Bank has used its 200 shared messages for this month. They free up as the last 30 days roll past.",
+      };
+    }
+    if (await count("message", { days: 1 }) >= 50) {
+      return {
+        allow: false,
+        message: "That's your 50 messages for today. The branch's allowance is shared, so this picks back up tomorrow.",
+      };
+    }
+    return true;
+  },
   mcp: mapleMcpConfig(),
   // Maple's customers can text the assistant: they link their phone from the
   // "Text with Maple" card on /settings (components/settings/text-channel-card.tsx

--- a/examples/demo-bank/tests/vendo/limits.test.ts
+++ b/examples/demo-bank/tests/vendo/limits.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Maple's shipped `limits` policy (./server.ts) — the org cap and the guard it
+ * needs, because Maple serves identities it asserts no membership for.
+ *
+ * The `count` reader is the limiter's, and the limiter is not host surface, so it
+ * is bound here instead: what the policy ASKS is the whole fact under test —
+ * counting a pool the user is not in throws inside the real limiter, and a policy
+ * that asks for one refuses the turn (proved in @vendoai/vendo's limits suite).
+ * The identities are Maple's own seams, unmocked.
+ */
+import type { LimitUser, LimitWindow } from "@vendoai/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mapleAuth, mapleLimits } from "../../src/vendo/server";
+
+afterEach(() => vi.unstubAllEnvs());
+
+const THREADS = "http://localhost:3000/api/vendo/threads";
+
+/** Ask the policy, with a meter that answers `counts` per pool ("me" = this user
+    alone) and remembers every window it was asked for. */
+async function ask(user: LimitUser, counts: Record<string, number> = {}) {
+  const asked: LimitWindow[] = [];
+  const verdict = await mapleLimits({
+    user,
+    action: "message",
+    count: async (_action, window) => {
+      asked.push(window ?? {});
+      return counts[window?.pool ?? "me"] ?? 0;
+    },
+  });
+  return { verdict, pooled: asked.filter(({ pool }) => pool !== undefined) };
+}
+
+const member: LimitUser = { kind: "user", subject: "vendo-demo", pools: ["org:maple"] };
+
+describe("Maple's limits policy", () => {
+  it("shares the branch's 200 monthly messages across its members", async () => {
+    // `pools: ["org:maple"]` above is what the limiter derives from THIS seam.
+    await expect(mapleAuth.memberships?.({ kind: "user", subject: "vendo-demo" }))
+      .resolves.toMatchObject([{ org: "maple", admin: true }]);
+
+    expect(await ask(member, { "org:maple": 199 })).toMatchObject({ verdict: true });
+    const { verdict } = await ask(member, { "org:maple": 200 });
+    expect(verdict).toMatchObject({ allow: false, message: expect.stringContaining("200 shared messages") });
+  });
+
+  it("still caps one person's day inside the shared allowance", async () => {
+    const { verdict } = await ask(member, { me: 50 });
+    expect(verdict).toMatchObject({ allow: false, message: expect.stringContaining("50 messages for today") });
+  });
+
+  it("never counts the org pool for an identity Maple asserts no membership for", async () => {
+    // Two real ones: the signed-out visitor Maple resolves to a shared ephemeral
+    // guest, and an inbound text — `runChannelTurn` builds its own ctx and asks no
+    // memberships seam, so that turn's user carries no pools either.
+    const guest = await mapleAuth.principal(new Request(THREADS));
+    expect(guest).toEqual({ kind: "user", subject: "maple_guest", ephemeral: true });
+    await expect(mapleAuth.memberships?.(guest!)).resolves.toEqual([]);
+
+    const { verdict, pooled } = await ask(guest!);
+    expect(verdict).toBe(true);
+    expect(pooled).toEqual([]);
+  });
+
+  it("keeps working in the DEPLOYED posture, where auto-login needs no password env", async () => {
+    // No MAPLE_DEMO_PASSWORD in production means no seeded users to resolve, so
+    // Maple asserts nothing about anyone and the org pool exists for no one.
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("MAPLE_DEMO_PASSWORD", undefined);
+    await expect(mapleAuth.memberships?.({ kind: "user", subject: "vendo-demo" })).resolves.toEqual([]);
+
+    expect(await ask({ kind: "user", subject: "vendo-demo" })).toMatchObject({ verdict: true, pooled: [] });
+  });
+});

--- a/packages/core/src/limits.ts
+++ b/packages/core/src/limits.ts
@@ -15,7 +15,10 @@ export const limitActionSchema = z.enum(["message", "generation"]) satisfies z.Z
 
     `pool` counts the whole shared bucket rather than the one user — a seat pool,
     a team, an org — and is only answerable for a pool the user is actually in
-    ({@link LimitUser.pools}). */
+    ({@link LimitUser.pools}). Every org the host asserts in
+    `RunContext.memberships` is one of those pools already, named `org:<orgId>`
+    (§9.2's principal encoding, the same string an app grant names it by), so an
+    org-wide cap needs nothing wired for it. */
 export interface LimitWindow {
   days?: number;
   hours?: number;

--- a/packages/vendo/src/channel-turn.ts
+++ b/packages/vendo/src/channel-turn.ts
@@ -13,6 +13,7 @@ import {
   AGENT_CONTEXT_MARK,
   type ApprovalRequest,
   type AutomationId,
+  type Membership,
   type Principal,
   type RunContext,
 } from "@vendoai/core";
@@ -100,6 +101,12 @@ export interface ChannelTurnDeps {
   /** Read-only, and only to NAME an automation whose grant set is being asked
    *  about: the asks themselves are read off the guard's pending feed. */
   automations: Pick<AutomationsEngine, "get">;
+  /** Build contract §9.1 — the host's orgs for the LINKED subject. The seam is
+   *  keyed on the principal rather than the request precisely so a session-less
+   *  path can ask it, and a texted turn must: without it a member who texts is in
+   *  none of their org's pools, so their messages and builds neither count against
+   *  the org's allowance nor accrue to it. */
+  memberships?: (principal: Principal) => Promise<Membership[]>;
 }
 
 /** A schema property description cut down to a label: everything before the
@@ -329,6 +336,10 @@ export async function runChannelTurn(
 ): Promise<void> {
   const { event, link } = input;
   const principal: Principal = { kind: "user", subject: link.subject };
+  // Asserted, never stored — one call, like the wire's own resolver. A link is
+  // minted for a host subject, so this principal is never the ephemeral visitor
+  // that resolver skips the seam for.
+  const memberships = await deps.memberships?.(principal);
   const ctx: RunContext = {
     principal,
     venue: "chat",
@@ -341,6 +352,7 @@ export async function runChannelTurn(
     // path, calls the host API with nothing, and the agent ends up apologising
     // for a sign-in problem the person cannot do anything about.
     channelLink: { channel: "text", linkedAt: link.linkedAt ?? new Date().toISOString() },
+    ...(memberships === undefined ? {} : { memberships }),
   };
   const send = (text: string): Promise<void> =>
     deps.channel.send({ conversationId: event.conversationId, text });

--- a/packages/vendo/src/compose-channels.ts
+++ b/packages/vendo/src/compose-channels.ts
@@ -164,6 +164,7 @@ export const composeChannels = (composition: VendoComposition): Pick<VendoCompos
           links,
           asks,
           automations: composition.automations,
+          memberships: composition.membershipsSeam,
         },
         { event, link: known },
       );

--- a/packages/vendo/src/limits.ts
+++ b/packages/vendo/src/limits.ts
@@ -58,6 +58,10 @@ const ALL_TIME = new Date(0);
  *  bucket the host asked to meter. */
 const orgPools = (memberships: RunContext["memberships"]): Record<string, string> =>
   Object.fromEntries((memberships ?? [])
+    // A JS host's seam can answer anything, and this runs OUTSIDE gate's try, so a
+    // malformed entry is skipped rather than thrown on: a TypeError here would be
+    // the turn rejecting instead of a verdict.
+    .filter((entry) => typeof entry?.org === "string")
     .map(({ org }) => encodeGrantPrincipal({ kind: "org", org }))
     // An id the grammar cannot parse BACK — empty, or carrying its own `/` — is a
     // name no grant can be stored under either (`validate.ts` refuses the row), so

--- a/packages/vendo/src/limits.ts
+++ b/packages/vendo/src/limits.ts
@@ -15,6 +15,7 @@
 import {
   VENDO_MAKE_TOOL,
   VENDO_VIEW_STREAM,
+  encodeGrantPrincipal,
   isVendoError,
   VendoError,
   log,
@@ -47,6 +48,19 @@ const DAY = 24 * HOUR;
 /** `UsageCountQuery.since` is required, so "all time" is the epoch. */
 const ALL_TIME = new Date(0);
 
+/** Every org the host ASSERTS is already a pool, so an org-wide cap costs the
+ *  host nothing to wire. Name and key are both §9.2's principal encoding — the
+ *  one an app grant naming that org spells the same way — so a policy counting
+ *  `org:<orgId>` and a grant addressing it are never two grammars.
+ *
+ *  Teams are deliberately absent: a team is a slice of an org's allowance, not a
+ *  bucket the host asked to meter. */
+const orgPools = (memberships: RunContext["memberships"] = []): Record<string, string> =>
+  Object.fromEntries(memberships.map(({ org }) => {
+    const pool = encodeGrantPrincipal({ kind: "org", org });
+    return [pool, pool];
+  }));
+
 /** The host's policy, bound to the meter it decides on.
  *
  *  `ops` is the usage family and not the whole `StoreOps` because a limiter
@@ -59,11 +73,14 @@ export function createLimiter({ callback, ops }: {
   return {
     async gate(action, ctx) {
       const { subject } = ctx.principal;
-      const pools = ctx.pools ?? {};
+      // Host-asserted LAST: an explicit pool of the same name wins over the
+      // derived one, so a host who meters its orgs by their own key still can.
+      const pools = { ...orgPools(ctx.memberships), ...ctx.pools };
+      const poolNames = Object.keys(pools);
       const user: LimitUser = {
         ...ctx.principal,
         ...(ctx.user === undefined ? {} : { facts: ctx.user }),
-        ...(ctx.pools === undefined ? {} : { pools: Object.keys(pools) }),
+        ...(poolNames.length === 0 ? {} : { pools: poolNames }),
       };
       // Pre-bound to THIS subject: a policy never names one, so it can never
       // read another person's usage by accident.
@@ -80,8 +97,9 @@ export function createLimiter({ callback, ops }: {
           throw new VendoError(
             "validation",
             `The limits policy counted the \`${window.pool}\` pool, which this user is not in `
-            + `(their pools: ${Object.keys(pools).map((name) => `\`${name}\``).join(", ") || "none"}). `
-            + "Pools come from the auth preset's `pools` seam — assert the pool there, or count a pool the user is in.",
+            + `(their pools: ${poolNames.map((name) => `\`${name}\``).join(", ") || "none"}). `
+            + "Pools come from the auth preset's `pools` seam, or an org the host asserted in `memberships` "
+            + "(each one is the pool `org:<orgId>`) — assert the pool there, or count a pool the user is in.",
           );
         }
         return ops.count({ action: counted, since, poolKey });

--- a/packages/vendo/src/limits.ts
+++ b/packages/vendo/src/limits.ts
@@ -16,6 +16,7 @@ import {
   VENDO_MAKE_TOOL,
   VENDO_VIEW_STREAM,
   encodeGrantPrincipal,
+  isGrantPrincipal,
   isVendoError,
   VendoError,
   log,
@@ -55,11 +56,14 @@ const ALL_TIME = new Date(0);
  *
  *  Teams are deliberately absent: a team is a slice of an org's allowance, not a
  *  bucket the host asked to meter. */
-const orgPools = (memberships: RunContext["memberships"] = []): Record<string, string> =>
-  Object.fromEntries(memberships.map(({ org }) => {
-    const pool = encodeGrantPrincipal({ kind: "org", org });
-    return [pool, pool];
-  }));
+const orgPools = (memberships: RunContext["memberships"]): Record<string, string> =>
+  Object.fromEntries((memberships ?? [])
+    .map(({ org }) => encodeGrantPrincipal({ kind: "org", org }))
+    // An id the grammar cannot parse BACK — empty, or carrying its own `/` — is a
+    // name no grant can be stored under either (`validate.ts` refuses the row), so
+    // it is no pool: a derived name is always one a grant could address.
+    .filter(isGrantPrincipal)
+    .map((pool) => [pool, pool]));
 
 /** The host's policy, bound to the meter it decides on.
  *
@@ -80,7 +84,10 @@ export function createLimiter({ callback, ops }: {
       const user: LimitUser = {
         ...ctx.principal,
         ...(ctx.user === undefined ? {} : { facts: ctx.user }),
-        ...(poolNames.length === 0 ? {} : { pools: poolNames }),
+        // A host that ANSWERED the pools seam said something even with `{}` — "in
+        // none" is not "not wired" — so the key is absent only when neither the
+        // seam nor a membership produced one.
+        ...(ctx.pools === undefined && poolNames.length === 0 ? {} : { pools: poolNames }),
       };
       // Pre-bound to THIS subject: a policy never names one, so it can never
       // read another person's usage by accident.
@@ -125,8 +132,10 @@ export function createLimiter({ callback, ops }: {
       }
       if (decision !== true) return decision === false ? { allow: false } : decision;
       // Awaited, not fire-and-forget: the next action's count has to see this
-      // one, and a dropped write is a limit that never arrives.
-      await ops.record({ subject, action, at: new Date(), poolKeys: Object.values(pools) });
+      // one, and a dropped write is a limit that never arrives. Keys DEDUPED: a
+      // host pool naming a derived org's own key is one bucket, stamped once.
+      const poolKeys = [...new Set(Object.values(pools))];
+      await ops.record({ subject, action, at: new Date(), poolKeys });
       return { allow: true };
     },
   };

--- a/packages/vendo/tests/channel-turn-ctx.test.ts
+++ b/packages/vendo/tests/channel-turn-ctx.test.ts
@@ -1,7 +1,9 @@
 import type { RunContext } from "@vendoai/core";
+import { memoryStoreOps } from "@vendoai/core/conformance";
 import { describe, expect, it, vi } from "vitest";
 import type { ChannelLink } from "../src/channel-links.js";
-import { cronProse, runChannelTurn } from "../src/channel-turn.js";
+import { cronProse, runChannelTurn, type ChannelTurnDeps } from "../src/channel-turn.js";
+import { createLimiter } from "../src/limits.js";
 
 describe("cronProse", () => {
   it("words the shapes an agent actually mints, beside the raw value", () => {
@@ -54,8 +56,9 @@ const event = {
   receivedAt: "2026-08-17T10:22:11.211Z",
 };
 
-function turnDeps(captured: { ctx?: RunContext }) {
+function turnDeps(captured: { ctx?: RunContext }, memberships?: ChannelTurnDeps["memberships"]) {
   return {
+    memberships,
     harness: {
       stream: vi.fn(async (input: { ctx: RunContext }) => {
         captured.ctx = input.ctx;
@@ -101,6 +104,22 @@ describe("the ctx a texted turn runs under", () => {
       principal: { kind: "user", subject: "vendo-demo" },
       sessionId: "evt_1",
     });
+  });
+
+  it("asks the memberships seam for the linked subject, so the org's allowance is spent and debited", async () => {
+    // The org pool is DERIVED from the ctx's memberships (limits.ts), so a texted
+    // turn that never asked the seam is silently outside every org cap: it does
+    // not count against the allowance and does not accrue to it. The real limiter
+    // over a real meter is what says otherwise.
+    const captured: { ctx?: RunContext } = {};
+    const usage = memoryStoreOps().usage!;
+    const limiter = createLimiter({ callback: () => true, ops: usage });
+
+    await runChannelTurn(turnDeps(captured, async () => [{ org: "maple" }]), { event, link });
+    await limiter.gate("message", captured.ctx!);
+
+    expect(captured.ctx?.memberships).toEqual([{ org: "maple" }]);
+    expect(await usage.count({ action: "message", poolKey: "org:maple", since: new Date(0) })).toBe(1);
   });
 
   it("stamps a link that never recorded its time, rather than omitting the evidence", async () => {

--- a/packages/vendo/tests/limits-pools.seam.test.ts
+++ b/packages/vendo/tests/limits-pools.seam.test.ts
@@ -17,6 +17,10 @@
  * absent, the policy's `count({ pool: "workspace" })` hits an unknown meter, and
  * the gate fails closed. The `allow: true` below is what makes every hop
  * load-bearing.
+ *
+ * The second case drives the same hops for a user the host asserted NOTHING but
+ * an org: the `org:<id>` pool is derived, not resolved, so a break anywhere from
+ * the `memberships` seam to the limiter's derivation reads as an unknown meter.
  */
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -111,5 +115,49 @@ describe("limits — the host's pools reach the policy and the meter", () => {
     // of the shared meter sees both.
     expect(await usage.count({ action: "message", poolKey: "ws_maple", since: ALL_TIME })).toBe(2);
     expect(await usage.count({ action: "message", subject: "host_mia", since: ALL_TIME })).toBe(1);
+  });
+});
+
+describe("limits — an asserted org is a pool with nothing wired for it", () => {
+  it("counts and accrues to `org:<id>` from a membership alone, over the same real hops", async () => {
+    let seen: { user: LimitUser; pooled: number } | undefined;
+
+    const composition = createComposition({
+      store: await realStore(),
+      // Ana has NO `pools` of her own — the org is the only thing asserted about
+      // her, so every pool the policy sees below can only have been derived.
+      auth: jwt({
+        secret: SECRET,
+        user: (subject) => (subject === "host_ana" ? { display: "Ana" } : null),
+        memberships: async () => [{ org: "maple", display: "Maple Bank", teams: ["support"] }],
+      }),
+      limits: async ({ user, count }) => {
+        seen = { user, pooled: await count("message", { pool: "org:maple" }) };
+        return true;
+      },
+    });
+    await composition.ready();
+    const usage = composition.ops!.usage!;
+
+    // A colleague already spent one against the key the DERIVATION mints.
+    await usage.record({
+      subject: "host_raj",
+      action: "message",
+      at: new Date(),
+      poolKeys: ["org:maple"],
+    });
+
+    const ctx = await createContextResolver(wireDepsFor(composition))(
+      await sessionRequest("host_ana"),
+      "chat",
+    );
+
+    await expect(composition.limiter!.gate("message", ctx)).resolves.toEqual({ allow: true });
+
+    expect(seen?.user.pools).toEqual(["org:maple"]);
+    expect(seen?.pooled).toBe(1);
+    expect(await usage.count({ action: "message", poolKey: "org:maple", since: ALL_TIME })).toBe(2);
+    // Her team was asserted too and is deliberately NOT a pool.
+    expect(await usage.count({ action: "message", poolKey: "team:maple/support", since: ALL_TIME })).toBe(0);
   });
 });

--- a/packages/vendo/tests/limits.test.ts
+++ b/packages/vendo/tests/limits.test.ts
@@ -18,6 +18,7 @@ import {
   type LimitUser,
   type RunContext,
   type StoreOps,
+  type UsageEvent,
   type VendoLogEvent,
   type VendoViewStreamingToolCall,
   type VendoViewStreamUpdate,
@@ -81,6 +82,16 @@ describe("the limiter's verdict", () => {
 
     await expect(limiter.gate("message", ctxFor())).resolves.toEqual({ allow: false });
     expect(await usage.count({ action: "message", subject: "mia", since: ALL_TIME })).toBe(0);
+  });
+
+  it("answers a verdict when the memberships seam says NULL", async () => {
+    const limiter = createLimiter({ callback: () => true, ops: meter() });
+
+    // The pool derivation reads `ctx.memberships` OUTSIDE the policy's try, so a
+    // throw there is not a deny — it is the whole turn rejecting. A JS host's seam
+    // can answer null, and every other consumer of it tolerates one.
+    await expect(limiter.gate("message", ctxFor({ memberships: null as never })))
+      .resolves.toEqual({ allow: true });
   });
 
   it("carries the host's own sentence out of a denial", async () => {
@@ -279,6 +290,19 @@ describe("the meter reader the policy is handed", () => {
     expect(await usage.count({ action: "generation", poolKey: "ws_maple", since: ALL_TIME })).toBe(1);
     expect(await usage.count({ action: "generation", poolKey: "org_maple", since: ALL_TIME })).toBe(1);
   });
+
+  it("stamps a key ONCE when a host pool names a derived org's own key", async () => {
+    const usage = meter();
+    const recorded: UsageEvent[] = [];
+    const limiter = createLimiter({
+      callback: () => true,
+      ops: { ...usage, record: async (event) => { recorded.push(event); await usage.record(event); } },
+    });
+
+    await limiter.gate("message", ctxFor({ memberships: [{ org: "maple" }], pools: { seat: "org:maple" } }));
+
+    expect(recorded[0]?.poolKeys).toEqual(["org:maple"]);
+  });
 });
 
 describe("the user the policy decides about", () => {
@@ -311,6 +335,24 @@ describe("the user the policy decides about", () => {
     }));
 
     expect(seen?.pools).toEqual(["org:maple", "org:acme"]);
+  });
+
+  it("says `[]` when the host wired pools and this user is in none — in-none is not un-wired", async () => {
+    let seen: LimitUser | undefined;
+    const limiter = createLimiter({ callback: ({ user }) => { seen = user; return true; }, ops: meter() });
+
+    await limiter.gate("message", ctxFor({ pools: {} }));
+
+    expect(seen?.pools).toEqual([]);
+  });
+
+  it("skips an org id the §9.2 grammar cannot parse back — a derived name a grant could never address", async () => {
+    let seen: LimitUser | undefined;
+    const limiter = createLimiter({ callback: ({ user }) => { seen = user; return true; }, ops: meter() });
+
+    await limiter.gate("message", ctxFor({ memberships: [{ org: "maple" }, { org: "maple/eu" }, { org: "" }] }));
+
+    expect(seen?.pools).toEqual(["org:maple"]);
   });
 
   it("carries NO pools key when the host asserted neither pools nor memberships", async () => {

--- a/packages/vendo/tests/limits.test.ts
+++ b/packages/vendo/tests/limits.test.ts
@@ -84,14 +84,16 @@ describe("the limiter's verdict", () => {
     expect(await usage.count({ action: "message", subject: "mia", since: ALL_TIME })).toBe(0);
   });
 
-  it("answers a verdict when the memberships seam says NULL", async () => {
+  it("answers a verdict when the memberships seam answers NULL, or a malformed entry", async () => {
     const limiter = createLimiter({ callback: () => true, ops: meter() });
 
     // The pool derivation reads `ctx.memberships` OUTSIDE the policy's try, so a
     // throw there is not a deny — it is the whole turn rejecting. A JS host's seam
-    // can answer null, and every other consumer of it tolerates one.
-    await expect(limiter.gate("message", ctxFor({ memberships: null as never })))
-      .resolves.toEqual({ allow: true });
+    // can answer any of these, and every other consumer of it tolerates them.
+    for (const memberships of [null, [null], [{ org: 7 }], [{}]]) {
+      await expect(limiter.gate("message", ctxFor({ memberships: memberships as never })))
+        .resolves.toEqual({ allow: true });
+    }
   });
 
   it("carries the host's own sentence out of a denial", async () => {

--- a/packages/vendo/tests/limits.test.ts
+++ b/packages/vendo/tests/limits.test.ts
@@ -167,6 +167,18 @@ describe("the limiter fails CLOSED", () => {
       .resolves.toEqual({ allow: false });
     expect(events.filter((event) => event.code === "limits.callback_error")).toHaveLength(1);
   });
+
+  it("denies on an org the host never asserted — a membership is the only thing that mints one", async () => {
+    const events = logged();
+    const limiter = createLimiter({
+      callback: async ({ count }) => (await count("message", { pool: "org:acme" })) < 5,
+      ops: meter(),
+    });
+
+    await expect(limiter.gate("message", ctxFor({ memberships: [{ org: "maple" }] })))
+      .resolves.toEqual({ allow: false });
+    expect(events.filter((event) => event.code === "limits.callback_error")).toHaveLength(1);
+  });
 });
 
 describe("the meter reader the policy is handed", () => {
@@ -219,6 +231,45 @@ describe("the meter reader the policy is handed", () => {
     expect(pooled).toBe(2);
   });
 
+  it("counts an org the host merely ASSERTED — every membership is already a pool", async () => {
+    const usage = meter();
+    await usage.record({ subject: "raj", action: "message", at: hoursAgo(1), poolKeys: ["org:maple"] });
+
+    let pooled = 0;
+    const limiter = createLimiter({
+      callback: async ({ count }) => { pooled = await count("message", { pool: "org:maple" }); return true; },
+      ops: usage,
+    });
+
+    await limiter.gate("message", ctxFor({ memberships: [{ org: "maple", teams: ["support"] }] }));
+    expect(pooled).toBe(1);
+    // The allow accrued to the derived key too, so the next read sees both…
+    expect(await usage.count({ action: "message", poolKey: "org:maple", since: ALL_TIME })).toBe(2);
+    // …and nothing accrued to the team, which is not a pool.
+    expect(await usage.count({ action: "message", poolKey: "team:maple/support", since: ALL_TIME })).toBe(0);
+  });
+
+  it("lets a host-asserted pool of the same NAME win over the derived one", async () => {
+    const usage = meter();
+    await usage.record({ subject: "raj", action: "message", at: hoursAgo(1), poolKeys: ["org:maple"] });
+    await usage.record({ subject: "raj", action: "message", at: hoursAgo(1), poolKeys: ["ent_maple"] });
+    await usage.record({ subject: "ana", action: "message", at: hoursAgo(1), poolKeys: ["ent_maple"] });
+
+    let pooled = 0;
+    const limiter = createLimiter({
+      callback: async ({ count }) => { pooled = await count("message", { pool: "org:maple" }); return true; },
+      ops: usage,
+    });
+
+    await limiter.gate("message", ctxFor({
+      memberships: [{ org: "maple" }],
+      pools: { "org:maple": "ent_maple" },
+    }));
+    // The host's own key answered, not the derived `org:maple`.
+    expect(pooled).toBe(2);
+    expect(await usage.count({ action: "message", poolKey: "org:maple", since: ALL_TIME })).toBe(1);
+  });
+
   it("stamps every resolved pool key on what an allow records", async () => {
     const usage = meter();
     const limiter = createLimiter({ callback: () => true, ops: usage });
@@ -248,6 +299,27 @@ describe("the user the policy decides about", () => {
       facts: { email: "mia@maple.test", plan: "free" },
       pools: ["workspace"],
     });
+  });
+
+  it("lists the orgs the host asserted, so a policy can NAME the pool it counts", async () => {
+    let seen: LimitUser | undefined;
+    const limiter = createLimiter({ callback: ({ user }) => { seen = user; return true; }, ops: meter() });
+
+    // Memberships and nothing else: a `pools` here can only have been derived.
+    await limiter.gate("message", ctxFor({
+      memberships: [{ org: "maple", teams: ["support"] }, { org: "acme" }],
+    }));
+
+    expect(seen?.pools).toEqual(["org:maple", "org:acme"]);
+  });
+
+  it("carries NO pools key when the host asserted neither pools nor memberships", async () => {
+    let seen: LimitUser | undefined;
+    const limiter = createLimiter({ callback: ({ user }) => { seen = user; return true; }, ops: meter() });
+
+    await limiter.gate("message", ctxFor());
+
+    expect(seen).toEqual({ kind: "user", subject: "mia" });
   });
 });
 


### PR DESCRIPTION
## What

An org the host already asserts is now a usage pool, with nothing wired for it. Every asserted membership on the run context becomes a pool whose **name and key are both `org:<orgId>`**, rendered by core's existing `encodeGrantPrincipal({ kind: "org", org })` — so a limits policy can cap a whole team the day it can name one:

```ts
limits: async ({ count }) =>
  (await count("message", { days: 30, pool: "org:maple" })) < 200,
```

## Why

`ctx.pools` was the only way to meter a shared bucket, so an org-wide cap meant the host hand-wiring a pool for an org it had *already* asserted through `memberships`. Deriving it costs the host nothing and reuses the grammar that exists: the string a policy counts is the string an app grant names that org by (§9.2's principal encoding), not a second convention.

Three decisions worth calling out:

- **Host-asserted wins.** `ctx.pools` merges last, so an explicit pool of the same name overrides the derived one — a host that meters its orgs by its own key keeps working.
- **The `LimitUser.pools` guard had to change.** It tested `ctx.pools === undefined`; it now tests the merged map for emptiness. Without that, a memberships-only user got org pools inside `count()` while `user.pools` stayed absent — the producer and the consumer disagreeing about the same request.
- **Teams are not pools.** A team is a slice of an org's allowance, not a bucket the host asked to meter.

Unknown pools still fail closed: a policy naming an org nobody asserted throws validation rather than reading zero, and the message now points at `memberships` as a second source of pools. `composeLimits` is untouched.

Maple carries the living example — the branch shares 200 messages a month through `org:maple`, on top of a modest per-person daily cap.

## Test evidence

`packages/vendo` — 22/22 green in the two touched files; the whole package suite green (2458 passed) with these changes.

The seam phase drives a REAL composition end to end with nothing stubbed on either side: real HS256 host session → real `jwt()` preset asserting a membership → real wire resolver → real limiter → real PGlite meter, read back through `ops.count({ poolKey: "org:maple" })`.

**Both fixes proven able to fail** (revert, watch red, restore):

| Reverted | Result |
| --- | --- |
| the `orgPools` merge | `3 failed \| 19 passed` — the seam gate returns `{ allow: false }` (fails closed on the now-unknown meter) |
| only the `LimitUser.pools` guard | `2 failed \| 20 passed` — `expected undefined to deeply equal [ 'org:maple' ]` |

## Note for reviewers

`pnpm test:affected` reports 22 failures in `tests/cli/{doctor,init,provider-deps}.test.ts`. These are **pre-existing on `main` and unrelated to this PR** — the same 22 tests in the same 3 files fail on a pristine `origin/main` checkout when run through the turbo path (`turbo run test --filter=@vendoai/vendo`), while all 240 files pass when the package's vitest is invoked directly. The failures are environment-detection assertions (an extra `--workspace` arg), and `turbo.json` declares no `envMode`, so turbo 2.x prunes the env the CLI sniffs. None of those files import anything this PR touches.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Derives org usage pools from asserted org memberships in `@vendoai/vendo` and `@vendoai/core`, and ensures text-channel turns debit and accrue the org’s allowance. Previously hosts wired org pools via `ctx.pools`, and texted turns did not count toward org caps.

- Each asserted org becomes pool `org:<orgId>`; explicit host `ctx.pools` still override. Recorded pool keys are de-duplicated.
- The limiter tolerates `memberships` being null and skips malformed entries; invalid org ids (unparseable by the §9.2 grammar) derive no pool.
- `LimitUser.pools` reflects the merged pools (or `[]` when wired pools exist but this user is in none); it is absent only when neither memberships nor host pools produce any.
- The text channel path now asks `memberships` for the linked subject so SMS usage counts against `org:<orgId>`.
- Policies can cap orgs by counting `org:<orgId>`; guard on `user.pools` for identities with no orgs (guests, webhooks) to avoid denying those turns.
- Teams are not pools. Keep custom org keys by overriding for all members to avoid split meters.

<sup>Written for commit f6956ceac5d99433fd90411e9b96ce23ee238d58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1471?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

