### PR TITLE
refactor(ui): the ✦ is one door into the chat, and a remix wears the pin chrome

### DIFF
--- a/packages/ui/e2e/harness/main.tsx
+++ b/packages/ui/e2e/harness/main.tsx
@@ -23,6 +23,7 @@ import {
   GrantSetCard,
   useApprovalModal,
   NoPolicyNotice,
+  Remixable,
   VendoOverlay,
   VendoPalette,
   VendoSlot,
@@ -1841,6 +1842,51 @@ const pinnedViewTree: UIPayload = {
   ],
 };
 
+/** S2 — the ✦ is ONE DOOR. Two host components side by side: an unremixed one,
+ *  whose ✦ opens the conversation about it, and a remixed one, wearing the pin
+ *  chrome's single menu (Edit in chat · Update · Revert). */
+function PlainMerchants() {
+  return <section style={{ padding: 16 }}><h2 style={{ margin: 0, fontSize: 16 }}>Top merchants</h2><p style={{ margin: "6px 0 0" }}>Blue Bottle · $124.50</p></section>;
+}
+
+function RemixedMerchants() {
+  return <section style={{ padding: 16 }}><h2 style={{ margin: 0, fontSize: 16 }}>Recent payees</h2><p style={{ margin: "6px 0 0" }}>Ritual · $88.00</p></section>;
+}
+// A production bundle erases `Function.name`, so a wrapped component must carry
+// `displayName` for the affordance to exist at all (remixable.tsx `slotOf`) —
+// and this harness is built for real, which is how the browser gate catches it.
+PlainMerchants.displayName = "PlainMerchants";
+RemixedMerchants.displayName = "RemixedMerchants";
+
+function remixClient(client: VendoClient): VendoClient {
+  const remix = {
+    format: "vendo/app@1", id: "app_remix", name: "Recent payees", ui: "tree" as const,
+    seed: { component: "RemixedMerchants" },
+  };
+  return {
+    ...client,
+    apps: {
+      ...client.apps,
+      get: async () => remix,
+      list: async () => [remix],
+      open: async () => ({ kind: "tree", payload: pinnedViewTree }),
+    } as VendoClient["apps"],
+  };
+}
+
+function RemixableScenario() {
+  const client = useMemo(() => remixClient(baseClient), []);
+  return (
+    <VendoProvider client={client} components={components} theme={mapleTheme}>
+      <div style={{ display: "grid", gap: 32, maxWidth: 560 }}>
+        <Remixable><PlainMerchants /></Remixable>
+        <Remixable><RemixedMerchants /></Remixable>
+      </div>
+      <VendoOverlay launcher="none" />
+    </VendoProvider>
+  );
+}
+
 /** Existing-agents polish — a BYO chat page: plain host markup (Georgia serif,
  *  no Vendo chrome, like the examples' quickstarts) rendering a `vendo_*` tool
  *  output through `VendoToolResult` against the real wire fixture. */
