### PR TITLE
fix(docs): install-DX corrections from the 0.28.0 audit

### DIFF
--- a/docs-site/agents/index.mdx
+++ b/docs-site/agents/index.mdx
@@ -39,7 +39,7 @@ surface as any other install: do the install below, then [MCP door](#mcp-door).
    add Vendo's tool pack. Never assume the full install in a repo that
    already has an agent.
 
-   **If they choose the tool pack, take the walkthrough first.** Fetch exactly ONE
+   **If they choose the tool pack, one walkthrough is your page.** Fetch exactly ONE
    framework walkthrough and follow it end to end — do not read both:
    - AI SDK loop → `https://docs.vendo.run/existing-agent/ai-sdk.md`
    - Mastra loop → `https://docs.vendo.run/existing-agent/mastra.md`
@@ -55,10 +55,17 @@ surface as any other install: do the install below, then [MCP door](#mcp-door).
    when the walkthrough imports from it; it is the one exception to the
    one-page rule, not an invitation to browse.
 
+   **Steps 2 to 5 still apply on that path, and they come first.** Detect the
+   stack, install the package, run init — with `--use-case agent-loop`, the
+   answer that records this shape and tells doctor not to look for a
+   `<VendoProvider>` or a visible Vendo surface — and hand-wire whatever the
+   agent tail names. The walkthrough is the code that goes INTO your human's
+   loop; it is not a substitute for the install underneath it.
+
    Then come back for steps 6 and 7. The walkthrough wires your human's chat.
    It never asks where their users keep the screens they build, and that
-   question is here. Steps 2 to 10 in order are the FULL-install path, for the
-   human who chose Vendo's agent.
+   question is here. Taken straight through, steps 2 to 10 are the FULL-install
+   path, for the human who chose Vendo's agent.
 
 2. **Detect the stack.** Read `package.json`. A `next` dependency means
    Next.js; an `express` dependency means Express. Anything else — Cloudflare
@@ -68,21 +75,27 @@ surface as any other install: do the install below, then [MCP door](#mcp-door).
    env)`, which your runtime mounts in one line
    ([Edge runtimes](/production/edge-runtimes)).
 
-   **Workspace repos: pick the app package first.** A root `package.json`
-   with a `workspaces` field (or a `pnpm-workspace.yaml`) means the framework
-   dependency lives in an app package (`apps/web`, `packages/app`, …), not at
-   the root — and detection reads the `package.json` of the directory init
-   targets. Run at the root of a workspace repo and detection finds no
-   framework: init errors non-interactively, or lands on the runtime-neutral
-   custom scaffold a Next or Express app should not get. Choose the app
-   package now; the install in step 3 targets it, and every later command
-   runs in (or is pointed at) that directory.
+   **Workspace repos: pick the app package first.** A root `package.json` with
+   a `workspaces` field — or a `pnpm-workspace.yaml` that declares a
+   `packages:` list — means the framework dependency lives in an app package
+   (`apps/web`, `packages/app`, …), not at the root — and detection reads the
+   `package.json` of the directory init targets. Run at the root of a workspace
+   repo and detection finds no framework: init errors non-interactively, or
+   lands on the runtime-neutral custom scaffold a Next or Express app should
+   not get. Choose the app package now; the install in step 3 targets it, and
+   every later command runs in (or is pointed at) that directory.
+
+   Read that file before you believe it. Under pnpm 10 `pnpm-workspace.yaml` is
+   also where plain settings live — `onlyBuiltDependencies`,
+   `minimumReleaseAge`, the exclude list in step 3 — so a copy with no
+   `packages:` key is an ordinary single-app repo, and treating it as a
+   monorepo sends you hunting for an app package that does not exist.
 
 3. **Install the package, then verify what actually resolved.**
 
    ```bash
-   npm install vendoai @vendoai/vendo
-   npx vendo --version   # must be >= 0.4.0
+   npm install @vendoai/vendo
+   npx vendo --version   # must be >= 0.28.0
    ```
 
    In a workspace repo, install into the app package with the host's own
@@ -90,17 +103,22 @@ surface as any other install: do the install below, then [MCP door](#mcp-door).
    lockfile:
 
    ```bash
-   npm install vendoai @vendoai/vendo --workspace apps/web   # npm workspaces
-   yarn workspace <app-package-name> add vendoai @vendoai/vendo
-   pnpm --filter <app-package-name> add vendoai @vendoai/vendo
+   npm install @vendoai/vendo --workspace apps/web   # npm workspaces
+   yarn workspace <app-package-name> add @vendoai/vendo
+   pnpm --filter <app-package-name> add @vendoai/vendo
    ```
 
    Then run the version check — and every `npx vendo …` step below — from
    that same app directory.
 
-   `vendoai` is a thin alias of `@vendoai/vendo`, and every file init writes
-   imports `@vendoai/vendo/*` — so install BOTH: with the alias alone, pnpm's
-   strict `node_modules` cannot resolve those imports and every route 500s with
+   ONE package, and it is the umbrella. `@vendoai/vendo` carries every
+   `@vendoai/vendo/*` subpath the files init writes import, and it carries the
+   `vendo` binary into `node_modules/.bin` — which is what the version check
+   above and the `predev`/`prebuild` hooks init adds to `package.json` run.
+   `vendoai` is a thin ALIAS of it, for `npx vendoai@latest …` before anything
+   is installed; as a dependency it adds nothing, and installing it INSTEAD of
+   the umbrella is the shape that breaks — pnpm's strict `node_modules` cannot
+   resolve `@vendoai/vendo/*` through an alias, so every route 500s with
    `Module not found: Can't resolve '@vendoai/vendo/server'`. The version
    check is not optional: stale placeholder versions (0.1.x) exist on npm, and package
    managers with a release-age cooldown (pnpm 11 holds new releases for a
@@ -463,9 +481,13 @@ sets up a service key (`--service-key`). Answer both as flags on the next run;
   nothing more is required.
 - **Run `vendo init` before touching `.vendo/`.** Init writes the whole
   `.vendo/` contract (`tools.json`, `overrides.json`, `policy.json`,
-  `brief.md`, `theme.json`) itself. Don't author or edit any of those files
+  `brief.md`, `theme.json`) itself, and the AI grading pass writes
+  `judgments.json` beside them. Don't author or edit any of those files
   before the first init run; re-run `npx vendo init` instead of hand-writing
   scaffold files (the route, the registry skeleton, `.vendo/` contents).
+  `judgments.json` is a LAYER, never a copy: each entry is keyed by tool name
+  and applied on top of that tool's `tools.json` entry (description, title,
+  risk, and the rest), with `overrides.json` — the human layer — winning last.
 - **The star ask acts only on an explicit yes.** Your prompt ends by asking
   your human whether to star the repo. If they say yes and the GitHub CLI is
   authenticated, run `gh api --method PUT /user/starred/runvendo/vendo`;
@@ -488,6 +510,7 @@ sets up a service key (`--service-key`). Answer both as flags on the next run;
 | --- | --- |
 | `https://vendo.run/agents.md` | This playbook as raw Markdown (append `.md` to any docs page) |
 | `https://docs.vendo.run/existing-agent/quickstart.md` | The tool-pack path for hosts that already have an agent |
+| `https://docs.vendo.run/backend/quickstart.md` | The backend path: `agent()`, `respond()`, `run()`, and no Vendo UI to mount |
 | `https://vendo.run/auth.md` | The raw claim-ceremony protocol behind `vendo login` |
 | `https://docs.vendo.run/llms.txt` | Index of every docs page for LLM ingestion (also at `/.well-known/llms.txt`) |
 | `https://docs.vendo.run/llms-full.txt` | The whole docs site as one file |

--- a/docs-site/backend/quickstart.mdx
+++ b/docs-site/backend/quickstart.mdx
@@ -20,24 +20,36 @@ required.
 <CodeGroup>
 
 ```bash npm
-npm install @vendoai/agents ai@^6
+npm install @vendoai/agents @vendoai/vendo ai@^6
 npx vendoai@latest login
 npx vendoai@latest init
 ```
 
 ```bash pnpm
-pnpm add @vendoai/agents ai@^6
+pnpm add @vendoai/agents @vendoai/vendo ai@^6
 pnpm dlx vendoai@latest login
 pnpm dlx vendoai@latest init
 ```
 
 </CodeGroup>
 
+`@vendoai/vendo` carries none of the code on this page. It is there because
+every file init writes imports `@vendoai/vendo/*`, and the `predev` and
+`prebuild` hooks init adds to your `package.json` run the `vendo` binary that
+package installs.
+
 `vendo login` mints a `VENDO_API_KEY` into `.env.local` and never prints it.
+Already have one in `.env.local`? Skip that line — init merges the key into its
+own run, uses it as it is, and never asks.
 `vendo init` writes `.vendo/tools.json`, your API read into tool definitions
 with a schema and a dispatch binding on each one. Extraction grades only what
 the protocol proves; `vendo sync` grades the rest, and until it runs an
 ungraded tool asks before every call.
+
+Answer the first question with **Through my own agent loop (AI SDK / Mastra)**.
+A backend agent is your own loop, and that answer is what tells `vendo doctor`
+to skip the mounted-UI checks — a `<VendoProvider>` and a visible surface —
+that a backend with no UI of Vendo's has nothing to satisfy.
 
 ```ts lib/agent.ts focus={3-7}
 import { agent, api } from "@vendoai/agents";
@@ -93,8 +105,8 @@ its own.
 </CardGroup>
 
 <Note>
-  No umbrella and no client here. The composed agent has exactly two verbs, and
-  steps 2 and 3 are both of them.
+  No umbrella call and no client in your code. The composed agent has exactly
+  two verbs, and steps 2 and 3 are both of them.
 </Note>
 
 </Step>

--- a/docs-site/existing-agent/ai-sdk.mdx
+++ b/docs-site/existing-agent/ai-sdk.mdx
@@ -48,6 +48,8 @@ Resolve both from the same session, and never take a principal from the client. 
 
 The shim builds every tool with the AI SDK's `dynamicTool`, so `useChat` streams them as `dynamic-tool` parts rather than `tool-<name>`. Match on that.
 
+Where that match lives is yours. The path below is a name, not a contract — only your own chat imports it, so a `components/` directory you do not have is a directory you do not need. [`examples/ai-sdk-agent`](https://github.com/runvendo/vendo/tree/main/examples/ai-sdk-agent) inlines the same branch in `app/page.tsx` instead.
+
 ```tsx components/vendo-part.tsx focus={5-8}
 import type { UIMessage } from "ai";
 import { VendoToolResult } from "@vendoai/vendo/react";

--- a/docs-site/existing-agent/mastra.mdx
+++ b/docs-site/existing-agent/mastra.mdx
@@ -75,6 +75,8 @@ await vendo.store.ensureSchema();
 
 Mastra streams tool calls as `dynamic-tool` or as `tool-<name>`, depending on how the tool was declared. Match both.
 
+Where that match lives is yours. The path below is a name, not a contract — only your own chat imports it, so a `components/` directory you do not have is a directory you do not need. [`examples/mastra-agent`](https://github.com/runvendo/vendo/tree/main/examples/mastra-agent) inlines the same branch in `src/app/page.tsx` instead.
+
 ```tsx components/vendo-part.tsx focus={5-8}
 import { getToolName, isToolUIPart, type UIMessage } from "ai";
 import { VendoToolResult } from "@vendoai/vendo/react";

--- a/docs-site/existing-agent/quickstart.mdx
+++ b/docs-site/existing-agent/quickstart.mdx
@@ -19,18 +19,18 @@ The pack takes the caller you already resolved, so it is built inside the handle
 <CodeGroup>
 
 ```bash npm
-npm install @vendoai/vendo ai@^6 @ai-sdk/react@^3
+npm install @vendoai/vendo ai@^6 @ai-sdk/react@^3 @ai-sdk/anthropic@^3
 npx vendo init
 ```
 
 ```bash pnpm
-pnpm add @vendoai/vendo ai@^6 @ai-sdk/react@^3
+pnpm add @vendoai/vendo ai@^6 @ai-sdk/react@^3 @ai-sdk/anthropic@^3
 pnpm exec vendo init
 ```
 
 </CodeGroup>
 
-Pin the majors. Vendo peers `ai` at 6, and a bare `ai` installs 7 today — npm accepts the conflict, then every turn fails at runtime and `vendo doctor` reports [E-DEP-001](/production/troubleshooting/e-dep-001).
+Pin the majors. Vendo peers `ai` at 6 and `@ai-sdk/anthropic` at 3, and bare installs pull 7 and 4 today — npm accepts the conflict, then every turn fails at runtime and `vendo doctor` reports [E-DEP-001](/production/troubleshooting/e-dep-001).
 
 Answer the first question with **Through my own agent loop (AI SDK / Mastra)**, and take **Vendo Cloud** on the model one. Init writes the wire route and lands a `VENDO_API_KEY` in `.env.local`.
 
@@ -47,7 +47,24 @@ export const vendo = createVendo({ auth });
 
 Every snippet on this track imports those two from there. Swap `authJs()` for your own provider's preset — [Auth](/production/auth) lists all five.
 
-```ts AI SDK · app/api/chat/route.ts focus={14}
+No provider yet? Then init wrote a demo principal in place of a preset, and the resolver you export beside it hands your chat route that same subject:
+
+```ts lib/vendo.ts
+import { createVendo } from "@vendoai/vendo/server";
+
+// init writes the principal; the resolver is
+// yours. Swap both for a real session lookup.
+const principal = async () => ({
+  kind: "user" as const,
+  subject: "demo-user",
+});
+export const resolvePrincipal = (_req: Request) => principal();
+export const vendo = createVendo({ principal });
+```
+
+Both sides have to resolve the SAME subject. Your loop and the wire route the embeds call are two different requests, and an app or approval created under one subject is invisible to a surface asking as another — the embed then polls a screen it will never be shown. Everything below stays as written: the demo resolver never returns `null`, so the 401 guard simply never fires.
+
+```ts AI SDK · app/api/chat/route.ts focus={13,15}
 import { convertToModelMessages, streamText } from "ai";
 import { vendoTools } from "@vendoai/vendo/ai-sdk";
 import { vendoModel } from "@vendoai/vendo/server";
@@ -60,11 +77,14 @@ export async function POST(req: Request) {
   return streamText({
     model: vendoModel(),
     messages: await convertToModelMessages(messages),
+    system: "…your system prompt as it is",
     // your own tools spread in here too
     tools: { ...(await vendoTools(vendo, { principal: caller })) },
   }).toUIMessageStreamResponse();
 }
 ```
+
+That `system` line is yours and stays yours — Vendo assembles nothing into it, and a turn that loses it answers like a different product. The section at the bottom of this page is what you ADD to it.
 
 ```ts Mastra · src/mastra/agents/your-agent.ts focus={10}
 import { Agent } from "@mastra/core/agent";

--- a/docs-site/outside-agents/quickstart.mdx
+++ b/docs-site/outside-agents/quickstart.mdx
@@ -9,14 +9,38 @@ sidebarTitle: "Quickstart"
 A door, a token, and your agent. `npx vendo init` writes the door, and the
 console holds the key.
 
-Haven't run init? It is the setup command from the [quickstart](/): it reads
-your repo, then asks. Its first question is **How will people use your agent?** —
-answer **From outside agents over MCP**, and it writes everything this page walks
-through. Picking that answer is also what unlocks the two questions below it: who
-runs the OAuth plumbing (the posture), and whether your own backend needs a
-service key.
-
 <Steps>
+
+<Step title="Install and run init">
+
+One package, then the setup command from the [quickstart](/): it reads your
+repo, then asks.
+
+<CodeGroup>
+
+```bash npm
+npm install @vendoai/vendo
+npx vendo init
+```
+
+```bash pnpm
+pnpm add @vendoai/vendo
+pnpm exec vendo init
+```
+
+</CodeGroup>
+
+Its first question is **How will people use your agent?** — answer **From
+outside agents over MCP**, and it writes everything this page walks through.
+
+That answer is also what adds init's MCP-only questions. There is always one:
+whether your own backend will call these tools machine to machine, which is the
+service key. The posture question — who runs the OAuth plumbing — joins it only
+when a Vendo Cloud key is already in hand, because a keyless run cannot reach a
+broker, so init settles on the local posture and asks about the service key
+alone.
+
+</Step>
 
 <Step title="Open the door">
 
@@ -24,7 +48,20 @@ service key.
 the **broker** posture: keys managed in the console, a stable tenant URL, and
 the OAuth surface off your domain.
 
-Take it. The door then trusts that broker.
+Is the agent your own, driven from your own backend with no browser in the loop
+— or is your stack one the broker posture does not fit? Take the **local**
+posture instead:
+
+```bash
+npx vendo init --use-case mcp --posture local --service-key
+```
+
+Everything then stays on your origin — no broker, no console, no browser — and
+the token exchange in the next step is served by your own app. Both flags answer
+questions init asks only on the MCP use case, so `--use-case mcp` has to ride
+along; without it init stops and says so.
+
+Otherwise, take the broker. The door then trusts that broker.
 
 ```ts src/vendo/server.ts focus={3}
 export const vendo = createVendo({
@@ -60,7 +97,7 @@ Two routes come with it, both written by `init`.
 | `/.well-known/oauth-*` | discovery, at your origin root, naming your broker |
 
 A broker-fronted door serves no token endpoint of its own. The exchange lives
-in the broker, in step 2.
+in the broker, in the next step.
 
 </Step>
 
@@ -99,11 +136,32 @@ guard, policy, and audit your own UI answers to.
 A subject your product has never heard of is not rejected here. It dies at the
 first real tool call, the same kill switch every other grant answers to.
 
-Your own agent, or a stack the broker posture does not fit? Run
-`npx vendo init --use-case mcp --posture local --service-key` instead and the
-exchange stays on your origin — no broker, no browser. Both flags are answers to
-questions init only asks on the MCP use case, so `--use-case mcp` has to ride
-along; without it init stops and says so.
+<Warning>
+  **On Auth.js v5, `session.user.id` is `undefined` until you add a callback.**
+  The subject the door resolves for an Auth.js session is the session token's
+  `sub`, but a v5 session hands your own code only `name`, `email`, and `image`.
+  A backend that reads `session.user.id` for `subject_token` therefore posts
+  `undefined`, the exchange mints a token happily, and the first tool call
+  401s. Copy `sub` across once, in the `NextAuth({ … })` config your
+  `auth.ts` exports:
+
+  ```ts auth.ts
+  callbacks: {
+    session({ session, token }) {
+      session.user.id = token.sub!;
+      return session;
+    },
+  },
+  ```
+
+  That is the JWT session strategy, which is the default without a database
+  adapter. With an adapter the session callback gets `user` instead, and
+  `user.id` is already the subject.
+</Warning>
+
+On the **local** posture — the branch in the step above — none of this lives in
+the console. Init writes the key into your own composition, and the door serves
+the exchange itself:
 
 ```ts src/vendo/server.ts focus={3}
 export const vendo = createVendo({

--- a/docs-site/outside-agents/service-keys-and-broker.mdx
+++ b/docs-site/outside-agents/service-keys-and-broker.mdx
@@ -42,6 +42,12 @@ broker, so the broker is where your backend spends it.
 The door never sees the key. It only ever sees the short-lived token the broker
 minted from it.
 
+That is the broker posture. A **local** door has no console in the path: the key
+is any opaque string you generate, it lives in your own environment as
+`VENDO_SERVICE_KEY`, the composition lists it under
+`mcp: { serviceAuth: { keys: [...] } }`, and `vendo init --service-key` writes
+one for you.
+
 ## The exchange
 
 One form post, RFC 8693, at your tenant's `/token`.
@@ -55,6 +61,21 @@ curl -s https://maple.mcp.vendo.run/token \
   -d subject_token_type=urn:vendo:params:oauth:token-type:user-id
 ```
 
+That URL is the broker's. On a local door the same body goes to your own origin,
+where the door serves the endpoint itself:
+
+```bash focus={1}
+curl -s https://app.maple.com/api/vendo/mcp/token \
+  -d grant_type=urn:ietf:params:oauth:grant-type:token-exchange \
+  -d client_id=vendo-service \
+  -d client_secret="$VENDO_SERVICE_KEY" \
+  -d subject_token=user_1904 \
+  -d subject_token_type=urn:vendo:params:oauth:token-type:user-id
+```
+
+The URL is the only difference. Every field below, the answer, the ten-minute
+life, and the `svc:` attribution are the same on both postures.
+
 | Field | Value |
 | --- | --- |
 | `grant_type` | `urn:ietf:params:oauth:grant-type:token-exchange` |
@@ -63,6 +84,12 @@ curl -s https://maple.mcp.vendo.run/token \
 | `subject_token` | one of *your* user ids |
 | `subject_token_type` | `urn:vendo:params:oauth:token-type:user-id` |
 | `resource` | optional, and must identify this MCP server if sent |
+
+Which value is *your* user id is whatever your own `principal()` resolves for
+that person. On Auth.js v5 that is the session token's `sub`, and
+`session.user.id` is `undefined` until you copy it across — the three-line
+callback, and the 401 it saves you, are in the token-minting step of the
+[quickstart](/outside-agents/quickstart).
 
 The answer is an ordinary OAuth token response.
 

--- a/docs-site/product/quickstart.mdx
+++ b/docs-site/product/quickstart.mdx
@@ -7,7 +7,9 @@ sidebarTitle: "Quickstart"
 Vendo brings the loop, the model, and the chat surface. You paste three things
 into your own client.
 
-This picks up where [`vendo init`](/) left off:
+This picks up after the two commands on the [main quickstart](/) —
+`npm install @vendoai/vendo`, then `npx vendo init` (`pnpm add @vendoai/vendo`
+and `pnpm exec vendo init` on pnpm). Those leave you
 `app/api/vendo/[...vendo]/route.ts` written, and a model credential settled.
 
 Which credential depends on how you answered init's models question. **Vendo
@@ -25,24 +27,23 @@ answer. [Model credentials](/production/model-credentials) covers all three.
 Paste what init printed into your client layout. Your paths and theme are
 already filled in.
 
-```tsx app/layout.tsx focus={10}
+```tsx app/layout.tsx focus={7}
 import { VendoProvider } from "@vendoai/vendo/react";
 import type { VendoTheme } from "@vendoai/vendo";
-import type { ReactNode } from "react";
 import theme from "../.vendo/theme.json";
 
-export default function RootLayout({ children }: { children: ReactNode }) {
-  return (
-    <html lang="en">
-      <body>
-        <VendoProvider baseUrl="/api/vendo" theme={theme as VendoTheme}>
-          {children}
-        </VendoProvider>
-      </body>
-    </html>
-  );
-}
+// in your own RootLayout, props type untouched:
+<body>
+  <VendoProvider baseUrl="/api/vendo" theme={theme as VendoTheme}>
+    {children}
+  </VendoProvider>
+</body>
 ```
+
+Leave that props type alone. Next already types `children` for you —
+create-next-app writes `Readonly<{ children: React.ReactNode }>`, and an app on
+typed routes has a generated props type of its own — so annotating it again as
+`{ children: ReactNode }` only throws away what your app already knows.
 
 `baseUrl` is where the route is mounted, path prefix included. An app served
 under `/maple` passes `baseUrl="/maple/api/vendo"`.
@@ -77,6 +78,11 @@ Put a slot where a card would go. A screen the agent builds can live there
 instead of in the panel.
 
 `VendoSlot` comes from the package you already installed — no second one.
+
+The id and the file are both yours. `spend-breakdown` on a bank's overview page
+is this example's choice: pick any string, and put the slot on whichever page you
+want the surface to appear on. The one rule is that the same string appears in
+both places — on `VendoSlot` here, and on the provider's `pinSlot` below.
 
 ```tsx app/overview/page.tsx focus={3,9}
 "use client";


### PR DESCRIPTION
Docs-only. Every item below is a finding from installing published **0.28.0** by hand on four real apps, each approved individually. Nothing outside `docs-site/` is touched, no pages added, nav unchanged.

### 1. `backend/quickstart.mdx`
- Install line gains `@vendoai/vendo` in both tabs — init's generated files import `@vendoai/vendo/*`, and the `predev`/`prebuild` hooks init writes to `package.json` run the `vendo` binary, which only that package ships (`@vendoai/agents` has no `bin`).
- Names the init answer to pick: **Through my own agent loop (AI SDK / Mastra)**, with the reason — that use case is what makes doctor skip the mounted-UI checks (`doctor-wiring-checks.ts:241`).
- The login line is now skippable when a `VENDO_API_KEY` already sits in `.env.local` (the pattern `agents/index.mdx` already documents).

### 2. `existing-agent/quickstart.mdx`
- `@ai-sdk/anthropic@^3` added to both install tabs, and the "Pin the majors" line now names it.
- Adds the **no-provider** `lib/vendo.ts` variant — the demo principal init writes with `--auth none`, plus the resolver the reader exports beside it, and the both-sides-same-subject rule.
- The AI SDK chat-route snippet keeps a `system:` line, with one line saying the prompt stays the reader's.

### 3. `existing-agent/ai-sdk.mdx` + `mastra.mdx`
`components/vendo-part.tsx` is now explicitly a name and not a contract, and each page points at where its own shipped example puts that branch (`app/page.tsx` / `src/app/page.tsx`).

### 4. `outside-agents/quickstart.mdx`
- New first step: install + `npx vendo init` (the page had no install command at all).
- The **local posture** branch moved ahead of the broker recommendation, so a reader driving their own backend agent doesn't walk into a console-only path first.
- "unlocks the two questions below it" corrected: the service-key question always appears; the posture question only exists with a Vendo Cloud key in hand, because a keyless run can't reach a broker (`init-questions.ts:98-120`).

### 5. Auth.js v5 user-id callout
With the preset init wires, `session.user.id` is `undefined` by default while the door resolves the session token's `sub` — so the documented `subject_token` call 401s. Full callout (with the session callback) on the quickstart; the `subject_token` row on `service-keys-and-broker.mdx` references it.

### 6. `product/quickstart.mdx`
- Prerequisite is now explicit: `npm install @vendoai/vendo` then `npx vendo init`, inline.
- The layout snippet no longer retypes `children` as `{ children: ReactNode }` — it shows the provider wrap and says to leave your app's own props type alone (Next 16's create-next-app writes `Readonly<{ children: React.ReactNode }>`).
- Step 3 says the slot id and the file are the reader's choice; the bank stays an example.

### 7. `outside-agents/service-keys-and-broker.mdx`
Adds the local-posture exchange (same RFC 8693 body, posted to `<your app>/api/vendo/mcp/token`) and where a local key lives, so the page covers both postures.

### 8. `agents/index.mdx` (agent playbook)
- **"install BOTH" was wrong — verified empirically** (see below): one package, `@vendoai/vendo`, and the commands now install only it. The alias is for `npx vendoai@latest …`; installing it *instead of* the umbrella is the shape that breaks.
- Version floor `>= 0.4.0` → `>= 0.28.0`.
- `pnpm-workspace.yaml` only counts as a monorepo signal when it declares a `packages:` list (under pnpm 10 that file is also where plain settings live — including the exclude list this same step tells agents to add).
- The tool-pack fork now states that steps 2–5 still apply, and come first (`--use-case agent-loop` included).
- Surfaces table gains a `backend/quickstart.md` row.
- `.vendo/judgments.json` added to the contract list, with one line on the `tools.json` merge (per-tool layer, `overrides.json` wins last).

### Item 8a experiment (throwaway pnpm apps in `/tmp`, npm registry, pnpm 10.33.4)

**Only `@vendoai/vendo@0.28.0` installed:**
```
OK    @vendoai/vendo
OK    @vendoai/vendo/react
OK    @vendoai/vendo/ai-sdk
OK    @vendoai/vendo/auth/auth-js
FAIL  @vendoai/vendo/mastra  Cannot find package '@mastra/core'   (host's own peer, expected)
RESOLVED @vendoai/vendo/server; exports: CONFIG_SURFACES, UNATTENDED_IRREVERSIBILITY_RULE, byoConnections, …
node_modules/.bin: sucrase  sucrase-node  vendo
pnpm exec vendo --version → 0.28.0
```

**Only the `vendoai@0.28.0` alias installed:**
```
FAIL  @vendoai/vendo         Cannot find package '@vendoai/vendo'
FAIL  @vendoai/vendo/server  Cannot find package '@vendoai/vendo'
FAIL  @vendoai/vendo/react   Cannot find package '@vendoai/vendo'
OK    vendoai
node_modules: vendoai            (only)
```

So the umbrella alone is sufficient for both the imports and the CLI; the alias alone is what 500s every route. That matches the audit's four single-package installs.

### Verification
- `pnpm build` ✅ · `pnpm lint` ✅ (0 errors; 4 pre-existing `demo-bank` warnings)
- Docs-rot suites in `packages/vendo` (`your-agent-docs`, `mcp-byo-docs`, `server-api`, `handler-options`, `doctor-codes`): **59 passed**. The 2 remaining failures are an environment artifact of a worktree path containing a space (`URL.pathname` → `%20` → ENOENT) and reproduce identically on a clean tree; the checks they perform (every internal link resolves, nav matches the page set) were re-run with a decoded path: **115 pages, 0 problems**.
- Every touched page rendered in a local `mint dev`: HTTP 200, no error markers, no console/page errors, and each new passage present in the served HTML. Screenshots taken of the new install step, the Auth.js callout, the no-provider snippet, the local exchange, the layout snippet, and the playbook install passage. Two code blocks were reflowed after seeing them clip inside a callout/Step.

### Note for review
`@ai-sdk/anthropic` is not in `@vendoai/vendo`'s `peerDependencies`; the v3 pin comes from the AI SDK v6 family and doctor's own E-DEP-001 remedy text (`doctor-deps-checks.ts:17` prescribes `ai@^6 @ai-sdk/anthropic@^3 @ai-sdk/react@^3`). The approved wording ("Vendo peers `ai` at 6 and `@ai-sdk/anthropic` at 3") is kept verbatim.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Docs-only updates to fix install and setup guidance after auditing published `0.28.0` on real apps. This prevents broken CLI/imports, clarifies MCP posture, and avoids common dependency and Auth.js pitfalls.

- Install one package: use `@vendoai/vendo` only. Remove the `vendoai` alias from dependencies. Verify `npx vendo --version >= 0.28.0`. Workspace detection now checks `pnpm-workspace.yaml` for a `packages:` list.
- Backend quickstart: add `@vendoai/vendo` to install lines; `login` is skippable if `VENDO_API_KEY` exists; choose “Through my own agent loop (AI SDK / Mastra)” to skip mounted-UI checks.
- Existing agent quickstart: pin `ai@^6` and `@ai-sdk/anthropic@^3`; add a no-provider `lib/vendo.ts` with a demo principal and `resolvePrincipal`; require the same subject on route and loop; keep your own `system` prompt.
- AI SDK / Mastra pages: treat `components/vendo-part.tsx` as a sample path; examples inline the same branch in `app/page.tsx` or `src/app/page.tsx`.
- Outside agents quickstart: add install + `npx vendo init`; surface the local posture before broker and show flags (`--use-case mcp --posture local --service-key`); clarify that the posture question appears only with a Cloud key; add an Auth.js v5 note to copy `token.sub` into `session.user.id`.
- Service keys and broker: document the local-posture token exchange at `/api/vendo/mcp/token` using `VENDO_SERVICE_KEY`; broker and local exchanges share the same RFC 8693 body.
- Product quickstart: call out the two prerequisites (`npm install @vendoai/vendo`, `npx vendo init`); stop retyping the RootLayout `children` prop; state that slot id and placement are user-defined.
- Agents playbook: steps 2–5 apply to the tool-pack path; add a link to `backend/quickstart.md`; add `.vendo/judgments.json` to the contract and describe merge order.

<sup>Written for commit d9226ccfae311aafe8216bade6aeca2de399332d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1480?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

