### PR TITLE
fix(ui,vendo): a settled approval receipt stops claiming it is still waiting

### DIFF
--- a/.changeset/approval-receipt-result-label.md
+++ b/.changeset/approval-receipt-result-label.md
@@ -1,0 +1,11 @@
+---
+"@vendoai/ui": patch
+---
+
+A settled approval receipt names the data it got back. The receipt built its rows
+with the same body the ask uses, and that body calls a value with no name of its
+own "Input" — so an approved `getTodos` listed the returned todos under "Input",
+as if the list were what the person had agreed to send. Rows on the way back are
+labelled "Result". A call that returned a bare value now shows it at all, too:
+the object-only guard in front of those rows showed a person nothing, which is
+exactly the data-chosen body §16 law 1 exists to prevent.

--- a/.changeset/approval-ref-line-state-free.md
+++ b/.changeset/approval-ref-line-state-free.md
@@ -1,0 +1,13 @@
+---
+"@vendoai/vendo": patch
+---
+
+A parked call's one line says what is waiting, not what state it is in. The tool
+pack minted it as "Awaiting user approval: List your todos — host_getTodos
+{…}", and `<VendoApprovalEmbed>` titles the card with that line for the rest of
+the request's life — so after the person pressed Approve, the receipt read
+"Awaiting user approval: List your todos" directly over its own "Approved —
+ran". The mint now describes only the call; the state stays with the surface
+that knows it, which was already saying it on the line underneath. The line
+keeps the guard's preview vocabulary, so a BYO loop reads the same call it
+always did.

--- a/packages/ui/src/chrome/embeds.tsx
+++ b/packages/ui/src/chrome/embeds.tsx
@@ -34,7 +34,7 @@ import {
 } from "./card-shell.js";
 import { ChromeRoot } from "./chrome-root.js";
 import { developmentMode } from "./dev-mode.js";
-import { fieldRows } from "./field-rows.js";
+import { resultRows } from "./field-rows.js";
 import { buildFailureNotice } from "./thread/message-data.js";
 
 /**
@@ -137,10 +137,12 @@ function ResolvedApprovalCard({ summary, ok, line, detail }: {
 function executedCard(summary: string, outcome: ToolOutcome): ReactNode {
   if (outcome.status === "ok") {
     // The result reads as the shell's ONE body — field rows, never the raw JSON
-    // dump this used to print at an end user (spec §16.2).
-    const rows = outcome.output !== null && typeof outcome.output === "object"
-      ? fieldRows(outcome.output)
-      : [];
+    // dump this used to print at an end user (spec §16.2). `resultRows`, not
+    // `fieldRows`: what came BACK is a result, and rows that came back labelled
+    // "Input" read as the call's arguments. It answers any shape (law 1 — the
+    // body is not chosen by its data), so a bare value is one row too, where the
+    // object-only guard this replaces showed a person nothing at all.
+    const rows = resultRows(outcome.output);
     const detail = rows.length > 0 ? <CardFields rows={rows} label="Result" /> : undefined;
     return <ResolvedApprovalCard summary={summary} ok line="Approved — ran" detail={detail} />;
   }

--- a/packages/ui/src/chrome/field-rows.ts
+++ b/packages/ui/src/chrome/field-rows.ts
@@ -13,9 +13,10 @@ import { argProperties, argValue, humanizeToolName, type ToolMeta } from "./huma
 import { truncateHead } from "./truncate.js";
 
 export interface CardFieldRow {
-  /** WHICH argument this row is — the top-level input key, verbatim ("Input"
-      for a non-object arg). Identity, never display: `humanizeToolName` is
-      many-to-one (`recipient_name`, `recipientName` and `RecipientName` all
+  /** WHICH argument this row is — the top-level input key, verbatim ("Input",
+      or "Result" on the way back, for a value with no name of its own).
+      Identity, never display: `humanizeToolName` is many-to-one
+      (`recipient_name`, `recipientName` and `RecipientName` all
       read "Recipient name"), so anything matching a row against something else
       — the consent question's `questionKeys`, say — matches on this. */
   key: string;