@@ -1958,6 +2004,7 @@ function scenario(pathname: string): { title: string; theme?: Partial<VendoTheme
     case "/slot-building": return { title: "Inline slot — a build landing in place", content: <SlotBuildingScenario /> };
     case "/slot-states": return { title: "Inline slot — ready / failed", content: <SlotStatesScenario /> };
     case "/slot-picker": return { title: "Add to… — embed writes a placement", content: <SlotPickerScenario />, ownProvider: true };
+    case "/remixable": return { title: "Remixable — the ✦ is one door into the chat", content: <RemixableScenario />, ownProvider: true };
     case "/appframe": return { title: "App execution planes", content: <AppFrameScenario /> };
     case "/appframe-resize": return { title: "App frame resize — the host's bounds win", content: <AppFrameResizeScenario /> };
     case "/appframe-devserver": return { title: "Live dev-server preview (HMR)", content: <DevServerPreviewScenario /> };

--- a/packages/ui/e2e/harness/main.tsx
+++ b/packages/ui/e2e/harness/main.tsx
@@ -1853,24 +1853,38 @@ function PlainMerchants() {
 function RemixedMerchants() {
   return <section style={{ padding: 16 }}><h2 style={{ margin: 0, fontSize: 16 }}>Recent payees</h2><p style={{ margin: "6px 0 0" }}>Ritual · $88.00</p></section>;
 }
+
+/** The third case: a remix the build never produced. Its seed row exists, so
+ *  the ✦ is the remix's chrome — over the host's own untouched markup. */
+function FailedMerchants() {
+  return <section style={{ padding: 16 }}><h2 style={{ margin: 0, fontSize: 16 }}>Subscriptions</h2><p style={{ margin: "6px 0 0" }}>Netflix · $15.49</p></section>;
+}
 // A production bundle erases `Function.name`, so a wrapped component must carry
 // `displayName` for the affordance to exist at all (remixable.tsx `slotOf`) —
 // and this harness is built for real, which is how the browser gate catches it.
 PlainMerchants.displayName = "PlainMerchants";
 RemixedMerchants.displayName = "RemixedMerchants";
+FailedMerchants.displayName = "FailedMerchants";
 
 function remixClient(client: VendoClient): VendoClient {
   const remix = {
     format: "vendo/app@1", id: "app_remix", name: "Recent payees", ui: "tree" as const,
     seed: { component: "RemixedMerchants" },
   };
+  // The FAILED remix is not stubbed: its seed row and its terminal `failed`
+  // envelope both come from the wire fixture (vite.config.ts), so the wrapper
+  // discovers it and reads its dead end through the ordinary client — the same
+  // path a real build failure travels. Only the SUCCEEDING remix is canned,
+  // because the harness has no model to write one.
   return {
     ...client,
     apps: {
       ...client.apps,
-      get: async () => remix,
-      list: async () => [remix],
-      open: async () => ({ kind: "tree", payload: pinnedViewTree }),
+      get: async (id: string) => (id === remix.id ? remix : await client.apps.get(id)),
+      list: async () => [remix, ...(await client.apps.list()).filter(app => app.seed !== undefined)],
+      open: async (id: string, options?: { pending?: boolean }) => (id === remix.id
+        ? { kind: "tree", payload: pinnedViewTree }
+        : await client.apps.open(id, options)),
     } as VendoClient["apps"],
   };
 }
@@ -1890,6 +1904,7 @@ function RemixableScenario() {
       <div style={{ display: "grid", gap: 32, maxWidth: 560 }}>
         <Remixable><PlainMerchants /></Remixable>
         <Remixable><RemixedMerchants /></Remixable>
+        <Remixable><FailedMerchants /></Remixable>
       </div>
       <VendoOverlay launcher="none" thread={StarterThread} />
     </VendoProvider>

--- a/packages/ui/e2e/harness/main.tsx
+++ b/packages/ui/e2e/harness/main.tsx
@@ -32,6 +32,7 @@ import {
   VendoToolResult,
   vendoToast,
   type VendoCommand,
+  type VendoThreadProps,
 } from "../../src/chrome/index.js";
 import { AppFrame, PayloadView, TreeView } from "../../src/tree/index.js";
 import { browserTreeFixture } from "../fixtures/tree.js";
@@ -1874,6 +1875,14 @@ function remixClient(client: VendoClient): VendoClient {
   };
 }
 
+/** The host's own starter cards on the empty landing — what the panel shows a
+ *  person who opened it with nothing in mind, exactly as the demo host wires
+ *  them (VendoLayer). The ✦ opens the SAME panel about a particular component,
+ *  which is where these five have to get out of the way. */
+function StarterThread(props: VendoThreadProps) {
+  return <VendoThread {...props} suggestions={MAPLE_SUGGESTIONS} discoverability="quiet" />;
+}
+
 function RemixableScenario() {
   const client = useMemo(() => remixClient(baseClient), []);
   return (
@@ -1882,7 +1891,7 @@ function RemixableScenario() {
         <Remixable><PlainMerchants /></Remixable>
         <Remixable><RemixedMerchants /></Remixable>
       </div>
-      <VendoOverlay launcher="none" />
+      <VendoOverlay launcher="none" thread={StarterThread} />
     </VendoProvider>
   );
 }

--- a/packages/ui/e2e/harness/vite.config.ts
+++ b/packages/ui/e2e/harness/vite.config.ts
@@ -31,6 +31,23 @@ export default defineConfig(async ({ command }) => {
       retryable: true,
       prompt: "a board showing where my money goes each month",
     });
+    // (/remixable) — the ✦'s own dead end, over the REAL wire: the seed row
+    // lands first and is listable, so the wrapper discovers a remix, and the
+    // build then fails, so `open` answers the terminal `failed` envelope
+    // forever. That order is what put a settled "Edit" over a screen that never
+    // existed. The reason carries the same developer sentence the rest of the
+    // harness uses, because the page must not print any of it.
+    wire.state.apps.push({
+      ...fixtureApp("app_remix_failed", "FailedMerchants remix"),
+      seed: { component: "FailedMerchants", baseline: "sha256:fixture", wishes: ["make it a chart"] },
+    });
+    wire.state.failedApps.set("app_remix_failed", {
+      reason: "This app wasn't created, because it didn't pass the checks that keep an app honest:"
+        + " the `value` expression is a declarative string that the DataTable does not evaluate,"
+        + " not JavaScript: amount / sum(spending.data.amount)",
+      retryable: true,
+      prompt: "make it a chart",
+    });
     // (/slot-states, /slot-building) — the slot's own build vocabulary over the
     // real wire. `app_slot_building` lands on the second placements read; the
     // spec places it itself so each attempt rewinds that window. `slot-ready`

--- a/packages/ui/e2e/remixable-one-door.spec.ts
+++ b/packages/ui/e2e/remixable-one-door.spec.ts
@@ -19,7 +19,7 @@ test("the ✦ opens the chat about the component, and the remixed one wears the 
   const remixed = page.locator('[data-vendo-remixable="RemixedMerchants"]');
 
   // 1 — at rest: the 9px seed, and a pill nobody can press by accident.
-  const door = plain.getByRole("button", { name: "Remix PlainMerchants with Vendo" });
+  const door = plain.getByRole("button", { name: "Remix this view with Vendo" });
   await expect(plain.locator(".fl-remix-seed")).toHaveCSS("opacity", "0.32");
   await expect(door).toHaveCSS("opacity", "0");
   await expect(door).toHaveCSS("pointer-events", "none");
@@ -48,8 +48,8 @@ test("the ✦ opens the chat about the component, and the remixed one wears the 
   await expect(remixed).toContainText("Outstanding this week");
   await expect(remixed).not.toContainText("Recent payees");
   await remixed.hover();
-  await remixed.getByRole("button", { name: "Edit RemixedMerchants" }).click();
-  const menu = remixed.getByRole("group", { name: "RemixedMerchants" });
+  await remixed.getByRole("button", { name: "Edit this view" }).click();
+  const menu = remixed.getByRole("group", { name: "this view" });
   await expect(menu.getByRole("button")).toHaveText(["Edit in chat", "Update", "Revert"]);
   await expect(menu.getByRole("status")).toHaveCount(0);
   await page.screenshot({ path: `${SHOTS}/4-remixed-menu.png`, fullPage: true, animations: "disabled" });
@@ -57,8 +57,10 @@ test("the ✦ opens the chat about the component, and the remixed one wears the 
   // 5 — and its "Edit in chat" is the same door, about that remix.
   await menu.getByRole("button", { name: "Edit in chat" }).click();
   await expect(panel).toBeVisible();
-  await expect(panel.getByRole("textbox", { name: "Message" })).toHaveValue("Update RemixedMerchants: ");
+  await expect(panel.getByRole("textbox", { name: "Message" })).toHaveValue("Update this view: ");
   await expect(panel).not.toContainText("app_remix");
+  // `slot` is an id too — both sides of the ✦ say the same human words now.
+  await expect(panel).not.toContainText("RemixedMerchants");
   await page.screenshot({ path: `${SHOTS}/5-edit-in-chat.png`, fullPage: true, animations: "disabled" });
 });
 
@@ -79,7 +81,7 @@ test("the ✦ lands on the component, not on a generic assistant", async ({ page
 
   const plain = page.locator('[data-vendo-remixable="PlainMerchants"]');
   await plain.hover();
-  await plain.getByRole("button", { name: "Remix PlainMerchants with Vendo" }).click();
+  await plain.getByRole("button", { name: "Remix this view with Vendo" }).click();
   await expect(panel).toBeVisible();
 
   // The person's own intent reads as words, never as the identifier sync
@@ -111,7 +113,7 @@ test.describe("on a touchscreen", () => {
   test("a tap reveals the ✦ door, and the lift does not take it away", async ({ page }) => {
     await openScenario(page, "remixable");
     const plain = page.locator('[data-vendo-remixable="PlainMerchants"]');
-    const door = plain.getByRole("button", { name: "Remix PlainMerchants with Vendo" });
+    const door = plain.getByRole("button", { name: "Remix this view with Vendo" });
 
     await plain.tap();
     await expect(plain).toHaveAttribute("data-vendo-revealed", "");

--- a/packages/ui/e2e/remixable-one-door.spec.ts
+++ b/packages/ui/e2e/remixable-one-door.spec.ts
@@ -101,6 +101,35 @@ test("the ✦ lands on the component, not on a generic assistant", async ({ page
 });
 
 /**
+ * A remix that never built. The seed row is listable and `open` answers the
+ * terminal `failed` envelope, both from the wire fixture — the order a real
+ * failure arrives in — so the ✦ is the remix's chrome sitting over the host's
+ * own untouched markup. It read a settled "Edit", offering to edit a screen
+ * that does not exist, beside the agent's own "that remix failed" in the chat.
+ */
+test("the ✦ does not offer to edit a screen the build never produced", async ({ page }) => {
+  await openScenario(page, "remixable");
+  const failed = page.locator('[data-vendo-remixable="FailedMerchants"]');
+  const pill = failed.locator(".fl-remix-pill");
+
+  // The host's own component is still the content — that part was always right.
+  await expect(failed).toContainText("Netflix · $15.49");
+  await expect(pill).toHaveText(/Didn’t load/);
+  await expect(pill).toHaveAttribute("aria-label", "This view didn’t load");
+  await expect(pill).not.toHaveAttribute("aria-busy", "true");
+
+  await failed.hover();
+  await pill.click();
+  const menu = failed.getByRole("group", { name: "this view" });
+  // Announced, and it points at the chat rather than becoming a second place
+  // that explains — the developer sentence never reaches the page.
+  await expect(menu.getByRole("status")).toHaveText(/didn’t load/i);
+  await expect(failed).not.toContainText("sum(spending.data.amount)");
+  await expect(failed).not.toContainText("DataTable");
+  await page.screenshot({ path: `${SHOTS}/9-failed-remix.png`, fullPage: true, animations: "disabled" });
+});
+
+/**
  * Touch has no hover, and a finger's `pointerleave` fires the instant it lifts
  * — so the reveal's leave rule, written for a cursor, took the door away 200ms
  * after the tap that asked for it while CSS left the pill non-interactive.

--- a/packages/ui/e2e/remixable-one-door.spec.ts
+++ b/packages/ui/e2e/remixable-one-door.spec.ts
@@ -36,7 +36,7 @@ test("the ✦ opens the chat about the component, and the remixed one wears the 
   await door.click();
   const panel = page.getByRole("dialog", { name: "Vendo assistant" });
   await expect(panel).toBeVisible();
-  await expect(panel.getByRole("textbox", { name: "Message" })).toHaveValue("Remix my PlainMerchants: ");
+  await expect(panel.getByRole("textbox", { name: "Message" })).toHaveValue("Remix this view: ");
   await expect(page.locator(".fl-remix-ask")).toHaveCount(0);
   await page.screenshot({ path: `${SHOTS}/3-chat-opened.png`, fullPage: true, animations: "disabled" });
 
@@ -60,4 +60,74 @@ test("the ✦ opens the chat about the component, and the remixed one wears the 
   await expect(panel.getByRole("textbox", { name: "Message" })).toHaveValue("Update RemixedMerchants: ");
   await expect(panel).not.toContainText("app_remix");
   await page.screenshot({ path: `${SHOTS}/5-edit-in-chat.png`, fullPage: true, animations: "disabled" });
+});
+
+/**
+ * The door has to land the person ON the thing they clicked. The first person
+ * to walk this cold got the generic landing instead — headline, five starter
+ * cards about other things, and their own intent reading as the React
+ * identifier `NetWorthView` — and could not tell whether the click had
+ * registered on the right component.
+ */
+test("the ✦ lands on the component, not on a generic assistant", async ({ page }) => {
+  await openScenario(page, "remixable");
+  const panel = page.getByRole("dialog", { name: "Vendo assistant" });
+  const composer = panel.getByRole("textbox", { name: "Message" });
+  // The host wires starter cards onto this panel's empty landing (StarterThread
+  // in the harness, exactly as the demo host does).
+  const starters = panel.locator(".fl-chips button, .fl-cards button");
+
+  const plain = page.locator('[data-vendo-remixable="PlainMerchants"]');
+  await plain.hover();
+  await plain.getByRole("button", { name: "Remix PlainMerchants with Vendo" }).click();
+  await expect(panel).toBeVisible();
+
+  // The person's own intent reads as words, never as the identifier sync
+  // captured the component under — the agent still gets that, out of sight.
+  await expect(composer).toHaveValue("Remix this view: ");
+  await expect(panel).not.toContainText("PlainMerchants");
+  // And nothing on screen argues against it: the starters are about other
+  // things, and the person has just said which thing they mean.
+  await expect(starters).toHaveCount(0);
+  await page.screenshot({ path: `${SHOTS}/6-door-landing.png`, fullPage: true, animations: "disabled" });
+
+  // The contrast, in the same panel: take the intent away and the host's
+  // starters are exactly where they always were.
+  await composer.fill("");
+  await expect(starters.first()).toBeVisible();
+  await page.screenshot({ path: `${SHOTS}/7-generic-landing.png`, fullPage: true, animations: "disabled" });
+});
+
+/**
+ * Touch has no hover, and a finger's `pointerleave` fires the instant it lifts
+ * — so the reveal's leave rule, written for a cursor, took the door away 200ms
+ * after the tap that asked for it while CSS left the pill non-interactive.
+ * jsdom cannot say this: it ships no PointerEvent, so it cannot tell a finger
+ * from a cursor. A real touchscreen context can.
+ */
+test.describe("on a touchscreen", () => {
+  test.use({ hasTouch: true });
+
+  test("a tap reveals the ✦ door, and the lift does not take it away", async ({ page }) => {
+    await openScenario(page, "remixable");
+    const plain = page.locator('[data-vendo-remixable="PlainMerchants"]');
+    const door = plain.getByRole("button", { name: "Remix PlainMerchants with Vendo" });
+
+    await plain.tap();
+    await expect(plain).toHaveAttribute("data-vendo-revealed", "");
+    // The finger is already off the glass. Well past the 200ms grace, the door
+    // is still there and still pressable.
+    await page.waitForTimeout(600);
+    await expect(plain).toHaveAttribute("data-vendo-revealed", "");
+    await expect(door).toHaveCSS("pointer-events", "auto");
+    await page.screenshot({ path: `${SHOTS}/8-touch-revealed.png`, fullPage: true, animations: "disabled" });
+
+    await door.tap();
+    await expect(page.getByRole("dialog", { name: "Vendo assistant" })).toBeVisible();
+
+    // And it still puts itself away — a press outside, the way every ✦ does.
+    await page.keyboard.press("Escape");
+    await page.locator("body").tap({ position: { x: 5, y: 5 } });
+    await expect(plain).not.toHaveAttribute("data-vendo-revealed", "");
+  });
 });

--- a/packages/ui/e2e/remixable-one-door.spec.ts
+++ b/packages/ui/e2e/remixable-one-door.spec.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "@playwright/test";
+import { openScenario } from "./helpers.js";
+
+/**
+ * S2 — the ✦ is ONE DOOR. The wish used to be typed into a form the wrapper
+ * drew itself, which the chat knew nothing about; now the mark opens the
+ * conversation the page already has, and a remixed component wears the pin
+ * chrome's single menu instead of a lookalike of it.
+ *
+ * A real browser, because the bloom is a CSS reveal and the popover is real
+ * layout: jsdom cannot say whether the pill can actually be hovered to.
+ */
+const SHOTS = "/tmp/s2-shots";
+
+test("the ✦ opens the chat about the component, and the remixed one wears the pin chrome", async ({ page }) => {
+  await openScenario(page, "remixable");
+
+  const plain = page.locator('[data-vendo-remixable="PlainMerchants"]');
+  const remixed = page.locator('[data-vendo-remixable="RemixedMerchants"]');
+
+  // 1 — at rest: the 9px seed, and a pill nobody can press by accident.
+  const door = plain.getByRole("button", { name: "Remix PlainMerchants with Vendo" });
+  await expect(plain.locator(".fl-remix-seed")).toHaveCSS("opacity", "0.32");
+  await expect(door).toHaveCSS("opacity", "0");
+  await expect(door).toHaveCSS("pointer-events", "none");
+  await page.screenshot({ path: `${SHOTS}/1-at-rest.png`, fullPage: true, animations: "disabled" });
+
+  // 2 — hovering blooms the seed into the pill, in place.
+  await plain.hover();
+  await expect(plain).toHaveAttribute("data-vendo-revealed", "");
+  await expect(door).toHaveCSS("opacity", "1");
+  await page.screenshot({ path: `${SHOTS}/2-bloomed.png`, fullPage: true, animations: "disabled" });
+
+  // 3 — the door: one press lands in the conversation, prefilled and unsent.
+  // No wish form of its own anywhere on the page.
+  await door.click();
+  const panel = page.getByRole("dialog", { name: "Vendo assistant" });
+  await expect(panel).toBeVisible();
+  await expect(panel.getByRole("textbox", { name: "Message" })).toHaveValue("Remix my PlainMerchants: ");
+  await expect(page.locator(".fl-remix-ask")).toHaveCount(0);
+  await page.screenshot({ path: `${SHOTS}/3-chat-opened.png`, fullPage: true, animations: "disabled" });
+
+  await page.keyboard.press("Escape");
+  await expect(panel).toBeHidden();
+
+  // 4 — the remixed component: its screen took the host original's place, and
+  // it carries ONE ✦ menu, which is the pin chrome's.
+  await expect(remixed).toContainText("Outstanding this week");
+  await expect(remixed).not.toContainText("Recent payees");
+  await remixed.hover();
+  await remixed.getByRole("button", { name: "Edit RemixedMerchants" }).click();
+  const menu = remixed.getByRole("group", { name: "RemixedMerchants" });
+  await expect(menu.getByRole("button")).toHaveText(["Edit in chat", "Update", "Revert"]);
+  await expect(menu.getByRole("status")).toHaveCount(0);
+  await page.screenshot({ path: `${SHOTS}/4-remixed-menu.png`, fullPage: true, animations: "disabled" });
+
+  // 5 — and its "Edit in chat" is the same door, about that remix.
+  await menu.getByRole("button", { name: "Edit in chat" }).click();
+  await expect(panel).toBeVisible();
+  await expect(panel.getByRole("textbox", { name: "Message" })).toHaveValue("Update RemixedMerchants: ");
+  await expect(panel).not.toContainText("app_remix");
+  await page.screenshot({ path: `${SHOTS}/5-edit-in-chat.png`, fullPage: true, animations: "disabled" });
+});

--- a/packages/ui/src/chrome/chrome-css.ts
+++ b/packages/ui/src/chrome/chrome-css.ts
@@ -1452,12 +1452,12 @@ html[data-vendo-dock] {
   .fl-remix-pill { transition: opacity 180ms cubic-bezier(.23,1,.32,1), transform 180ms cubic-bezier(.23,1,.32,1); }
 }
 
-/* ---- ✦ management popover (2026-08-02 final shape) ----
-   The pill on an already-remixed component opens this instead of forking:
-   status line, open-in-panel, revert. Borrows the slot menu's glass look.
-   The wrap carries the pill's absolute position so pill and menu share an
-   anchor; the pill inside it drops its own offset. No entry animation — the
-   popover appears in place (reduced motion needs no special case). */
+/* ---- the ✦ menu (pin-chrome.tsx) ----
+   The one popover over an app the page is showing on the person's behalf, a
+   remix and a pinned app alike: edit in chat, update, revert. The wrap carries
+   the pill's absolute position so pill and menu share an anchor; the pill
+   inside it drops its own offset. No entry animation — the popover appears in
+   place (reduced motion needs no special case). */
 .fl-remix-menu-wrap { position: absolute; top: 3px; right: 4px; z-index: 7; }
 .fl-remix-menu-wrap .fl-remix-pill { position: static; }
 .fl-remix-menu { position: absolute; top: 26px; right: 0; min-width: 188px; padding: 6px;
@@ -1465,19 +1465,11 @@ html[data-vendo-dock] {
   border: 1px solid var(--vendo-border-strong); border-radius: 12px;
   background: var(--vendo-surface);
   box-shadow: var(--vendo-shadow-float); font-family: var(--vendo-font-family); }
-.fl-remix-status { padding: 6px 9px 7px; font: 500 11px/1.4 var(--vendo-font-family);
-  color: var(--vendo-fg-muted); border-bottom: 1px solid var(--vendo-border); margin-bottom: 3px; }
 .fl-remix-menu button { text-align: left; font: 500 12.5px/1.2 var(--vendo-font-family); padding: 7px 9px;
   border: 0; border-radius: 8px; background: transparent; color: var(--vendo-fg); cursor: pointer; }
 .fl-remix-menu button:hover { background: var(--vendo-accent-soft); }
 .fl-remix-menu button:disabled { color: var(--vendo-fg-muted); cursor: default; }
 .fl-remix-menu button.is-danger { color: var(--vendo-danger); }
-/* The ✦ gesture's own popover: the instruction it collects before it fires. */
-.fl-remix-ask { width: 220px; margin: 1px 0 4px; padding: 7px 9px;
-  border: 1px solid var(--vendo-border); border-radius: 8px;
-  background: var(--vendo-surface); color: var(--vendo-fg);
-  font: 500 12.5px/1.2 var(--vendo-font-family); }
-.fl-remix-ask:focus-visible { outline: 2px solid var(--vendo-accent); outline-offset: 1px; }
 
 /* ---- filled state ---- */
 .fl-slot-filled { position: relative; flex: 1; }

--- a/packages/ui/src/chrome/chrome-css.ts
+++ b/packages/ui/src/chrome/chrome-css.ts
@@ -1465,6 +1465,10 @@ html[data-vendo-dock] {
   border: 1px solid var(--vendo-border-strong); border-radius: 12px;
   background: var(--vendo-surface);
   box-shadow: var(--vendo-shadow-float); font-family: var(--vendo-font-family); }
+/* The unsettled app's one line, above the actions: quieter and smaller than
+   them, because it is what IS rather than something to do. */
+.fl-remix-status { padding: 6px 9px 7px; font: 500 11px/1.4 var(--vendo-font-family);
+  color: var(--vendo-fg-muted); border-bottom: 1px solid var(--vendo-border); margin-bottom: 3px; }
 .fl-remix-menu button { text-align: left; font: 500 12.5px/1.2 var(--vendo-font-family); padding: 7px 9px;
   border: 0; border-radius: 8px; background: transparent; color: var(--vendo-fg); cursor: pointer; }
 .fl-remix-menu button:hover { background: var(--vendo-accent-soft); }

--- a/packages/ui/src/chrome/pin-chrome.tsx
+++ b/packages/ui/src/chrome/pin-chrome.tsx
@@ -1,42 +1,70 @@
 import { log } from "@vendoai/core";
 import { useEffect, useRef, useState, type ReactNode } from "react";
-import { useVendoProvider } from "../context.js";
 import { developmentMode } from "./dev-mode.js";
 import { openVendoConversation } from "./overlay-registry.js";
-import { GRACE_MS, useMenuDismiss } from "./remixable.js";
 import { vendoToast } from "./vendo-toasts.js";
 
+/** Long enough for cursor travel from the element to the pill, short enough
+ *  that the pill does not linger over the page. Shared with `<Remixable>`
+ *  (remixable.tsx), which wears the same marks — two copies of this number is
+ *  two blooms that can drift apart. */
+export const GRACE_MS = 200;
+
+/** Every ✦ popover dismisses like any menu: Escape, or pointer-down outside
+ *  it. Returns the ref that marks "inside". */
+function useMenuDismiss(open: boolean, onToggle: (open: boolean) => void) {
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (event: PointerEvent) => {
+      if (!(event.target instanceof Node) || !ref.current?.contains(event.target)) onToggle(false);
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onToggle(false);
+    };
+    document.addEventListener("pointerdown", onPointerDown);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [open, onToggle]);
+  return ref;
+}
+
 /**
- * S3 — what a person can DO with the app someone pinned into a host slot.
+ * The ONE ✦ menu — Edit in chat · Update · Revert — over any app the page is
+ * showing on the person's behalf: one someone pinned into a host slot, and one
+ * a `<Remixable>` component was remixed into (remixable.tsx mounts this same
+ * chrome rather than a lookalike of it, so there is one ✦ vocabulary on the
+ * page instead of two that almost match).
  *
- * A pinned app had no handle at all: it was a view that appeared, and changing
- * or removing it meant knowing to go ask the assistant. This is the handle, in
- * the grammar the page already speaks — the same 9px ✦ seed, the same bloom
- * into a pill, the same small popover as `<Remixable>` (remixable.tsx), because
- * a second vocabulary for the same gesture is a vocabulary nobody learns.
+ * Only `Revert` differs by owner, so only `Revert` is injected: a pinned app's
+ * placement is unplaced, a remix's whole app is deleted. Both mean the same
+ * thing to the person — the host's own markup comes back.
  *
  * REVEALED IS STATE, NOT `:hover`, for the reason Remixable documents: a
  * CSS-only reveal dies on the way to the pill, so the pill could never be
  * clicked. Touch has no hover at all, so a tap on the app reveals the seed and
  * a tap anywhere else puts it away.
  *
- * The bloom's timing and the dismissal are Remixable's own — imported, not
- * restated, so the two ✦ marks can never drift apart. `useMenuDismiss` is
- * scoped TWICE here, which is the whole of the touch behavior: the popover
- * closes on a press outside the popover, and the mark only goes away on a press
- * outside the APP, so tapping the app cannot undo the tap that revealed it.
+ * `useMenuDismiss` is scoped TWICE here, which is the whole of the touch
+ * behavior: the popover closes on a press outside the popover, and the mark
+ * only goes away on a press outside the APP, so tapping the app cannot undo the
+ * tap that revealed it.
  */
 
-export function PinChrome({ appId, slotId, title, onRefresh, onUnpinned, children }: {
+export function PinChrome({ appId, title, context, onRefresh, onRevert, children }: {
   appId: string;
-  slotId: string;
   /** What the app calls itself — the prefill names the THING, never an id. */
   title: string;
+  /** The grounding "Edit in chat" hands the agent — never rendered. */
+  context: string;
   onRefresh(): void;
-  onUnpinned(): void;
+  /** Undo this app's presence on the page; rejecting keeps the popover open. */
+  onRevert(): Promise<void>;
   children: ReactNode;
 }) {
-  const { client } = useVendoProvider();
   const [revealed, setRevealed] = useState(false);
   const [open, setOpen] = useState(false);
   const [busy, setBusy] = useState(false);
@@ -63,42 +91,36 @@ export function PinChrome({ appId, slotId, title, onRefresh, onUnpinned, childre
   const edit = () => {
     setOpen(false);
     setRevealed(false);
-    // Same hand-off as the ✦ remix popover's "Open in panel": the person reads
-    // the app's name, the agent reads the grounding, and nothing is sent.
-    const opened = openVendoConversation({
-      appId,
-      prompt: `Update ${title}: `,
-      context: `The view being edited is the "${title}" app (${appId}), pinned in the "${slotId}" slot.`,
-      send: false,
-    });
+    // The person reads the app's name, the agent reads the grounding, and
+    // nothing is sent.
+    const opened = openVendoConversation({ appId, prompt: `Update ${title}: `, context, send: false });
     if (!opened && developmentMode()) {
       log({
         code: "ui.pin-chrome-no-overlay",
         level: "warn",
-        message: `[vendo] VendoSlot "${slotId}": "Edit in chat" opens the conversation surface — mount a VendoOverlay for it to land in.`,
+        message: `[vendo] ✦ "${title}": "Edit in chat" opens the conversation surface — mount a VendoOverlay for it to land in.`,
       });
     }
   };
 
-  const unpin = () => {
+  const revert = () => {
     setBusy(true);
-    void client.apps.unplace(appId, slotId).then(
+    void onRevert().then(
       () => {
         setOpen(false);
         setRevealed(false);
-        onUnpinned();
       },
       (reason: unknown) => {
-        // The row is still there, so nothing here may settle as though it were
+        // The app is still there, so nothing here may settle as though it were
         // gone: closing the popover over an app that stayed put is the same lie
         // the pin ring used to tell from a timer. One honest line — the exact
         // sentence a refused `apps.place` shows (pin-ceremony.ts) — and the
-        // popover stays open, so Unpin is still under the cursor to try again.
+        // popover stays open, so Revert is still under the cursor to try again.
         if (developmentMode()) {
           log({
-            code: "ui.pin-chrome-unplace-failed",
+            code: "ui.pin-chrome-revert-failed",
             level: "warn",
-            message: `[vendo] VendoSlot "${slotId}": unpinning ${appId} failed — ${String(reason)}`,
+            message: `[vendo] ✦ "${title}": reverting ${appId} failed — ${String(reason)}`,
           });
         }
         vendoToast({ text: "That didn’t go through — try again.", state: "error" });
@@ -136,9 +158,9 @@ export function PinChrome({ appId, slotId, title, onRefresh, onUnpinned, childre
         {open ? (
           <div className="fl-remix-menu" role="group" aria-label={title}>
             <button type="button" onClick={edit}>Edit in chat</button>
-            <button type="button" onClick={() => { setOpen(false); onRefresh(); }}>Refresh</button>
-            <button type="button" className="is-danger" disabled={busy} onClick={unpin}>
-              {busy ? "Unpinning…" : "Unpin"}
+            <button type="button" onClick={() => { setOpen(false); onRefresh(); }}>Update</button>
+            <button type="button" className="is-danger" disabled={busy} onClick={revert}>
+              {busy ? "Reverting…" : "Revert"}
             </button>
           </div>
         ) : null}

--- a/packages/ui/src/chrome/pin-chrome.tsx
+++ b/packages/ui/src/chrome/pin-chrome.tsx
@@ -11,8 +11,9 @@ import { vendoToast } from "./vendo-toasts.js";
 export const GRACE_MS = 200;
 
 /** Every ✦ popover dismisses like any menu: Escape, or pointer-down outside
- *  it. Returns the ref that marks "inside". */
-function useMenuDismiss(open: boolean, onToggle: (open: boolean) => void) {
+ *  it. Returns the ref that marks "inside". Shared with `<Remixable>`
+ *  (remixable.tsx), where it is touch's only way to put the mark away. */
+export function useMenuDismiss(open: boolean, onToggle: (open: boolean) => void) {
   const ref = useRef<HTMLDivElement>(null);
   useEffect(() => {
     if (!open) return;

--- a/packages/ui/src/chrome/pin-chrome.tsx
+++ b/packages/ui/src/chrome/pin-chrome.tsx
@@ -55,12 +55,19 @@ export function useMenuDismiss(open: boolean, onToggle: (open: boolean) => void)
  * tap that revealed it.
  */
 
-export function PinChrome({ appId, title, context, onRefresh, onRevert, children }: {
+export function PinChrome({ appId, title, context, state, onRefresh, onRevert, children }: {
   appId: string;
   /** What the app calls itself — the prefill names the THING, never an id. */
   title: string;
   /** The grounding "Edit in chat" hands the agent — never rendered. */
   context: string;
+  /** An app that is NOT a finished screen. The mark reads `label`, answers to
+   *  `name`, and the menu announces `status` — because the ✦ sits over the
+   *  host's own original in both of those states, and a settled "Edit" over one
+   *  is the page claiming a screen that is not there. Absent is the ordinary
+   *  settled app. Vocabulary belongs to the caller: a remix that never built and
+   *  a pinned app that will not load are not the same sentence. */
+  state?: { label: string; name: string; status: string; busy?: boolean };
   onRefresh(): void;
   /** Undo this app's presence on the page; rejecting keeps the popover open. */
   onRevert(): Promise<void>;
@@ -148,16 +155,22 @@ export function PinChrome({ appId, title, context, onRefresh, onRevert, children
         <button
           type="button"
           className="fl-remix-pill"
-          aria-label={`Edit ${title}`}
+          aria-label={state?.name ?? `Edit ${title}`}
           aria-haspopup="true"
           aria-expanded={open}
+          aria-busy={state?.busy === true || undefined}
           onClick={() => setOpen(!open)}
         >
           <span aria-hidden="true" className="fl-remix-pill-mark">✦</span>
-          Edit
+          {state?.label ?? "Edit"}
         </button>
         {open ? (
           <div className="fl-remix-menu" role="group" aria-label={title}>
+            {/* The state's own sentence, announced. The menu is where it lived
+                before the two ✦ marks converged, and it stays a LINE rather than
+                a surface: what went wrong, and what to do about it, belong to
+                the conversation that asked (remixable.tsx). */}
+            {state === undefined ? null : <span className="fl-remix-status" role="status">{state.status}</span>}
             <button type="button" onClick={edit}>Edit in chat</button>
             <button type="button" onClick={() => { setOpen(false); onRefresh(); }}>Update</button>
             <button type="button" className="is-danger" disabled={busy} onClick={revert}>

--- a/packages/ui/src/chrome/remixable.tsx
+++ b/packages/ui/src/chrome/remixable.tsx
@@ -177,6 +177,21 @@ function RemixedFork({ appId, slot, review, liveProps, original, onReverted }: {
   // never builds gets NO surface of its own here: the wish was typed in the
   // chat, so the failure is the chat's to report (the thread's build-failed
   // beat), and a second error surface on the page is what S2 deleted.
+  //
+  // What the ✦ itself says is a different question, and deleting that surface
+  // took the answer with it. The provenance row lands the instant the remix is
+  // minted and its screen arrives tens of seconds later, so through the whole
+  // build — and forever, when the build terminally fails — the mark sat over
+  // the host's untouched original reading a settled "Edit", offering to edit a
+  // screen that does not exist. Read off the SAME open payload the mount waits
+  // on, so the mark and the page can never disagree.
+  const pending = surface === undefined && error === undefined;
+  const failed = surface?.kind === "failed" || (surface === undefined && error !== undefined);
+  const state = pending
+    ? { label: "Remixing…", name: "Remixing this view…", status: "Making your remix.", busy: true }
+    : failed
+      ? { label: "Didn’t load", name: "This view didn’t load", status: "The remix didn’t load — the chat that asked for it says why." }
+      : undefined;
   const Original = () => <>{original}</>;
   return (
     <ChromeRoot>
@@ -188,6 +203,7 @@ function RemixedFork({ appId, slot, review, liveProps, original, onReverted }: {
         // says — and it matches the pill's own visible word, which is the name
         // a voice-control user can actually speak.
         title="this view"
+        {...(state === undefined ? {} : { state })}
         // The grounding rides `context` — a marked text part on the sent
         // message that no surface renders — so the prefill can name the THING
         // and never an id (spec §16 law 3).

--- a/packages/ui/src/chrome/remixable.tsx
+++ b/packages/ui/src/chrome/remixable.tsx
@@ -5,27 +5,32 @@ import { useApp } from "../hooks/use-app.js";
 import { useResource } from "../hooks/use-resource.js";
 import { FluidReveal } from "../tree/fluid-reveal.js";
 import { AppFrame, PinMount } from "../tree/frames.js";
-import type { InClientVenue, OpenSurface } from "../wire-types.js";
+import type { InClientVenue } from "../wire-types.js";
 import { useApprovalModal } from "./approval-modal.js";
 import { ChromeRoot } from "./chrome-root.js";
 import { developmentMode } from "./dev-mode.js";
 import { openVendoConversation } from "./overlay-registry.js";
+import { GRACE_MS, PinChrome } from "./pin-chrome.js";
 
 /**
- * The remixable-surface affordance (2026-08-02 final shape): the host marking
- * one of its own components as remixable. There are no bare forks — the ✦
- * gesture COLLECTS AN INSTRUCTION first and sends it with the wire seed, so the
- * fork and its first edit are one operation — and the resulting screen mounts
- * IN PLACE, replacing the wrapped child at this boundary for that user only.
- * Until that screen is ready the host's own live original stays on the page.
+ * The remixable-surface affordance: the host marking one of its own components
+ * as remixable. The ✦ is ONE DOOR — it opens the conversation the page already
+ * has, about this component, and the person types their wish there. It used to
+ * open a wish form of its own, which was a second place to ask the same
+ * question: the chat could answer, show its work, and say when a remix failed;
+ * the form could only mint and go quiet.
+ *
+ * The remix that conversation makes mounts IN PLACE, replacing the wrapped
+ * child at this boundary for that user only. Until its screen is ready the
+ * host's own live original stays on the page.
  *
  * At rest a 9px muted ✦ seed sits inside the wrapped element's top-right
  * corner — visible if you look for it, invisible while you are working.
  * Pointing at the element blooms that seed IN PLACE into the ✦ pill — same
  * corner, same optical centre — so it reads as one mark opening rather than a
- * glyph swapping for a button. On an unforked surface the pill IS the fork
- * gesture; on a remixed one it opens the small management popover (status /
- * open in panel / revert).
+ * glyph swapping for a button. On an unremixed surface the pill IS the door;
+ * on a remixed one it is the pin chrome (pin-chrome.tsx), because a remix is a
+ * pinned app and one ✦ menu is the whole point.
  *
  * REVEALED IS STATE, NOT `:hover`. A CSS-only reveal dies the instant the
  * cursor leaves the box, which is exactly what it does on the way to the pill
@@ -35,12 +40,6 @@ import { openVendoConversation } from "./overlay-registry.js";
  * keyboard-reachable.
  */
 
-/** Long enough for cursor travel from the element to the pill, short enough
- *  that the pill does not linger over the page. Shared with the pinned app's ✦
- *  chrome (pin-chrome.tsx), which wears the same marks — two copies of this
- *  number is two blooms that can drift apart. */
-export const GRACE_MS = 200;
-
 const DISCOVERY_POLL_MS = 5000;
 
 export interface RemixableProps {
@@ -48,7 +47,8 @@ export interface RemixableProps {
    *  baseline). Review buys the venue, never visibility: a reviewed
    *  component's approved fork mounts natively; an instant (default) one
    *  renders sandboxed, forever, with no review process at all. The gating
-   *  itself is server-side — here it only shapes the popover's status line. */
+   *  itself is server-side — here it only holds the host's own component on
+   *  the page until the verdict arrives. */
   review?: boolean;
   children: ReactNode;
 }
@@ -99,29 +99,6 @@ function serializableProps(children: ReactNode): Record<string, Json> {
 
 const NO_APPS: AppDocument[] = [];
 
-/** Every ✦ popover dismisses like any menu: Escape, or pointer-down outside
- *  it. Returns the ref that marks "inside". Shared with pin-chrome.tsx, which
- *  scopes one to its popover and one to the app the mark sits on. */
-export function useMenuDismiss(open: boolean, onToggle: (open: boolean) => void) {
-  const ref = useRef<HTMLDivElement>(null);
-  useEffect(() => {
-    if (!open) return;
-    const onPointerDown = (event: PointerEvent) => {
-      if (!(event.target instanceof Node) || !ref.current?.contains(event.target)) onToggle(false);
-    };
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") onToggle(false);
-    };
-    document.addEventListener("pointerdown", onPointerDown);
-    document.addEventListener("keydown", onKeyDown);
-    return () => {
-      document.removeEventListener("pointerdown", onPointerDown);
-      document.removeEventListener("keydown", onKeyDown);
-    };
-  }, [open, onToggle]);
-  return ref;
-}
-
 /** Remix discovery: the user's remix for this component is the app whose `seed`
  *  names it (provenance — the 2026-08-02 provenance/placement split). An
  *  in-place remix needs no placement: its location IS the wrapper it replaced,
@@ -143,52 +120,16 @@ function useRemixFork(slot: string | null) {
   return { appId, refresh };
 }
 
-/** The popover's status line, read straight off the open payload — the venue
- *  verdict is SERVER-authoritative (lane W1c owns the review lifecycle; this
- *  only renders what the payload reports). */
-function remixStatus(review: boolean, surface: OpenSurface | undefined, failed: boolean): string {
-  // The server said terminally why, so say that rather than the generic
-  // sentence below — on either kind of remix.
-  if (surface?.kind === "failed") return surface.reason;
-  // The bounded load gave up (use-app.ts) — the generation outran the build
-  // window, or the wire stopped answering. Same sentence either way: the fact,
-  // and the reassurance that the host's own component is still what is on screen.
-  if (failed) return "The remix didn’t load — nothing changed on the page.";
-  if (!review) return "Sandboxed — only you see this";
-  if (surface?.kind !== "tree") return "Waiting for review";
-  const venue = (surface.payload as { inClient?: InClientVenue }).inClient;
-  if (venue?.granted === true) {
-    // An older approved version can be serving while the CURRENT one awaits
-    // review (the `review` rider) — the status reports BOTH, or it would hide
-    // the pending state and the reviewer's note behind "Approved".
-    const serving = `Approved by ${venue.approvedBy} — runs in the page`;
-    if (venue.review?.status === "pending") return `${serving}; your latest edit is waiting for review`;
-    if (venue.review?.status === "rejected") return `${serving}; your latest edit was rejected — "${venue.review.note}"`;
-    return serving;
-  }
-  if (venue?.granted === false && venue.reason === "pending-review" && venue.review.status === "rejected") {
-    return `Rejected — "${venue.review.note}". Edit the remix to resubmit it for review.`;
-  }
-  if (venue?.granted === false && venue.reason === "version-changed") {
-    return "Changed since approval — sandboxed until re-approved";
-  }
-  return "Waiting for review";
-}
-
-function RemixedFork({ appId, slot, review, liveProps, menuOpen, onMenuToggle, original, onReverted }: {
+function RemixedFork({ appId, slot, review, liveProps, original, onReverted }: {
   appId: string;
   slot: string;
   review: boolean;
   liveProps: Record<string, Json>;
-  menuOpen: boolean;
-  onMenuToggle(open: boolean): void;
   original: ReactNode;
   onReverted(): Promise<void>;
 }) {
   const { client, components } = useVendoProvider();
-  const { surface, error, isLoading } = useApp(appId);
-  const menuRef = useMenuDismiss(menuOpen, onMenuToggle);
-  const [reverting, setReverting] = useState(false);
+  const { surface, error, isLoading, refresh } = useApp(appId);
   // A press inside the mounted fork that parks on the guard asks its question
   // over this surface (the VendoSlot seam). The modal hangs off the ✦ chrome
   // below rather than the fork's own boundary: it must outlive a fork that
@@ -220,58 +161,36 @@ function RemixedFork({ appId, slot, review, liveProps, menuOpen, onMenuToggle, o
     return { ...surface, payload };
   }, [surface, slot, livePropsKey]);
 
-  const revert = () => {
-    if (reverting) return;
-    setReverting(true);
-    client.apps.delete(appId)
-      .then(() => {
-        onMenuToggle(false);
-        return onReverted();
-      })
-      .catch((reason: unknown) => {
-        if (developmentMode()) {
-          log({
-            code: "ui.remixable-revert-failed",
-            level: "warn",
-            message: `[vendo] Remixable "${slot}": revert failed — ${reason instanceof Error ? reason.message : String(reason)}`,
-          });
-        }
-      })
-      .finally(() => setReverting(false));
-  };
-
   // The founder's binding rule (2026-08-02): until a reviewer approves, the
   // ORIGINAL host component stays rendered, untouched. A pending or rejected
   // review-kind remix mounts NOTHING here — no AppFrame, no notice in the
-  // page; its status lives in the panel and the ✦ popover. The venue verdict
-  // is server-authoritative ("pending-review" ships no executable source);
-  // the wrapper's own `review` flag covers a payload that carries no venue.
+  // page; its status lives in the conversation that asked for it. The venue
+  // verdict is server-authoritative ("pending-review" ships no executable
+  // source); the wrapper's own `review` flag covers a payload with no venue.
   const venue = surface?.kind === "tree" ? (surface.payload as { inClient?: InClientVenue }).inClient : undefined;
   const underReview = venue?.granted !== true
     && (review || (venue !== undefined && !venue.granted && venue.reason === "pending-review"));
 
-  // The seed's provenance row lands the instant the fork is minted; its screen
-  // arrives tens of seconds later (until then `open` answers the build window's
-  // pending, which `useApp` keeps asking through rather than failing). The
-  // pill reads that OPEN PAYLOAD — the same signal the mount below waits on —
-  // or it claims "Remixed" over the host's untouched original for the whole
-  // generation, which reads as broken.
-  const pending = surface === undefined && error === undefined;
-  // That wait is bounded, so the pill needs a third state in the slot's own
-  // failure voice ("This view didn't load"): claiming work forever is the same
-  // lie "Remixed" was, one step later. A terminal `{kind:"failed"}` surface is
-  // the same dead end arriving as an answer rather than as a timeout — it
-  // mounts no screen, so it must not read "Remixed" either.
-  const failed = surface?.kind === "failed" || (surface === undefined && error !== undefined);
-
   // Until the fork's surface arrives (or if it never does), the original child
   // is the honest content — the wrapper never trades working host markup for
-  // a skeleton, and a crashing fork drops back to it (PinMount).
+  // a skeleton, and a crashing fork drops back to it (PinMount). A remix that
+  // never builds gets NO surface of its own here: the wish was typed in the
+  // chat, so the failure is the chat's to report (the thread's build-failed
+  // beat), and a second error surface on the page is what S2 deleted.
   const Original = () => <>{original}</>;
   return (
-    <>
-      {staged?.kind === "tree" && !underReview ? (
-        <ChromeRoot>
+    <ChromeRoot>
+      <PinChrome
+        appId={appId}
+        title={slot}
+        // The grounding rides `context` — a marked text part on the sent
+        // message that no surface renders — so the prefill can name the THING
+        // and never an id (spec §16 law 3).
+        context={`The view being remixed is the "${slot}" slot, app ${appId}.`}
+        onRefresh={() => void refresh()}
+        onRevert={() => client.apps.delete(appId).then(onReverted)}
+      >
+        {staged?.kind === "tree" && !underReview ? (
           <FluidReveal stateKey={`fork:${appId}`} initialExit={original}>
             <PinMount slot={slot} fallback={Original}>
               <AppFrame
@@ -282,90 +201,20 @@ function RemixedFork({ appId, slot, review, liveProps, menuOpen, onMenuToggle, o
               />
             </PinMount>
           </FluidReveal>
-        </ChromeRoot>
-      ) : original}
-      <ChromeRoot className="fl-remixable-chrome">
-        <span className="fl-remix-seed" aria-hidden="true">✦</span>
-        <div className="fl-remix-menu-wrap" ref={menuRef}>
-          <button
-            type="button"
-            className="fl-remix-pill"
-            aria-label={`Manage the ${slot} remix`}
-            aria-haspopup="true"
-            aria-expanded={menuOpen}
-            aria-busy={pending || undefined}
-            onClick={() => onMenuToggle(!menuOpen)}
-          >
-            <span aria-hidden="true" className="fl-remix-pill-mark">✦</span>
-            {failed ? "Didn’t load" : pending ? "Remixing…" : "Remixed"}
-          </button>
-          {menuOpen ? (
-            <div className="fl-remix-menu" role="group" aria-label={`Remix of ${slot}`}>
-              <span className="fl-remix-status" role="status">{remixStatus(review, surface, failed)}</span>
-              <button
-                type="button"
-                onClick={() => {
-                  onMenuToggle(false);
-                  // The prefill names the THING, never an id (spec §16 law 3):
-                  // it used to read "Update my <slot> remix (app app_…): " and
-                  // an app id is our plumbing, not something a person types.
-                  // The agent's app tools are appId-keyed with no list tool, so
-                  // the grounding rides `context` — a marked text part on the
-                  // sent message that no surface renders.
-                  const opened = openVendoConversation({
-                    prompt: `Update my ${slot} remix: `,
-                    context: `The view being remixed is the "${slot}" slot, app ${appId}.`,
-                    send: false,
-                  });
-                  if (!opened && developmentMode()) {
-                    log({
-                    code: "ui.remixable-no-overlay",
-                    level: "warn",
-                    message: `[vendo] Remixable "${slot}": "Open in panel" opens the conversation surface — mount a VendoOverlay for it to land in.`,
-                  });
-                  }
-                }}
-              >
-                Open in panel
-              </button>
-              <button type="button" className="is-danger" disabled={reverting} onClick={revert}>
-                {reverting ? "Reverting…" : "Revert to original"}
-              </button>
-            </div>
-          ) : null}
-        </div>
-        {approval.modal}
-      </ChromeRoot>
-    </>
+        ) : original}
+      </PinChrome>
+      {approval.modal}
+    </ChromeRoot>
   );
 }
 
 export function Remixable({ review = false, children }: RemixableProps) {
-  const { client } = useVendoProvider();
   const [revealed, setRevealed] = useState(false);
   const grace = useRef<number | undefined>(undefined);
   useEffect(() => () => window.clearTimeout(grace.current), []);
 
   const slot = slotOf(children);
   const { appId, refresh } = useRemixFork(slot);
-
-  // Both ✦ popovers — the instruction the gesture collects, and the management
-  // menu on an existing remix — share this open state, because it holds the
-  // bloom: closing the reveal on pointer-leave would rip the popover out from
-  // under the cursor. `RemixedFork` runs its own dismissal, so this one is armed
-  // only while the ask is the popover on screen.
-  const [menuOpen, setMenuOpen] = useState(false);
-  const askRef = useMenuDismiss(menuOpen && appId === undefined, setMenuOpen);
-
-  // The gesture latch. The ref (not state) is the double-fire guard — a second
-  // synchronous tap can never mint a second call, and the server's
-  // per-(subject, slot) dedupe makes even a raced duplicate return the same
-  // app. State only drives the label, and holds until the fork surfaces.
-  const forking = useRef(false);
-  const [latched, setLatched] = useState(false);
-  useEffect(() => {
-    if (appId !== undefined) setLatched(false);
-  }, [appId]);
 
   useEffect(() => {
     if (slot === null && developmentMode()) {
@@ -388,30 +237,23 @@ export function Remixable({ review = false, children }: RemixableProps) {
     grace.current = window.setTimeout(() => setRevealed(false), GRACE_MS);
   };
 
-  // The ✦ gesture asks the wire for an ordinary app that starts from this
-  // component AND for the person's first edit on it, as one call. Nothing here
-  // can fire a turn; the host's original stays on the page until that app has a
-  // screen to mount.
-  const fork = (instruction: string) => {
-    if (forking.current || appId !== undefined) return;
-    forking.current = true;
-    setMenuOpen(false);
-    setLatched(true);
-    client.apps.seedFrom({ component: slot, instruction })
-      .then(() => refresh())
-      .catch((reason: unknown) => {
-        setLatched(false);
-        if (developmentMode()) {
-          log({
-            code: "ui.remixable-fork-create-failed",
-            level: "warn",
-            message: `[vendo] Remixable "${slot}": the remix fork failed — ${reason instanceof Error ? reason.message : String(reason)}`,
-          });
-        }
-      })
-      .finally(() => {
-        forking.current = false;
+  // ONE DOOR: the ✦ opens the conversation about this component, prefilled and
+  // unsent, and the person finishes the sentence there. It mints nothing —
+  // what a remix should do is the agent's question to answer, and its progress
+  // and its failures belong in the same thread as the asking.
+  const openChat = () => {
+    const opened = openVendoConversation({
+      prompt: `Remix my ${slot}: `,
+      context: `The view being remixed is the "${slot}" component on the host's page.`,
+      send: false,
+    });
+    if (!opened && developmentMode()) {
+      log({
+        code: "ui.remixable-no-overlay",
+        level: "warn",
+        message: `[vendo] Remixable "${slot}": ✦ opens the conversation surface — mount a VendoOverlay for it to land in.`,
       });
+    }
   };
 
   return (
@@ -420,7 +262,7 @@ export function Remixable({ review = false, children }: RemixableProps) {
     <div
       className="fl-remixable"
       data-vendo-remixable={slot}
-      {...(revealed || latched || menuOpen ? { "data-vendo-revealed": "" } : {})}
+      {...(revealed ? { "data-vendo-revealed": "" } : {})}
       onPointerEnter={reveal}
       onPointerLeave={release}
       onFocus={reveal}
@@ -432,8 +274,6 @@ export function Remixable({ review = false, children }: RemixableProps) {
           slot={slot}
           review={review}
           liveProps={serializableProps(children)}
-          menuOpen={menuOpen}
-          onMenuToggle={setMenuOpen}
           original={children}
           onReverted={refresh}
         />
@@ -442,43 +282,15 @@ export function Remixable({ review = false, children }: RemixableProps) {
           {children}
           <ChromeRoot className="fl-remixable-chrome">
             <span className="fl-remix-seed" aria-hidden="true">✦</span>
-            <div className="fl-remix-menu-wrap" ref={askRef}>
-              <button
-                type="button"
-                className="fl-remix-pill"
-                aria-label={`Remix ${slot} with Vendo`}
-                aria-haspopup="true"
-                aria-expanded={menuOpen}
-                aria-busy={latched || undefined}
-                disabled={latched}
-                onClick={() => setMenuOpen(!menuOpen)}
-              >
-                <span aria-hidden="true" className="fl-remix-pill-mark">✦</span>
-                {latched ? "Remixing…" : "Remix"}
-              </button>
-              {menuOpen ? (
-                // The instruction IS the gesture: a remix is what the person
-                // asked for, so nothing is minted until they have said it.
-                <form
-                  className="fl-remix-menu"
-                  onSubmit={(event) => {
-                    event.preventDefault();
-                    const asked = new FormData(event.currentTarget).get("instruction");
-                    const instruction = typeof asked === "string" ? asked.trim() : "";
-                    if (instruction !== "") fork(instruction);
-                  }}
-                >
-                  <input
-                    className="fl-remix-ask"
-                    name="instruction"
-                    autoFocus
-                    aria-label={`What should your ${slot} do?`}
-                    placeholder="What should this do instead?"
-                  />
-                  <button type="submit">Remix it</button>
-                </form>
-              ) : null}
-            </div>
+            <button
+              type="button"
+              className="fl-remix-pill"
+              aria-label={`Remix ${slot} with Vendo`}
+              onClick={openChat}
+            >
+              <span aria-hidden="true" className="fl-remix-pill-mark">✦</span>
+              Remix
+            </button>
           </ChromeRoot>
         </>
       )}

--- a/packages/ui/src/chrome/remixable.tsx
+++ b/packages/ui/src/chrome/remixable.tsx
@@ -182,7 +182,12 @@ function RemixedFork({ appId, slot, review, liveProps, original, onReverted }: {
     <ChromeRoot>
       <PinChrome
         appId={appId}
-        title={slot}
+        // A PINNED APP arrives here with a name the person chose; a remix has
+        // only `slot`, the React identifier sync captures under, which appears
+        // nowhere else on their page. So this side says what the unremixed ✦
+        // says — and it matches the pill's own visible word, which is the name
+        // a voice-control user can actually speak.
+        title="this view"
         // The grounding rides `context` — a marked text part on the sent
         // message that no surface renders — so the prefill can name the THING
         // and never an id (spec §16 law 3).
@@ -294,7 +299,7 @@ export function Remixable({ review = false, children }: RemixableProps) {
             <button
               type="button"
               className="fl-remix-pill"
-              aria-label={`Remix ${slot} with Vendo`}
+              aria-label="Remix this view with Vendo"
               onClick={openChat}
             >
               <span aria-hidden="true" className="fl-remix-pill-mark">✦</span>

--- a/packages/ui/src/chrome/remixable.tsx
+++ b/packages/ui/src/chrome/remixable.tsx
@@ -244,7 +244,7 @@ export function Remixable({ review = false, children }: RemixableProps) {
   const openChat = () => {
     const opened = openVendoConversation({
       prompt: `Remix my ${slot}: `,
-      context: `The view being remixed is the "${slot}" component on the host's page.`,
+      context: `The view being remixed is the host component "${slot}". When you make the remix, pass component=${slot} verbatim.`,
       send: false,
     });
     if (!opened && developmentMode()) {

--- a/packages/ui/src/chrome/remixable.tsx
+++ b/packages/ui/src/chrome/remixable.tsx
@@ -10,7 +10,7 @@ import { useApprovalModal } from "./approval-modal.js";
 import { ChromeRoot } from "./chrome-root.js";
 import { developmentMode } from "./dev-mode.js";
 import { openVendoConversation } from "./overlay-registry.js";
-import { GRACE_MS, PinChrome } from "./pin-chrome.js";
+import { GRACE_MS, PinChrome, useMenuDismiss } from "./pin-chrome.js";
 
 /**
  * The remixable-surface affordance: the host marking one of its own components
@@ -210,6 +210,7 @@ function RemixedFork({ appId, slot, review, liveProps, original, onReverted }: {
 
 export function Remixable({ review = false, children }: RemixableProps) {
   const [revealed, setRevealed] = useState(false);
+  const root = useMenuDismiss(revealed, setRevealed);
   const grace = useRef<number | undefined>(undefined);
   useEffect(() => () => window.clearTimeout(grace.current), []);
 
@@ -243,7 +244,11 @@ export function Remixable({ review = false, children }: RemixableProps) {
   // and its failures belong in the same thread as the asking.
   const openChat = () => {
     const opened = openVendoConversation({
-      prompt: `Remix my ${slot}: `,
+      // The person never sees `slot` anywhere else on the page — it is the
+      // React identifier sync captures under, and it read as a leaked internal
+      // to the first person who clicked this. The AGENT still gets it verbatim,
+      // in the context below, which is where a name it must echo belongs.
+      prompt: "Remix this view: ",
       context: `The view being remixed is the host component "${slot}". When you make the remix, pass component=${slot} verbatim.`,
       send: false,
     });
@@ -262,9 +267,13 @@ export function Remixable({ review = false, children }: RemixableProps) {
     <div
       className="fl-remixable"
       data-vendo-remixable={slot}
+      ref={root}
       {...(revealed ? { "data-vendo-revealed": "" } : {})}
       onPointerEnter={reveal}
-      onPointerLeave={release}
+      // Only a CURSOR leaves. A touch pointer's leave fires the instant the
+      // finger lifts, which would take the pill away with the tap that asked
+      // for it; the outside-press above is touch's dismissal.
+      onPointerLeave={event => { if (event.pointerType === "mouse") release(); }}
       onFocus={reveal}
       onBlur={release}
     >

--- a/packages/ui/src/chrome/thread/index.tsx
+++ b/packages/ui/src/chrome/thread/index.tsx
@@ -176,7 +176,7 @@ export function VendoThread({
     // A message typed mid-turn is offered to that turn before it queues.
     ...(thread.steer === undefined ? {} : { steer: thread.steer }),
   });
-  const { setDraft, setQueued, textareaRef, send } = composerApi;
+  const { draft, setDraft, setQueued, textareaRef, send } = composerApi;
   const risks = useMemo(() => riskByCall(thread.messages), [thread.messages]);
   const guardApprovals = useMemo(() => approvalByCall(thread.messages), [thread.messages]);
   // Grant SETS (demo-live-readiness): a parked call claimed by a
@@ -469,7 +469,13 @@ export function VendoThread({
                 {intro ? <p className="fl-intro">{intro}</p> : null}
               </>
             )}
-            {!tutorialActive && suggestions.length > 0 ? (
+            {!tutorialActive && draft.trim().length === 0 && suggestions.length > 0 ? (
+              // Starters are for a landing with nothing on it. Once an intent is
+              // in the composer — typed, or handed over by a ✦ that opened this
+              // panel ABOUT something — five cards proposing other things argue
+              // against the thing the person just asked for, which is how a
+              // remix click read as a generic assistant (cold walk, 2026-08-18).
+              //
               // Object suggestions render as two-line starter
               // cards (title + concrete outcome, optional host icon); plain
               // strings keep the pill chip. A MIXED array renders both

--- a/packages/ui/src/chrome/vendo-slot.tsx
+++ b/packages/ui/src/chrome/vendo-slot.tsx
@@ -276,7 +276,7 @@ export function VendoSlot({ id, label, description, appId: appIdProp, pin, onAut
   };
   children?: ReactNode;
 }) {
-  const { components } = useVendoProvider();
+  const { client, components } = useVendoProvider();
   // Screen-initiated approvals: a press inside the mounted view that parks on
   // the guard hands itself here, and the modal asks the question centered over
   // the page. The slot owns the presses inside it, so it owns the question
@@ -452,6 +452,7 @@ export function VendoSlot({ id, label, description, appId: appIdProp, pin, onAut
       <PinMount slot={id} fallback={Fallback}>{mounted}</PinMount>
     </FluidReveal>
   );
+  const pinTitle = discovery.title !== undefined && discovery.title !== "" ? discovery.title : name;
   return (
     <ChromeRoot>
       <div className="fl-slot" data-vendo-slot={id}>
@@ -461,10 +462,10 @@ export function VendoSlot({ id, label, description, appId: appIdProp, pin, onAut
         {appId !== undefined && resolvesItself ? (
           <PinChrome
             appId={appId}
-            slotId={id}
-            title={discovery.title !== undefined && discovery.title !== "" ? discovery.title : name}
+            title={pinTitle}
+            context={`The view being edited is the "${pinTitle}" app (${appId}), pinned in the "${id}" slot.`}
             onRefresh={() => setReload(n => n + 1)}
-            onUnpinned={() => void discovery.refresh()}
+            onRevert={() => client.apps.unplace(appId, id).then(() => void discovery.refresh())}
           >
             {body}
           </PinChrome>

--- a/packages/ui/test/chrome/lane-thread-picks.test.tsx
+++ b/packages/ui/test/chrome/lane-thread-picks.test.tsx
@@ -52,6 +52,30 @@ describe("lane pick 4B — landing starter cards", () => {
     });
   });
 
+  // Starters are for a landing with nothing on it. A ✦ opens this panel ABOUT
+  // something and hands the composer that intent, and cards proposing other
+  // things then argue against the thing the person just clicked — which is how
+  // clicking ✦ on a card read as a generic assistant (cold walk, 2026-08-18).
+  it("puts the starters away once the composer carries an intent", async () => {
+    render(
+      <VendoProvider client={client}>
+        <VendoThread
+          discoverability="quiet"
+          suggestions={[{ title: "Build a view", description: "Renewals sorted by risk", prompt: "p" }]}
+        />
+      </VendoProvider>,
+    );
+    expect(await screen.findByRole("button", { name: /Build a view/ })).toBeTruthy();
+
+    // The same bridge `openVendoConversation` drives behind the ✦.
+    fireEvent(window, new CustomEvent("vendo:prefill", { detail: { prompt: "Remix this view: " } }));
+
+    await waitFor(() => expect(screen.queryByRole("button", { name: /Build a view/ })).toBeNull());
+    // And the intent itself survived — the cards went, not the prefill.
+    const composer = screen.getByRole("textbox", { name: "Message" }) as HTMLTextAreaElement;
+    expect(composer.value).toBe("Remix this view: ");
+  });
+
   it("keeps plain string suggestions as pill chips (back-compat)", async () => {
     render(
       <VendoProvider client={client}>

--- a/packages/ui/test/chrome/pin-chrome-keyboard.test.tsx
+++ b/packages/ui/test/chrome/pin-chrome-keyboard.test.tsx
@@ -47,14 +47,14 @@ describe("pinned-app ✦ chrome (keyboard)", () => {
 
     fireEvent.click(edit);
     expect(edit.getAttribute("aria-expanded")).toBe("true");
-    for (const label of ["Edit in chat", "Refresh", "Unpin"]) {
+    for (const label of ["Edit in chat", "Update", "Revert"]) {
       expect(screen.getByRole("button", { name: label })).toBeTruthy();
     }
     // There is no History item — the popover is exactly these three.
     expect(screen.queryByRole("button", { name: /history/i })).toBeNull();
 
     fireEvent.keyDown(document, { key: "Escape" });
-    await waitFor(() => expect(screen.queryByRole("button", { name: "Unpin" })).toBeNull());
+    await waitFor(() => expect(screen.queryByRole("button", { name: "Revert" })).toBeNull());
   });
 
   it("“Edit in chat” opens the overlay scoped to the app, composer prefilled and unsent", async () => {
@@ -73,7 +73,7 @@ describe("pinned-app ✦ chrome (keyboard)", () => {
     await waitFor(() => expect((composer as HTMLTextAreaElement).value).toBe("Update Invoices: "));
   });
 
-  it("a refused unpin says so and stays retryable — it never settles as done", async () => {
+  it("a refused revert says so and stays retryable — it never settles as done", async () => {
     const refused = vi.spyOn(client.apps, "unplace").mockRejectedValue(new Error("nope"));
     render(
       <VendoProvider client={client}>
@@ -83,13 +83,13 @@ describe("pinned-app ✦ chrome (keyboard)", () => {
     );
 
     fireEvent.click(await pill());
-    fireEvent.click(screen.getByRole("button", { name: "Unpin" }));
+    fireEvent.click(screen.getByRole("button", { name: "Revert" }));
 
-    // The row is still there, so the popover is too — with Unpin under the
+    // The row is still there, so the popover is too — with Revert under the
     // cursor where the person left it.
     expect(await screen.findByText(/didn.t go through/i)).toBeTruthy();
     await waitFor(() =>
-      expect(screen.getByRole("button", { name: "Unpin" }).hasAttribute("disabled")).toBe(false));
+      expect(screen.getByRole("button", { name: "Revert" }).hasAttribute("disabled")).toBe(false));
     expect(refused).toHaveBeenCalledWith("app_1", "hero");
   });
 });

--- a/packages/ui/test/chrome/remixable.test.tsx
+++ b/packages/ui/test/chrome/remixable.test.tsx
@@ -11,6 +11,24 @@ import { Remixable, VendoOverlay } from "../../src/chrome/index.js";
 import { CHROME_CSS } from "../../src/chrome/chrome-css.js";
 import { createWireServer } from "../wire-server.js";
 
+/**
+ * jsdom 25 ships no `PointerEvent`, so every synthetic pointer event arrives
+ * with an undefined `pointerType` and a finger cannot be told from a cursor —
+ * which is the whole of the reveal's leave rule. This carries the init through
+ * (the plain `extends MouseEvent` shim in kit/base-ui-bricks.test.tsx drops it),
+ * so the two devices are expressible here. It stays an ENVIRONMENT stand-in: the
+ * real touchscreen behaviour is proven in the browser pass.
+ */
+if (typeof window.PointerEvent !== "function") {
+  window.PointerEvent = class extends MouseEvent {
+    readonly pointerType: string;
+    constructor(type: string, init: PointerEventInit = {}) {
+      super(type, init);
+      this.pointerType = init.pointerType ?? "";
+    }
+  } as unknown as typeof PointerEvent;
+}
+
 /** The slot is the wrapped component's identifier — what sync captures under. */
 const SLOT = "TopMerchants";
 
@@ -79,12 +97,30 @@ describe("Remixable — one door into the chat, one ✦ menu on the remix", () =
   it("blooms on hover and holds through the grace period on the way out", () => {
     vi.useFakeTimers();
     mount();
-    fireEvent.pointerEnter(wrapper());
+    fireEvent.pointerEnter(wrapper(), { pointerType: "mouse" });
     expect(revealed()).toBe(true);
-    fireEvent.pointerLeave(wrapper());
+    fireEvent.pointerLeave(wrapper(), { pointerType: "mouse" });
     act(() => void vi.advanceTimersByTime(150));
     expect(revealed()).toBe(true);
     act(() => void vi.advanceTimersByTime(100));
+    expect(revealed()).toBe(false);
+  });
+
+  // Only a CURSOR leaves. A finger's pointerleave fires the instant it lifts,
+  // so treating it as a cursor took the door away 200ms after the tap that
+  // asked for it — while CSS leaves the pill non-interactive until revealed,
+  // which left touch with no reliable way to reach Remix at all.
+  it("keeps the door up when a TOUCH pointer lifts, and puts it away on a press outside", () => {
+    vi.useFakeTimers();
+    mount();
+    fireEvent.pointerEnter(wrapper(), { pointerType: "touch" });
+    expect(revealed()).toBe(true);
+    fireEvent.pointerLeave(wrapper(), { pointerType: "touch" });
+    act(() => void vi.advanceTimersByTime(400));
+    expect(revealed()).toBe(true);
+
+    // Touch dismisses the way every other ✦ mark does: a press outside it.
+    fireEvent.pointerDown(document.body);
     expect(revealed()).toBe(false);
   });
 
@@ -101,7 +137,7 @@ describe("Remixable — one door into the chat, one ✦ menu on the remix", () =
     // The door lands in the conversation the page already has, prefilled and
     // unsent: the person finishes the sentence where the agent can answer it.
     const panel = await screen.findByRole("dialog", { name: "Vendo assistant" });
-    await waitFor(() => expect(composerIn(panel).value).toBe(`Remix my ${SLOT}: `));
+    await waitFor(() => expect(composerIn(panel).value).toBe("Remix this view: "));
 
     // The inline wish form is GONE — not hidden, not behind a flag.
     expect(screen.queryByRole("textbox", { name: `What should your ${SLOT} do?` })).toBeNull();
@@ -116,9 +152,9 @@ describe("Remixable — one door into the chat, one ✦ menu on the remix", () =
     mount();
     fireEvent.click(remixDoor());
     const panel = await screen.findByRole("dialog", { name: "Vendo assistant" });
-    await waitFor(() => expect(composerIn(panel).value).toBe(`Remix my ${SLOT}: `));
+    await waitFor(() => expect(composerIn(panel).value).toBe("Remix this view: "));
 
-    fireEvent.change(composerIn(panel), { target: { value: `Remix my ${SLOT}: make it a chart` } });
+    fireEvent.change(composerIn(panel), { target: { value: "Remix this view: make it a chart" } });
     fireEvent.keyDown(composerIn(panel), { key: "Enter" });
 
     const sent = await waitFor(() => {

--- a/packages/ui/test/chrome/remixable.test.tsx
+++ b/packages/ui/test/chrome/remixable.test.tsx
@@ -1,11 +1,10 @@
 // @vitest-environment jsdom
-// 2026-08-02 remix final shape (lane W1b) — <Remixable> owns the whole remix
-// surface: the ✦ gesture executes the DETERMINISTIC wire seed, the seeded app
-// takes the wrapped child's place, and the ✦ mark on a remixed component is
-// the management handle (status / open in panel / revert). The old
-// context-chip behavior is deleted, not renamed.
+// S2 one door — <Remixable> stopped being a second place to ask. The ✦ on an
+// unremixed component OPENS THE CHAT about it; the wish is typed there, where
+// the agent can answer and say so when the remix fails. On a remixed one the ✦
+// is the pin chrome itself (Edit in chat · Update · Revert), not a lookalike.
+// The inline wish form, its status line, and its pill states are deleted.
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
-import { StrictMode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { VendoProvider, createVendoClient, type VendoClient } from "../../src/index.js";
 import { Remixable, VendoOverlay } from "../../src/chrome/index.js";
@@ -26,7 +25,7 @@ function TopMerchants(_props: {
   return <table><tbody><tr><td>Blue Bottle</td></tr></tbody></table>;
 }
 
-describe("Remixable — the wrapper fork gesture + in-place mount", () => {
+describe("Remixable — one door into the chat, one ✦ menu on the remix", () => {
   let wire: Awaited<ReturnType<typeof createWireServer>>;
   let client: VendoClient;
 
@@ -44,38 +43,35 @@ describe("Remixable — the wrapper fork gesture + in-place mount", () => {
   });
 
   const wrapper = () => document.querySelector<HTMLElement>(`[data-vendo-remixable="${SLOT}"]`)!;
-  const forkPill = () => screen.getByRole("button", { name: `Remix ${SLOT} with Vendo` });
-  const managePill = () => screen.getByRole("button", { name: `Manage the ${SLOT} remix` });
+  const remixDoor = () => screen.getByRole("button", { name: `Remix ${SLOT} with Vendo` });
+  /** The remixed component wears the PIN chrome's pill — same mark, same words. */
+  const managePill = () => screen.getByRole("button", { name: `Edit ${SLOT}` });
   const revealed = () => wrapper().hasAttribute("data-vendo-revealed");
-  const forkCalls = () => wire.requests.filter(r => r.method === "POST" && r.path === "/apps/seed");
   // An instant remix carries no in-client approval, so the fork surface IS the
   // contained drop-back notice — the one venue a generated node has left.
   const forkSurface = () => screen.queryByRole("note", { name: "Not approved for this page" });
+  const opens = () => wire.requests.filter(r => r.method === "GET" && /\/apps\/.+\/open/.test(r.path));
 
-  /** The whole gesture: the pill opens the ask, and the remix is what the person
-   *  wrote in it. There are no bare forks, so every fork below goes through here. */
-  const remix = (instruction = "make it a chart") => {
-    fireEvent.click(forkPill());
-    const ask = screen.getByRole("textbox", { name: `What should your ${SLOT} do?` });
-    fireEvent.change(ask, { target: { value: instruction } });
-    fireEvent.click(screen.getByRole("button", { name: "Remix it" }));
-  };
+  /** The remix the CHAT minted — the wrapper no longer mints anything itself. */
+  const seedRemix = () => client.apps.seedFrom({ component: SLOT, instruction: "make it a chart" });
 
-  function mount(node = <Remixable><TopMerchants title="Top merchants" /></Remixable>, strict = false) {
-    const inner = (
+  function mount(node = <Remixable><TopMerchants title="Top merchants" /></Remixable>) {
+    return render(
       <VendoProvider client={client}>
         {node}
         <VendoOverlay launcher="none" />
-      </VendoProvider>
+      </VendoProvider>,
     );
-    return render(strict ? <StrictMode>{inner}</StrictMode> : inner);
   }
 
-  it("renders the host's own markup untouched, with the seed and the pill over it", () => {
+  const composerIn = (panel: HTMLElement) =>
+    within(panel).getByRole("textbox", { name: "Message" }) as HTMLTextAreaElement;
+
+  it("renders the host's own markup untouched, with the seed and the ✦ door over it", () => {
     mount();
     expect(screen.getByText("Blue Bottle")).toBeTruthy();
     expect(wrapper().querySelector(".fl-remix-seed")?.textContent).toBe("✦");
-    expect(forkPill()).toBeTruthy();
+    expect(remixDoor()).toBeTruthy();
     // At rest the pill is inert — nothing invisible to misclick.
     expect(revealed()).toBe(false);
   });
@@ -85,8 +81,6 @@ describe("Remixable — the wrapper fork gesture + in-place mount", () => {
     mount();
     fireEvent.pointerEnter(wrapper());
     expect(revealed()).toBe(true);
-    // Leaving starts the grace, it does NOT hide immediately: this is the
-    // cursor's travel to the pill, and a CSS-only reveal would kill it here.
     fireEvent.pointerLeave(wrapper());
     act(() => void vi.advanceTimersByTime(150));
     expect(revealed()).toBe(true);
@@ -94,303 +88,189 @@ describe("Remixable — the wrapper fork gesture + in-place mount", () => {
     expect(revealed()).toBe(false);
   });
 
-  it("reveals on focus, so the pill is keyboard-reachable", () => {
+  it("reveals on focus, so the door is keyboard-reachable", () => {
     mount();
-    act(() => forkPill().focus());
+    act(() => remixDoor().focus());
     expect(revealed()).toBe(true);
   });
 
-  it("✦ gesture → ONE deterministic seed call naming the component, and nothing else", async () => {
-    mount(
-      <Remixable>
-        <TopMerchants
-          title="Top merchants"
-          rows={[{ merchant: "Blue Bottle", amountCents: 1250 }]}
-          onSelect={() => undefined}
-        />
-      </Remixable>,
-    );
-    remix("make it a chart");
-    await waitFor(() => expect(forkCalls()).toHaveLength(1));
-    // A remix is an ordinary create that starts from something AND the first
-    // edit on it: the call names the host component and the person's own words,
-    // and carries no snapshot — call-site props are LIVE, streamed into the
-    // mounted remix on every render (below), never frozen in at mint time.
-    expect(forkCalls()[0]?.body).toEqual({ component: SLOT, instruction: "make it a chart" });
-    // No model turn: the model lost the remix decision entirely.
+  it("✦ opens the CHAT about this component — there is no second place to ask", async () => {
+    mount();
+    fireEvent.click(remixDoor());
+
+    // The door lands in the conversation the page already has, prefilled and
+    // unsent: the person finishes the sentence where the agent can answer it.
+    const panel = await screen.findByRole("dialog", { name: "Vendo assistant" });
+    await waitFor(() => expect(composerIn(panel).value).toBe(`Remix my ${SLOT}: `));
+
+    // The inline wish form is GONE — not hidden, not behind a flag.
+    expect(screen.queryByRole("textbox", { name: `What should your ${SLOT} do?` })).toBeNull();
+    expect(document.querySelector(".fl-remix-ask")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Remix it" })).toBeNull();
+    // And the wrapper mints nothing on its own — the ask is the chat's now.
+    expect(wire.requests.filter(r => r.method === "POST" && r.path === "/apps/seed")).toHaveLength(0);
     expect(wire.requests.filter(r => r.method === "POST" && r.path === "/threads")).toHaveLength(0);
   });
 
-  it("mounts the fork IN PLACE of the wrapped child", async () => {
+  it("hands the agent the component's grounding out of sight", async () => {
     mount();
-    remix();
-    // The fork's surface takes the spot inside the wrapper boundary, and the
-    // original child yields it.
-    await waitFor(() => expect(forkSurface()).toBeTruthy());
-    expect(wrapper().contains(forkSurface())).toBe(true);
-    await waitFor(() => expect(screen.queryByText("Blue Bottle")).toBeNull(), { timeout: 2000 });
-    // The management pill replaced the fork gesture.
-    expect(managePill()).toBeTruthy();
-    expect(screen.queryByRole("button", { name: `Remix ${SLOT} with Vendo` })).toBeNull();
-  });
-
-  it("revert unmounts the fork and restores the original child", async () => {
-    mount();
-    remix();
-    await waitFor(() => expect(forkSurface()).toBeTruthy());
-    const appId = wire.state.apps.at(-1)!.id;
-    fireEvent.click(managePill());
-    fireEvent.click(screen.getByRole("button", { name: "Revert to original" }));
-    await waitFor(() => {
-      expect(wire.requests.some(r => r.method === "DELETE" && r.path === `/apps/${appId}`)).toBe(true);
-    });
-    // The fork is gone — the host's own markup renders again.
-    await waitFor(() => expect(forkSurface()).toBeNull());
-    await waitFor(() => expect(screen.getByText("Blue Bottle")).toBeTruthy());
-    // And the gesture is available again (the dedupe pair was freed).
-    expect(screen.getByRole("button", { name: `Remix ${SLOT} with Vendo` })).toBeTruthy();
-  });
-
-  it("StrictMode double-invoke does not double-fork", async () => {
-    mount(<Remixable><TopMerchants title="Top merchants" /></Remixable>, true);
-    remix();
-    await waitFor(() => expect(forkCalls()).toHaveLength(1));
-    await waitFor(() => expect(forkSurface()).toBeTruthy());
-    // Flush any trailing effects — still exactly one fork, one minted app.
-    await new Promise(resolve => setTimeout(resolve, 80));
-    expect(forkCalls()).toHaveLength(1);
-    expect(wire.state.apps.filter(app => app.seed?.component === SLOT)).toHaveLength(1);
-  });
-
-  it("latches the pill while the fork is in flight (no second tap, cosmetic — the server dedupes anyway)", async () => {
-    mount();
-    // The ask closes on submit, so the second and third taps land on a pill that
-    // is already latched and carries no instruction to send.
-    remix();
-    fireEvent.click(forkPill());
-    fireEvent.click(forkPill());
-    await waitFor(() => expect(forkCalls()).toHaveLength(1));
-    await new Promise(resolve => setTimeout(resolve, 60));
-    expect(forkCalls()).toHaveLength(1);
-  });
-
-  it("the ✦ popover reports an instant-kind remix as sandboxed and personal", async () => {
-    mount();
-    remix();
-    await waitFor(() => expect(forkSurface()).toBeTruthy());
-    fireEvent.click(managePill());
-    const menu = screen.getByRole("group", { name: `Remix of ${SLOT}` });
-    expect(within(menu).getByRole("status").textContent).toBe("Sandboxed — only you see this");
-  });
-
-  // Round-2 finding 1 (the founder's binding rule): until a reviewer
-  // approves, the ORIGINAL host component stays rendered, untouched — this
-  // test previously asserted the fork mount for a pending review-kind
-  // remix, which was the WRONG behavior.
-  it("keeps the ORIGINAL rendered for a review-kind remix awaiting review — no fork mount, status in the ✦ popover only", async () => {
-    mount(<Remixable review><TopMerchants title="Top merchants" /></Remixable>);
-    remix();
-    await waitFor(() => expect(managePill()).toBeTruthy());
-    // Wait past the fork surface actually arriving: STILL the original.
-    await waitFor(() => expect(wire.requests.some(r => r.method === "GET" && /\/apps\/.+\/open/.test(r.path))).toBe(true));
-    await new Promise(resolve => setTimeout(resolve, 60));
-    expect(screen.getByText("Blue Bottle")).toBeTruthy();
-    expect(forkSurface()).toBeNull();
-    // The pending state lives in the panel/popover ONLY — never as an
-    // in-page notice replacing the host component.
-    expect(screen.queryByText(/sent for review/i)).toBeNull();
-    fireEvent.click(managePill());
-    expect(screen.getByRole("status").textContent).toBe("Waiting for review");
-  });
-
-  it("keeps the ORIGINAL rendered for a REJECTED review-kind remix, with the note in the ✦ popover", async () => {
-    const forked = await client.apps.seedFrom({ component: SLOT, instruction: "make it a chart" });
-    wire.state.surfaces.get(forked.id)!["inClient"] = {
-      granted: false,
-      versionHash: "sha256:v1",
-      reason: "pending-review",
-      review: { status: "rejected", versionHash: "sha256:v1", note: "Keep the table layout.", by: "host-admin", at: "2026-08-02T00:00:00.000Z" },
-    };
-    mount(<Remixable review><TopMerchants title="Top merchants" /></Remixable>);
-    await waitFor(() => expect(managePill()).toBeTruthy());
-    fireEvent.click(managePill());
-    await waitFor(() => expect(screen.getByRole("status").textContent)
-      .toBe('Rejected — "Keep the table layout.". Edit the remix to resubmit it for review.'));
-    expect(screen.getByText("Blue Bottle")).toBeTruthy();
-    expect(forkSurface()).toBeNull();
-    expect(screen.queryByText(/remix rejected/i)).toBeNull();
-  });
-
-  it("reports BOTH states when an older approved version serves while the current one is pending review", async () => {
-    const forked = await client.apps.seedFrom({ component: SLOT, instruction: "make it a chart" });
-    wire.state.surfaces.get(forked.id)!["inClient"] = {
-      granted: true,
-      versionHash: "sha256:v1",
-      approvedBy: "host-admin",
-      at: "2026-08-02T00:00:00.000Z",
-      review: { status: "pending", versionHash: "sha256:v2" },
-    };
-    mount(<Remixable review><TopMerchants title="Top merchants" /></Remixable>);
-    await waitFor(() => expect(managePill()).toBeTruthy());
-    fireEvent.click(managePill());
-    await waitFor(() => expect(screen.getByRole("status").textContent)
-      .toBe("Approved by host-admin — runs in the page; your latest edit is waiting for review"));
-  });
-
-  it("reports BOTH states when an older approved version serves and the current one was rejected", async () => {
-    const forked = await client.apps.seedFrom({ component: SLOT, instruction: "make it a chart" });
-    wire.state.surfaces.get(forked.id)!["inClient"] = {
-      granted: true,
-      versionHash: "sha256:v1",
-      approvedBy: "host-admin",
-      at: "2026-08-02T00:00:00.000Z",
-      review: { status: "rejected", versionHash: "sha256:v2", note: "Too wide.", by: "host-admin", at: "2026-08-02T01:00:00.000Z" },
-    };
-    mount(<Remixable review><TopMerchants title="Top merchants" /></Remixable>);
-    await waitFor(() => expect(managePill()).toBeTruthy());
-    fireEvent.click(managePill());
-    await waitFor(() => expect(screen.getByRole("status").textContent)
-      .toBe('Approved by host-admin — runs in the page; your latest edit was rejected — "Too wide."'));
-  });
-
-  it("the ✦ popover surfaces a server-granted venue verdict verbatim", async () => {
-    // Seed a fork whose open payload carries the SERVER-authoritative venue
-    // verdict (lane W1c owns minting it; the popover only renders it).
-    const forked = await client.apps.seedFrom({ component: SLOT, instruction: "make it a chart" });
-    wire.state.surfaces.get(forked.id)!["inClient"] = {
-      granted: true, versionHash: "sha256:v1", approvedBy: "host-admin", at: "2026-08-02T00:00:00.000Z",
-    };
-    mount(<Remixable review><TopMerchants title="Top merchants" /></Remixable>);
-    await waitFor(() => expect(screen.queryByRole("button", { name: `Manage the ${SLOT} remix` })).toBeTruthy());
-    fireEvent.click(managePill());
-    // The open payload may still be in flight when the popover opens — the
-    // status line settles on the server's verdict.
-    await waitFor(() => expect(screen.getByRole("status").textContent).toBe("Approved by host-admin — runs in the page"));
-  });
-
-  it("\"Open in panel\" opens the conversation scoped to the remix — prefilled, never sent", async () => {
-    mount();
-    remix();
-    await waitFor(() => expect(forkSurface()).toBeTruthy());
-    // The prefill NAMES THE THING and carries no id: this used to read
-    // "…remix (app app_…): ", and an app id is our plumbing, not something a
-    // person types (spec §16 law 3, LEAK 4).
-    const appId = wire.state.apps.find(app => app.seed?.component === SLOT)!.id;
-    fireEvent.click(managePill());
-    fireEvent.click(screen.getByRole("button", { name: "Open in panel" }));
+    fireEvent.click(remixDoor());
     const panel = await screen.findByRole("dialog", { name: "Vendo assistant" });
-    await waitFor(() => {
-      const composer = within(panel).getByRole("textbox", { name: "Message" }) as HTMLTextAreaElement;
-      expect(composer.value).toBe(`Update my ${SLOT} remix: `);
-    });
-    expect(within(panel).getByRole("textbox", { name: "Message" }).textContent).not.toContain(appId);
-    expect(panel.textContent).not.toMatch(/app_[A-Za-z0-9]{4,}/);
-    expect(wire.requests.filter(r => r.method === "POST" && r.path === "/threads")).toHaveLength(0);
-  });
+    await waitFor(() => expect(composerIn(panel).value).toBe(`Remix my ${SLOT}: `));
 
-  it("hands the agent its grounding out of sight — the app id reaches the turn, never the screen", async () => {
-    mount();
-    remix();
-    await waitFor(() => expect(forkSurface()).toBeTruthy());
-    const appId = wire.state.apps.find(app => app.seed?.component === SLOT)!.id;
-    fireEvent.click(managePill());
-    fireEvent.click(screen.getByRole("button", { name: "Open in panel" }));
-    const panel = await screen.findByRole("dialog", { name: "Vendo assistant" });
-    const composer = () => within(panel).getByRole("textbox", { name: "Message" }) as HTMLTextAreaElement;
-    await waitFor(() => expect(composer().value).toBe(`Update my ${SLOT} remix: `));
+    fireEvent.change(composerIn(panel), { target: { value: `Remix my ${SLOT}: make it a chart` } });
+    fireEvent.keyDown(composerIn(panel), { key: "Enter" });
 
-    fireEvent.change(composer(), { target: { value: `Update my ${SLOT} remix: make it blue` } });
-    fireEvent.keyDown(composer(), { key: "Enter" });
-
-    // It REACHES the agent: the turn's own message carries it.
     const sent = await waitFor(() => {
       const post = wire.requests.find(r => r.method === "POST" && r.path === "/threads");
       expect(post).toBeTruthy();
       return JSON.stringify(post!.body);
     });
-    expect(sent).toContain(appId);
-    expect(sent).toContain("make it blue");
-
-    // And it is nowhere a person looks — not the textarea, not the transcript.
-    await waitFor(() => expect(panel.textContent).toContain("make it blue"));
-    expect(document.body.textContent).not.toContain(appId);
-    expect(composer().value).toBe("");
+    // The agent is told WHICH component; the person is told nothing they did
+    // not type — the grounding rides the turn, never the screen.
+    expect(sent).toContain(SLOT);
+    expect(sent).toContain("make it a chart");
+    await waitFor(() => expect(panel.textContent).toContain("make it a chart"));
+    expect(panel.textContent).not.toContain("The view being remixed");
   });
 
-  it("discovers an existing fork on mount, so a remix survives a reload", async () => {
-    await client.apps.seedFrom({ component: SLOT, instruction: "make it a chart" });
+  it("warns in development when nothing is mounted for the chat to land in", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    render(
+      <VendoProvider client={client}>
+        <Remixable><TopMerchants title="Top merchants" /></Remixable>
+      </VendoProvider>,
+    );
+    fireEvent.click(remixDoor());
+    expect(warn.mock.calls.some(([first]) => String(first).includes("mount a VendoOverlay"))).toBe(true);
+  });
+
+  it("mounts the remix the chat minted IN PLACE of the wrapped child", async () => {
+    await seedRemix();
     mount();
     await waitFor(() => expect(forkSurface()).toBeTruthy());
-    expect(screen.getByRole("button", { name: `Manage the ${SLOT} remix` })).toBeTruthy();
+    expect(wrapper().contains(forkSurface())).toBe(true);
+    await waitFor(() => expect(screen.queryByText("Blue Bottle")).toBeNull(), { timeout: 2000 });
+    // The pin chrome's pill replaced the door.
+    expect(managePill()).toBeTruthy();
+    expect(screen.queryByRole("button", { name: `Remix ${SLOT} with Vendo` })).toBeNull();
   });
 
-  it("says Remixing… until the edited screen actually lands, then Remixed", async () => {
-    // The seed's provenance row exists the instant the fork is minted, seconds
-    // before its screen does — `open` answers "tree app has no ui payload" for
-    // that whole window. The pill used to report the row, so it said "Remixed"
-    // over the host's untouched original for ~4s of a ~5s remix.
-    const forked = await client.apps.seedFrom({ component: SLOT, instruction: "make it a chart" });
-    const notYet = { method: "GET", path: `/apps/${forked.id}/open`, code: "validation", message: "tree app has no ui payload", status: 400 };
-    wire.state.failures.push({ ...notYet }, { ...notYet });
+  it("the remixed ✦ menu IS the pin chrome: Edit in chat · Update · Revert, and nothing else", async () => {
+    await seedRemix();
     mount();
+    await waitFor(() => expect(forkSurface()).toBeTruthy());
+    fireEvent.click(managePill());
+    const menu = screen.getByRole("group", { name: SLOT });
+    expect(within(menu).getAllByRole("button").map(button => button.textContent))
+      .toEqual(["Edit in chat", "Update", "Revert"]);
+    // No bespoke status line: what the remix is doing, and what went wrong with
+    // it, belong to the conversation that asked for it.
+    expect(within(menu).queryByRole("status")).toBeNull();
+  });
+
+  it("“Edit in chat” opens the conversation featuring the remix — prefilled, never sent", async () => {
+    const forked = await seedRemix();
+    mount();
+    await waitFor(() => expect(forkSurface()).toBeTruthy());
+    fireEvent.click(managePill());
+    fireEvent.click(screen.getByRole("button", { name: "Edit in chat" }));
+
+    const panel = await screen.findByRole("dialog", { name: "Vendo assistant" });
+    await waitFor(() => expect(composerIn(panel).value).toBe(`Update ${SLOT}: `));
+    // The prefill names the THING, never an id (spec §16 law 3).
+    expect(panel.textContent).not.toContain(forked.id);
+    expect(panel.textContent).not.toMatch(/app_[A-Za-z0-9]{4,}/);
+    expect(wire.requests.filter(r => r.method === "POST" && r.path === "/threads")).toHaveLength(0);
+  });
+
+  it("“Update” re-reads the remix", async () => {
+    await seedRemix();
+    mount();
+    await waitFor(() => expect(forkSurface()).toBeTruthy());
+    const before = opens().length;
+    fireEvent.click(managePill());
+    fireEvent.click(screen.getByRole("button", { name: "Update" }));
+    await waitFor(() => expect(opens().length).toBeGreaterThan(before));
+  });
+
+  it("“Revert” deletes the remix and restores the original child", async () => {
+    const forked = await seedRemix();
+    mount();
+    await waitFor(() => expect(forkSurface()).toBeTruthy());
+    fireEvent.click(managePill());
+    fireEvent.click(screen.getByRole("button", { name: "Revert" }));
+    await waitFor(() => {
+      expect(wire.requests.some(r => r.method === "DELETE" && r.path === `/apps/${forked.id}`)).toBe(true);
+    });
+    await waitFor(() => expect(forkSurface()).toBeNull());
+    await waitFor(() => expect(screen.getByText("Blue Bottle")).toBeTruthy());
+    // And the door is back — the component is unremixed again.
+    expect(screen.getByRole("button", { name: `Remix ${SLOT} with Vendo` })).toBeTruthy();
+  });
+
+  // The founder's binding rule (2026-08-02): until a reviewer approves, the
+  // ORIGINAL host component stays rendered, untouched.
+  it("keeps the ORIGINAL rendered for a review-kind remix awaiting review", async () => {
+    await seedRemix();
+    mount(<Remixable review><TopMerchants title="Top merchants" /></Remixable>);
     await waitFor(() => expect(managePill()).toBeTruthy());
-    // Still the host's own markup, so the pill must not claim otherwise.
+    await waitFor(() => expect(opens().length).toBeGreaterThan(0));
+    await new Promise(resolve => setTimeout(resolve, 60));
     expect(screen.getByText("Blue Bottle")).toBeTruthy();
     expect(forkSurface()).toBeNull();
-    expect(managePill().textContent).toContain("Remixing…");
-    expect(managePill().getAttribute("aria-busy")).toBe("true");
-    // The screen lands — and only now is the work done.
-    await waitFor(() => expect(forkSurface()).toBeTruthy());
-    expect(managePill().textContent).toContain("Remixed");
-    expect(managePill().getAttribute("aria-busy")).toBeNull();
+    // The pending state is never an in-page notice replacing the host component.
+    expect(screen.queryByText(/sent for review/i)).toBeNull();
+  });
+
+  it("mounts a review-kind remix natively once the server grants the venue", async () => {
+    const forked = await seedRemix();
+    wire.state.surfaces.get(forked.id)!["inClient"] = {
+      granted: true, versionHash: "sha256:v1", approvedBy: "host-admin", at: "2026-08-02T00:00:00.000Z",
+    };
+    mount(<Remixable review><TopMerchants title="Top merchants" /></Remixable>);
+    await waitFor(() => expect(screen.queryByText("Blue Bottle")).toBeNull(), { timeout: 2000 });
+  });
+
+  it("a remix that never builds leaves the host's own component alone and adds NO error surface of its own", async () => {
+    // The wish was typed in the chat, so the failure is the chat's to report
+    // (the thread's build-failed beat). The page keeps the host's working
+    // markup and says nothing — a second error surface is the thing S2 deleted.
+    const forked = await seedRemix();
+    wire.state.failedApps.set(forked.id, { reason: "the model ran out of quota" });
+    mount();
+    await waitFor(() => expect(managePill()).toBeTruthy());
+    await waitFor(() => expect(opens().length).toBeGreaterThan(0));
+    await new Promise(resolve => setTimeout(resolve, 60));
+
+    expect(screen.getByText("Blue Bottle")).toBeTruthy();
+    expect(forkSurface()).toBeNull();
+    expect(wrapper().textContent).not.toMatch(/didn.t load|didn.t build|ran out of quota/i);
+    expect(within(wrapper()).queryByRole("status")).toBeNull();
+    expect(within(wrapper()).queryByRole("alert")).toBeNull();
+    // The recourse is the one door: the chat that asked for it.
+    fireEvent.click(managePill());
+    expect(screen.getByRole("button", { name: "Edit in chat" })).toBeTruthy();
   });
 
   it("waits out a generation far longer than the load retries, and mounts the screen with no reload", async () => {
     // The real model takes 9–38s to write the remix's screen. The load's three
-    // retries are spent in ~900ms, and the surface then never asked again: the
-    // pill sat on "Remixing…" until the person reloaded the page. A screen that
-    // is not ready is the build window's pending, and the wait rides it out.
-    const forked = await client.apps.seedFrom({ component: SLOT, instruction: "make it a chart" });
+    // retries are spent in ~900ms, and the surface then never asked again.
+    const forked = await seedRemix();
     wire.state.pendingScreens.set(forked.id, 3);
     mount();
-    await waitFor(() => expect(managePill().textContent).toContain("Remixing…"));
+    await waitFor(() => expect(managePill()).toBeTruthy());
     expect(forkSurface()).toBeNull();
     // No remount, no reload — the same mounted wrapper picks the screen up.
     await waitFor(() => expect(forkSurface()).toBeTruthy(), { timeout: 30_000 });
-    expect(managePill().textContent).toContain("Remixed");
-    expect(managePill().getAttribute("aria-busy")).toBeNull();
   }, 30_000);
 
-  it("stops claiming work when the load gives up, and says the page is untouched", async () => {
-    // The wait is bounded, so the pill must have somewhere to land: "Remixing…"
-    // past the point of asking is the same lie the badge was added to end.
-    const forked = await client.apps.seedFrom({ component: SLOT, instruction: "make it a chart" });
-    const dead = { method: "GET", path: `/apps/${forked.id}/open`, code: "validation", message: "boom", status: 400 };
-    wire.state.failures.push({ ...dead }, { ...dead }, { ...dead });
+  it("discovers an existing remix on mount, so it survives a reload", async () => {
+    await seedRemix();
     mount();
-    await waitFor(() => expect(managePill().textContent).toContain("Didn’t load"));
-    expect(managePill().getAttribute("aria-busy")).toBeNull();
-    // The host's own markup never left, and the popover says so.
-    expect(screen.getByText("Blue Bottle")).toBeTruthy();
-    fireEvent.click(managePill());
-    expect(screen.getByRole("status").textContent).toContain("nothing changed on the page");
-  });
-
-  it("lands the same way when the build ANSWERS that it failed, and says why", async () => {
-    // The other dead end: the wire does not stop answering, it answers the
-    // terminal {kind:"failed"}. That is a surface like any other to useApp, so
-    // the pill said "Remixed" and the popover "Sandboxed — only you see this"
-    // over a page that never got a screen.
-    const forked = await client.apps.seedFrom({ component: SLOT, instruction: "make it a chart" });
-    wire.state.failedApps.set(forked.id, { reason: "the model ran out of quota" });
-    mount();
-    await waitFor(() => expect(managePill().textContent).toContain("Didn’t load"));
-    expect(managePill().getAttribute("aria-busy")).toBeNull();
-    // The host's own markup is still the only thing on the page.
-    expect(screen.getByText("Blue Bottle")).toBeTruthy();
-    expect(forkSurface()).toBeNull();
-    fireEvent.click(managePill());
-    expect(screen.getByRole("status").textContent).toBe("the model ran out of quota");
+    await waitFor(() => expect(forkSurface()).toBeTruthy());
+    expect(managePill()).toBeTruthy();
   });
 
   it("wraps only a statically importable component: inline JSX gets no affordance, and a dev warning", () => {
@@ -406,20 +286,7 @@ describe("Remixable — the wrapper fork gesture + in-place mount", () => {
     expect(warn.mock.calls[0]?.[0]).toContain("<Remixable>");
   });
 
-  it("warns in development when the fork call fails, and unlatches", async () => {
-    vi.stubEnv("NODE_ENV", "development");
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
-    wire.state.failures.push({ method: "POST", path: "/apps/seed", code: "not-found", message: "no captured baseline", status: 404 });
-    mount();
-    remix();
-    await waitFor(() => expect(warn.mock.calls.some(([first]) => String(first).includes("no captured baseline"))).toBe(true));
-    expect((forkPill() as HTMLButtonElement).disabled).toBe(false);
-  });
-
   it("puts the bloom behind prefers-reduced-motion, so the states snap", () => {
-    // The reveal is a data attribute; only the travel is animated, and every
-    // transition on the two marks lives inside the no-preference guard. The
-    // popover has no entry animation at all.
     const bloom = CHROME_CSS.split("@media (prefers-reduced-motion: no-preference) {")
       .find(block => block.includes(".fl-remix-seed { transition:"));
     expect(bloom).toBeTruthy();

--- a/packages/ui/test/chrome/remixable.test.tsx
+++ b/packages/ui/test/chrome/remixable.test.tsx
@@ -64,6 +64,8 @@ describe("Remixable — one door into the chat, one ✦ menu on the remix", () =
   const remixDoor = () => screen.getByRole("button", { name: "Remix this view with Vendo" });
   /** The remixed component wears the PIN chrome's pill — same mark, same words. */
   const managePill = () => screen.getByRole("button", { name: "Edit this view" });
+  /** The same mark WITHOUT assuming what it says — the word is the state. */
+  const pill = () => wrapper().querySelector<HTMLButtonElement>(".fl-remix-pill")!;
   const revealed = () => wrapper().hasAttribute("data-vendo-revealed");
   // An instant remix carries no in-client approval, so the fork surface IS the
   // contained drop-back notice — the one venue a generated node has left.
@@ -258,7 +260,7 @@ describe("Remixable — one door into the chat, one ✦ menu on the remix", () =
   it("keeps the ORIGINAL rendered for a review-kind remix awaiting review", async () => {
     await seedRemix();
     mount(<Remixable review><TopMerchants title="Top merchants" /></Remixable>);
-    await waitFor(() => expect(managePill()).toBeTruthy());
+    await waitFor(() => expect(pill()).toBeTruthy());
     await waitFor(() => expect(opens().length).toBeGreaterThan(0));
     await new Promise(resolve => setTimeout(resolve, 60));
     expect(screen.getByText("Blue Bottle")).toBeTruthy();
@@ -283,19 +285,61 @@ describe("Remixable — one door into the chat, one ✦ menu on the remix", () =
     const forked = await seedRemix();
     wire.state.failedApps.set(forked.id, { reason: "the model ran out of quota" });
     mount();
-    await waitFor(() => expect(managePill()).toBeTruthy());
+    await waitFor(() => expect(pill()).toBeTruthy());
     await waitFor(() => expect(opens().length).toBeGreaterThan(0));
     await new Promise(resolve => setTimeout(resolve, 60));
 
     expect(screen.getByText("Blue Bottle")).toBeTruthy();
     expect(forkSurface()).toBeNull();
-    expect(wrapper().textContent).not.toMatch(/didn.t load|didn.t build|ran out of quota/i);
-    expect(within(wrapper()).queryByRole("status")).toBeNull();
+    // The REASON is the chat's, and nothing on the page repeats it.
+    expect(wrapper().textContent).not.toMatch(/ran out of quota/i);
     expect(within(wrapper()).queryByRole("alert")).toBeNull();
     // The recourse is the one door: the chat that asked for it.
-    fireEvent.click(managePill());
+    fireEvent.click(pill());
     expect(screen.getByRole("button", { name: "Edit in chat" })).toBeTruthy();
   });
+
+  // The other half of that rule, and the half deleting the error surface took
+  // with it: the ✦ must not CLAIM the screen it is offering to edit. A failed
+  // remix mounts nothing, so the mark sits over the host's untouched original —
+  // and it read a settled "Edit", beside a green "Did 1 thing" receipt, over a
+  // remix the agent had just said failed.
+  it("says the remix didn’t load rather than offering to edit a screen that isn’t there", async () => {
+    const forked = await seedRemix();
+    wire.state.failedApps.set(forked.id, { reason: "the model ran out of quota" });
+    mount();
+    await waitFor(() => expect(pill().textContent).toContain("Didn’t load"));
+
+    // The accessible name carries the same words the mark shows, so a screen
+    // reader is not told the remix is fine.
+    expect(pill().getAttribute("aria-label")).toBe("This view didn’t load");
+    expect(screen.queryByRole("button", { name: "Edit this view" })).toBeNull();
+    // Nothing is in flight, so nothing claims to be.
+    expect(pill().getAttribute("aria-busy")).toBeNull();
+    // And the state is ANNOUNCED, not merely drawn — without becoming the error
+    // surface S2 deleted: it says the chat has the reason, never the reason.
+    fireEvent.click(pill());
+    const status = within(screen.getByRole("group", { name: "this view" })).getByRole("status");
+    expect(status.textContent).toMatch(/didn’t load/i);
+    expect(status.textContent).not.toMatch(/ran out of quota/i);
+  });
+
+  it("says it is still working while the screen is still being built", async () => {
+    const forked = await seedRemix();
+    wire.state.pendingScreens.set(forked.id, 3);
+    mount();
+
+    await waitFor(() => expect(pill().textContent).toContain("Remixing…"));
+    // aria-busy is the half a screen reader gets: the mark is the only thing on
+    // the page that knows a build is running.
+    expect(pill().getAttribute("aria-busy")).toBe("true");
+    expect(pill().getAttribute("aria-label")).toBe("Remixing this view…");
+
+    // And it settles to the ordinary mark once the screen lands.
+    await waitFor(() => expect(forkSurface()).toBeTruthy(), { timeout: 30_000 });
+    expect(pill().textContent).toContain("Edit");
+    expect(pill().getAttribute("aria-busy")).toBeNull();
+  }, 30_000);
 
   it("waits out a generation far longer than the load retries, and mounts the screen with no reload", async () => {
     // The real model takes 9–38s to write the remix's screen. The load's three
@@ -303,7 +347,7 @@ describe("Remixable — one door into the chat, one ✦ menu on the remix", () =
     const forked = await seedRemix();
     wire.state.pendingScreens.set(forked.id, 3);
     mount();
-    await waitFor(() => expect(managePill()).toBeTruthy());
+    await waitFor(() => expect(pill()).toBeTruthy());
     expect(forkSurface()).toBeNull();
     // No remount, no reload — the same mounted wrapper picks the screen up.
     await waitFor(() => expect(forkSurface()).toBeTruthy(), { timeout: 30_000 });

--- a/packages/ui/test/chrome/remixable.test.tsx
+++ b/packages/ui/test/chrome/remixable.test.tsx
@@ -61,9 +61,9 @@ describe("Remixable — one door into the chat, one ✦ menu on the remix", () =
   });
 
   const wrapper = () => document.querySelector<HTMLElement>(`[data-vendo-remixable="${SLOT}"]`)!;
-  const remixDoor = () => screen.getByRole("button", { name: `Remix ${SLOT} with Vendo` });
+  const remixDoor = () => screen.getByRole("button", { name: "Remix this view with Vendo" });
   /** The remixed component wears the PIN chrome's pill — same mark, same words. */
-  const managePill = () => screen.getByRole("button", { name: `Edit ${SLOT}` });
+  const managePill = () => screen.getByRole("button", { name: "Edit this view" });
   const revealed = () => wrapper().hasAttribute("data-vendo-revealed");
   // An instant remix carries no in-client approval, so the fork surface IS the
   // contained drop-back notice — the one venue a generated node has left.
@@ -190,7 +190,7 @@ describe("Remixable — one door into the chat, one ✦ menu on the remix", () =
     await waitFor(() => expect(screen.queryByText("Blue Bottle")).toBeNull(), { timeout: 2000 });
     // The pin chrome's pill replaced the door.
     expect(managePill()).toBeTruthy();
-    expect(screen.queryByRole("button", { name: `Remix ${SLOT} with Vendo` })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Remix this view with Vendo" })).toBeNull();
   });
 
   it("the remixed ✦ menu IS the pin chrome: Edit in chat · Update · Revert, and nothing else", async () => {
@@ -198,12 +198,16 @@ describe("Remixable — one door into the chat, one ✦ menu on the remix", () =
     mount();
     await waitFor(() => expect(forkSurface()).toBeTruthy());
     fireEvent.click(managePill());
-    const menu = screen.getByRole("group", { name: SLOT });
+    const menu = screen.getByRole("group", { name: "this view" });
     expect(within(menu).getAllByRole("button").map(button => button.textContent))
       .toEqual(["Edit in chat", "Update", "Revert"]);
     // No bespoke status line: what the remix is doing, and what went wrong with
     // it, belong to the conversation that asked for it.
     expect(within(menu).queryByRole("status")).toBeNull();
+    // A screen reader hears the same words the pill shows — never `slot`, which
+    // is a name the person can neither see nor say to a voice control.
+    expect(wrapper().innerHTML).not.toContain(`aria-label="Edit ${SLOT}"`);
+    expect(managePill().getAttribute("aria-label")).toBe("Edit this view");
   });
 
   it("“Edit in chat” opens the conversation featuring the remix — prefilled, never sent", async () => {
@@ -214,10 +218,13 @@ describe("Remixable — one door into the chat, one ✦ menu on the remix", () =
     fireEvent.click(screen.getByRole("button", { name: "Edit in chat" }));
 
     const panel = await screen.findByRole("dialog", { name: "Vendo assistant" });
-    await waitFor(() => expect(composerIn(panel).value).toBe(`Update ${SLOT}: `));
-    // The prefill names the THING, never an id (spec §16 law 3).
+    await waitFor(() => expect(composerIn(panel).value).toBe("Update this view: "));
+    // The prefill names the THING, never an id (spec §16 law 3) — and `slot` is
+    // an id too: the React identifier sync captures under, which the person
+    // sees nowhere else on their page.
     expect(panel.textContent).not.toContain(forked.id);
     expect(panel.textContent).not.toMatch(/app_[A-Za-z0-9]{4,}/);
+    expect(panel.textContent).not.toContain(SLOT);
     expect(wire.requests.filter(r => r.method === "POST" && r.path === "/threads")).toHaveLength(0);
   });
 
@@ -243,7 +250,7 @@ describe("Remixable — one door into the chat, one ✦ menu on the remix", () =
     await waitFor(() => expect(forkSurface()).toBeNull());
     await waitFor(() => expect(screen.getByText("Blue Bottle")).toBeTruthy());
     // And the door is back — the component is unremixed again.
-    expect(screen.getByRole("button", { name: `Remix ${SLOT} with Vendo` })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Remix this view with Vendo" })).toBeTruthy();
   });
 
   // The founder's binding rule (2026-08-02): until a reviewer approves, the


### PR DESCRIPTION
**Slice 2 of 3** in the remix stack. S1 merged as `2d06e6b0f`; this now sits directly on `main`, and S3 (#1482) sits on this. **Net −27 lines across 10 files while adding a feature and fixing five review findings.**

## What changed

The bespoke inline wish form is **deleted** — the form, the input, `fork()`, the `seedFrom` call, the double-fire latch, the `.fl-remix-ask` CSS. The forked ✦ menu **is** the pin chrome (`Edit in chat · Update · Revert`), and the wrapper's own error surface is gone, so a failure speaks in one place: the chat thread.

Also breaks the `remixable ↔ pin-chrome` import cycle by moving `GRACE_MS` / `useMenuDismiss` into pin-chrome.

## Five review findings fixed — none of which a green suite could see

**Touch could not reach Remix at all.** A finger's `pointerleave` fires the instant it lifts, so the reveal's leave rule — written for a cursor travelling to the pill — took the door away 200ms after the tap that asked for it, while CSS leaves the pill non-interactive until revealed. `PinChrome` had already solved this; its guard **and its outside-press dismissal** are now shared rather than restated. (The guard alone would have stranded the pill open on a touchscreen.)

**The door landed on a generic assistant.** Five starter cards about other things, and the person's own intent reading as `PlainMerchants` — the React identifier sync captures under, which appears nowhere else on the page. Starters now stand down whenever the composer already carries an intent, and the prefill reads `Remix this view: `. The agent still receives the identifier verbatim, in the `context` it never renders.

**The remixed side leaked the same identifier.** `RemixedFork` handed `PinChrome` the slot as its title, so the remixed ✦ still said `Update NetWorthView: ` — one component over from the side just fixed. It also reached the **accessible names**: the pill announced "Edit NetWorthView" while displaying "Edit", so a screen reader read a name that is nowhere on the page and a voice-control user could not speak the control. Both ✦ marks now say "this view". A pinned app is untouched — it arrives with a name the person chose, so `Update Invoices:` stays exactly that.

The agent-facing side is byte-identical: both `context` strings still carry the slot verbatim, including the `pass component=<slot> verbatim` instruction the mint depends on.

## Verification

Four browser specs on a fresh production build. The first production attempt FAILED because minification erases `Function.name` — which is why a fresh production build is the proof of record and a warm dev harness never is.

jsdom ships no `PointerEvent`, so it cannot tell a finger from a cursor; the shim here makes both devices expressible, and the real touchscreen proof is the browser pass beside it.

## User-visible

`Refresh` → `Update` and `Unpin` → `Revert` also change the labels for **pinned slots**, not just remixes — that follows from having one menu.

## FINDING — pre-existing on `main`, NOT introduced here, still unowned

In a minified production bundle `slotOf` breaks: it resolves an id as `type.displayName ?? type.name`, guarded by `/^[A-Z]/`, and minification mangles `type.name`. Of 10 wrapped components with no hand-written `displayName`, **8** render a ✦ whose id is mangled (`NetWorthView` → `RNe`) so it can never match a captured baseline, and **2** render no ✦ at all. Reproduced in a real browser at base `3d85eb548` (6 and 4 at that commit); `slotOf` is byte-identical between base and HEAD.

`examples/demo-bank` only works because `displayName` was hand-written in #732, and `vendo sync` never warns about a missing one — so a real host gets no signal until the feature is silently dead in production. **Not fixed here; needs an owner.**

**The ✦ claimed a screen the build never produced.** Before this slice the pill read `{failed ? "Didn't load" : pending ? "Remixing…" : "Remixed"}` with `aria-busy` and a `role="status"` line (`remixable.tsx:296-304` at `1dce3173c`). `PinChrome` is fixed-label, so deleting the wrapper's error surface — correct in itself — took the mark's own honesty with it: a remix that never built wore a settled **"Edit"**, offering to edit a screen that does not exist, over the host's untouched markup, with nothing for a screen reader at all. Observed live — the first real mint failed and the page said nothing.

`PinChrome` now takes one optional `state` (the mark's word, its matching accessible name, the sentence the menu announces), computed from **the same open payload the mount waits on** — so the mark and the page cannot disagree by construction rather than by being kept in sync by hand. Vocabulary stays with the caller: a remix that never built and a pinned app that will not load are not the same sentence. `aria-busy` and `.fl-remix-status` are restored. The chat still owns the explanation: the status line says *the chat has the reason*, never the reason, so the developer sentence still reaches no page.

**One assertion was LOOSENED, and it was loosened toward honesty.** The existing test *"a remix that never builds … adds NO error surface of its own"* required the wrapper to contain no failure word **and** no `role="status"` at all — it had encoded the lie as the contract. Its real invariant is kept and tightened (host markup intact, no `role="alert"`, the failure reason never printed); only the clauses forbidding the mark from telling the truth are gone.

Proved with a **genuinely failed remix**, not a simulated one: a third harness component whose seed row is listable and whose `open` answers the terminal `failed` envelope, both from the wire fixture, in the arrival order that caused the bug — the stub now delegates everything that is not the canned remix to the real client. Reverted the fix → red on `expected '✦Edit' to contain 'Didn't load'`, the exact observed symptom.

**Deliberately not done here:** `Update` over a failed remix stays a harmless refetch — `Edit in chat` and `Revert` are both the right recourse, and state-dependent menu contents are not worth the slice. The green "Did 1 thing" receipt is `BeatSummary` (`build-beat.tsx:602`), which hardcodes the tick for **every** settled turn; threading per-turn failure through the beat system is its own blast radius and is routed separately.
