### PR TITLE
fix(ui): the ask's quiet line copies as a sentence, not as one run-together word

### DIFF
--- a/.changeset/approval-line-copies-separated.md
+++ b/.changeset/approval-line-copies-separated.md
@@ -1,0 +1,15 @@
+---
+"@vendoai/ui": patch
+---
+
+The quiet line under a consent card survives being copied. The " · " between its
+facts was drawn by CSS (`content` on a pseudo-element), and a browser hands
+generated content to the accessibility tree but never to the clipboard — so
+pasting the line into a bug report or a message to support gave back "This makes
+a change you can’t undo, as you.asked in an app", every fact run into the next.
+The separator is real text now, leading every item but the first, on all three
+surfaces that draw the line (the approval ask, the press modal, the connect
+row). It lives INSIDE the list item: a separator between the items copies just as
+well and fails WCAG 1.3.1 ("`<ul>` and `<ol>` must only directly contain
+`<li>`"). Screen readers hear exactly what they heard before, and screenshots of
+all three cards are byte-identical.

--- a/packages/ui/src/chrome/approval-card.tsx
+++ b/packages/ui/src/chrome/approval-card.tsx
@@ -8,7 +8,7 @@ import { useState } from "react";
 import { useVendoTools } from "../context.js";
 import { ContainedNotice } from "../tree/notice.js";
 import { consentAsk, toolPresentation } from "./build-beat.js";
-import { CardActions, CardLine, CardShell } from "./card-shell.js";
+import { CardActions, CardLine, CardShell, NOTE_SEPARATOR } from "./card-shell.js";
 import { ChromeRoot } from "./chrome-root.js";
 import { fieldRows } from "./field-rows.js";
 
@@ -178,10 +178,14 @@ export function ApprovalCard({ approval, onDecide, allowRemember = true, showCon
         {/* One LINE to the eye, a LIST to a screen reader: the notes are a set
             of distinct facts (each remaining input, what approving does, who
             asked), and a joined paragraph gave a reader no way to step through
-            them — the field table it replaced was navigable. The " · " between
-            them is punctuation, so it is drawn in CSS rather than read out. */}
+            them — the field table it replaced was navigable. The " · " leads
+            every item but the first (`NOTE_SEPARATOR`), as real text: a CSS
+            `content` rule drew it for free, but generated content never reaches
+            the clipboard, so the copied line ran its facts together. */}
         <ul className="fl-approval-sub" aria-label="Request details">
-          {notes.map((note, index) => <li key={index}>{note}</li>)}
+          {notes.map((note, index) => (
+            <li key={index}>{index > 0 ? NOTE_SEPARATOR : null}{note}</li>
+          ))}
         </ul>
         {approval.invalidatedGrant ? (
           <div style={{ marginTop: "12px" }}>

--- a/packages/ui/src/chrome/approval-modal.tsx
+++ b/packages/ui/src/chrome/approval-modal.tsx
@@ -44,7 +44,7 @@ import { themeCssVariables } from "../theme.js";
 import type { ApprovalResolution } from "../wire-types.js";
 import { refusalCopy } from "./approval-card.js";
 import { consentAsk, toolPresentation } from "./build-beat.js";
-import { CARD_EYEBROWS, CardFields } from "./card-shell.js";
+import { CARD_EYEBROWS, CardFields, NOTE_SEPARATOR } from "./card-shell.js";
 import { ensureChromeStyles } from "./chrome-root.js";
 import { fieldRows } from "./field-rows.js";
 import { inertBehind } from "./inert-behind.js";
@@ -302,9 +302,11 @@ export function ApprovalModal({ approvalId, onClose }: {
               <>
                 <h2 className="fl-apmodal-ask">{detail.ask.question}</h2>
                 {/* One line to the eye, a LIST to a screen reader — the card's
-                    own treatment, so the " · " stays CSS punctuation. */}
+                    own treatment, `NOTE_SEPARATOR` and all. */}
                 <ul className="fl-approval-sub fl-apmodal-notes" aria-label="What approving does">
-                  {detail.ask.notes.map((note, index) => <li key={index}>{note}</li>)}
+                  {detail.ask.notes.map((note, index) => (
+                    <li key={index}>{index > 0 ? NOTE_SEPARATOR : null}{note}</li>
+                  ))}
                 </ul>
                 <CardFields rows={detail.rows} />
               </>

--- a/packages/ui/src/chrome/card-shell.tsx
+++ b/packages/ui/src/chrome/card-shell.tsx
@@ -44,6 +44,20 @@ export const CARD_EYEBROWS = {
   waiting: "Waiting on you",
 } as const;
 
+/** What separates the facts on the sentence family's one quiet line
+    (`ul.fl-approval-sub` — the ask, the press modal, the connect row). It leads
+    every item but the first, as REAL text inside the `<li>`, where a CSS
+    `content` rule used to draw it between them.
+    Generated content is not invisible to a screen reader — Chromium puts it in
+    the accessibility tree, and the item reads "· Permanent: Yes" either way. It
+    is invisible to the CLIPBOARD: copying the line gave back "This makes a
+    change you can’t undo, as you.asked in an app", every fact run into the
+    next. Inside the item is the only place that fixes the copy and keeps the
+    list a list — a separator BETWEEN the items is a text node whose parent is
+    the `<ul>`, which axe fails as WCAG 1.3.1 ("<ul> and <ol> must only directly
+    contain <li>"). */
+export const NOTE_SEPARATOR = " · ";
+
 /* Law 3's fallback used to live here as `runsAsYouLine(title)` — "Vendo will
    run Send money as you.", the tool's label read back at the user. It is now
    `consentClassLine(name, risk)` in build-beat.tsx, which says what an approval

--- a/packages/ui/src/chrome/chrome-css.ts
+++ b/packages/ui/src/chrome/chrome-css.ts
@@ -2007,11 +2007,13 @@ html[data-vendo-dock] {
 .fl-approval-sub { margin: 4px 0 0; font: 400 12px/1.5 var(--vendo-font);
   color: var(--vendo-fg-muted); overflow-wrap: anywhere; white-space: pre-line; }
 /* The ask's notes are a LIST (each remaining input, what approving does, who
-   asked) that reads as one line: the items run inline and the " · " between
-   them is drawn here, as punctuation a screen reader never announces. */
+   asked) that reads as one line: the items run inline, and the " · " leading
+   each one after the first is REAL text in the markup (NOTE_SEPARATOR), not a
+   \`content\` rule here. Generated content was never hidden from a screen
+   reader — Chromium hands it to the accessibility tree — but it is hidden from
+   the CLIPBOARD, so the copied line read "…as you.asked in an app". */
 ul.fl-approval-sub { padding: 0; list-style: none; }
 .fl-approval-sub li { display: inline; }
-.fl-approval-sub li + li::before { content: " · "; }
 /* A settled receipt that FAILED keeps the thread's error register — the same
    danger ✕ its beat wears. Colour is never the only carrier (the glyph is). */
 .fl-approval-sub--failed { color: var(--vendo-danger); }

--- a/packages/ui/src/chrome/connect-card.tsx
+++ b/packages/ui/src/chrome/connect-card.tsx
@@ -4,7 +4,7 @@ import { useVendoProvider } from "../context.js";
 import { useConnections } from "../hooks/use-connections.js";
 import { useConnectorCatalog } from "../hooks/use-connector-catalog.js";
 import { toolkitLogoUrl } from "./build-beat.js";
-import { CardShell, LINK_GLYPH, TICK_GLYPH, ToolkitLogo } from "./card-shell.js";
+import { CardShell, LINK_GLYPH, NOTE_SEPARATOR, TICK_GLYPH, ToolkitLogo } from "./card-shell.js";
 import { ChromeRoot } from "./chrome-root.js";
 import { completeConnection, connectRefusalCopy, openConnectPopup } from "./connect-dock.js";
 import { developmentMode } from "./dev-mode.js";
@@ -234,14 +234,17 @@ export function ConnectCard({ connector, toolkit, message, onConnected, live = t
           <div className="fl-connect-copy">
             <div className="fl-connect-name">{displayName}</div>
             {/* Law 3's line, drawn the way the approval card draws its notes:
-                ONE line to the eye, a LIST to a screen reader, with the " · "
-                between items in CSS so it is never announced. Named for what it
-                holds: the ask's terms before, the account's receipt after. */}
+                ONE line to the eye, a LIST to a screen reader, joined by the
+                same real `NOTE_SEPARATOR` (a CSS-drawn one never reached the
+                clipboard). Named for what it holds: the ask's terms before, the
+                account's receipt after. */}
             <ul
               className="fl-card-line fl-approval-sub"
               aria-label={connected ? `What ${displayName} can now do` : `What connecting ${displayName} does`}
             >
-              {notes.map((item, index) => <li key={index}>{item}</li>)}
+              {notes.map((item, index) => (
+                <li key={index}>{index > 0 ? NOTE_SEPARATOR : null}{item}</li>
+              ))}
             </ul>
           </div>
           <div className="fl-connect-act">

--- a/packages/ui/test/chrome/approval-and-notice.test.tsx
+++ b/packages/ui/test/chrome/approval-and-notice.test.tsx
@@ -52,15 +52,19 @@ describe("ApprovalCard and NoPolicyNotice exports", () => {
     //
     // ⚠️ TEST EDIT (review of #1149): the notes are a LIST — one item per fact,
     // so a screen reader can step through them the way it could step through
-    // the field table this replaced. The " · " between them is CSS punctuation
-    // and is deliberately not in the accessible text.
+    // the field table this replaced.
+    // ⚠️ TEST EDIT (clipboard separator): the " · " leads every item but the
+    // first as real text. It was CSS `content`, which a screen reader DOES
+    // announce (Chromium puts generated content in the accessibility tree) but
+    // the clipboard never sees — so a copied line read "…as you.asked in an
+    // app". These are the exact items, which is also exactly what copies.
     const notes = container.querySelector("ul.fl-approval-sub")!;
     expect(notes.getAttribute("aria-label")).toBe("Request details");
     expect(Array.from(notes.querySelectorAll("li")).map(item => item.textContent)).toEqual([
       "Invoice id: inv_42",
-      "Permanent: Yes",
-      "This makes a change you can’t undo, as you.",
-      "asked in an app",
+      " · Permanent: Yes",
+      " · This makes a change you can’t undo, as you.",
+      " · asked in an app",
     ]);
     // No amber and no pill: the grade is a machine affordance on the shell, and
     // its plain words are in the line above.

--- a/packages/ui/test/chrome/approval-degraded.test.tsx
+++ b/packages/ui/test/chrome/approval-degraded.test.tsx
@@ -73,10 +73,16 @@ const rowsOf = (container: HTMLElement): Array<[string, string]> => {
   return rows;
 };
 
-/** One note per list item, in order — the " · " between them is CSS
-    punctuation now, so this is the exact set with no split heuristic. */
+/** One note per list item, in order — the exact set, with no split heuristic.
+    ⚠️ TEST EDIT (clipboard separator): the " · " is real text leading every item
+    but the first now (it has to be in the text to be copyable), and it is
+    stripped here rather than written into every expectation below — `rowsOf`
+    reads a LABEL off the front of each note, and " · Tags" is not a label this
+    card renders. `approval-notes-copy.test.tsx` owns the separator itself, in
+    both directions; a doubled one would survive this strip and fail these. */
 const notesOf = (container: HTMLElement): string[] =>
-  Array.from(container.querySelectorAll(".fl-approval-sub li")).map(li => li.textContent!);
+  Array.from(container.querySelectorAll(".fl-approval-sub li"))
+    .map(li => li.textContent!.replace(/^ · /, ""));
 
 describe("degraded data never changes the card", () => {
   it("keeps the mandatory line with an empty schema, no description and no host metadata", () => {

--- a/packages/ui/test/chrome/approval-modal.test.tsx
+++ b/packages/ui/test/chrome/approval-modal.test.tsx
@@ -102,7 +102,10 @@ describe("the screen-initiated approval modal", () => {
       // The honesty law: what the question did not name is on the surface,
       // never behind a fold — and the raw 4750 never reaches a person.
       expect(rows()).toEqual(["Memo: July water bill"]);
-      expect(notes()).toEqual(["Sends now, as you", "Can’t be undone"]);
+      // ⚠️ TEST EDIT (clipboard separator): the " · " leads every item but the
+      // first as real text now — a CSS-drawn one never reached the clipboard —
+      // so the items ARE what a person copies out of the modal.
+      expect(notes()).toEqual(["Sends now, as you", " · Can’t be undone"]);
       expect(screen.getByRole("dialog").textContent).not.toContain("4750");
     });
 

--- a/packages/ui/test/chrome/approval-money.test.tsx
+++ b/packages/ui/test/chrome/approval-money.test.tsx
@@ -63,9 +63,15 @@ function cardOf(approval: ApprovalRequest): { question: string; notes: string[] 
   );
   return {
     question: container.querySelector(".fl-approval-ask")!.textContent!,
-    // One note per list item — the " · " between them is CSS punctuation, so
-    // the items are also the exact set, with no split heuristic in the middle.
-    notes: Array.from(container.querySelectorAll(".fl-approval-sub li")).map(li => li.textContent!),
+    // One note per list item, with no split heuristic in the middle. ⚠️ TEST
+    // EDIT (clipboard separator): the " · " is real text leading every item but
+    // the first now, so it is stripped HERE rather than written into every
+    // expectation below — this file's subject is the money value, and a
+    // separator in front of a label is exactly the noise that hides one.
+    // `approval-notes-copy.test.tsx` owns the separator itself, in both
+    // directions; a doubled one would survive this strip and fail these.
+    notes: Array.from(container.querySelectorAll(".fl-approval-sub li"))
+      .map(li => li.textContent!.replace(/^ · /, "")),
   };
 }
 

--- a/packages/ui/test/chrome/approval-notes-copy.test.tsx
+++ b/packages/ui/test/chrome/approval-notes-copy.test.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+import type { ApprovalRequest } from "@vendoai/core";
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { VendoProvider, createVendoClient } from "../../src/index.js";
+import { ApprovalCard } from "../../src/chrome/index.js";
+
+// The ask's quiet line, taken SOMEWHERE ELSE — pasted into a bug report, a
+// message to support, a note to self. The " · " between its facts used to be
+// drawn by CSS (`content` on a pseudo-element), and a browser hands generated
+// content to the accessibility tree but never to the clipboard: the copied line
+// read "…This makes a change you can’t undo, as you.asked in an app". A browser
+// copies the TEXT, so the separator lives in the text — and inside the items,
+// because a text node whose parent is the <ul> is a WCAG 1.3.1 failure (axe
+// `list`, caught by e2e/accessibility.spec.ts).
+//
+// This file owns that contract for every surface that draws the line; the ask
+// is the one with the most facts on it.
+
+const client = createVendoClient({ baseUrl: "https://host.test/api/vendo" });
+
+const approval: ApprovalRequest = {
+  id: "apr_copy",
+  call: { id: "call_copy", tool: "host_delete_invoice", args: { invoiceId: "inv_42", permanent: true } },
+  descriptor: { name: "host_delete_invoice", description: "Delete invoice", inputSchema: {}, risk: "destructive" },
+  inputPreview: "invoiceId=inv_42\npermanent=true",
+  ctx: { principal: { kind: "user", subject: "user_1" }, venue: "app", presence: "present", appId: "app_1" },
+  createdAt: "2026-07-11T12:00:00.000Z",
+};
+
+const FACTS = [
+  "Invoice id: inv_42",
+  "Permanent: Yes",
+  "This makes a change you can’t undo, as you.",
+  "asked in an app",
+];
+
+describe("the ask's quiet line, copied", () => {
+  afterEach(cleanup);
+
+  function line(): HTMLElement {
+    const { container } = render(
+      <VendoProvider client={client}>
+        <ApprovalCard approval={approval} onDecide={() => undefined} />
+      </VendoProvider>,
+    );
+    return container.querySelector<HTMLElement>("ul.fl-approval-sub")!;
+  }
+
+  it("reads as one separated sentence, never as facts run together", () => {
+    expect(line().textContent).toBe(FACTS.join(" · "));
+  });
+
+  it("carries the separator inside the items, so the list only contains items", () => {
+    const list = line();
+    expect(Array.from(list.querySelectorAll("li")).map(item => item.textContent)).toEqual([
+      "Invoice id: inv_42",
+      " · Permanent: Yes",
+      " · This makes a change you can’t undo, as you.",
+      " · asked in an app",
+    ]);
+    // The WCAG 1.3.1 half: every child of the list is an item. A separator
+    // between them copies just as well and fails axe's `list` rule.
+    expect(Array.from(list.childNodes).every(node => node.nodeName === "LI")).toBe(true);
+  });
+});

--- a/packages/ui/test/chrome/connect.test.tsx
+++ b/packages/ui/test/chrome/connect.test.tsx
@@ -63,10 +63,13 @@ describe("ConnectCard", () => {
     // capitalized) were deleted, which is the whole reason it exists.
     const notes = screen.getByRole("article", { name: "Connect Gmail" })
       .querySelector("ul.fl-approval-sub")!;
+    // ⚠️ TEST EDIT (clipboard separator): the " · " leads every item but the
+    // first as real text now — it was CSS `content`, which never reaches the
+    // clipboard, so this line copied as one run-together sentence.
     expect([...notes.querySelectorAll("li")].map(item => item.textContent)).toEqual([
       "Connect your gmail account to run gmail_GMAIL_SEND_EMAIL",
-      "Read and send mail as you",
-      "Secured with OAuth",
+      " · Read and send mail as you",
+      " · Secured with OAuth",
     ]);
     fireEvent.click(screen.getByRole("button", { name: "Connect Gmail" }));
 


### PR DESCRIPTION
The third item from the approval-card fix wave, the WCAG-clean way. Follow-up to
#1481, which shipped the other two and documented why this one needed its own PR.

## The defect

The " · " between the facts on a consent card's quiet line was drawn by CSS
(`.fl-approval-sub li + li::before { content: " · " }`). A browser hands
generated content to the accessibility tree but **never to the clipboard**, so
copying that line — into a bug report, a message to support, a note to self —
gave back every fact run into the next:

```
Invoice id: inv_42Permanent: YesThis makes a change you can’t undo, as you.asked in an app
```

Half the original premise turned out to be wrong, and the code said so too. The
comment claimed the separator was "punctuation a screen reader never announces";
Chromium puts generated content in the accessibility tree, and the aria snapshot
reads `listitem: "· Permanent: Yes"` both before and after this change. Screen
readers were never affected. The comments now say what is actually true: the
separator was invisible to the clipboard only.

## The fix

`NOTE_SEPARATOR` (`card-shell.tsx`) is real text leading every item but the
first, on all three surfaces that draw the line — the approval ask, the
press modal, the connect row. The CSS rule is gone.

It rides **inside** the `<li>`, not between them. Between is the version I tried
first (#1481's description): it copies just as well and keeps every existing
`li.textContent` intact, but `e2e/accessibility.spec.ts` fails it on three pages
— axe `list`, serious, WCAG 2.1 A / 1.3.1, "`<ul>` and `<ol>` must only directly
contain `<li>`". Inside the item is the only place that fixes the clipboard and
leaves the list a list.

## Test changes, out loud

26 tests in 5 existing test files read those list items and saw this change.
None was weakened; the split is by what each file is *about*:

- **Re-pinned literally — 3 assertions, 6 strings** (the rendered items ARE the
  subject there, and what they render is now exactly what copies):
  `approval-and-notice.test.tsx`, `connect.test.tsx`, `approval-modal.test.tsx`.
- **Separator stripped once in the note reader — 2 files, 23 tests, every
  expectation byte-for-byte** (the subject is a VALUE contract read through the
  line): `approval-money.test.tsx` (`cardOf`) and `approval-degraded.test.tsx`
  (`notesOf`). `rowsOf` in the latter derives a label off the front of each note,
  and " · Tags" is not a label this card renders — writing the separator into
  those expectations would hide the money formatting they exist to pin. Each
  strip is one leading separator, so a doubled one still fails them, and each
  carries a comment naming the test that owns the separator itself.
- **New — `test/chrome/approval-notes-copy.test.tsx`**: owns the contract in both
  directions. The joined line (`FACTS.join(" · ")` — what the clipboard gets),
  the per-item text including the leading separator, and the WCAG half: every
  child of the list is an `<li>`.

## Proof

- **`e2e/accessibility.spec.ts` on a fresh production harness build**: `approval`
  and `thread` pass — the two pages the between-the-items version failed. The one
  remaining failure, `thread-citations`, is an axe colour-contrast violation on
  `.fl-know-unavail` that reproduces on a clean tree (verified in #1481).
- **Real clipboard read, production build**, `/approval` and
  `/thread-ordinary-consent`:
  `"Invoice id: inv_42 · Permanent: Yes · This makes a change you can’t undo, as you. · asked in an app"`
- **Aria snapshot unchanged** from the CSS version: `listitem: "· Permanent: Yes"`.
- **Byte-identical screenshots**, production build, before vs after, on all three
  surfaces: `/approval`, `/thread-ordinary-consent`, `/connect-lifecycle`
  (`cmp` reports no difference; `/tmp/ui-copy-separator/{before,after}-*.png`).
- `packages/ui` vitest: 79 files, 667 tests green. `pnpm build`, `pnpm typecheck`,
  `pnpm lint` green; `pnpm test:affected` green apart from the three
  `Cool%20Code` path failures this worktree has on a clean tree (`new
  URL(…).pathname` percent-encodes the space in the checkout directory).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes consent card “quiet line” copy behavior by replacing the CSS-drawn separator with real text. Previously, copying merged facts into one word because the " · " came from a pseudo-element; now each item after the first includes a leading " · " in the markup, so copied text is correctly separated while keeping the list WCAG-compliant. Screen-reader output and visuals are unchanged.

- Adds `NOTE_SEPARATOR` in `card-shell.tsx` and uses it inside each `<li>` in `approval-card.tsx`, `approval-modal.tsx`, and `connect-card.tsx`; removes the `.fl-approval-sub li + li::before` rule in `chrome-css.ts`.
- Introduces `approval-notes-copy.test.tsx` to lock copy/structure; updates existing tests to either re-pin rendered text or strip a single leading separator where they validate values.
- No feature flags or UI changes; if you assert raw `.fl-approval-sub li` text in downstream tests, expect a leading " · " on items after the first.

<sup>Written for commit 6b0f337a079f5fd04744c3d51f852bbf75c53dc0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1483?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