@@ -96,15 +97,30 @@ function display(key: string, value: unknown, schema: JsonSchema | undefined, me
 
 /** The one body, for any args a tool call can carry. */
 export function fieldRows(args: unknown, inputSchema?: JsonSchema, meta?: ToolMeta): CardFieldRow[] {
+  return valueRows(args, "Input", inputSchema, meta);
+}
+
+/** The same one body for what the call RETURNED — one word different, and the
+    word is the DIRECTION. A value with no name of its own (a bare value, or a
+    list) is the whole thing, and the arg-side name for that row labelled a
+    settled receipt's returned todo list "Input", as if the list were what the
+    person had approved sending. */
+export function resultRows(output: unknown): CardFieldRow[] {
+  return valueRows(output, "Result");
+}
+
+/** `unnamed` is what a value with no name of its own is called on this side of
+    the call — the only difference between the two bodies above. */
+function valueRows(input: unknown, unnamed: string, inputSchema?: JsonSchema, meta?: ToolMeta): CardFieldRow[] {
   const row = (key: string, label: string, value: string, raw: string, numeric: boolean): CardFieldRow =>
     ({ key, label, value: bound(value), raw: bound(raw), numeric });
-  if (args === undefined || args === null) return [];
-  if (typeof args !== "object") {
-    return [row("Input", "Input", display("Input", args, inputSchema, meta), leaf(args), typeof args === "number")];
+  if (input === undefined || input === null) return [];
+  if (typeof input !== "object") {
+    return [row(unnamed, unnamed, display(unnamed, input, inputSchema, meta), leaf(input), typeof input === "number")];
   }
-  if (Array.isArray(args)) return [row("Input", "Input", display("Input", args, inputSchema, meta), leaf(args), false)];
+  if (Array.isArray(input)) return [row(unnamed, unnamed, display(unnamed, input, inputSchema, meta), leaf(input), false)];
   const properties = argProperties(inputSchema);
-  return Object.entries(args as Record<string, unknown>).map(([key, value]) => row(
+  return Object.entries(input as Record<string, unknown>).map(([key, value]) => row(
     key,
     humanizeToolName(key),
     display(key, value, properties?.[key], meta),

--- a/packages/ui/test/embed-result-rows.test.tsx
+++ b/packages/ui/test/embed-result-rows.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import type { VendoApprovalRef } from "@vendoai/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  VendoApprovalEmbed,
+  VendoProvider,
+  createVendoClient,
+  type VendoClient,
+} from "../src/index.js";
+import { createWireServer } from "./wire-server.js";
+
+// What a settled receipt says about the data the resumed call handed BACK.
+// The rows come off the one body the ask itself uses (spec §16 law 1), and that
+// body names a value with no name of its own after the side it was written for:
+// "Input". On the way back that is the wrong direction — a returned todo list
+// read as the input the person had approved sending.
+
+const approvalRef: VendoApprovalRef = {
+  kind: "vendo/approval-ref@1",
+  approvalId: "apr_1",
+  summary: "Email the June statement",
+};
+
+describe("the settled receipt's result rows", () => {
+  let wire: Awaited<ReturnType<typeof createWireServer>>;
+  let client: VendoClient;
+
+  beforeEach(async () => {
+    wire = await createWireServer();
+    client = createVendoClient({ baseUrl: wire.url });
+    // Nothing pending: this file is about the receipt, so the wire answers the
+    // executed resolution the umbrella's park→resume writes.
+    wire.state.approvals = [];
+  });
+
+  afterEach(async () => {
+    cleanup();
+    await wire.close();
+  });
+
+  /** The real read path: the embed polls the wire for apr_1 and settles. */
+  async function receipt(output: unknown): Promise<string[][]> {
+    wire.state.approvalResolutions.set("apr_1", {
+      state: "executed",
+      outcome: { status: "ok", output: output as never },
+    });
+    render(
+      <VendoProvider client={client}>
+        <VendoApprovalEmbed refValue={approvalRef} />
+      </VendoProvider>,
+    );
+    await waitFor(() => expect(screen.getByText("Approved — ran")).toBeDefined());
+    return Array.from(document.querySelectorAll(".fl-card-field")).map(field => [
+      field.querySelector("dt")!.textContent!,
+      field.querySelector("dd")!.textContent!,
+    ]);
+  }
+
+  it("labels a returned list by its direction — the row is the result, never the call's input", async () => {
+    expect(await receipt(["Buy milk", "Ship the release"])).toEqual([
+      ["Result", "Buy milk\nShip the release"],
+    ]);
+    expect(document.body.textContent).not.toContain("Input");
+  });
+
+  it("shows a bare returned value at all — the object-only guard showed a person nothing", async () => {
+    expect(await receipt("3 todos are open")).toEqual([["Result", "3 todos are open"]]);
+  });
+
+  it("keeps a named result's own field names, humanized as everywhere else", async () => {
+    expect(await receipt({ delivered: true })).toEqual([["Delivered", "Yes"]]);
+  });
+
+  it("adds no body at all for a call that returned nothing", async () => {
+    expect(await receipt(null)).toEqual([]);
+  });
+});

--- a/packages/vendo/src/pack.ts
+++ b/packages/vendo/src/pack.ts
@@ -121,8 +121,14 @@ function executionError(): ToolOutcome {
   };
 }
 
-/** One human-readable line describing what is waiting — the tool descriptor
- *  plus the guard's inputPreview vocabulary (`<tool> <canonical args>`). */
+/** One human-readable line describing WHAT is waiting — the tool descriptor
+ *  plus the guard's inputPreview vocabulary (`<tool> <canonical args>`).
+ *
+ *  State-free on purpose. This line is minted ONCE, and `<VendoApprovalEmbed>`
+ *  titles the card with it for the rest of the request's life — so a lifecycle
+ *  claim baked in here outlives the lifecycle: it read "Awaiting user approval:
+ *  …" over "Approved — ran" on every settled receipt. The state belongs to
+ *  whoever knows it at render time (the embed's own resolution line). */
 function approvalSummary(descriptor: ToolDescriptor, args: unknown): string {
   let preview: string;
   try {
@@ -130,7 +136,7 @@ function approvalSummary(descriptor: ToolDescriptor, args: unknown): string {
   } catch {
     preview = "";
   }
-  const summary = `Awaiting user approval: ${descriptor.description || descriptor.name} — ${descriptor.name} ${preview}`
+  const summary = `${descriptor.description || descriptor.name} — ${descriptor.name} ${preview}`
     .replace(/\s+/g, " ")
     .trim();
   return summary.length > SUMMARY_CAP ? `${summary.slice(0, SUMMARY_CAP - 1)}…` : summary;

--- a/packages/vendo/tests/approval-ref-title.seam.test.ts
+++ b/packages/vendo/tests/approval-ref-title.seam.test.ts
@@ -1,0 +1,162 @@
+// @vitest-environment jsdom
+/**
+ * The approval-ref TITLE seam.
+ *
+ * The pack mints the ref's one line (`approvalSummary`, this package) and the
+ * shipped `<VendoApprovalEmbed>` (@vendoai/ui) titles the card with that same
+ * line for the rest of the request's life — waiting, approved, declined,
+ * expired. Two packages that never import each other, joined by one string, so
+ * each side's own suite could only ever agree with itself: the mint said
+ * "Awaiting user approval: …" and the settled receipt printed it, unchanged,
+ * directly over "Approved — ran".
+ *
+ * Nothing on either side of the string is arranged here. A real store, a real
+ * guard and the real pack park a real call and mint the real envelope; the real
+ * decide path executes it; the resolution the embed reads back is the one
+ * `createByoApprovals` actually serves. The only double is the transport.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  vendoApprovalRefSchema,
+  type AgentRunner,
+  type ApprovalId,
+  type Principal,
+  type RunContext,
+  type ToolDescriptor,
+  type ToolRegistry,
+} from "@vendoai/core";
+import { createGuard } from "@vendoai/guard";
+import { createStore, createStoreOps } from "@vendoai/store";
+import { VendoProvider, VendoToolResult, createVendoClient } from "@vendoai/ui";
+import { act, createElement, type ReactElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it } from "vitest";
+import { createByoApprovals } from "../src/byo-approvals.js";
+import { buildVendoToolPack } from "../src/pack.js";
+
+const BASE = "https://host.test/api/vendo";
+const principal: Principal = { kind: "user", subject: "user_seam" };
+/** The pack's frozen context tuple: a chat that is not Vendo's, user present. */
+const ctx: RunContext = { principal, venue: "chat", presence: "present", sessionId: "session_seam" };
+
+const cleanups: Array<() => Promise<void> | void> = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+  document.body.innerHTML = "";
+});
+
+const nullRunner: AgentRunner = async () => ({ status: "ok", summary: "noop", toolCalls: [] });
+
+/** One host tool that lists a person's todos — the exact call the defect was
+ *  reported on, and a `write` grade so the guard's ask rule parks it. */
+const listTodos: ToolDescriptor = {
+  name: "host_getTodos",
+  description: "List your todos",
+  inputSchema: { type: "object", properties: { owner: { type: "string" } } },
+  risk: "write",
+};
+
+const host: ToolRegistry = {
+  descriptors: async () => [listTodos],
+  execute: async () => ({ status: "ok", output: { open: 3 } }),
+};
+
+/** Real store, real guard, real parking registry — the composition the umbrella
+ *  hands a BYO loop. */
+async function harness() {
+  const root = await mkdtemp(join(tmpdir(), "vendo-approval-title-seam-"));
+  cleanups.push(async () => rm(root, { recursive: true, force: true }));
+  const store = createStore({ dataDir: join(root, ".data") });
+  cleanups.push(async () => store.close());
+  await store.ensureSchema();
+  const guard = createGuard({ store, policy: { rules: [{ match: { risk: "write" }, action: "ask" }] } });
+  const byo = createByoApprovals({ guard, tools: guard.bind(host), ops: createStoreOps(store) });
+  const pack = await buildVendoToolPack({ registry: byo.registry, runner: nullRunner });
+  const tool = pack.find((entry) => entry.name === `vendo_${listTodos.name}`);
+  if (tool === undefined) throw new Error("the pack never wrapped the host tool");
+  return { guard, byo, tool };
+}
+
+// --- rendering, without a component-test harness in this package -------------
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+async function mount(element: ReactElement): Promise<void> {
+  const container = document.createElement("div");
+  document.body.append(container);
+  const root = createRoot(container);
+  cleanups.push(() => act(() => root.unmount()));
+  await act(async () => { root.render(element); });
+}
+
+/** Poll the painted DOM. The budget is the test's own — a tighter inner clock
+ *  would report a product bug whenever the machine is merely busy. */
+async function until<T>(what: string, probe: () => T | null | undefined | false): Promise<T> {
+  const deadline = Date.now() + 25_000;
+  for (;;) {
+    let found: T | null | undefined | false;
+    await act(async () => {
+      found = probe();
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    });
+    if (found) return found;
+    if (Date.now() > deadline) throw new Error(`timed out waiting for ${what}`);
+  }
+}
+
+/** One real parked call, minted by the real pack. */
+async function park(tool: Awaited<ReturnType<typeof harness>>["tool"]) {
+  return vendoApprovalRefSchema.parse(await tool.execute({ owner: "ada" }, { ctx, callId: "call_todos" }));
+}
+
+describe("the approval ref's one line, from the mint to the settled card", () => {
+  it("mints WHAT is waiting, and no state the request will outlive", async () => {
+    const { tool } = await harness();
+    const ref = await park(tool);
+    // The guard's own preview vocabulary, so the model still reads the call…
+    expect(ref.summary).toContain(listTodos.name);
+    expect(ref.summary).toContain("ada");
+    // …and not one word of lifecycle: this line is minted once and rendered
+    // under every later state of the request.
+    expect(ref.summary).not.toMatch(/awaiting|pending|approved|declined|expired/i);
+  });
+
+  it("titles the settled receipt with what was asked, and lets the state line say the state", async () => {
+    const { guard, byo, tool } = await harness();
+    const ref = await park(tool);
+
+    // The decision, through the real approval API the wire serves.
+    await guard.approvals.decide(ref.approvalId, { approve: true }, principal);
+    const resolutions = new Map([[ref.approvalId, await byo.read(ref.approvalId, principal)]]);
+    expect(resolutions.get(ref.approvalId)).toMatchObject({ state: "executed" });
+
+    // The consumer: the shipped embed, reading that resolution over the wire.
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = new URL(typeof input === "string" || input instanceof URL ? String(input) : (input as { url: string }).url);
+      const id = url.pathname.split("/").pop() as ApprovalId;
+      const resolution = resolutions.get(id);
+      if (resolution === undefined) return new Response("{}", { status: 404 });
+      return new Response(JSON.stringify(resolution), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+    cleanups.push(() => { globalThis.fetch = realFetch; });
+
+    await mount(createElement(VendoProvider, {
+      client: createVendoClient({ baseUrl: BASE }),
+      children: createElement(VendoToolResult, { output: ref }),
+    }));
+
+    const card = await until("the settled receipt", () => {
+      const article = document.querySelector<HTMLElement>('[data-vendo-embed="approval"]');
+      return article !== null && article.textContent!.includes("Approved — ran") ? article : null;
+    });
+    // The title is the ask; the state line is the only thing claiming a state.
+    expect(card.querySelector(".fl-approval-ask")!.textContent).toBe(ref.summary);
+    expect(card.textContent).not.toMatch(/awaiting/i);
+  });
+});


### PR DESCRIPTION
Two of the three approval-card defects from the fix wave. The third is
deliberately **not** here — the browser gate proved the only WCAG-clean version
of it needs test-file changes I was told not to make. Detail at the bottom.

## 1. The settled receipt stopped claiming it was still waiting

`approvalSummary` (packages/vendo) baked the state into the ref's one line —
`Awaiting user approval: List your todos — host_getTodos {…}` — and
`<VendoApprovalEmbed>` titles the card with that line for the rest of the
request's life. So the moment after someone pressed Approve, the receipt read
"Awaiting user approval: List your todos" directly over its own "Approved —
ran", and the same lie sat over "Declined — nothing ran" and "Expired".

The mint now describes only the call. Nothing on the render side changed: the
resolution line underneath was already saying the state truthfully, on all four
terminal states. The line keeps the guard's preview vocabulary, so a BYO loop
reads the same call it always did.

One tradeoff worth a reviewer's eye: that prefix was also the only *prose* cue
telling a BYO model the call had not run. What remains is the machine-readable
one — `kind: "vendo/approval-ref@1"`, plus both shims' docs ("parks
server-side"). If we want the app-ref treatment (`VendoAppRef.status:
"building"` exists because models narrated a finished dashboard off an
under-specified envelope), that is a `status` field on the envelope and its own
decision — I did not widen the public contract here.

Screenshots (local, not committed — this repo does not carry proof artefacts):
`/tmp/ui-approval-fixes/00-title-before.png` and `…/00-title-after.png`, the
same settled receipt titled with the string each mint produces.

## 2. Returned data is labelled "Result", not "Input"

The receipt built its rows with `fieldRows`, the same body the ask uses, which
names a value with no name of its own after the side it was written for:
"Input". An approved `getTodos` therefore listed the todos it got back under
"Input", as if the list were what the person had approved sending. `resultRows`
is the same body with that one word carrying the direction.

It also answers any shape, so a call that returned a bare value shows it: the
`typeof output === "object"` guard in front of those rows showed a person
nothing at all, which is the data-chosen body §16 law 1 exists to prevent.

## Tests

- `packages/vendo/tests/approval-ref-title.seam.test.ts` — the mint→title seam.
  A real store, a real guard and the real pack park a real call and mint the
  real envelope; the real decide path executes it; the resolution is the one
  `createByoApprovals` serves, and the shipped embed renders it. Only the
  transport is doubled. Reverting `pack.ts` fails it on the rendered DOM:
  `"Awaiting user approval: List your todos — host_getTodos {\"owner\":\"ada\"}Approved — ran…"`.
- `packages/ui/test/embed-result-rows.test.tsx` — the receipt over the real wire
  fixture, for a list, a bare value, a named object and a void result. Reverting
  the fix fails two: `'Input'` for the list, and `[]` for the bare value.

## Verified in a real browser

Production harness build (`vite build` + `vite preview`, not the dev server),
driven by one throwaway Playwright script — 11 checks, screenshots in
`/tmp/ui-approval-fixes/`:

- `02-lifecycle-pending.png` — the pending ask
- `03-settled-list-result.png` — Approve pressed for real over the wire, list
  result under "Result"
- `04-settled-bare-result.png` — a bare returned value, shown at all
- `05-declined.png`, `06-expired.png` — the other terminal states, neither
  titled with a state
- `01-ask-notes-line.png` — the ask's quiet line, with the clipboard read back

Also run locally: the full `@vendoai/ui` Playwright suite (65 passed; the one
`thread-citations` axe colour-contrast failure reproduces on a clean tree, and
`scroll-management` passed on re-run). `pnpm build`, `pnpm typecheck` and
`pnpm lint` green; `pnpm test:affected` green apart from three failures that
reproduce on a clean tree in this worktree and are its PATH, not this change:
`your-agent-docs.docs.test.ts` (×2) and `cli/init-mcp.test.ts` read a repo path
through `new URL(…).pathname`, which percent-encodes the space in the checkout
directory (`Cool%20Code`). Unrelated, and invisible on a space-free path.

## Not landed: the run-together copy on the ask's quiet line

The third item was "the " · " between the notes is CSS-generated, so screen
readers and copy-paste get 'it runs as you.asked here in chat'". Half of that
premise does not hold, and the other half has no clean fix inside this PR's
rules:

- **Screen readers are fine.** Chromium exposes generated content to the
  accessibility tree — the aria snapshot of the line reads
  `listitem: "· Permanent: Yes"`. Nothing runs together for AT.
- **Copy-paste is real.** A real clipboard read gives
  `"Invoice id: inv_42Permanent: YesThis makes a change you can't undo, as
  you.asked in an app"`.
- I fixed it with the separator as a real text node **between** the `<li>`s,
  which keeps every `li.textContent` (and so every existing assertion) intact —
  and `e2e/accessibility.spec.ts` failed it on three pages: axe `list`, serious,
  WCAG 2.1 A / 1.3.1, "`<ul>` and `<ol>` must only directly contain `<li>`".
  Reverted.
- The WCAG-clean version puts the separator (visually hidden or not) **inside**
  each `<li>`, which changes `li.textContent` — and ~21 exact-text assertions
  across five existing test files pin those strings
  (`approval-money`, `approval-degraded`, `approval-and-notice`, `connect`,
  `approval-modal`), several with comments deliberately pinning the
  CSS-punctuation design.

Recommendation: do it as its own small change that re-pins those five files in
the same commit — a test edit stated out loud, which is the house rule for one.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops settled approval receipts from saying “Awaiting user approval” and correctly labels returned data as “Result”. Previously, the summary baked in a waiting state and the receipt body reused “Input” rows that hid primitives; now the summary is state-free and results render for any shape.

- In `@vendoai/vendo`, `approvalSummary` describes only the call; `<VendoApprovalEmbed>` keeps using that line as the title while the state line underneath reports “Approved — ran”, “Declined — nothing ran”, etc.
- In `@vendoai/ui`, the receipt uses `resultRows` instead of `fieldRows`, so lists and primitives show up and are labeled “Result” instead of “Input”.

**Review notes**
- Core change: `packages/vendo/src/pack.ts` (`approvalSummary`) drops lifecycle text; `packages/vendo/tests/approval-ref-title.seam.test.ts` verifies the mint→embed title seam.
- UI change: `packages/ui/src/chrome/embeds.tsx` switches to `resultRows`; `packages/ui/src/chrome/field-rows.ts` adds `resultRows`; `packages/ui/test/embed-result-rows.test.tsx` covers list, primitive, object, and void outputs.

**Rollout**
- No API changes; the approval ref summary text changes and UI labels “Result”. Update any snapshots or tests that asserted the old “Awaiting …” title or “Input” label.

<sup>Written for commit 78f4232c6132723b76a6a07570e1421068fbdec9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1481?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

