### PR TITLE
fix(vendo,actions): init stops answering for you, agent mode grades, and the paste it prints compiles

### DIFF
--- a/.changeset/init-install-dx-repairs.md
+++ b/.changeset/init-install-dx-repairs.md
@@ -1,0 +1,61 @@
+---
+"@vendoai/vendo": patch
+---
+
+`vendo init` stops deciding things for you in silence, and the install it leaves
+behind can compile what it wrote.
+
+A run that cannot ask no longer answers. Piped stdin and CI used to settle the
+use case doctor grades against, the auth the agent acts as, the model story and
+the dev origin, then print the same success frame an attended install prints —
+so nothing said a decision had been made and the first sign was a tool call
+failing days later. Such a run now prints the defaults it would take, each
+naming the flag that answers it, and exits non-zero; `--yes` proceeds and still
+says what it settled.
+
+`--agent` grades. Judgment was "delegated to you" on the grounds that the caller
+is a model, but the pass is a scripted engine run with a verbatim quote behind
+every proposal and an independent skeptic over each one, so every agent install
+shipped a catalog whose every tool asked on each call. It now runs the pass with
+whatever engine resolves, asking nothing; with no engine on the machine at all
+the receipt hands the checklist back as REQUIRED work and says so out loud.
+
+The use-case question reads the evidence the scanner already had: a host whose
+own API runs an agent loop gets "through your own agent loop" recommended, with
+the route named, in both the interactive select and the `--agent` question form.
+The `--agent` auth question gained the same detection interactive mode has, so
+`none` is recommended — and says why — when no auth dependency is there.
+
+Repairs to the rest of the install:
+
+- A re-run over an existing composition no longer refuses the MCP door with
+  "wire an auth preset". Init never re-decides auth for a file it did not write,
+  so the file itself is read instead.
+- `VENDO_SERVICE_KEY` is reused when the host already has a well-formed one,
+  instead of being reminted and written over the key every backend caller was
+  already exchanging.
+- Every package the generated files import is now a declared host dependency:
+  the backend path's docs never install `@vendoai/vendo`, so a host following
+  them got a `lib/vendo.ts` importing a package its build could not resolve.
+- `VENDO_BASE_URL` reaches `.env.local` from any attended terminal. The question
+  borrowed the run-wide interactivity flag, which folds in "a package script
+  launched this" — and npm sets that for every `npm run …` — so the same person
+  in the same terminal was asked by `npx vendo init` and not asked at all
+  through a wrapper script.
+- No `<VendoProvider>` / `<VendoOverlay>` paste for an agent-loop or MCP
+  install, which mount no Vendo UI by design (the rule doctor already grades by).
+- The agent-loop snippets compile as printed: they declare the `principal` they
+  pass — resolved from the preset the composition wires, or the same anonymous
+  literal the composition resolves — name the host's real chat-route path under
+  `src/`, and name the Mastra agent file the host actually has.
+- Five stale docs URLs, and a test that maps every docs.vendo.run URL the CLI
+  can print to a file under `docs-site/`. Doctor's `fix_ref` now lands on the
+  code's own troubleshooting page instead of a retired playbook with the code in
+  a fragment the server never sees.
+- The judgment receipt names the file the grades landed in and the merge that
+  keeps `tools.json` saying `ungraded` — three auditors read the old receipt and
+  concluded the pass had done nothing — and tells you to restart the dev server,
+  which read the judgments once, at boot.
+- `vendo ready` and the hosted-store notice are latched per PROCESS, not per
+  module. Next's dev server re-instantiates the module graph, so both came back
+  every couple of seconds and flooded the log.

--- a/.changeset/route-scan-vendo-agents.md
+++ b/.changeset/route-scan-vendo-agents.md
@@ -1,0 +1,19 @@
+---
+"@vendoai/actions": patch
+---
+
+Route extraction recognises Vendo's own backend library as an agent loop.
+
+The exclusion that keeps a host's agent endpoint out of the callable catalog knew
+every OTHER framework — `ai`, `@ai-sdk/*`, `@mastra/*`, the umbrella's own
+ai-sdk and mastra entries — and missed `@vendoai/agents`. Its call marker was
+anchored on the literal receiver `vendo.respond(`, which nobody writes when their
+agent is called `support`. So a route running `agent()` or `support.respond(…)`
+became a callable tool and was handed back to the agent hosted in it.
+
+`@vendoai/agents` joins the recognised imports, and `.respond(` / `.run(` now
+match on any receiver. The escape hatch is unchanged: the tool is emitted
+`disabled: true` with the reason on it, and one `"disabled": false` in
+`.vendo/overrides.json` puts it back. The predicate is exported so `vendo init`
+can recommend the agent-loop use case off the same evidence rather than a second
+copy of the regex.

--- a/packages/actions/src/sync/public.ts
+++ b/packages/actions/src/sync/public.ts
@@ -40,3 +40,7 @@ export {
   type ToolSchemaPatchResult,
   type ToolSchemaSlot,
 } from "./schema-patch.js";
+// "Does this module run an agent/model loop?" — the marker the route scanner
+// excludes on, exported so `vendo init` recommends the agent-loop use case off
+// the SAME evidence rather than a second copy of the regex.
+export { runsAgentLoop } from "./route-scan.js";

--- a/packages/actions/src/sync/route-scan.ts
+++ b/packages/actions/src/sync/route-scan.ts
@@ -128,6 +128,18 @@ function isVendoWireMount(route: RouteSource, walked: readonly string[]): boolea
 
 const AUTH_HANDLER_REASON = "it is an authentication handler";
 
+const AGENT_LOOP_MARKER =
+  /from\s*["'](?:ai|@anthropic-ai\/sdk|@ai-sdk\/[^"']+|@mastra\/[^"']+|@vendoai\/agents(?:\/[^"']+)?|@vendoai\/vendo\/(?:ai-sdk|mastra))["']|\b(?:streamText|generateText|vendoTools)\s*\(|\.\s*(?:respond|run)\s*\(/;
+
+/** Does this module run an agent/model loop? The SAME marker the exclusion below
+    matches, exported so `vendo init` can recommend the agent-loop use case off
+    the very evidence that would exclude the route — two copies of this regex
+    would drift on what a loop is, and then the tool the scanner refuses to
+    catalog would sit behind a use case init never offered. */
+export function runsAgentLoop(source: string): boolean {
+  return AGENT_LOOP_MARKER.test(source);
+}
+
 /**
  * Routes that belong to the HOST but must not be offered as tools. Unlike the
  * wire mount above, each one is still extracted: the tool keeps its real
@@ -142,9 +154,16 @@ const AUTH_HANDLER_REASON = "it is an authentication handler";
  * 1. The host's own agent endpoint — an AI-SDK / Mastra / raw-Anthropic loop,
  *    or a route that spreads Vendo's own tool pack. Cataloging one hands the
  *    agent a tool that calls the agent. Only the AGENT-shaped Vendo entry
- *    points count (`@vendoai/vendo/ai-sdk`, `/mastra`, a `vendoTools` or
- *    `vendo.respond` call): a route importing the umbrella for `vendo.store`
- *    is ordinary host code, and Maple's `/api/demo/reset` is exactly that.
+ *    points count (`@vendoai/vendo/ai-sdk`, `/mastra`, `@vendoai/agents`, a
+ *    `vendoTools` / `.respond(` / `.run(` call): a route importing the umbrella
+ *    for `vendo.store` is ordinary host code, and Maple's `/api/demo/reset` is
+ *    exactly that. `@vendoai/agents` is Vendo's OWN backend library, and a
+ *    `support.respond(…)` loop is never spelled `vendo.respond(…)` — the
+ *    receiver is whatever the host named its agent — so the call marker cannot
+ *    be anchored on one identifier. A host route that genuinely happens to call
+ *    something's `.run(` keeps the same escape every exclusion has: the tool is
+ *    emitted `disabled: true` with the reason on it, and one `disabled: false`
+ *    in `.vendo/overrides.json` puts it back.
  * 2. Auth.js's catch-all, which answers sign-in, callback, session, and CSRF
  *    for every provider behind one URL.
  *
@@ -157,7 +176,7 @@ const AUTH_HANDLER_REASON = "it is an authentication handler";
 const ROUTE_EXCLUSION_MARKERS: ReadonlyArray<{ reason: string; marker: RegExp }> = [
   {
     reason: "its handler runs an agent/model loop",
-    marker: /from\s*["'](?:ai|@anthropic-ai\/sdk|@ai-sdk\/[^"']+|@mastra\/[^"']+|@vendoai\/vendo\/(?:ai-sdk|mastra))["']|\b(?:streamText|generateText|vendoTools)\s*\(|\bvendo\.respond\s*\(/,
+    marker: AGENT_LOOP_MARKER,
   },
   {
     reason: AUTH_HANDLER_REASON,

--- a/packages/actions/tests/sync/route-exclusions.agents.test.ts
+++ b/packages/actions/tests/sync/route-exclusions.agents.test.ts
@@ -1,0 +1,122 @@
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { ExtractedTool } from "../../src/formats.js";
+import { runsAgentLoop, scanRoutes } from "../../src/sync/route-scan.js";
+
+/**
+ * The exclusion missed VENDO'S OWN backend library.
+ *
+ * `@vendoai/agents` is how a host writes an agent loop with Vendo, and the two
+ * shapes it produces — `agent().run(…)` and a named agent's `.respond(…)` — were
+ * both invisible here: the import list named every OTHER framework, and the call
+ * marker was anchored on the literal receiver `vendo.`, which nobody writes when
+ * their agent is called `support`. So the route hosting the agent became a
+ * callable tool and was handed back to the agent running in it.
+ */
+
+/** Assembled at runtime: the dependency guard reads import-shaped strings even
+ *  inside fixtures, and @vendoai/actions may not import the umbrella or its
+ *  siblings. */
+const VENDO_AGENTS = ["@vendoai", "agents"].join("/");
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((directory) => fs.rm(directory, { recursive: true, force: true })));
+});
+
+async function temporaryRoot(): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "vendo-actions-agents-exclusion-"));
+  temporaryDirectories.push(root);
+  return root;
+}
+
+async function write(root: string, relativePath: string, source: string): Promise<void> {
+  const file = path.join(root, relativePath);
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  await fs.writeFile(file, source, "utf8");
+}
+
+async function toolsAt(root: string, urlPath: string): Promise<ExtractedTool[]> {
+  const { tools } = await scanRoutes(root);
+  return tools.filter((tool) => tool.binding.kind === "route" && tool.binding.path === urlPath);
+}
+
+const AGENT_LOOP_REASON = "its handler runs an agent/model loop";
+
+describe("a route that runs a @vendoai/agents loop is excluded", () => {
+  it("excludes an agent() route, and leaves the plain CRUD route beside it callable", async () => {
+    const root = await temporaryRoot();
+    await write(
+      root,
+      "app/api/assistant/route.ts",
+      [
+        `import { agent } from "${VENDO_AGENTS}";`,
+        `const support = agent({ instructions: "help" });`,
+        `export async function POST(request: Request) {`,
+        `  return Response.json(await support.respond(await request.json()));`,
+        `}`,
+        ``,
+      ].join("\n"),
+    );
+    await write(
+      root,
+      "app/api/todos/route.ts",
+      [
+        `export async function GET() { return Response.json({ todos: [] }); }`,
+        ``,
+      ].join("\n"),
+    );
+
+    const [assistant] = await toolsAt(root, "/api/assistant");
+    expect(assistant?.disabled).toBe(true);
+    expect(assistant?.note).toContain(AGENT_LOOP_REASON);
+
+    const [todos] = await toolsAt(root, "/api/todos");
+    expect(todos?.disabled).toBeUndefined();
+  });
+
+  it("matches .respond( and .run( on ANY receiver, not just the literal `vendo.`", async () => {
+    const root = await temporaryRoot();
+    // The agent is imported from the host's OWN module, so no @vendoai specifier
+    // reaches this file at all — the CALL is the only evidence left.
+    await write(root, "lib/support.ts", "export const support = { respond: async () => ({}) };\n");
+    await write(
+      root,
+      "app/api/support/route.ts",
+      [
+        `import { support } from "${["..", "..", "..", "lib", "support"].join("/")}";`,
+        `export async function POST(request: Request) {`,
+        `  return Response.json(await support.respond(await request.json()));`,
+        `}`,
+        ``,
+      ].join("\n"),
+    );
+    await write(
+      root,
+      "app/api/tasks/route.ts",
+      [
+        `import { runner } from "${["..", "..", "..", "lib", "support"].join("/")}";`,
+        `export async function POST() { return Response.json(await runner.run({})); }`,
+        ``,
+      ].join("\n"),
+    );
+
+    const [support] = await toolsAt(root, "/api/support");
+    expect(support?.disabled).toBe(true);
+    expect(support?.note).toContain(AGENT_LOOP_REASON);
+
+    const [tasks] = await toolsAt(root, "/api/tasks");
+    expect(tasks?.disabled).toBe(true);
+    expect(tasks?.note).toContain(AGENT_LOOP_REASON);
+  });
+
+  it("exports the same predicate the exclusion matches on, so init cannot drift from it", () => {
+    expect(runsAgentLoop(`import { agent } from "${VENDO_AGENTS}";`)).toBe(true);
+    expect(runsAgentLoop("await support.respond(body)")).toBe(true);
+    expect(runsAgentLoop("await support.run(body)")).toBe(true);
+    expect(runsAgentLoop("export async function GET() { return Response.json({}); }")).toBe(false);
+  });
+});

--- a/packages/vendo/src/boot-summary.ts
+++ b/packages/vendo/src/boot-summary.ts
@@ -139,10 +139,17 @@ export function renderBootSummary(summary: BootSummary, style: VendoStyle): stri
   return (style.pretty ? prettyLines(summary, style) : plainLines(summary)).join("\n");
 }
 
-/** ONE block per process (see the header). Module-scoped on purpose: the latch
-    belongs to the process, not to an instance — a host holding two `createVendo`
-    handles is one deployment and says "ready" once. */
-let announced = false;
+/** ONE block per process (see the header). The latch belongs to the PROCESS, not
+    to an instance — a host holding two `createVendo` handles is one deployment
+    and says "ready" once — and not to the module either: Next's dev server
+    re-instantiates this module on nearly every request, so a module-scoped `let`
+    is reborn with it and the block floods the log every couple of seconds.
+    `Symbol.for` so two copies of @vendoai/vendo in one tree still share it. */
+const ANNOUNCED = Symbol.for("vendo.boot-summary.announced");
+
+/** The process-wide latch table. Cast because `globalThis` carries no index
+    signature; the symbol keys above are the whole namespace. */
+const latches = globalThis as unknown as Record<symbol, true | undefined>;
 
 /**
  * Say it, once. Everything Vendo says out loud goes through core's sink
@@ -151,8 +158,8 @@ let announced = false;
  * arrive interleaved with something else.
  */
 export function announceBootSummary(summary: BootSummary, style: VendoStyle = vendoStyle()): void {
-  if (announced) return;
-  announced = true;
+  if (latches[ANNOUNCED] === true) return;
+  latches[ANNOUNCED] = true;
   log({
     code: "vendo.ready",
     level: summary.warnings.length > 0 ? "warn" : "info",

--- a/packages/vendo/src/cli.ts
+++ b/packages/vendo/src/cli.ts
@@ -182,12 +182,10 @@ async function initCommand(args: string[]): Promise<number> {
   if (initAi && args.includes("--no-ai")) {
     problems.push("--ai and --no-ai answer the same question — pass one or the other");
   }
-  // Agent mode delegates judgment to the caller, so an engine can never run on
-  // it. Saying so beats dropping the flag: silently ignoring one is exactly how
-  // the "--agent writes nothing" promise broke in the field.
-  if (args.includes("--agent") && (initAi || engine !== undefined)) {
-    problems.push(`${initAi ? "--ai" : "--engine"} has no effect with --agent: judgment is delegated to you and the receipt names what it left. Drop it, or drop --agent to let init judge`);
-  }
+  // Agent mode GRADES (2026-08-18): the pass is a scripted, skeptic-checked
+  // engine run, and every agent install used to ship an ungraded catalog whose
+  // every tool asked on each call. `--ai` is the mode's own default there, so
+  // both flags mean what they always meant and neither is rejected.
   const themePairs = options(args, "--theme");
   const badTheme = themePairs.find((pair) => !/^[A-Za-z]+=./.test(pair));
   if (badTheme !== undefined) {

--- a/packages/vendo/src/cli/doctor-codes.ts
+++ b/packages/vendo/src/cli/doctor-codes.ts
@@ -92,14 +92,19 @@ export type DoctorErrorCode = keyof typeof DOCTOR_ERROR_CODES;
 /** Complete list of every code doctor can emit, for CI enumeration. */
 export const doctorErrorCodes = Object.keys(DOCTOR_ERROR_CODES) as readonly DoctorErrorCode[];
 
-/** The verify playbook page the fix_ref URLs anchor into. The docs host
-    serves it directly — the marketing-site path 302s there, and some agent
-    HTTP clients refuse the hop (FINDINGS F7a). */
-export const VERIFY_URL = "https://docs.vendo.run/agents/verify";
+/** Where the per-code troubleshooting pages live: one page per code, named for
+    the lowercased code (the 1:1 contract doctor-codes.docs.test.ts enforces).
+    The docs host serves them directly — the marketing-site path 302s, and some
+    agent HTTP clients refuse the hop (FINDINGS F7a).
 
-/** Full fix URL for a code: the installed vendoai version rides as a query
- *  param BEFORE the fragment so the URL stays valid and the verify page can
- *  version-match its guidance. */
+    The retired `/agents/verify#<code>` spelling was a dead link twice over: the
+    page moved in the Cloud restructure, and a code in a URL FRAGMENT never
+    reaches the server, so every fix_ref landed on the same index and left the
+    reader to find their own code. */
+export const TROUBLESHOOTING_URL = "https://docs.vendo.run/production/troubleshooting";
+
+/** Full fix URL for a code: its own page, with the installed vendoai version as
+ *  a query param so the page can version-match its guidance. */
 export function doctorFixRef(code: DoctorErrorCode, version: string = CLI_VERSION): string {
-  return `${VERIFY_URL}?v=${encodeURIComponent(version)}#${code}`;
+  return `${TROUBLESHOOTING_URL}/${code.toLowerCase()}?v=${encodeURIComponent(version)}`;
 }

--- a/packages/vendo/src/cli/framework.ts
+++ b/packages/vendo/src/cli/framework.ts
@@ -1,5 +1,6 @@
 import { readFile, readdir } from "node:fs/promises";
-import { join } from "node:path";
+import { join, relative, sep } from "node:path";
+import { runsAgentLoop } from "@vendoai/actions/sync";
 import { exists, stripBom } from "./shared.js";
 import { walk } from "./theme/walk.js";
 
@@ -195,6 +196,45 @@ export async function wiresTenantConnectors(root: string): Promise<boolean> {
     says. */
 export async function composesOwnStore(root: string): Promise<boolean> {
   return hostSourceMatches(root, /\bcreateStore\s*\(/);
+}
+
+/** An API route file: an app-router `route.*` under an `api` segment, or
+    anything under `pages/api`. The agent-loop probe below is deliberately
+    narrower than the whole source tree — a lib module that happens to call
+    `generateText` is not a loop the host serves. */
+const API_ROUTE_FILE = /(?:^|\/)api\/(?:.*\/)?route\.[cm]?[jt]sx?$|(?:^|\/)pages\/api\//;
+
+/** The host's own agent-loop route, as a posix-style root-relative directory
+ *  (`app/api/chat`), or null.
+ *
+ *  This is what makes "through your own agent loop" the RECOMMENDED use case for
+ *  a host that already has one, instead of a third option nobody reads. The
+ *  evidence is the route scanner's own marker (`runsAgentLoop`), which is also
+ *  what excludes that route from the callable catalog — so the recommendation
+ *  and the exclusion can never disagree about what a loop is.
+ *
+ *  Not `hostSourceMatches`: that one walks every source file and answers a
+ *  boolean, and this needs both the narrower route filter and the PATH — the
+ *  route's directory is what the recommendation shows the developer.
+ *
+ *  Same bounded walk and comment-stripping as `detectVendoWiring`, so a host too
+ *  big to scan is judged consistently. First match wins: one loop is the whole
+ *  answer, and the directory is what a human recognises. */
+export async function detectAgentLoopRoute(root: string): Promise<string | null> {
+  const files = await walk(
+    root,
+    (relativePath) => SOURCE_FILE.test(relativePath) && API_ROUTE_FILE.test(relativePath.split(sep).join("/")),
+    SOURCE_SCAN_MAX_FILES,
+  );
+  for (const file of files) {
+    const source = await readFile(file, "utf8").catch(() => "");
+    const code = source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
+    if (runsAgentLoop(code)) {
+      const parts = relative(root, file).split(sep);
+      return parts.slice(0, -1).join("/");
+    }
+  }
+  return null;
 }
 
 /** Bounded source scan shared by init and doctor so their wiring verdicts

--- a/packages/vendo/src/cli/init-auth.ts
+++ b/packages/vendo/src/cli/init-auth.ts
@@ -19,6 +19,29 @@ export const AUTH_PRESET_SPECIFIER: Record<AuthPresetName, string> = {
   auth0: "@vendoai/vendo/auth/auth0",
 };
 
+/** The oauth-carrying preset a composition ALREADY on disk wires, or null.
+ *
+ *  Read from the file's own source, because a re-run over an existing
+ *  composition never asks the auth question — so the run's `authWired` is null
+ *  even for a host whose `lib/vendo.ts` says `auth: authJs()`, and the MCP
+ *  planner used to refuse such a host with "wire an auth preset".
+ *
+ *  Both spellings of each preset's subpath (an aliased host is wired too),
+ *  comments stripped like every other source probe here, and the `auth: preset(`
+ *  call has to be there as well — an import on its own is not a wiring. `jwt()`
+ *  and an anonymous composition carry no oauth half, so neither is an answer. */
+export async function composedAuthPreset(compositionPath: string): Promise<AuthPresetName | null> {
+  const source = await readOptional(compositionPath);
+  if (source === null) return null;
+  const code = source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
+  const presets = Object.keys(AUTH_PRESET_SPECIFIER) as AuthPresetName[];
+  return presets.find((preset) => {
+    const subpath = AUTH_PRESET_SPECIFIER[preset].replace("@vendoai/vendo", "");
+    return new RegExp(`["'](?:@vendoai/vendo|vendoai)${subpath}["']`).test(code)
+      && new RegExp(`\\bauth\\s*:\\s*${preset}\\s*\\(`).test(code);
+  }) ?? null;
+}
+
 export interface AuthMatch {
   preset: AuthPresetName;
   dependency: string;
@@ -199,7 +222,7 @@ export async function pickScaffoldAuth(
     return {
       wired: null,
       advice: `Auth: your own JWT — add one line in ${compositionPath}: auth: jwt({ secret: <your signing secret> }). ` +
-        "Options and the claim mapping: https://docs.vendo.run/connect/act-as-presets.",
+        "Options and the claim mapping: https://docs.vendo.run/production/auth.",
     };
   }
   const detectedMatch = detected.find((match) => match.preset === picked);

--- a/packages/vendo/src/cli/init-mcp.ts
+++ b/packages/vendo/src/cli/init-mcp.ts
@@ -46,6 +46,18 @@ export interface McpPlanInput {
    * `jwt` and "none" do not, and both surface here as null.
    */
   authWired: AuthMatch | null;
+  /**
+   * Does the composition ALREADY on disk wire one of those presets? A re-run
+   * over an existing composition asks no auth question — init never rewrites a
+   * file it did not author — so `authWired` is null even for a host whose
+   * `lib/vendo.ts` says `auth: authJs()`, and refusing on that alone told a
+   * correctly wired host to "wire an auth preset" and wrote no door at all.
+   * Resolved by the caller (`composedAuthPreset`); this module stays fs-free.
+   *
+   * Never true at the same time as a non-null `authWired`: init only decides
+   * auth for a composition it is CREATING, and then there is nothing on disk.
+   */
+  authAlreadyWired?: boolean;
   /** Does the host have a live `"use server"` surface? The composition imports
       the generated registration map when it does. The map itself stays the
       caller's to plan: an EXISTING one is compared by the keys it registers,
@@ -59,6 +71,12 @@ export interface McpPlanInput {
   /** Did the user say yes to "will your own backend call these tools
       machine-to-machine?" */
   serviceKey: boolean;
+  /** A well-formed `VENDO_SERVICE_KEY` already in the host's env files, to
+      REUSE. Minting one unconditionally rotated the secret on every re-run and
+      the caller then overwrote .env.local with it, so every backend already
+      exchanging the old key started failing — the same reuse-don't-remint rule
+      `VENDO_API_KEY` follows. Read by the caller; this module stays fs-free. */
+  existingServiceKey?: string;
   /** The origin captured earlier this run — the DEV one, which is what a client
       config and doctor both want while the developer is still local. Null when
       the run could not ask. */
@@ -87,7 +105,9 @@ export interface McpPlan {
       `before` it already read. Null when the plan is `blocked`. */
   compositionSource: string | null;
   /**
-   * The generated service key, for the caller to write to `.env.local`.
+   * The service key the composition wires, for the caller to write to
+   * `.env.local` — `existingServiceKey` when the host already has a well-formed
+   * one, else freshly minted.
    * Present on local posture with a yes, and NOWHERE else. `serviceAuth` is
    * local-door mechanics: the RFC 8693 exchange lives at the door's own
    * `/token`, which a broker-fronted door does not serve — and an explicit
@@ -134,10 +154,17 @@ export function mcpStepLines(plan: Pick<McpPlan, "steps" | "envLines">): string[
 }
 
 /** A fresh service key: 32 random bytes, hex. `planMcp` mints one itself when
-    the answers call for it; this is separately callable so the shape can be
-    asserted without a plan. */
+    the answers call for it AND the host has none to reuse; this is separately
+    callable so the shape can be asserted without a plan. */
 export function generateServiceKey(): string {
   return randomBytes(32).toString("hex");
+}
+
+/** Is the value already in the host's env a key this door can exchange? The
+    shape `generateServiceKey` mints, and nothing else: anything other than 32
+    hex bytes is not reusable, so it is replaced rather than trusted. */
+export function wellFormedServiceKey(value: string | null | undefined): boolean {
+  return value !== null && value !== undefined && /^[0-9a-f]{64}$/i.test(value.trim());
 }
 
 /**
@@ -176,15 +203,15 @@ export function planMcp(input: McpPlanInput): McpPlan {
     return refuse(
       "MCP scaffolding is Next.js-only: the discovery documents live at origin-root paths, which only a "
       + "file-routed app directory can claim. Open the door by hand instead — pass `mcp: true` to createVendo "
-      + "and serve the well-known paths from your runtime: https://docs.vendo.run/existing-agents/mcp.",
+      + "and serve the well-known paths from your runtime: https://docs.vendo.run/outside-agents/quickstart.",
     );
   }
-  if (authWired === null) {
+  if (authWired === null && input.authAlreadyWired !== true) {
     return refuse(
       "The MCP door mints its own principals through an OAuth adapter and cannot open without one, so "
       + "nothing MCP was written. Wire an auth preset — auth: clerk(), authJs(), supabase() or auth0() all "
       + "carry it — then re-run `npx vendo init`. (jwt() and an anonymous composition do not carry the "
-      + "oauth half: https://docs.vendo.run/existing-agents/mcp.)",
+      + "oauth half: https://docs.vendo.run/outside-agents/quickstart.)",
     );
   }
 
@@ -222,7 +249,9 @@ export function planMcp(input: McpPlanInput): McpPlan {
   return {
     changes,
     compositionSource: compositionModuleSource({ serverActions, auth: authWired, models, mcp: { serviceAuth } }),
-    ...(serviceAuth ? { serviceKeyValue: generateServiceKey() } : {}),
+    ...(serviceAuth
+      ? { serviceKeyValue: wellFormedServiceKey(input.existingServiceKey) ? input.existingServiceKey!.trim() : generateServiceKey() }
+      : {}),
     modelWritten: models === null ? null : { provider: models.provider, path: relative(root, composition).split(sep).join("/") },
     steps,
     envLines: posture === "broker"

--- a/packages/vendo/src/cli/init-questions.ts
+++ b/packages/vendo/src/cli/init-questions.ts
@@ -42,15 +42,34 @@ export interface InitQuestions {
   questions: InitQuestion[];
 }
 
-const USE_CASE: InitQuestion = {
-  id: "use-case",
-  prompt: "How will people use your agent? Most apps embed it: your users chat with your product and it builds them real working screens from your data, dashboards, forms, views, right inside your app (recommended). Or: through your own agent loop. Or: from outside AI apps over MCP.",
-  options: [
-    { label: "Full-Stack Agent: chat + generated screens in your app", flag: "--use-case embedded", recommended: true },
-    { label: "Through your own agent loop (AI SDK / Mastra)", flag: "--use-case agent-loop" },
-    { label: "From outside AI apps over MCP", flag: "--use-case mcp" },
-  ],
-};
+const EMBEDDED_OPTION: InitQuestionOption = { label: "Full-Stack Agent: chat + generated screens in your app", flag: "--use-case embedded" };
+const AGENT_LOOP_OPTION: InitQuestionOption = { label: "Through your own agent loop (AI SDK / Mastra)", flag: "--use-case agent-loop" };
+const MCP_OPTION: InitQuestionOption = { label: "From outside AI apps over MCP", flag: "--use-case mcp" };
+
+/** The first question. Most apps embed — but a host whose own API already runs
+    an agent loop has ALREADY decided, and recommending "embedded" to it sent
+    people down a path they then had to undo while the route scanner was
+    meanwhile excluding that very route from the callable catalog. The
+    recommended option comes FIRST and carries its evidence: a recommendation
+    whose reason is invisible reads as a guess. */
+function useCaseQuestion(agentLoopRoute: string | null): InitQuestion {
+  if (agentLoopRoute === null) {
+    return {
+      id: "use-case",
+      prompt: "How will people use your agent? Most apps embed it: your users chat with your product and it builds them real working screens from your data, dashboards, forms, views, right inside your app (recommended). Or: through your own agent loop. Or: from outside AI apps over MCP.",
+      options: [{ ...EMBEDDED_OPTION, recommended: true }, AGENT_LOOP_OPTION, MCP_OPTION],
+    };
+  }
+  return {
+    id: "use-case",
+    prompt: `How will people use your agent? This app already runs an agent loop in ${agentLoopRoute}, so adding Vendo's guarded tools to that loop is the shortest path (recommended) — its route is excluded from the callable catalog either way, so nothing hands the agent a tool that calls itself. Or: embed Vendo's own chat and generated screens in your app. Or: from outside AI apps over MCP.`,
+    options: [
+      { ...AGENT_LOOP_OPTION, recommended: true, note: `detected an agent loop in ${agentLoopRoute}` },
+      EMBEDDED_OPTION,
+      MCP_OPTION,
+    ],
+  };
+}
 
 const MODELS: InitQuestion = {
   id: "models",
@@ -121,17 +140,38 @@ function mcpQuestions(cloudKey: boolean): InitQuestion[] {
 
 const PRESETS = Object.keys(AUTH_FAMILY_INFO) as AuthPresetName[];
 
-function authQuestion(detected: AuthPresetName | undefined): InitQuestion {
+const FULL_LIST: InitQuestionOption[] = [
+  ...PRESETS.map((preset) => ({ label: AUTH_FAMILY_INFO[preset].name, flag: `--auth ${preset}` })),
+  { label: "Your own JWT scheme", flag: "--auth jwt" },
+  { label: "No signed-in user", flag: "--auth none" },
+];
+
+/** Interactive mode DETECTS the provider and only confirms it; the agent form
+ *  handed back the full list with no recommendation whenever `wired` was empty,
+ *  so a coding agent relaying it had to guess for the person. Same detection,
+ *  same answer, all three ways it can come out:
+ *
+ *   · one family wired → that family is recommended (today's question);
+ *   · NOTHING detected → `none` is recommended, and the option says why. That is
+ *     exactly what an interactive run settles for: it never asks at all, because
+ *     there is nothing to choose from the advisory does not already name;
+ *   · SEVERAL families → the full list with no recommendation, deliberately. Two
+ *     matches is AMBIGUOUS, and naming one would name a provider the host may not
+ *     use and hide the other — the same reason interactive shows its picker.
+ */
+function authQuestion(detection: { wired?: AuthPresetName; matches: number }): InitQuestion {
+  const detected = detection.wired;
   if (detected === undefined) {
-    return {
-      id: "auth",
-      prompt: "Which auth should Vendo wire?",
-      options: [
-        ...PRESETS.map((preset) => ({ label: AUTH_FAMILY_INFO[preset].name, flag: `--auth ${preset}` })),
-        { label: "Your own JWT scheme", flag: "--auth jwt" },
-        { label: "No signed-in user", flag: "--auth none" },
-      ],
-    };
+    return detection.matches > 0
+      ? { id: "auth", prompt: "Which auth should Vendo wire?", options: FULL_LIST }
+      : {
+          id: "auth",
+          prompt: "Which auth should Vendo wire? Nothing was detected in package.json, so unless you name one the assistant acts with no signed-in user.",
+          options: [
+            { label: "No signed-in user", flag: "--auth none", recommended: true, note: "no auth dependency in package.json" },
+            ...FULL_LIST.filter((option) => option.flag !== "--auth none"),
+          ],
+        };
   }
   const name = AUTH_FAMILY_INFO[detected].name;
   const others = [...PRESETS.filter((preset) => preset !== detected), "jwt"].join("|");
@@ -161,15 +201,22 @@ export async function initQuestions(input: {
   /** The port the host's `dev` script names — the dev-URL question's prefill.
       Passed in rather than read here so the whole set stays assertable. */
   devPort: number;
+  /** The host's own agent-loop route (`app/api/chat`), or null — what moves the
+      use-case recommendation. Detected by the caller (framework.ts), so this set
+      stays assertable without a temp directory. */
+  agentLoopRoute?: string | null;
 }): Promise<InitQuestions | null> {
   const { options } = input;
   // `wired`, never `matches[0]`: two families matching is AMBIGUOUS, and
   // claiming the first one would name a provider the host may not use and hide
   // the other. Ambiguity falls through to the full-list question.
-  const detected = (await detectAuthPreset(input.root)).wired?.preset;
+  const detection = await detectAuthPreset(input.root);
+  const detected = detection.wired?.preset;
   const questions: InitQuestion[] = [];
-  if (options.useCase === undefined) questions.push(USE_CASE);
-  if (options.auth === undefined) questions.push(authQuestion(detected));
+  if (options.useCase === undefined) questions.push(useCaseQuestion(input.agentLoopRoute ?? null));
+  if (options.auth === undefined) {
+    questions.push(authQuestion({ ...(detected === undefined ? {} : { wired: detected }), matches: detection.matches.length }));
+  }
   if (!input.modelKey && options.byo !== true && options.cloudKey === undefined) questions.push(MODELS);
   if (options.baseUrl === undefined) questions.push(devUrlQuestion(input.devPort));
   // ONE gate for the MCP extras: they travel in the same relay, so `--posture`

--- a/packages/vendo/src/cli/init-scaffolds.ts
+++ b/packages/vendo/src/cli/init-scaffolds.ts
@@ -20,7 +20,7 @@ export function authConfigLines(auth: AuthMatch): string {
     : `Detected ${auth.dependency}`;
   return `  // ${origin} — ${auth.preset}() fills the identity seams\n` +
     `  // (request→user, actAs, door OAuth); options and the per-seam escape\n` +
-    `  // hatch: https://docs.vendo.run/connect/act-as-presets.\n` +
+    `  // hatch: https://docs.vendo.run/production/auth.\n` +
     `  auth: ${auth.preset}(),\n`;
 }
 

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile } from "node:fs/promises";
+import { mkdir, readdir, readFile } from "node:fs/promises";
 import { dirname, join, relative, resolve, sep } from "node:path";
 import type { ExtractedTool } from "@vendoai/actions";
 import { isVendoError, VendoError } from "@vendoai/core";
@@ -9,14 +9,16 @@ import { detectDepVersions, installedAiVersion } from "./dep-versions.js";
 import { AUTH_MD_URL, ensureEnvLocalIgnored, runCloudStep, upsertEnvLocal, type CloudStepOptions } from "./cloud-init.js";
 import { runDoctor } from "./doctor.js";
 import type { InitPolishSeam } from "./init-judgment.js";
-import { mcpStepLines, planMcp, type McpPosture } from "./init-mcp.js";
+import { mcpStepLines, planMcp, wellFormedServiceKey, type McpPosture } from "./init-mcp.js";
 import { initQuestions } from "./init-questions.js";
 import { rendererFlowOptions, runSyncFlow, writeFonts, type SyncFlowResult } from "./sync-flow.js";
 import { BRIEF_TEMPLATE } from "./extract/stages.js";
 import { ENV_KEY_VARS, resolveDevCredential, describeDevCredential, type DevCredential } from "../dev-creds/resolve.js";
-import { NEXT_SERVER_EXTERNALS, NEXT_SERVER_EXTERNALS_LINE, SERVER_EXTERNALS_ARRAY, blankComments, detectFramework, detectVendoWiring, missingServerExternals, nextConfigPath, transpileConflictNote, transpiledServerExternals, workspaceHostCandidates, type HostFramework } from "./framework.js";
+import { NEXT_SERVER_EXTERNALS, NEXT_SERVER_EXTERNALS_LINE, SERVER_EXTERNALS_ARRAY, blankComments, detectAgentLoopRoute, detectFramework, detectVendoWiring, missingServerExternals, nextConfigPath, transpileConflictNote, transpiledServerExternals, workspaceHostCandidates, type HostFramework } from "./framework.js";
 import {
   AUTH_FAMILY_INFO,
+  AUTH_PRESET_SPECIFIER,
+  composedAuthPreset,
   detectAuthPreset,
   resolveScaffoldAuth,
   type AuthMatch,
@@ -24,7 +26,7 @@ import {
   type ConfirmAuth,
   type SelectAuth,
 } from "./init-auth.js";
-import { aiBelowPeerFloor, ensureProviderDeps, ensureVendoPackage, ensureZodFloor, type InstallRunner } from "./provider-deps.js";
+import { aiBelowPeerFloor, ensureGeneratedImports, ensureProviderDeps, ensureVendoPackage, ensureZodFloor, type InstallRunner } from "./provider-deps.js";
 import {
   compositionModulePath,
   compositionModuleSource,
@@ -152,9 +154,13 @@ export interface InitReceipt {
   pasteEdits: ManualEdit[];
   tools: number;
   riskRecommendations: RiskRecommendation[];
-  /** Agent mode never spends a model on judgment: the caller IS the model, so
-      the work is named rather than done. */
-  judgment: { status: "delegated"; checklist: string[] };
+  /** Agent mode grades like every other run — `graded` means the pass ran here
+      and the grades are on disk. `delegated` is the one fallback left: no
+      judgment engine resolved on this machine, so the catalog is ungraded and
+      the checklist is REQUIRED work for the caller, not a suggestion. */
+  judgment:
+    | { status: "graded"; file: string }
+    | { status: "delegated"; checklist: string[] };
 }
 
 const JUDGMENT_CHECKLIST = [
@@ -614,8 +620,10 @@ async function setupSkillSource(): Promise<string | null> {
     agree. The why-line names the escape: hosts rendering their own surface
     delete the overlay line. A host that already mounts a surface needs
     nothing. Null on Express and custom hosts: their wiring has no single
-    host file to name, so it stays in the printed lines below. */
-async function mountStep(root: string, layout: LayoutWiring): Promise<ManualEdit | null> {
+    host file to name, so it stays in the printed lines below — and null for an
+    install that mounts no Vendo UI at all (see `mountsUi`). */
+async function mountStep(root: string, layout: LayoutWiring, mountedUi: boolean): Promise<ManualEdit | null> {
+  if (!mountedUi) return null;
   if (layout.kind === "already" || layout.kind === "express" || layout.kind === "custom") return null;
   const { file: entry, children } = await clientRoot(root);
   const entryDir = dirname(entry);
@@ -647,21 +655,26 @@ function editLines(step: ManualEdit): string[] {
 
 /** Everything the run could not do itself: the mount paste plus, on Express
     and custom runtimes, their own two wiring lines. */
-async function manualWiringLines(root: string, layout: LayoutWiring): Promise<string[]> {
+async function manualWiringLines(root: string, layout: LayoutWiring, mountedUi: boolean): Promise<string[]> {
+  // The client mount is dropped where no Vendo UI is mounted by design; the
+  // server-side line stays, because that is what serves apps and approvals.
+  const clientMount = mountedUi
+    ? [`<VendoProvider baseUrl="/api/vendo" theme={theme}>…</VendoProvider>  // around your client root`]
+    : [];
   if (layout.kind === "express") {
     return [
       `app.use("/api/vendo", mountVendo());   // in your server`,
-      `<VendoProvider baseUrl="/api/vendo" theme={theme}>…</VendoProvider>  // around your client root`,
+      ...clientMount,
     ];
   }
   if (layout.kind === "custom") {
     return [
       `Route your runtime's requests through the generated module — Cloudflare Workers: export default { fetch: (request, env) => handleVendoRequest(request, env) };`,
-      `<VendoProvider baseUrl="/api/vendo" theme={theme}>…</VendoProvider>  // around your client root`,
+      ...clientMount,
       `Set VENDO_BASE_URL to the deployment's FULL public URL, path prefix included (credential forwarding fails closed without it).`,
     ];
   }
-  const step = await mountStep(root, layout);
+  const step = await mountStep(root, layout, mountedUi);
   return step === null ? [] : editLines(step);
 }
 
@@ -683,6 +696,8 @@ async function agentTailLines(args: {
   cloudKeyMissing: boolean;
   /** Files that already existed, so init printed the change instead. */
   edits: ManualEdit[];
+  /** Does this install mount a Vendo surface at all (see `mountsUi`)? */
+  mountedUi: boolean;
 }): Promise<string[]> {
   const lines: string[] = [];
   // Auth is a tail fact only when a composition was created this run — a
@@ -702,8 +717,10 @@ async function agentTailLines(args: {
   if (args.framework === "express") {
     // No exact entry file exists to name on Express — point at the printed
     // wiring lines instead of guessing a path.
-    lines.push("edit your server and client entries — paste the mountVendo() and <VendoProvider> lines above (without a mounted provider, nothing on the page can reach Vendo)");
-  } else if (args.layout.kind === "manual") {
+    lines.push(args.mountedUi
+      ? "edit your server and client entries — paste the mountVendo() and <VendoProvider> lines above (without a mounted provider, nothing on the page can reach Vendo)"
+      : "edit your server entry — paste the mountVendo() line above (this install mounts no Vendo UI, so there is no provider to wrap)");
+  } else if (args.layout.kind === "manual" && args.mountedUi) {
     const entry = relative(args.root, (await clientRoot(args.root)).file);
     lines.push(`edit ${entry} — wrap the app in the <VendoProvider> lines above (without it, nothing on the page can reach Vendo)`);
   }
@@ -724,17 +741,41 @@ async function agentTailLines(args: {
   return lines;
 }
 
-const USE_CASE_OPTIONS: SelectOption[] = [
-  { value: "embedded", label: "Embedded in my app — chat + generated UI", hint: "recommended" },
-  { value: "agent-loop", label: "Through my own agent loop (AI SDK / Mastra)" },
-  { value: "mcp", label: "From outside agents over MCP — Claude, ChatGPT, Cursor, or any MCP agent (experimental)" },
-];
+const EMBEDDED_OPTION: SelectOption = { value: "embedded", label: "Embedded in my app — chat + generated UI" };
+const AGENT_LOOP_OPTION: SelectOption = { value: "agent-loop", label: "Through my own agent loop (AI SDK / Mastra)" };
+const MCP_OPTION: SelectOption = { value: "mcp", label: "From outside agents over MCP — Claude, ChatGPT, Cursor, or any MCP agent (experimental)" };
+
+/** The choices, recommended one FIRST — index 0 is what the select defaults to,
+    so ordering IS the recommendation. A host whose own API already runs an agent
+    loop has already made this choice; recommending "embedded" to it sent people
+    down a path they then had to undo, while the scanner was meanwhile excluding
+    that very route from the catalog. The evidence rides the hint: a
+    recommendation whose reason is invisible reads as a guess. */
+function useCaseOptions(agentLoopRoute: string | null): SelectOption[] {
+  return agentLoopRoute === null
+    ? [{ ...EMBEDDED_OPTION, hint: "recommended" }, AGENT_LOOP_OPTION, MCP_OPTION]
+    : [
+        { ...AGENT_LOOP_OPTION, hint: `recommended — detected an agent loop in ${agentLoopRoute}` },
+        EMBEDDED_OPTION,
+        MCP_OPTION,
+      ];
+}
+
+/** Does this install mount a visible Vendo surface? An agent-loop or MCP install
+    reaches the agent through the host's own loop or the MCP door and mounts no
+    Vendo UI by design, so the <VendoProvider>/<VendoOverlay> paste is not a step
+    it owes — printing it anyway ended those two runs with a paste nobody should
+    apply and a step count nobody could clear. The same rule doctor grades by
+    (doctor-wiring-checks.ts's `mountedUi`). */
+const mountsUi = (useCase: InitUseCase): boolean => useCase !== "agent-loop" && useCase !== "mcp";
 
 /** The run's FIRST question. Every path shares the same wired route, so a
     wrong pick costs nothing; the right one saves a docs round trip. --yes and
     non-interactive runs take the answer this install already recorded, else
     "embedded" — a re-run must not silently re-answer a question the project
-    settled, because doctor now grades against it. */
+    settled, because doctor now grades against it. (The DEFAULT stays embedded
+    even where the loop detection moves the recommendation: an unattended run
+    must not change what it writes because a host happens to have a chat route.) */
 async function resolveUseCase(input: {
   root: string;
   options: InitOptions;
@@ -745,7 +786,7 @@ async function resolveUseCase(input: {
   if (options.useCase !== undefined) return options.useCase;
   if (options.yes === true || !interactive) return await readUseCase(root) ?? "embedded";
   const select = options.selectUseCase ?? (pretty === null ? plainSelect : pretty.select);
-  const picked = await select("How will people use your agent?", USE_CASE_OPTIONS);
+  const picked = await select("How will people use your agent?", useCaseOptions(await detectAgentLoopRoute(root)));
   return (INIT_USE_CASES as readonly string[]).includes(picked) ? picked as InitUseCase : "embedded";
 }
 
@@ -768,18 +809,28 @@ export async function captureDevBaseUrl(input: {
   options: InitOptions;
   output: Output;
   pretty: PrettyOutput | null;
-  interactive: boolean;
 }): Promise<string | null> {
-  const { root, options, output, pretty, interactive } = input;
+  const { root, options, output, pretty } = input;
+  // This question's interactivity posture is its OWN, and deliberately looser
+  // than the auth confirm's: it asks whether there is a TERMINAL, not whether
+  // init was launched by a package script. `invokedByPackageScript()` is in the
+  // run-wide `interactive` flag so a `prebuild` hook can never block on a
+  // prompt — but npm sets `npm_lifecycle_event` for EVERY `npm run …`, so
+  // borrowing that flag here meant a human at a real terminal who launched init
+  // through any wrapper script got no question and no VENDO_BASE_URL, while
+  // `npx vendo init` (event "npx", excluded) asked and wrote one. That is the
+  // conflicting field observation: same terminal, same person, two outcomes.
+  //
   // plainText carries plainSelect's guard — a non-TTY input or output returns
   // "" and never prompts — so a piped run stays byte-identical while a NO_COLOR
   // terminal still gets the question. Making this pretty-only would silently
   // delete the feature for anyone who sets NO_COLOR. The test seam sits INSIDE
   // the interactivity gate, like the auth confirm's: a stubbed prompt must not
   // make an unattended run ask what the real one never reaches.
+  const attended = options.interactive ?? (Boolean(stdin.isTTY) && Boolean(stdout.isTTY));
   const ask = options.baseUrl !== undefined
     ? async () => options.baseUrl!
-    : options.yes === true || !interactive
+    : options.yes === true || options.agent === true || !attended
       ? undefined
       : options.askText ?? (pretty === null ? plainText : pretty.text);
   if (ask === undefined) return null;
@@ -809,13 +860,49 @@ export function runStats(input: {
   ].join(" · ");
 }
 
+/** The `principal` the loop snippets hand the pack, as lines that COMPILE for
+ *  the auth this composition wires. Both snippets used to name a bare
+ *  `principal` that was declared nowhere, so a verbatim paste did not typecheck
+ *  and the developer had to guess where a caller comes from.
+ *
+ *  A preset resolves it from the request — `principal` is not nullable and every
+ *  preset's resolver returns `Principal | null`, so the refusal is part of the
+ *  paste. Anonymous, it is the literal the scaffolded composition itself
+ *  resolves, subject and all: the loop and the wire MUST resolve the same
+ *  subject, or every app and approval made in chat is invisible to the embeds
+ *  (0.4.1 E2E cert blocker B4). */
+function principalLines(preset: AuthPresetName | null): { imports: string[]; lines: string[] } {
+  if (preset === null) {
+    return {
+      imports: [],
+      lines: [`const principal = { kind: "user", subject: "demo-user" } as const; // the SAME subject your composition resolves`],
+    };
+  }
+  return {
+    imports: [`import { ${preset} } from ${JSON.stringify(AUTH_PRESET_SPECIFIER[preset])};`],
+    lines: [
+      `const principal = await ${preset}().principal(request);`,
+      `if (principal === null) return new Response("Unauthorized", { status: 401 });`,
+    ],
+  };
+}
+
+/** The agent file the Mastra snippet names. `<your-agent>.ts` was a placeholder
+    the reader had to translate; a host that already has agents under
+    src/mastra/agents can be told which file. First file wins (readdir is
+    sorted), and the placeholder stays when there is nothing to name. */
+async function mastraAgentFile(root: string, agents: string): Promise<string> {
+  const entries = await readdir(join(root, agents)).catch(() => [] as string[]);
+  return entries.filter((name) => /\.[cm]?[jt]sx?$/.test(name)).sort()[0] ?? "<your-agent>.ts";
+}
+
 /** Variant B — the user's own agent loop. Which snippet prints is read off
     the same package.json init already parses (`ai` → AI SDK, `@mastra/core`
     → Mastra); the generated route stays either way, because it is what
     serves apps and approvals to the embeds. Mastra's principal step is a
     step of its own, not a footnote: vendoMastraTools reads the principal off
     the request context and a call without one fails closed. */
-async function agentLoopSteps(root: string): Promise<ManualEdit[]> {
+async function agentLoopSteps(root: string, preset: AuthPresetName | null): Promise<ManualEdit[]> {
   let dependencies: Record<string, unknown> = {};
   try {
     const manifest = JSON.parse((await readOptional(join(root, "package.json"))) ?? "{}") as {
@@ -831,37 +918,47 @@ async function agentLoopSteps(root: string): Promise<ManualEdit[]> {
   // share none of its state, so the import is part of the paste, not an
   // exercise for the reader.
   const agents = join("src", "mastra", "agents");
+  const caller = principalLines(preset);
+  // The chat route's own directory, off the SAME src-aware helper the scaffolds
+  // use: a host whose app router lives under src/ was told to edit app/api/chat,
+  // a path it does not have.
+  const chat = relative(root, join(await appDirectory(root), "api", "chat"));
   if (Object.hasOwn(dependencies, "@mastra/core")) {
     return [
       {
-        file: join(agents, "<your-agent>.ts"),
+        file: join(agents, await mastraAgentFile(root, agents)),
         lines: [
           `import { vendoMastraTools } from "@vendoai/vendo/mastra";`,
           `import { vendo } from ${JSON.stringify(await compositionSpecifier(root, join(root, agents)))};`,
           `… then spread the pack: tools: async () => ({ ...yourTools, ...(await vendoMastraTools(vendo)) })`,
         ],
-        why: "Your loop, your model — Vendo adds guarded vendo_* tools, vendo_make (inline micro-apps) and vendo_delegate. https://docs.vendo.run/existing-agents/mastra",
+        why: "Your loop, your model — Vendo adds guarded vendo_* tools, vendo_make (inline micro-apps) and vendo_delegate. https://docs.vendo.run/existing-agent/mastra",
       },
       {
-        file: join("app", "api", "chat", "route.ts"),
+        file: join(chat, "route.ts"),
         lines: [
           `import { VENDO_PRINCIPAL_KEY } from "@vendoai/vendo/mastra";`,
-          `… then set the per-request principal: requestContext.set(VENDO_PRINCIPAL_KEY, principal);`,
+          ...caller.imports,
+          `… then inside your POST handler, before the run:`,
+          ...caller.lines,
+          `requestContext.set(VENDO_PRINCIPAL_KEY, principal);`,
         ],
         why: "vendoMastraTools reads the principal off the request context — a call without one fails closed, so an install that skips this looks broken at the first tool call.",
       },
     ];
   }
   if (Object.hasOwn(dependencies, "ai")) {
-    const chat = join("app", "api", "chat");
     return [{
       file: join(chat, "route.ts"),
       lines: [
         `import { vendoTools } from "@vendoai/vendo/ai-sdk";`,
         `import { vendo } from ${JSON.stringify(await compositionSpecifier(root, join(root, chat)))};`,
-        `… then inside streamText: tools: { ...yourTools, ...(await vendoTools(vendo, { principal })) }`,
+        ...caller.imports,
+        `… then inside your POST handler:`,
+        ...caller.lines,
+        `… and inside streamText: tools: { ...yourTools, ...(await vendoTools(vendo, { principal })) }`,
       ],
-      why: "Your loop, your model — Vendo adds guarded vendo_* tools, vendo_make (inline micro-apps) and vendo_delegate. https://docs.vendo.run/existing-agents/ai-sdk",
+      why: "Your loop, your model — Vendo adds guarded vendo_* tools, vendo_make (inline micro-apps) and vendo_delegate. https://docs.vendo.run/existing-agent/ai-sdk",
     }];
   }
   return [];
@@ -913,6 +1010,9 @@ async function planMcpScaffold(input: {
 
   const composition = await compositionModulePath(root);
   const appDir = await appDirectory(root);
+  // The key the host already has, so a re-run reuses it instead of rotating the
+  // secret every backend caller is exchanging (see McpPlanInput.existingServiceKey).
+  const existingServiceKey = envFileValueSync(root, "VENDO_SERVICE_KEY");
   const mcp = planMcp({
     root,
     appDir,
@@ -920,10 +1020,15 @@ async function planMcpScaffold(input: {
     compositionSpecifier: await compositionSpecifier(root, join(appDir, ".well-known", "[...vendo]")),
     framework,
     authWired,
+    // A re-run over an existing composition never re-decides auth, so
+    // `authWired` is null even where lib/vendo.ts already says `auth: authJs()`
+    // — the file itself is the only remaining evidence.
+    authAlreadyWired: authWired === null && await composedAuthPreset(composition) !== null,
     serverActions: (await requiredServerActions(root)).length > 0,
     cloudKey,
     posture,
     serviceKey,
+    ...(existingServiceKey === null ? {} : { existingServiceKey }),
     // Resolved again here rather than reused: the `--byo` paste lands in
     // .env.local during the cloud step, which runs after the plan was built.
     models: scaffoldModel(root, options),
@@ -961,10 +1066,17 @@ async function planMcpScaffold(input: {
       diff: diff(change.path, null, change.after),
     });
   }
+  // A reused key is already where it belongs, so there is nothing to write and
+  // nothing to claim: saying "Generated" over an untouched value is what made a
+  // re-run read as a rotation.
   if (mcp.serviceKeyValue !== undefined) {
-    await upsertEnvLocal(root, "VENDO_SERVICE_KEY", mcp.serviceKeyValue);
-    output.log(`Generated VENDO_SERVICE_KEY → .env.local (…${mcp.serviceKeyValue.slice(-4)})`);
-    await ensureEnvLocalIgnored(root, output);
+    if (wellFormedServiceKey(existingServiceKey) && mcp.serviceKeyValue === existingServiceKey!.trim()) {
+      output.log(`VENDO_SERVICE_KEY already set — reused (…${mcp.serviceKeyValue.slice(-4)})`);
+    } else {
+      await upsertEnvLocal(root, "VENDO_SERVICE_KEY", mcp.serviceKeyValue);
+      output.log(`Generated VENDO_SERVICE_KEY → .env.local (…${mcp.serviceKeyValue.slice(-4)})`);
+      await ensureEnvLocalIgnored(root, output);
+    }
   }
   // …and the models line only counts where the composition was actually
   // written: a re-run against an existing one must not claim a line it left
@@ -1224,7 +1336,7 @@ async function planNextComposition(
   return scaffold;
 }
 
-async function buildPlan(options: InitOptions, confirmAuth?: ConfirmAuth, selectAuth?: SelectAuth): Promise<{
+async function buildPlan(options: InitOptions, mountedUi: boolean, confirmAuth?: ConfirmAuth, selectAuth?: SelectAuth): Promise<{
   plan: InitPlan;
   changes: PlannedChange[];
   manualSteps: string[];
@@ -1326,9 +1438,9 @@ async function buildPlan(options: InitOptions, confirmAuth?: ConfirmAuth, select
     ".vendo/fonts.css",
     ".vendo/data/.gitignore",
   ];
-  const mount = await mountStep(root, layout);
+  const mount = await mountStep(root, layout, mountedUi);
   const manualSteps = [
-    ...await manualWiringLines(root, layout),
+    ...await manualWiringLines(root, layout, mountedUi),
     ...edits.flatMap(editLines),
   ];
   return {
@@ -1555,6 +1667,142 @@ async function guardUndetectedFramework(input: {
   return true;
 }
 
+/** What an unattended run WOULD settle, one line per still-open question, each
+    naming the flag that answers it instead. Written from the SAME question list
+    `--agent` relays, so the two can never disagree about what a person owns. */
+async function unattendedDefaultLines(input: {
+  root: string;
+  options: InitOptions;
+  questions: readonly { id: string }[];
+}): Promise<string[]> {
+  const { root, options, questions } = input;
+  const lines: string[] = [];
+  for (const question of questions) {
+    if (question.id === "use-case") {
+      // `readUseCase` answers `undefined` for "no record", never null.
+      const recorded = await readUseCase(root);
+      lines.push(`use case: ${recorded ?? "embedded"}${recorded === undefined ? "" : " (recorded by an earlier init)"} — --use-case ${INIT_USE_CASES.join(" | ")}`);
+    } else if (question.id === "auth") {
+      const wired = (await detectAuthPreset(root)).wired;
+      lines.push(wired === null
+        ? "auth: none — every session stays anonymous — --auth clerk | authJs | supabase | auth0 | jwt | none"
+        : `auth: ${wired.preset}() (detected ${wired.dependency}) — --auth <preset>, or --auth none`);
+    } else if (question.id === "models") {
+      lines.push("model key: only what is already in the environment — no login offer, so a keyless host cannot answer one turn — --byo, or --cloud-key <key>");
+    } else if (question.id === "dev-url") {
+      lines.push(`VENDO_BASE_URL: not written — your own agent loop, any backend process and the MCP door each fail their FIRST tool call without it — --base-url ${devBaseUrl(await devPort(root))}`);
+    } else if (question.id === "posture") {
+      lines.push("MCP sign-in: local — your app serves its own OAuth — --posture local | broker");
+    } else if (question.id === "service-key") {
+      lines.push("service key: none minted — --service-key if your backend calls these tools machine-to-machine");
+    }
+  }
+  // Never one of `initQuestions`' relayed questions (it is mechanical, not a
+  // person's decision) but it IS a default this run would take in silence.
+  if (options.ai === undefined) {
+    lines.push("judgment: skipped — every tool stays ungraded, so the agent asks before every single call — --ai");
+  }
+  return lines;
+}
+
+/**
+ * A run that CANNOT ask must not answer for the developer.
+ *
+ * Piped stdin and CI used to settle every question a PERSON owns — the use case
+ * doctor then grades against, the auth the agent acts as, the model offer, the
+ * dev origin every backend tool call needs — and then print the same success
+ * frame an attended install prints. Nothing said a single decision had been made,
+ * so the first sign was a tool call failing days later.
+ *
+ * `--yes` is the explicit "take the defaults" and proceeds — still printing them,
+ * because a default nobody was told about is the whole failure mode.
+ *
+ * Returns false when init must stop with exit 1.
+ */
+async function guardNonInteractive(input: {
+  root: string;
+  options: InitOptions;
+  output: Output;
+  interactive: boolean;
+}): Promise<boolean> {
+  const { root, options, output, interactive } = input;
+  if (interactive) return true;
+  const cloudKey = (credentialEnv(root, options.env ?? process.env)["VENDO_API_KEY"] ?? "").trim() !== "";
+  const unanswered = await initQuestions({
+    root,
+    options,
+    framework: await resolveFramework(root, options),
+    modelKey: cloudKey || scaffoldModel(root, options) !== null,
+    cloudKey,
+    devPort: await devPort(root),
+  });
+  if (unanswered === null) return true;
+  const defaults = await unattendedDefaultLines({ root, options, questions: unanswered.questions });
+  // --yes IS the answer, so the run proceeds — but it still SAYS what it settled.
+  // A default nobody was told about is the whole failure mode, flag or no flag.
+  if (options.yes === true) {
+    output.log("Taking the defaults (--yes):");
+    for (const line of defaults) output.log(`  ${line}`);
+    return true;
+  }
+  output.error(
+    "vendo init: this run cannot ask (stdin is not a terminal), and answering for you is how a project ends up "
+    + "with an install nobody chose. Pass --yes to take the defaults below, or answer them with flags. "
+    + "`vendo init --agent` relays the same questions as JSON for a coding agent to ask.",
+  );
+  output.error("What --yes would settle here:");
+  for (const line of defaults) output.error(`  ${line}`);
+  return false;
+}
+
+/** The source of every CODE file this run created, and only those: a host file
+    init merely appended to (package.json, next.config) is not init's import to
+    own, and the packaged skill is prose whose fenced examples are not this app's. */
+const generatedSources = (changes: readonly PlannedChange[]): string[] =>
+  changes
+    .filter((change) => change.before === null && /\.[cm]?[jt]sx?$/.test(change.path))
+    .map((change) => change.after);
+
+/** What a run with no grades says. `--ai` and never the bare command: this line
+ *  is read by the runs that cannot answer a consent prompt (agents, CI), where a
+ *  bare `vendo sync` skips the pass again and the advice never lands.
+ *
+ *  Agent mode always ASKS for the pass now, so an agent reaching here has no
+ *  engine on the machine at all — and the caller is a model, so the grading is
+ *  its work and the line says so as work, not as background. */
+function ungradedLine(agent: boolean): string {
+  if (!agent) {
+    return "judgment: structural-only — only protocol facts are graded, so every ungraded tool asks on each call"
+      + " (add a model key and run `vendo sync --ai` to grade the catalog)";
+  }
+  return "judgment: REQUIRED, not done — no judgment engine resolved on this machine, so every tool is ungraded and asks on every call."
+    + " Install one (`npm install -g @anthropic-ai/claude-code`) and run `vendo sync --ai` to grade the catalog, or grade it yourself:"
+    + ` the receipt's judgment.checklist is the work, and grades land in ${join(".vendo", "judgments.json")}`;
+}
+
+/** BOTH stop-conditions for a run that would otherwise guess, in one call.
+ *
+ * Agent mode passes straight through: it keeps the fall-through to the
+ * runtime-neutral custom scaffold it has always had (resolveFramework answers
+ * "custom" for an undetectable host, which is a safe default rather than a
+ * guess), and it relays the person-questions as JSON instead of settling them.
+ *
+ * The second guard is additionally CLI-only. `output === undefined` is what
+ * "this is the CLI" means here — the same seam the renderer is selected by — and
+ * a programmatic caller that supplies its own sink drives init deliberately.
+ *
+ * Returns false when init must stop with exit 1. */
+async function guardUnattendedRun(input: {
+  root: string;
+  options: InitOptions;
+  output: Output;
+  interactive: boolean;
+}): Promise<boolean> {
+  if (input.options.agent === true) return true;
+  if (!await guardUndetectedFramework(input)) return false;
+  return input.options.output !== undefined || await guardNonInteractive(input);
+}
+
 /** The env every credential consumer reads. Dev keys may live in .env.local
     rather than this process's env — a PRIOR run's minted starter key, or
     hand-added provider keys — so they are merged in for the credential ladder,
@@ -1755,9 +2003,14 @@ async function runInstallSyncFlow(input: {
     interactive: extract.interactive
       ?? (!invokedByPackageScript() && Boolean(stdin.isTTY) && Boolean(stdout.isTTY)),
     yes: options.yes === true,
-    // Agent mode never spends a model here and never asks to: the caller IS
-    // the model, and the receipt hands it the checklist instead.
-    ...(options.agent === true ? { delegated: true } : {}),
+    // Agent mode ALWAYS grades. The caller being a model is not a substitute:
+    // the pass is a scripted engine run with a verbatim quote behind every
+    // proposal and an independent skeptic over each one, so "delegated to you"
+    // meant every agent install shipped an ungraded catalog whose every tool
+    // asked on each call. The mode IS the consent; only an explicit `--no-ai`
+    // still refuses, and a machine with no engine at all falls through to the
+    // receipt's checklist (runInit's judgment line says so out loud).
+    ...(options.agent === true && ai === undefined ? { ai: true } : {}),
     // --ai IS the consent (no prompt, non-interactive runs stop skipping);
     // --no-ai is the refusal. No flag = ask, every interactive run.
     ...(ai === undefined ? {} : { ai }),
@@ -1787,8 +2040,21 @@ async function ensureHostDeps(input: {
   credential: DevCredential;
   /** The provider whose import this run wrote into the composition, if any. */
   wrote: ScaffoldModel["provider"] | undefined;
+  /** The source of every code file this run CREATED — what its imports demand
+      of the host's package.json (see ensureGeneratedImports). */
+  generated: readonly string[];
 }): Promise<void> {
-  const { root, output, options, pretty, interactive, credential, wrote } = input;
+  const { root, output, options, pretty, interactive, credential, wrote, generated } = input;
+  // Every package those generated files import has to be a declared dependency
+  // of the host, or the app cannot compile what init just wrote. First, so the
+  // declaration is in place before the resolvability repair below asks about it.
+  await ensureGeneratedImports({
+    root,
+    sources: generated,
+    output,
+    ...(options.installVendo === undefined ? {} : { run: options.installVendo }),
+  });
+
   // #1153: the scaffolds this run wrote import `@vendoai/vendo/*`, and a host
   // installed under the `vendoai` alias alone cannot resolve them under pnpm's
   // strict node_modules — the route fails to COMPILE and every request 500s.
@@ -1858,24 +2124,32 @@ async function finishRun(input: {
       the catalog this run synced. Empty on every other run. */
   wrote: string[];
   risks: RiskRecommendation[];
+  /** Did the judgment pass actually run this run? The receipt reports `graded`
+      when it did, and hands back the REQUIRED checklist when it did not. */
+  judged: boolean;
 }): Promise<string> {
   const {
     root, options, output, pretty, interactive, useCase, mcp, mount, edits, manualSteps,
     credential, cloud, compositionPath, framework, authWired, layout, toolCount, brandCaptured,
-    wrote, risks,
+    wrote, risks, judged,
   } = input;
 
   // Where does this app run in dev? — every path but MCP, which needed the
   // answer before it wrote. The answer lands in .env.local inside, so there is
   // nothing to read back here.
-  if (useCase !== "mcp") await captureDevBaseUrl({ root, options, output, pretty, interactive });
+  if (useCase !== "mcp") await captureDevBaseUrl({ root, options, output, pretty });
 
   // Variant B: the wired route stays (it serves apps and approvals to the
-  // embeds) — what is added is the one snippet for their own loop.
+  // embeds) — what is added is the one snippet for their own loop, written for
+  // the auth this composition wires. A re-run over an existing composition never
+  // re-decides auth, so the file itself is the only evidence left (the same read
+  // the MCP arm makes).
+  const loopPreset = authWired?.preset
+    ?? (useCase === "agent-loop" ? await composedAuthPreset(await compositionModulePath(root)) : null);
   const handSteps = [
     ...(mount === null ? [] : [mount]),
     ...edits,
-    ...(useCase === "agent-loop" ? await agentLoopSteps(root) : []),
+    ...(useCase === "agent-loop" ? await agentLoopSteps(root, loopPreset) : []),
   ];
   printClosingSteps({ output, handSteps, manualSteps, credential, cloud, compositionPath });
   if (mcp !== null) {
@@ -1903,7 +2177,9 @@ async function finishRun(input: {
       pasteEdits: handSteps,
       tools: toolCount,
       riskRecommendations: risks,
-      judgment: { status: "delegated", checklist: JUDGMENT_CHECKLIST },
+      judgment: judged
+        ? { status: "graded", file: join(".vendo", "judgments.json") }
+        : { status: "delegated", checklist: JUDGMENT_CHECKLIST },
     } satisfies InitReceipt, null, 2));
     return runStats({ toolCount, brandCaptured, handSteps: handSteps.length, checkPassed });
   }
@@ -1913,7 +2189,7 @@ async function finishRun(input: {
   // Interactive human runs keep the clack-style output untouched.
   if (options.yes === true || !interactive) {
     output.log("\nAgent tail:");
-    const tail = await agentTailLines({ root, framework, compositionPath, authWired, layout, edits, cloudKeyMissing: credential.rung === "none" });
+    const tail = await agentTailLines({ root, framework, compositionPath, authWired, layout, edits, mountedUi: mountsUi(useCase), cloudKeyMissing: credential.rung === "none" });
     for (const line of tail) output.log(`  ${line}`);
   }
   // The run's LAST word is the outstanding paste (self-serve audit F5: the
@@ -1994,12 +2270,7 @@ const explainedPlanFailure = (error: unknown): boolean => {
   const interactive = options.agent !== true
     && (options.interactive
       ?? (!invokedByPackageScript() && Boolean(stdin.isTTY) && Boolean(stdout.isTTY)));
-  // The guard belongs to the runs that would otherwise GUESS. Agent mode keeps
-  // the fall-through to the runtime-neutral custom scaffold it has always had:
-  // resolveFramework answers "custom" for an undetectable host, which is the
-  // safe default rather than a guess, and detection behaves the same in every
-  // mode.
-  if (options.agent !== true && !await guardUndetectedFramework({ root, options, output, interactive })) return 1;
+  if (!await guardUnattendedRun({ root, options, output, interactive })) return 1;
 
   // Ask first (agent mode): detection has run, so whatever a PERSON still owes
   // an answer to leaves as ONE JSON object and this run writes nothing. The
@@ -2014,6 +2285,9 @@ const explainedPlanFailure = (error: unknown): boolean => {
       modelKey: cloudKey || scaffoldModel(root, options) !== null,
       cloudKey,
       devPort: await devPort(root),
+      // Only when the use case is still open — the scan costs a source walk, and
+      // an answered question has nothing left to recommend.
+      ...(options.useCase === undefined ? { agentLoopRoute: await detectAgentLoopRoute(root) } : {}),
     });
     if (questions !== null) {
       output.log(JSON.stringify(questions, null, 2));
@@ -2049,7 +2323,7 @@ const explainedPlanFailure = (error: unknown): boolean => {
     ? undefined
     : (options.selectAuth ?? (pretty === null ? plainSelect : pretty.select));
   const detectStarted = Date.now();
-  const built = await buildPlanOrExplained(options, confirmAuth, selectAuth);
+  const built = await buildPlanOrExplained(options, mountsUi(useCase), confirmAuth, selectAuth);
   if (built === null) return 1;
   const { plan, changes, edits, manualSteps, mount, authAdvice, authWired, compositionPath, layout, modelWritten, rewriteModels } = built;
   const detectMs = Date.now() - detectStarted;
@@ -2080,7 +2354,7 @@ const explainedPlanFailure = (error: unknown): boolean => {
     // where it is one Enter.
     let mcp: ReturnType<typeof planMcp> | null = null;
     if (useCase === "mcp") {
-      const baseUrl = await captureDevBaseUrl({ root, options, output, pretty, interactive });
+      const baseUrl = await captureDevBaseUrl({ root, options, output, pretty });
       mcp = await planMcpScaffold({
         root, options, output, pretty, interactive, changes, baseUrl,
         framework: plan.framework, authWired, cloudKey: cloud.keyValid,
@@ -2144,12 +2418,7 @@ const explainedPlanFailure = (error: unknown): boolean => {
 
     // Judgment state, one line: a pass that ran already narrated itself (it
     // owns the judged/queued/rejected counts); otherwise say so honestly.
-    if (!flow.judged.ran) {
-      // `--ai` and not the bare command: this line is read by the runs that
-      // cannot answer a consent prompt (agents, CI), where a bare `vendo sync`
-      // skips the judgment pass again and the advice never lands.
-      output.log("judgment: structural-only — only protocol facts are graded, so every ungraded tool asks on each call (add a model key and run `vendo sync --ai` to grade the catalog)");
-    }
+    if (!flow.judged.ran) output.log(ungradedLine(options.agent === true));
 
     // Project-shape enrichment (posthog-analytics §3): bools, closed enums,
     // counts, and bare dependency versions only — never names or content.
@@ -2189,6 +2458,7 @@ const explainedPlanFailure = (error: unknown): boolean => {
     await ensureHostDeps({
       root, output, options, pretty, interactive, credential,
       wrote: modelLanded?.provider,
+      generated: generatedSources(changes),
     });
 
     // The one line that closes the model story. A provider key is a credential
@@ -2230,6 +2500,7 @@ const explainedPlanFailure = (error: unknown): boolean => {
       // The SAME projection the plan used to make from a throwaway extraction,
       // over the catalog the flow already read this run.
       risks: riskRecommendations(flow.catalog),
+      judged: flow.judged.ran,
     });
     pretty?.done(Date.now() - started, true, stats);
     return 0;

--- a/packages/vendo/src/cli/judge/pass.ts
+++ b/packages/vendo/src/cli/judge/pass.ts
@@ -1,5 +1,5 @@
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { dirname, join, relative } from "node:path";
 import { z } from "zod";
 import { fieldSemanticSchema, gradedRiskLabelSchema, jsonSchemaSchema, type JsonSchema } from "@vendoai/core";
 import {
@@ -486,7 +486,8 @@ export async function runJudgmentPass(options: JudgmentPassOptions): Promise<Jud
   const file = judgmentsFileSchema.parse({ format: VENDO_JUDGMENTS_FORMAT, tools: sortedTools });
   // Don't create an empty file where none existed: a pass that found nothing to
   // record leaves the directory as it was.
-  if (storedFile !== null || Object.keys(sortedTools).length > 0) {
+  const wroteJudgments = storedFile !== null || Object.keys(sortedTools).length > 0;
+  if (wroteJudgments) {
     await writeIfChanged(judgmentsPath, `${JSON.stringify(file, null, 2)}\n`);
   }
 
@@ -504,6 +505,8 @@ export async function runJudgmentPass(options: JudgmentPassOptions): Promise<Jud
     loosenings: { approved, declined, queued },
     repairedStages: stages.repairedStages,
     notes,
+    wroteJudgments,
+    judgmentsPath: relative(options.root, judgmentsPath),
   });
 
   return {
@@ -1025,6 +1028,10 @@ function reportNarrative(input: {
   loosenings: { approved: number; declined: number; queued: number };
   repairedStages: string[];
   notes: string[];
+  /** Did this pass land grades on disk? */
+  wroteJudgments: boolean;
+  /** Where they landed, root-relative — named out loud, see below. */
+  judgmentsPath: string;
 }): void {
   const { output, credential, judged, routed, patched, repairedStages, notes } = input;
   const { approved, declined, queued } = input.loosenings;
@@ -1093,6 +1100,23 @@ function reportNarrative(input: {
   // adding a tool is the deterministic scanner's job.
   for (const missed of judged.missedSurfaces) {
     output.error(`warning: missed surface (not extracted yet): ${sanitize(missed)}`);
+  }
+  // WHERE the grades went, and why tools.json still says "ungraded".
+  //
+  // The tallies above are the only thing this pass used to say, and three
+  // separate auditors read "hardened fields (14)" next to an unchanged
+  // tools.json full of `risk: "ungraded"` and concluded the pass had done
+  // nothing. Grades are a SEPARATE layer on purpose — tools.json is the raw
+  // scan, judgments.json is what a model proposed and a skeptic kept, and the
+  // runtime merges them (actions/src/judgments.ts) — so the receipt has to name
+  // both files or the split reads as a bug.
+  //
+  // The restart line rides here because a running dev server read the judgments
+  // once, at boot: nothing re-reads the file, so grades written by `sync --ai`
+  // do not reach the process the developer is looking at until it restarts.
+  if (input.wroteJudgments) {
+    output.log(`grades written to ${input.judgmentsPath} — tools.json keeps the raw scan; the runtime merges both`);
+    output.log("restart your dev server to pick up the new grades (a running one read them at boot)");
   }
 }
 

--- a/packages/vendo/src/cli/pretty.ts
+++ b/packages/vendo/src/cli/pretty.ts
@@ -184,7 +184,7 @@ const MOUNT_WRAP = /^… then wrap: (<VendoProvider\b[^>]*>).*<\/VendoProvider>$
     pinned byte-for-byte by the receipt's `pasteEdits`, and a line added there
     would change that JSON. Emitted here, the --agent path never sees it (the
     rail is off in agent mode). */
-const MOUNT_DOCS = "docs.vendo.run/quickstart#the-client-mount — exact wording for layout.tsx and _app.tsx";
+const MOUNT_DOCS = "docs.vendo.run/product/mount-the-surface#the-provider — exact wording for layout.tsx and _app.tsx";
 const WIRED = /^(Wired \(\d+ files?\)):$/;
 const DIFF_MARKER = /^ {2}([+~]) (.+)$/;
 const THEME = /^Theme: (.*)$/;

--- a/packages/vendo/src/cli/provider-deps.ts
+++ b/packages/vendo/src/cli/provider-deps.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { readFile } from "node:fs/promises";
+import { access, readFile } from "node:fs/promises";
 import { dirname, join, relative, resolve, sep } from "node:path";
 import type { DevCredential, EnvKeyProvider } from "../dev-creds/resolve.js";
 import { installedVersion, installedZodVersion } from "./dep-versions.js";
@@ -50,6 +50,24 @@ async function readIfExists(root: string, name: string): Promise<string | null> 
 
 async function fileExists(root: string, name: string): Promise<boolean> {
   return (await readIfExists(root, name)) !== null;
+}
+
+/** Has this host installed ANYTHING yet? A host with no installed tree at all is
+    not a repair's business — its own install is the next thing to run, the same
+    rule `ensureVendoPackage` states below — and shelling a package manager at one
+    costs minutes for a dependency its install is about to resolve anyway.
+
+    Only TWO directories can answer: the app root, and the root the install would
+    run in (`installCommandFor`, which is the nearest lockfile or workspace
+    marker — that is the npm-workspaces case, where the tree is hoisted). A free
+    walk to `/` is what a stray `/tmp/node_modules` turns into a false yes, and
+    then a scratch directory gets a real package install shelled at it. */
+async function hasInstalledTree(root: string): Promise<boolean> {
+  const install = await installCommandFor(root);
+  for (const dir of new Set([resolve(root), resolve(install.cwd)])) {
+    if (await access(join(dir, "node_modules")).then(() => true, () => false)) return true;
+  }
+  return false;
 }
 
 export interface InstallCommand {
@@ -333,6 +351,95 @@ export async function ensureVendoPackage(options: { root: string; output: Output
   } else {
     options.output.error(
       `warning: could not install ${VENDO_PACKAGE_SPEC} — the wiring imports @vendoai/vendo/* and the vendoai alias keeps its copy nested, so the route will not compile; run \`${await vendoPackageInvocation(options.root)}\` yourself (E-WIRE-011).`,
+    );
+  }
+}
+
+/** Every BARE package a generated module imports, deduped: `@scope/name` or
+ *  `name`, subpath dropped. Relative and absolute specifiers are not packages,
+ *  and neither are node builtins. */
+function importedPackages(source: string): string[] {
+  const found = new Set<string>();
+  const specifiers = /(?:^|[\s;}])(?:import|export)\s[^;]*?from\s*["']([^"']+)["']|\bimport\s*\(\s*["']([^"']+)["']/g;
+  for (const match of source.matchAll(specifiers)) {
+    const specifier = match[1] ?? match[2] ?? "";
+    if (specifier === "" || specifier.startsWith(".") || specifier.startsWith("/") || specifier.startsWith("node:")) continue;
+    const parts = specifier.split("/");
+    found.add(specifier.startsWith("@") ? parts.slice(0, 2).join("/") : parts[0]!);
+  }
+  return [...found];
+}
+
+/** The version range each package init AUTHORS an import for is installed at.
+    Anything not listed is installed at its own latest — but nothing outside this
+    map is in a scaffold today, and a new one belongs here beside its siblings. */
+function specFor(packageName: string): string {
+  if (packageName === "@vendoai/vendo") return VENDO_PACKAGE_SPEC;
+  if (packageName === "ai") return AI_SPEC;
+  const provider = Object.values(PROVIDER_SPECS).find((entry) => entry.module === packageName);
+  return provider?.spec ?? packageName;
+}
+
+/**
+ * Every package the files this run GENERATED import, declared in the host's
+ * package.json — installing whatever is missing.
+ *
+ * Init authored those imports, so init owns their resolvability, exactly as it
+ * does for the model provider the first turn loads. `ensureVendoPackage` above
+ * covers only the alias case (`vendoai` declared, `@vendoai/vendo` nested), and
+ * it asks node_modules; this asks the MANIFEST, which is the half that bit the
+ * backend path — the docs there never install `@vendoai/vendo` at all, so a host
+ * following them got a generated `lib/vendo.ts` importing a package it does not
+ * depend on, and the build could not resolve it.
+ *
+ * The `vendoai` alias satisfies `@vendoai/vendo` here: a host that declared the
+ * alias has made its choice, and the nested-resolution half is
+ * `ensureVendoPackage`'s call to make. A host that has installed NOTHING yet is
+ * skipped for the same reason `ensureVendoPackage` skips it (hasInstalledTree).
+ * A failure degrades to the exact manual command, like every other repair here.
+ */
+export async function ensureGeneratedImports(options: {
+  root: string;
+  /** The source of every file this run created (generated code only — a file
+      init did not author says nothing about what init owes). */
+  sources: readonly string[];
+  output: Output;
+  run?: InstallRunner;
+}): Promise<void> {
+  const imported = new Set(options.sources.flatMap((source) => importedPackages(source)));
+  if (imported.size === 0) return;
+  if (!(await hasInstalledTree(options.root))) return;
+
+  const manifest = await readIfExists(options.root, "package.json");
+  if (manifest === null) return;
+  let declared: Record<string, unknown> = {};
+  try {
+    const parsed = JSON.parse(manifest) as {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    };
+    declared = { ...parsed.dependencies, ...parsed.devDependencies };
+  } catch {
+    // A manifest npm itself would refuse: init already fails loudly on it
+    // upstream, and adding a second voice here would only be noise.
+    return;
+  }
+  const missing = [...imported].filter((name) => {
+    if (Object.hasOwn(declared, name)) return false;
+    return !(name === "@vendoai/vendo" && Object.hasOwn(declared, "vendoai"));
+  }).sort();
+  if (missing.length === 0) return;
+
+  const specs = missing.map(specFor);
+  const install = await installCommandFor(options.root);
+  const invocation = invocationFor(install, specs, options.root);
+  options.output.log(`Installing what the generated files import: ${specs.join(" ")} (${install.command})…`);
+  const code = await (options.run ?? defaultRunner)(install.command, [...install.args, ...specs], install.cwd);
+  if (code === 0) {
+    options.output.log(`Installed ${specs.join(" ")}.`);
+  } else {
+    options.output.error(
+      `warning: could not install ${specs.join(" ")} — the files this run wrote import ${missing.join(", ")}, which your package.json does not declare, so the app will not compile; run \`${invocation}\` yourself.${installSaid(options.run)}`,
     );
   }
 }

--- a/packages/vendo/src/cli/sync-flow.ts
+++ b/packages/vendo/src/cli/sync-flow.ts
@@ -62,10 +62,6 @@ export interface SyncFlowOptions {
   interactive: boolean;
   yes: boolean;
   ai?: boolean;
-  /** `vendo init --agent`: the caller is itself a coding agent, so judgment is
-      its work, not ours. Beats every other answer — even `--ai` — because
-      spawning an engine underneath one is the one thing agent mode may not do. */
-  delegated?: boolean;
   engine?: string;
   force?: boolean;
   themeRefresh?: boolean;
@@ -362,10 +358,6 @@ async function chooseEngine(
   note: (message: string) => void,
 ): Promise<{ skip: true } | { skip: false; engine?: AvailableEngine }> {
   const { output } = options;
-  if (options.delegated === true) {
-    output.log("Judgment: delegated to you. The receipt lists what the catalog still needs.");
-    return { skip: true };
-  }
   if (options.ai === false) {
     output.log("AI polish (descriptions, risk review, brief, theme): off (--no-ai) — extractor defaults stand.");
     return { skip: true };

--- a/packages/vendo/src/compose-store.ts
+++ b/packages/vendo/src/compose-store.ts
@@ -19,10 +19,14 @@ import { cloudKeyOptions } from "./compose-selection.js";
 import { keepAliveFetch } from "./keep-alive-fetch.js";
 import { environment } from "./wire/shared.js";
 
-/** Per-process latch for the hosted-store automations notice below — a dev
+/** Per-PROCESS latch for the hosted-store automations notice below — a dev
     server recomposes on nearly every request, and the paragraph is a boot
-    fact, not a per-request one (self-serve audit F7). */
-let hostedStoreNoticePrinted = false;
+    fact, not a per-request one (self-serve audit F7). On `globalThis` and not in
+    module scope, for the same reason boot-summary.ts's latch is: Next's dev
+    server re-instantiates the module too, so a module-scoped `let` resets with
+    it and the notice comes back every couple of seconds. */
+const NOTICE_PRINTED = Symbol.for("vendo.compose-store.hosted-notice");
+const latches = globalThis as unknown as Record<symbol, true | undefined>;
 
 /** A host may also pass hostedStore({...}) explicitly via createVendo({ store }).
     Recognised by the erase cascade it carries over the store wire — the one
@@ -147,8 +151,8 @@ export function selectStore(
 
 /** The hosted-store automations notice, printed at most once per process. */
 export function reportHostedStoreOnce(): void {
-  if (hostedStoreNoticePrinted) return;
-  hostedStoreNoticePrinted = true;
+  if (latches[NOTICE_PRINTED] === true) return;
+  latches[NOTICE_PRINTED] = true;
   console.warn(
     "[vendo] Vendo Cloud is the hosted store for this deployment. Every automation still runs HERE, in "
     + "this process — Cloud holds no schedule and decides nothing about what is due; it just knocks on "

--- a/packages/vendo/tests/cli.test.ts
+++ b/packages/vendo/tests/cli.test.ts
@@ -97,7 +97,7 @@ describe("vendo CLI commands", () => {
 
     // Every option but the models answer, so this stays init's ask pass: it
     // writes nothing and hands back the one question still open. (`--ai` is
-    // absent because --agent refuses it by name — the AI-flag test owns that.)
+    // absent because the AI-flag test owns it.)
     expect(await main(["init", root, "--agent", "--yes", "--force",
       "--auth", "clerk", "--framework", "next", "--theme", "accent=#7c3bed",
       "--use-case", "mcp", "--base-url", "https://app.acme.com", "--posture", "broker",
@@ -254,14 +254,13 @@ describe("vendo CLI commands", () => {
     const root = await mkdtemp(join(tmpdir(), "vendo-cli-ai-flags-"));
     cleanup.push(root);
 
-    // Parsed, not rejected. Under --agent an `--ai` that can never run is
-    // refused BY NAME rather than dropped, since judgment is delegated to the
-    // caller; --no-ai agrees with what happens and passes.
-    for (const flag of ["--ai", "--ai-polish"]) {
-      expect(await main(["init", root, "--agent", flag])).toBe(1);
-      expect(error.mock.calls.flat().join("\n")).toContain("has no effect with --agent");
+    // Parsed, not rejected — on --agent too. Agent mode GRADES (2026-08-18), so
+    // `--ai` is that mode's own default and `--engine` pins its rung: neither is
+    // a flag that can never run any more, and rejecting one would refuse the
+    // ordinary spelling. (The run below is the ask pass, so it writes nothing.)
+    for (const flag of ["--ai", "--ai-polish", "--no-ai"]) {
+      expect(await main(["init", root, "--agent", flag])).toBe(0);
     }
-    expect(await main(["init", root, "--agent", "--no-ai"])).toBe(0);
     expect(await readdir(root)).toEqual([]);
 
     for (const flag of ["--ai", "--no-ai", "--no-watermark", "--yes", "--theme-refresh"]) {

--- a/packages/vendo/tests/cli/docs-links.test.ts
+++ b/packages/vendo/tests/cli/docs-links.test.ts
@@ -1,0 +1,101 @@
+import { readdir, readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { doctorErrorCodes, doctorFixRef } from "../../src/cli/doctor-codes.js";
+
+/**
+ * Every docs.vendo.run URL the CLI can PRINT has to reach a page that exists.
+ *
+ * Five of them did not. The docs restructure moved `existing-agents/*` to
+ * `existing-agent/*`, retired `/quickstart#the-client-mount`, and replaced the
+ * one `agents/verify` playbook with a page per doctor code — and the CLI kept
+ * printing the old spellings for months, because nothing in the repo connected a
+ * string literal in `src/cli/` to a file in `docs-site/`. This is that
+ * connection.
+ *
+ * Scope: `src/cli/`, which is what the CLI prints — the runtime's own links are
+ * a different surface with a different lifecycle.
+ *
+ * DIRECT resolution only. A `docs.json` redirect is deliberately not accepted:
+ * every one of the five stale URLs had one, so a redirect-following check greens
+ * a CLI that has been printing retired paths for a year — the redirect table is a
+ * compatibility shim for links already printed by SHIPPED binaries, not a licence
+ * for the next release to print them too. Anchors are checked only as far as the
+ * PAGE (a fragment never reaches the server, so it can select nothing).
+ */
+
+const CLI_DIR = new URL("../../src/cli/", import.meta.url);
+const DOCS_SITE = new URL("../../../../docs-site/", import.meta.url);
+
+/** `docs.vendo.run/...`, scheme optional, stopping before the sentence
+ *  punctuation prose wraps a URL in. */
+const DOCS_URL = /docs\.vendo\.run(\/[A-Za-z0-9/#._?=&-]*)?/g;
+/** Trailing prose that is not part of the path (`…/mcp.` at the end of a line). */
+const TRAILING = /[.,;:)\]]+$/;
+
+async function sourceFiles(directory: URL): Promise<URL[]> {
+  const files: URL[] = [];
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    if (entry.isDirectory()) files.push(...await sourceFiles(new URL(`${entry.name}/`, directory)));
+    else if (entry.name.endsWith(".ts")) files.push(new URL(entry.name, directory));
+  }
+  return files;
+}
+
+/** The docs path each printed URL asks for, deduped, with where it came from. */
+async function printedDocsPaths(): Promise<Map<string, string[]>> {
+  const found = new Map<string, string[]>();
+  const remember = (path: string, source: string): void => {
+    found.set(path, [...(found.get(path) ?? []), source]);
+  };
+  for (const file of await sourceFiles(CLI_DIR)) {
+    const source = await readFile(file, "utf8");
+    const name = fileURLToPath(file).split("/src/cli/")[1]!;
+    for (const [, rawPath] of source.matchAll(DOCS_URL)) {
+      remember((rawPath ?? "/").replace(TRAILING, ""), name);
+    }
+  }
+  // Built at runtime rather than written as a literal, and the one URL doctor
+  // puts in machine-readable output — so it is the one that most has to resolve.
+  for (const code of doctorErrorCodes) {
+    remember(new URL(doctorFixRef(code)).pathname, `doctorFixRef(${code})`);
+  }
+  return found;
+}
+
+const exists = async (url: URL): Promise<boolean> =>
+  await readFile(url, "utf8").then(() => true, () => false);
+
+/** Is there a page here? `<path>.mdx`, or the directory's `index.mdx`. */
+async function pageExists(path: string): Promise<boolean> {
+  const clean = path.replace(/^\//, "").replace(/\.md$/, "");
+  if (clean === "") return await exists(new URL("index.mdx", DOCS_SITE));
+  return await exists(new URL(`${clean}.mdx`, DOCS_SITE))
+    || await exists(new URL(`${clean}/index.mdx`, DOCS_SITE));
+}
+
+describe("every docs.vendo.run URL the CLI prints reaches a page that exists", () => {
+  it("resolves each one to a file under docs-site/", async () => {
+    const broken: string[] = [];
+    for (const [url, sources] of await printedDocsPaths()) {
+      // The fragment never reaches the server; only the page can be checked.
+      const path = url.split("#")[0]!.split("?")[0]!;
+      if (!(await pageExists(path))) {
+        broken.push(`docs.vendo.run${url} (printed by ${[...new Set(sources)].join(", ")})`);
+      }
+    }
+    expect(broken, "no page under docs-site/ for").toEqual([]);
+  });
+
+  it("found the URLs at all — an empty sweep would pass the check above vacuously", async () => {
+    const paths = await printedDocsPaths();
+    expect(paths.size).toBeGreaterThan(5);
+    // The five the audit caught, in their FIXED spellings.
+    const all = [...paths.keys()];
+    expect(all).toContain("/existing-agent/ai-sdk");
+    expect(all).toContain("/existing-agent/mastra");
+    expect(all).toContain("/outside-agents/quickstart");
+    expect(all).toContain("/product/mount-the-surface#the-provider");
+    expect(all).toContain("/production/troubleshooting/e-wire-001");
+  });
+});

--- a/packages/vendo/tests/cli/doctor-codes.test.ts
+++ b/packages/vendo/tests/cli/doctor-codes.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { DOCTOR_ERROR_CODES, VERIFY_URL, doctorErrorCodes, doctorFixRef } from "../../src/cli/doctor-codes.js";
+import { DOCTOR_ERROR_CODES, TROUBLESHOOTING_URL, doctorErrorCodes, doctorFixRef } from "../../src/cli/doctor-codes.js";
 import { CLI_VERSION } from "../../src/cli/shared.js";
 
 describe("doctor error-code registry", () => {
@@ -83,15 +83,17 @@ describe("doctor error-code registry", () => {
     `);
   });
 
-  it("builds a URL-valid fix_ref with the version param before the fragment", () => {
+  it("builds a URL-valid fix_ref that lands on the code's own page", () => {
     const ref = doctorFixRef("E-AUTH-001", "1.2.3");
-    // docs.vendo.run serves the verify playbook directly; the marketing-site
-    // path 302s (FINDINGS F7a) and some agents refuse to follow the hop.
-    expect(ref).toBe("https://docs.vendo.run/agents/verify?v=1.2.3#E-AUTH-001");
+    // docs.vendo.run serves the troubleshooting pages directly; the
+    // marketing-site path 302s (FINDINGS F7a) and some agents refuse the hop.
+    // The code is in the PATH, not a fragment — a fragment never reaches the
+    // server, so it could not select a page.
+    expect(ref).toBe("https://docs.vendo.run/production/troubleshooting/e-auth-001?v=1.2.3");
     const url = new URL(ref);
     expect(url.searchParams.get("v")).toBe("1.2.3");
-    expect(url.hash).toBe("#E-AUTH-001");
-    expect(`${url.origin}${url.pathname}`).toBe(VERIFY_URL);
+    expect(url.hash).toBe("");
+    expect(`${url.origin}${url.pathname}`).toBe(`${TROUBLESHOOTING_URL}/e-auth-001`);
   });
 
   it("defaults the version param to the installed CLI version", () => {

--- a/packages/vendo/tests/cli/doctor-store-persistence.test.ts
+++ b/packages/vendo/tests/cli/doctor-store-persistence.test.ts
@@ -43,7 +43,9 @@ describe("store/persistence (E-STORE-001)", () => {
     const check = doctor.checks.find((candidate) => candidate.id === "store/persistence");
     expect(check?.status).toBe("warning");
     expect(check?.error_code).toBe("E-STORE-001");
-    expect(check?.fix_ref).toContain("#E-STORE-001");
+    // The code is in the PATH, not a fragment: a fragment never reaches the
+    // server, so it could not select the code's own page.
+    expect(check?.fix_ref).toContain("/production/troubleshooting/e-store-001");
     expect(check?.message).toContain(join(root, ".vendo", "data"));
     expect(check?.message).toContain("wipes it on every redeploy");
     expect(doctor.failures).toBe(0); // ephemeral disk is a warning, never a block

--- a/packages/vendo/tests/cli/doctor-tenant-connectors.test.ts
+++ b/packages/vendo/tests/cli/doctor-tenant-connectors.test.ts
@@ -74,7 +74,9 @@ describe("the tenant-connector vault check", () => {
     expect(check?.message).toContain("VENDO_STORE_ENCRYPTION_KEY");
     // The failure it is really about is the DEPLOY, and it says so.
     expect(check?.message).toContain("REFUSED outright in production");
-    expect(check?.fix_ref).toContain("#E-TENANT-001");
+    // The code is in the PATH, not a fragment: a fragment never reaches the
+    // server, so it could not select the code's own troubleshooting page.
+    expect(check?.fix_ref).toContain("/production/troubleshooting/e-tenant-001");
   });
 
   it("passes on either vault: the host's own key, or Cloud's", async () => {

--- a/packages/vendo/tests/cli/doctor.test.ts
+++ b/packages/vendo/tests/cli/doctor.test.ts
@@ -639,8 +639,8 @@ describe("vendo doctor (model credentials + --json + cloud)", () => {
 
 /** Agent-install DX (design 2026-07-19 §CLI-3) — every check carries a stable
  *  id; failures and warnings additionally carry a registry `error_code` and a
- *  full `fix_ref` URL into docs.vendo.run/agents/verify. Passing checks carry
- *  neither (nothing to fix). */
+ *  full `fix_ref` URL into the code's own docs.vendo.run troubleshooting page.
+ *  Passing checks carry neither (nothing to fix). */
 describe("vendo doctor error codes + fix_refs", () => {
   it("stamps every failing check with a registered error_code and a full fix_ref URL", async () => {
     const root = await mkdtemp(join(tmpdir(), "vendo-doctor-codes-broken-"));
@@ -656,7 +656,7 @@ describe("vendo doctor error codes + fix_refs", () => {
       expect(check.id).toBeTruthy();
       expect(check.error_code).toMatch(/^E-[A-Z]+-\d{3}$/);
       expect(doctorErrorCodes).toContain(check.error_code);
-      expect(check.fix_ref).toBe(`https://docs.vendo.run/agents/verify?v=${CLI_VERSION}#${check.error_code}`);
+      expect(check.fix_ref).toBe(`https://docs.vendo.run/production/troubleshooting/${check.error_code!.toLowerCase()}?v=${CLI_VERSION}`);
     }
     // The remediation surface is broad: wiring, config, deps, tools.
     const codes = new Set(failures.map((check) => check.error_code));

--- a/packages/vendo/tests/cli/init-install-dx.test.ts
+++ b/packages/vendo/tests/cli/init-install-dx.test.ts
@@ -1,0 +1,507 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { runInit, type InitReceipt } from "../../src/cli/init.js";
+import type { InitQuestions } from "../../src/cli/init-questions.js";
+import { CLI_VERSION, type Output } from "../../src/cli/shared.js";
+
+/**
+ * The install-DX repairs from the 0.28.0 field audit. Each `it` here is one
+ * finding: a run that answered for the developer in silence, a recommendation
+ * that ignored evidence the scanner already had, a re-run that refused a
+ * correctly wired host, a secret rotated under a caller that was using it, a
+ * generated import nothing installed, and a paste that did not compile.
+ */
+
+const cleanup: string[] = [];
+
+afterEach(async () => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+  await Promise.all(cleanup.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+});
+
+const NO_CLOUD = {
+  cloudProbe: async () => ({ present: false, ok: false, unlocks: ["a starter allowance"] as readonly string[] }),
+};
+
+function output(): { output: Output; logs: string[]; errors: string[] } {
+  const logs: string[] = [];
+  const errors: string[] = [];
+  return { output: { log: (message) => logs.push(message), error: (message) => errors.push(message) }, logs, errors };
+}
+
+async function fixture(manifest: Record<string, unknown> = {}, name = "vendo-install-dx-"): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), name));
+  cleanup.push(root);
+  await mkdir(join(root, "app"), { recursive: true });
+  await writeFile(join(root, "package.json"), JSON.stringify({
+    name: "host",
+    dependencies: { next: "16.0.0", "@vendoai/vendo": "0.3.0" },
+    ...manifest,
+  }));
+  await writeFile(join(root, "app", "layout.tsx"),
+    "export default function Layout({ children }) { return <html><body>{children}</body></html>; }\n");
+  return root;
+}
+
+/** The common non-answer seams: no cloud probe, no telemetry, keyless. */
+function run(root: string, sink: { output: Output }, extra: Partial<Parameters<typeof runInit>[0]> = {}): Promise<number> {
+  return runInit({
+    targetDir: root,
+    output: sink.output,
+    env: {},
+    cloud: NO_CLOUD,
+    telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
+    extract: { harnesses: [] },
+    ...extra,
+  });
+}
+
+const receiptOf = (logs: string[]): InitReceipt => JSON.parse(logs.at(-1)!) as InitReceipt;
+const questionsOf = (logs: string[]): InitQuestions => JSON.parse(logs.join("\n")) as InitQuestions;
+
+/** A route that runs an agent loop — the evidence the scanner already excludes
+ *  on, and (item 3) the evidence the use-case recommendation now reads. */
+async function withChatRoute(root: string, at = join("app", "api", "chat")): Promise<void> {
+  await mkdir(join(root, at), { recursive: true });
+  await writeFile(join(root, at, "route.ts"),
+    'import { streamText } from "ai";\nexport async function POST(req: Request) { return streamText({ messages: await req.json() }).toUIMessageStreamResponse(); }\n');
+}
+
+/** Item 1 — the guard only fires for a CLI run (no injected `output`), so these
+ *  drive the real console and read it back. */
+function consoleSink(): { logs: string[]; errors: string[] } {
+  const logs: string[] = [];
+  const errors: string[] = [];
+  vi.spyOn(console, "log").mockImplementation((...parts: unknown[]) => { logs.push(parts.join(" ")); });
+  vi.spyOn(console, "error").mockImplementation((...parts: unknown[]) => { errors.push(parts.join(" ")); });
+  return { logs, errors };
+}
+
+describe("a run that cannot ask stops instead of answering for you", () => {
+  it("prints the defaults it would take and exits 1", async () => {
+    const root = await fixture({ scripts: { dev: "next dev --port 4100" } });
+    const sink = consoleSink();
+    expect(await runInit({
+      targetDir: root,
+      env: {},
+      cloud: NO_CLOUD,
+      telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
+    })).toBe(1);
+    const said = sink.errors.join("\n");
+    expect(said).toContain("this run cannot ask");
+    expect(said).toContain("Pass --yes to take the defaults below");
+    expect(said).toContain("--agent");
+    // Every default it WOULD have taken, each naming the flag that answers it.
+    expect(said).toContain("use case: embedded — --use-case embedded | agent-loop | mcp");
+    // A FRESH install has no recorded answer, so it must not claim one.
+    expect(said).not.toContain("recorded by an earlier init");
+    expect(said).toContain("auth: none");
+    expect(said).toContain("VENDO_BASE_URL: not written");
+    expect(said).toContain("--base-url http://localhost:4100");
+    expect(said).toContain("judgment: skipped");
+    // …and it wrote nothing.
+    await expect(readFile(join(root, "lib", "vendo.ts"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("--yes proceeds, and still says what it settled", async () => {
+    const root = await fixture();
+    const sink = consoleSink();
+    expect(await runInit({
+      targetDir: root,
+      yes: true,
+      env: {},
+      cloud: NO_CLOUD,
+      telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
+      extract: { harnesses: [] },
+    })).toBe(0);
+    const said = sink.logs.join("\n");
+    expect(said).toContain("Taking the defaults (--yes):");
+    expect(said).toContain("use case: embedded");
+    await expect(readFile(join(root, "lib", "vendo.ts"), "utf8")).resolves.toContain("createVendo");
+  });
+
+  it("names the recorded answer on a re-run, instead of a default it is not taking", async () => {
+    const root = await fixture();
+    await mkdir(join(root, ".vendo"), { recursive: true });
+    await writeFile(join(root, ".vendo", "install.json"),
+      JSON.stringify({ format: "vendo/install@1", useCase: "mcp" }));
+    const sink = consoleSink();
+    expect(await runInit({
+      targetDir: root,
+      env: {},
+      cloud: NO_CLOUD,
+      telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
+    })).toBe(1);
+    expect(sink.errors.join("\n")).toContain("use case: mcp (recorded by an earlier init)");
+  });
+
+  it("answer flags are an answer: a fully answered non-TTY run is never stopped", async () => {
+    const root = await fixture();
+    const sink = consoleSink();
+    expect(await runInit({
+      targetDir: root,
+      useCase: "embedded",
+      auth: "none",
+      byo: true,
+      baseUrl: "http://localhost:3000",
+      ai: false,
+      env: {},
+      cloud: NO_CLOUD,
+      telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
+    })).toBe(0);
+    expect(sink.errors.join("\n")).not.toContain("this run cannot ask");
+    expect(sink.logs.join("\n")).not.toContain("Taking the defaults");
+  });
+});
+
+describe("the use-case recommendation reads the loop detection", () => {
+  it("recommends agent-loop, with its reason, when the host already runs one", async () => {
+    const root = await fixture({ dependencies: { next: "16.0.0", ai: "6.0.0" } });
+    await withChatRoute(root);
+    const asked: Array<{ value: string; hint?: string }> = [];
+    expect(await run(root, output(), {
+      interactive: true,
+      selectUseCase: async (_question, options) => {
+        asked.push(...options.map((option) => ({ value: option.value, ...(option.hint === undefined ? {} : { hint: option.hint }) })));
+        return "agent-loop";
+      },
+      askText: async (_question, _hint, prefill) => prefill ?? "",
+      confirmCheck: async () => false,
+      confirmZodBump: async () => false,
+    })).toBe(0);
+    // Recommended means FIRST: index 0 is what the select defaults to.
+    expect(asked[0]?.value).toBe("agent-loop");
+    expect(asked[0]?.hint).toContain("recommended");
+    expect(asked[0]?.hint).toContain(join("app", "api", "chat").split("\\").join("/"));
+    expect(asked.map((option) => option.value)).toEqual(["agent-loop", "embedded", "mcp"]);
+  });
+
+  it("keeps embedded recommended for a host with no loop", async () => {
+    const root = await fixture();
+    const asked: Array<{ value: string; hint?: string }> = [];
+    expect(await run(root, output(), {
+      interactive: true,
+      selectUseCase: async (_question, options) => {
+        asked.push(...options.map((option) => ({ value: option.value, ...(option.hint === undefined ? {} : { hint: option.hint }) })));
+        return "embedded";
+      },
+      askText: async (_question, _hint, prefill) => prefill ?? "",
+      confirmCheck: async () => false,
+      confirmZodBump: async () => false,
+    })).toBe(0);
+    expect(asked[0]).toEqual({ value: "embedded", hint: "recommended" });
+  });
+
+  it("moves the recommendation in the --agent question form too", async () => {
+    const root = await fixture({ dependencies: { next: "16.0.0", ai: "6.0.0" } });
+    await withChatRoute(root);
+    const sink = output();
+    expect(await run(root, sink, { agent: true })).toBe(0);
+    const useCase = questionsOf(sink.logs).questions.find((question) => question.id === "use-case");
+    expect(useCase?.options[0]).toMatchObject({ flag: "--use-case agent-loop", recommended: true });
+    expect(useCase?.options[0]?.note).toContain("detected an agent loop in");
+    expect(useCase?.prompt).toContain("already runs an agent loop in");
+  });
+});
+
+describe("the --agent auth question carries the detection", () => {
+  it("recommends `none` when nothing is detected, and says why", async () => {
+    const root = await fixture();
+    const sink = output();
+    expect(await run(root, sink, { agent: true })).toBe(0);
+    const auth = questionsOf(sink.logs).questions.find((question) => question.id === "auth");
+    expect(auth?.options[0]).toMatchObject({ flag: "--auth none", recommended: true });
+    expect(auth?.options[0]?.note).toContain("no auth dependency in package.json");
+    expect(auth?.prompt).toContain("Nothing was detected");
+    // Every family is still offered — the recommendation is not a shortlist.
+    const flags = auth?.options.map((option) => option.flag);
+    expect(flags).toContain("--auth clerk");
+    expect(flags).toContain("--auth jwt");
+  });
+
+  it("recommends the DETECTED family when there is one", async () => {
+    const root = await fixture({ dependencies: { next: "16.0.0", "@clerk/nextjs": "7.0.0" } });
+    const sink = output();
+    expect(await run(root, sink, { agent: true })).toBe(0);
+    const questions = questionsOf(sink.logs);
+    expect(questions.detected.auth).toBe("clerk");
+    const auth = questions.questions.find((question) => question.id === "auth");
+    expect(auth?.options[0]).toMatchObject({ flag: "--auth clerk", recommended: true });
+  });
+});
+
+/** The MCP fixture: a Next host with a real auth family, so the door can open. */
+async function mcpFixture(): Promise<string> {
+  const root = await fixture({ dependencies: { next: "16.0.0", "@clerk/nextjs": "7.0.0" } }, "vendo-install-dx-mcp-");
+  return root;
+}
+
+describe("the MCP re-run false alarm", () => {
+  it("does not refuse a host whose existing composition already wires auth", async () => {
+    const root = await mcpFixture();
+    const first = output();
+    expect(await run(root, first, {
+      useCase: "mcp", auth: "clerk", yes: true, baseUrl: "http://localhost:3000",
+    })).toBe(0);
+    expect(await readFile(join(root, "lib", "vendo.ts"), "utf8")).toContain("auth: clerk()");
+    expect(await readFile(join(root, "app", ".well-known", "[...vendo]", "route.ts"), "utf8"))
+      .toContain("wellKnownVendoHandler");
+
+    // The re-run: no --auth, and init never re-opens a composition it did not
+    // write this run — so the ONLY evidence auth is wired is the file itself.
+    const again = output();
+    expect(await run(root, again, { useCase: "mcp", yes: true, baseUrl: "http://localhost:3000" })).toBe(0);
+    expect(again.errors.join("\n")).not.toContain("nothing MCP was written");
+    expect(again.logs.join("\n")).toContain("Point any MCP client at");
+  });
+
+  it("still refuses an anonymous composition — the door genuinely cannot open", async () => {
+    const root = await fixture({}, "vendo-install-dx-mcp-anon-");
+    const first = output();
+    expect(await run(root, first, { useCase: "mcp", auth: "none", yes: true })).toBe(0);
+    expect(first.errors.join("\n")).toContain("nothing MCP was written");
+    const again = output();
+    expect(await run(root, again, { useCase: "mcp", yes: true })).toBe(0);
+    expect(again.errors.join("\n")).toContain("nothing MCP was written");
+  });
+});
+
+describe("VENDO_SERVICE_KEY", () => {
+  const keyIn = (envLocal: string): string | undefined =>
+    /^VENDO_SERVICE_KEY=(.+)$/m.exec(envLocal)?.[1];
+
+  it("is reused on a re-run instead of rotated under the backend using it", async () => {
+    const root = await mcpFixture();
+    const answers = { useCase: "mcp" as const, yes: true, posture: "local" as const, serviceKey: true, baseUrl: "http://localhost:3000" };
+    const first = output();
+    expect(await run(root, first, { ...answers, auth: "clerk" })).toBe(0);
+    const minted = keyIn(await readFile(join(root, ".env.local"), "utf8"));
+    expect(minted).toMatch(/^[0-9a-f]{64}$/);
+    expect(first.logs.join("\n")).toContain("Generated VENDO_SERVICE_KEY");
+
+    const again = output();
+    expect(await run(root, again, answers)).toBe(0);
+    expect(keyIn(await readFile(join(root, ".env.local"), "utf8"))).toBe(minted);
+    expect(again.logs.join("\n")).toContain("VENDO_SERVICE_KEY already set — reused");
+    expect(again.logs.join("\n")).not.toContain("Generated VENDO_SERVICE_KEY");
+  });
+
+  it("replaces a value that is not a key this door could exchange", async () => {
+    const root = await mcpFixture();
+    await writeFile(join(root, ".env.local"), "VENDO_SERVICE_KEY=not-a-key\n");
+    const sink = output();
+    expect(await run(root, sink, {
+      useCase: "mcp", auth: "clerk", yes: true, posture: "local", serviceKey: true, baseUrl: "http://localhost:3000",
+    })).toBe(0);
+    expect(keyIn(await readFile(join(root, ".env.local"), "utf8"))).toMatch(/^[0-9a-f]{64}$/);
+    expect(sink.logs.join("\n")).toContain("Generated VENDO_SERVICE_KEY");
+  });
+});
+
+describe("what the generated files import becomes a host dependency", () => {
+  /** `hasInstalledTree`: a host that has installed nothing is not this repair's
+   *  business, so the fixture has to have a tree for the repair to be reached. */
+  async function installedHost(manifest: Record<string, unknown>): Promise<string> {
+    const root = await fixture(manifest, "vendo-install-dx-deps-");
+    await mkdir(join(root, "node_modules"), { recursive: true });
+    return root;
+  }
+
+  it("installs @vendoai/vendo when the host's package.json never declared it", async () => {
+    // The backend path: the docs there wire the composition without ever
+    // installing the package the scaffold imports.
+    const root = await installedHost({ dependencies: { next: "16.0.0" } });
+    const installs: Array<{ command: string; args: string[] }> = [];
+    const sink = output();
+    expect(await run(root, sink, {
+      yes: true,
+      installVendo: async (command, args) => { installs.push({ command, args }); return 0; },
+    })).toBe(0);
+    expect(installs).toHaveLength(1);
+    expect(installs[0]?.args).toContain(`@vendoai/vendo@${CLI_VERSION}`);
+    expect(sink.logs.join("\n")).toContain("Installing what the generated files import");
+    // The generated file really does import it — the claim is not canned.
+    expect(await readFile(join(root, "lib", "vendo.ts"), "utf8")).toContain('from "@vendoai/vendo/server"');
+  });
+
+  /** The gate has to be the app's OWN tree, or the nearest lockfile root — never a
+   *  free walk to `/`. A stray `/tmp/node_modules` (this machine has one) made a
+   *  scratch directory look installed, and init shelled a real `pnpm add` at it. */
+  it("never touches a host that has installed nothing yet", async () => {
+    const root = await fixture({ dependencies: { next: "16.0.0" } }, "vendo-install-dx-fresh-");
+    const installs: string[][] = [];
+    expect(await run(root, output(), {
+      yes: true,
+      installVendo: async (_command, args) => { installs.push(args); return 0; },
+    })).toBe(0);
+    expect(installs).toEqual([]);
+    // …and the composition it wrote really does import the package it did not
+    // install, so this is a deliberate deferral and not a missed case.
+    expect(await readFile(join(root, "lib", "vendo.ts"), "utf8")).toContain('from "@vendoai/vendo/server"');
+  });
+
+  it("stays quiet when the host already declares it (alias included)", async () => {
+    for (const dependencies of [
+      { next: "16.0.0", "@vendoai/vendo": "0.28.0" },
+      { next: "16.0.0", vendoai: "0.28.0" },
+    ]) {
+      const root = await installedHost({ dependencies });
+      const installs: string[][] = [];
+      expect(await run(root, output(), {
+        yes: true,
+        installVendo: async (_command, args) => { installs.push(args); return 0; },
+      })).toBe(0);
+      expect(installs).toEqual([]);
+    }
+  });
+
+  it("names the exact command when the install fails, instead of shipping a build that cannot compile", async () => {
+    const root = await installedHost({ dependencies: { next: "16.0.0" } });
+    const sink = output();
+    expect(await run(root, sink, { yes: true, installVendo: async () => 1 })).toBe(0);
+    const warned = sink.errors.join("\n");
+    expect(warned).toContain("could not install");
+    expect(warned).toContain("@vendoai/vendo");
+    expect(warned).toContain("which your package.json does not declare");
+  });
+});
+
+describe("the agent-loop paste compiles as printed", () => {
+  it("declares the principal from the preset the composition wires", async () => {
+    const root = await fixture({ dependencies: { next: "16.0.0", ai: "6.0.0", "@clerk/nextjs": "7.0.0" } });
+    const sink = output();
+    expect(await run(root, sink, { useCase: "agent-loop", auth: "clerk", yes: true })).toBe(0);
+    const logs = sink.logs.join("\n");
+    expect(logs).toContain('import { clerk } from "@vendoai/vendo/auth/clerk";');
+    expect(logs).toContain("const principal = await clerk().principal(request);");
+    expect(logs).toContain('if (principal === null) return new Response("Unauthorized", { status: 401 });');
+    // …and never the bare `principal` that was declared nowhere.
+    expect(logs).not.toContain("{ ...yourTools, ...(await vendoTools(vendo, { principal })) }\n  (Your loop");
+  });
+
+  it("declares the SAME anonymous principal the composition resolves", async () => {
+    const root = await fixture({ dependencies: { next: "16.0.0", ai: "6.0.0" } });
+    const sink = output();
+    expect(await run(root, sink, { useCase: "agent-loop", auth: "none", yes: true })).toBe(0);
+    expect(sink.logs.join("\n")).toContain('const principal = { kind: "user", subject: "demo-user" } as const;');
+    expect(await readFile(join(root, "lib", "vendo.ts"), "utf8")).toContain('subject: "demo-user"');
+  });
+
+  it("names the host's own chat route under src/, never a path it does not have", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vendo-install-dx-src-"));
+    cleanup.push(root);
+    await mkdir(join(root, "src", "app"), { recursive: true });
+    await writeFile(join(root, "package.json"), JSON.stringify({
+      name: "host",
+      dependencies: { next: "16.0.0", ai: "6.0.0", "@vendoai/vendo": "0.3.0" },
+    }));
+    await writeFile(join(root, "src", "app", "layout.tsx"),
+      "export default function Layout({ children }) { return <html><body>{children}</body></html>; }\n");
+    const sink = output();
+    expect(await run(root, sink, { useCase: "agent-loop", auth: "none", yes: true })).toBe(0);
+    expect(sink.logs.join("\n")).toContain(`File: ${join("src", "app", "api", "chat", "route.ts")}`);
+    expect(sink.logs.join("\n")).not.toContain(`File: ${join("app", "api", "chat", "route.ts")}`);
+  });
+
+  it("resolves <your-agent> to the Mastra agent the host actually has", async () => {
+    const root = await fixture({ dependencies: { next: "16.0.0", "@mastra/core": "1.0.0" } });
+    await mkdir(join(root, "src", "mastra", "agents"), { recursive: true });
+    await writeFile(join(root, "src", "mastra", "agents", "support.ts"), "export const support = {};\n");
+    const sink = output();
+    expect(await run(root, sink, { useCase: "agent-loop", auth: "none", yes: true })).toBe(0);
+    const logs = sink.logs.join("\n");
+    expect(logs).toContain(`File: ${join("src", "mastra", "agents", "support.ts")}`);
+    expect(logs).not.toContain("<your-agent>");
+  });
+
+  it("keeps the placeholder when there is no agent file to name", async () => {
+    const root = await fixture({ dependencies: { next: "16.0.0", "@mastra/core": "1.0.0" } });
+    const sink = output();
+    expect(await run(root, sink, { useCase: "agent-loop", auth: "none", yes: true })).toBe(0);
+    expect(sink.logs.join("\n")).toContain("<your-agent>.ts");
+  });
+});
+
+describe("the mount paste is gated on the use case", () => {
+  it.each(["agent-loop", "mcp"] as const)("owes no <VendoProvider> paste for %s", async (useCase) => {
+    const root = await fixture({ dependencies: { next: "16.0.0", "@clerk/nextjs": "7.0.0" } });
+    const sink = output();
+    expect(await run(root, sink, { useCase, auth: "clerk", yes: true, baseUrl: "http://localhost:3000" })).toBe(0);
+    const logs = sink.logs.join("\n");
+    expect(logs).not.toContain("VendoProvider");
+    expect(logs).not.toContain("VendoOverlay");
+  });
+
+  it("still owes it for an embedded install", async () => {
+    const root = await fixture();
+    const sink = output();
+    expect(await run(root, sink, { useCase: "embedded", auth: "none", yes: true })).toBe(0);
+    expect(sink.logs.join("\n")).toContain("VendoOverlay");
+  });
+});
+
+describe("VENDO_BASE_URL reaches .env.local from an attended terminal", () => {
+  /** The condition that made the field observations disagree: init's run-wide
+   *  `interactive` folds in `invokedByPackageScript()`, and npm sets
+   *  `npm_lifecycle_event` for EVERY `npm run …` — so the same person in the same
+   *  terminal got the question from `npx vendo init` (event "npx", excluded) and
+   *  no question at all through any wrapper script. This question's posture is
+   *  its own now: a terminal is all it asks for. */
+  it("asks and writes even when a package script launched init", async () => {
+    vi.stubEnv("npm_lifecycle_event", "setup");
+    const tty = { in: process.stdin.isTTY, out: process.stdout.isTTY };
+    process.stdin.isTTY = true;
+    process.stdout.isTTY = true;
+    const root = await fixture({ scripts: { dev: "next dev --port 4200", setup: "vendo init" } });
+    const sink = output();
+    try {
+      expect(await run(root, sink, {
+        ai: false,
+        cloud: { ...NO_CLOUD, models: "later" },
+        askText: async (_question, _hint, prefill) => prefill ?? "",
+        confirmCheck: async () => false,
+        confirmZodBump: async () => false,
+      })).toBe(0);
+    } finally {
+      process.stdin.isTTY = tty.in;
+      process.stdout.isTTY = tty.out;
+    }
+    expect(await readFile(join(root, ".env.local"), "utf8")).toContain("VENDO_BASE_URL=http://localhost:4200");
+    expect(sink.logs.join("\n")).toContain("Wrote VENDO_BASE_URL=http://localhost:4200 to .env.local");
+  });
+});
+
+describe("agent mode grades", () => {
+  it("runs the judgment pass with an available engine and receipts the file", async () => {
+    const root = await fixture();
+    const sink = output();
+    let ran = 0;
+    expect(await runInit({
+      targetDir: root,
+      output: sink.output,
+      env: {},
+      cloud: NO_CLOUD,
+      telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
+      agent: true,
+      useCase: "embedded",
+      auth: "none",
+      byo: true,
+      baseUrl: "http://localhost:3000",
+      extract: {
+        harnesses: [{
+          id: "scripted",
+          availability: async () => "a scripted harness",
+          run: async () => "```json\n" + JSON.stringify({ tools: [] }) + "\n```",
+        }],
+        confirm: async () => { throw new Error("agent mode must never ask for consent"); },
+      },
+    }).then((code) => { ran += 1; return code; })).toBe(0);
+    expect(ran).toBe(1);
+    const receipt = receiptOf(sink.logs);
+    expect(receipt.judgment.status).toBe("graded");
+    expect(receipt.judgment).toMatchObject({ file: join(".vendo", "judgments.json") });
+  });
+});

--- a/packages/vendo/tests/cli/init.test.ts
+++ b/packages/vendo/tests/cli/init.test.ts
@@ -127,13 +127,21 @@ function run(root: string, sink: { output: Output }, extra: Partial<Parameters<t
 
 /** An --agent run with every question already answered: the WRITE pass, whose
     last line is the receipt. Leaving any one of them off makes it the ask
-    pass instead. */
+    pass instead.
+
+    `harnesses: []` because agent mode GRADES now (2026-08-18): without an empty
+    ladder these runs would probe the developer's own machine and, where Claude
+    Code is installed, spend a real model call per test. A test that wants the
+    pass to run supplies its own scripted harness. */
 function agentRun(
   root: string,
   sink: { output: Output },
   extra: Partial<Parameters<typeof runInit>[0]> = {},
 ): Promise<number> {
-  return run(root, sink, { agent: true, useCase: "embedded", auth: "none", byo: true, baseUrl: "http://localhost:3000", ...extra });
+  return run(root, sink, {
+    agent: true, useCase: "embedded", auth: "none", byo: true, baseUrl: "http://localhost:3000",
+    extract: { harnesses: [] }, ...extra,
+  });
 }
 
 const receiptOf = (logs: string[]): InitReceipt => JSON.parse(logs.at(-1)!) as InitReceipt;
@@ -348,7 +356,7 @@ describe("vendo init (zero-question)", () => {
     expect(route).toContain(`auth: ${preset}(),`);
     // The detected line carries its escape hatch, and the preset owns the
     // principal seam — no hand-wired anonymous resolver remains.
-    expect(route).toContain("https://docs.vendo.run/connect/act-as-presets");
+    expect(route).toContain("https://docs.vendo.run/production/auth");
     expect(route).not.toContain("principal");
     // Detection is silent: no question, no advisory.
     expect(sink.logs.join("\n")).not.toContain("Auth:");
@@ -457,7 +465,7 @@ describe("vendo init (zero-question)", () => {
     expect(route).toContain("auth: clerk(),");
     expect(route).toContain("// Selected Clerk — clerk() fills the identity seams");
     expect(route).not.toContain("Detected");
-    expect(route).toContain("https://docs.vendo.run/connect/act-as-presets");
+    expect(route).toContain("https://docs.vendo.run/production/auth");
     expect(route).not.toContain("principal");
     // …plus one install hint, since @clerk/backend is not in package.json.
     const advisories = sink.logs.filter((line) => line.includes("Auth:"));
@@ -484,7 +492,7 @@ describe("vendo init (zero-question)", () => {
     const advisories = sink.logs.filter((line) => line.includes("Auth:"));
     expect(advisories).toHaveLength(1);
     expect(advisories[0]).toContain("auth: jwt({ secret:");
-    expect(advisories[0]).toContain("https://docs.vendo.run/connect/act-as-presets");
+    expect(advisories[0]).toContain("https://docs.vendo.run/production/auth");
   });
 
   it("ambiguous detection offers the picker with detected families first (after none)", async () => {
@@ -1936,8 +1944,9 @@ describe("vendo init --agent (ask first, then write)", () => {
     expect(Array.isArray(receipt.riskRecommendations)).toBe(true);
     // The retired plan dump's fields are gone with it.
     expect(sink.logs.join("\n")).not.toContain("codeChanges");
-    // Agent mode never spawns a judgment engine and never asks to.
-    expect(sink.logs.join("\n")).toContain("Judgment: delegated to you");
+    // Agent mode asks for the judgment pass now; no engine resolves in a test
+    // fixture, so the checklist comes back as the caller's required work.
+    expect(sink.logs.join("\n")).not.toContain("Judgment: delegated to you");
   });
 
   it("asks MCP's two extra questions on the re-run that picked mcp", async () => {
@@ -2005,24 +2014,40 @@ describe("vendo init --agent (ask first, then write)", () => {
     expect(questionsOf(after.logs).questions.map((question) => question.id)).toEqual(["use-case", "auth", "dev-url"]);
   });
 
-  /** `--ai` cannot buy an engine here: the caller IS one. The harness below
-      throws the moment the ladder probes it, so reaching it fails the test. */
-  it("stays delegated under --ai and never probes an engine", async () => {
+  /** Agent mode GRADES (2026-08-18, Yousef's direction): the pass is a scripted,
+      skeptic-checked engine run, so "delegated to you" meant every agent install
+      shipped an ungraded catalog whose every tool asked on each call. It never
+      ASKS for consent — the mode is the consent — and the delegated receipt is
+      the one fallback left, for a machine with no engine at all. */
+  it("grades under --agent with an available engine, and never asks for consent", async () => {
     const root = await fixture();
     const sink = output();
+    let ran = 0;
     expect(await agentRun(root, sink, {
-      ai: true,
       extract: {
         harnesses: [{
-          id: "never",
-          availability: async () => { throw new Error("probed an engine"); },
-          run: async () => { throw new Error("ran an engine"); },
+          id: "scripted",
+          availability: async () => "a scripted harness",
+          run: async () => { ran += 1; return "```json\n" + JSON.stringify({ tools: [] }) + "\n```"; },
         }],
         confirm: async () => { throw new Error("asked for AI consent"); },
       },
     })).toBe(0);
-    expect(sink.logs.join("\n")).toContain("Judgment: delegated to you");
-    expect(receiptOf(sink.logs).judgment.status).toBe("delegated");
+    expect(ran).toBeGreaterThan(0);
+    expect(sink.logs.join("\n")).not.toContain("Judgment: delegated to you");
+    expect(receiptOf(sink.logs).judgment.status).toBe("graded");
+  });
+
+  /** …and with NO engine on the machine, the checklist comes back as REQUIRED
+      work rather than as a default nobody chose. */
+  it("hands the grading back as required work when no engine resolves", async () => {
+    const root = await fixture();
+    const sink = output();
+    expect(await agentRun(root, sink, { extract: { harnesses: [] } })).toBe(0);
+    expect(sink.logs.join("\n")).toContain("judgment: REQUIRED, not done");
+    const receipt = receiptOf(sink.logs);
+    expect(receipt.judgment.status).toBe("delegated");
+    expect(receipt.judgment).toHaveProperty("checklist");
   });
 
   it("writes and receipts the agent-loop and mcp arms too", async () => {
@@ -2668,7 +2693,10 @@ describe("the five questions", () => {
     const aiSink = output();
     expect(await run(aiSdk, aiSink, { useCase: "agent-loop" })).toBe(0);
     const aiLogs = aiSink.logs.join("\n");
-    expect(aiLogs).toContain("2 STEPS LEFT");
+    // ONE step, not two: an agent-loop install mounts no Vendo UI by design, so
+    // the <VendoProvider> paste is not a step it owes (the rule doctor grades by).
+    expect(aiLogs).toContain("ONE STEP LEFT");
+    expect(aiLogs).not.toContain("VendoOverlay");
     expect(aiLogs).toContain('import { vendoTools } from "@vendoai/vendo/ai-sdk";');
     // The `vendo` the snippet calls has to COME from somewhere: a second
     // createVendo in the loop shares no state with the wire the embeds call.
@@ -2684,7 +2712,7 @@ describe("the five questions", () => {
     const mastraSink = output();
     expect(await run(mastra, mastraSink, { useCase: "agent-loop" })).toBe(0);
     const mastraLogs = mastraSink.logs.join("\n");
-    expect(mastraLogs).toContain("3 STEPS LEFT");
+    expect(mastraLogs).toContain("2 STEPS LEFT");
     expect(mastraLogs).toContain("vendoMastraTools");
     expect(mastraLogs).toContain("VENDO_PRINCIPAL_KEY");
   });

--- a/packages/vendo/tests/cli/judge/receipt.test.ts
+++ b/packages/vendo/tests/cli/judge/receipt.test.ts
@@ -1,0 +1,104 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { VENDO_TOOLS_FORMAT, type ExtractedTool } from "@vendoai/actions";
+import type { ExtractionHarness } from "../../../src/cli/extract/harness.js";
+import { runJudgmentPass, type JudgmentPassOptions } from "../../../src/cli/judge/pass.js";
+
+/**
+ * The judgment receipt used to name only its tallies, and three separate auditors
+ * read "hardened fields (2)" next to an unchanged `tools.json` full of
+ * `risk: "ungraded"` and concluded the pass had done nothing. Grades are a
+ * SEPARATE layer by design — tools.json is the raw scan, judgments.json is what a
+ * model proposed and a skeptic kept, and the runtime merges them — so the receipt
+ * has to name both files or the split reads as a bug.
+ *
+ * The restart hint rides with it: a running dev server read the judgments once,
+ * at boot, so grades written by `vendo sync --ai` do not reach the process the
+ * developer is looking at until it restarts.
+ */
+
+const temporary: string[] = [];
+afterEach(async () => {
+  await Promise.all(temporary.splice(0).map((directory) => rm(directory, { recursive: true, force: true })));
+});
+
+const tool = (name: string): ExtractedTool => ({
+  name,
+  description: `Use this to call ${name}.`,
+  inputSchema: { type: "object", properties: {} },
+  risk: "ungraded",
+  binding: { kind: "route", method: "GET", path: `/api/${name}`, argsIn: "query" },
+  srcHash: `sha256:${name}`,
+});
+
+const reply = (value: unknown): string => `\`\`\`json\n${JSON.stringify(value)}\n\`\`\``;
+
+function scripted(responses: string[]): ExtractionHarness {
+  return {
+    id: "scripted",
+    availability: async () => "scripted engine",
+    async run() {
+      const next = responses.shift();
+      if (next === undefined) throw new Error("scripted harness exhausted");
+      return next;
+    },
+  };
+}
+
+async function judgeOne(): Promise<{ logs: string[]; root: string }> {
+  const root = await mkdtemp(join(tmpdir(), "vendo-judge-receipt-"));
+  temporary.push(root);
+  const out = join(root, ".vendo");
+  await mkdir(out, { recursive: true });
+  await writeFile(
+    join(out, "tools.json"),
+    `${JSON.stringify({ format: VENDO_TOOLS_FORMAT, tools: [tool("host_customers_list")] }, null, 2)}\n`,
+    "utf8",
+  );
+  const logs: string[] = [];
+  const options: JudgmentPassOptions = {
+    root,
+    out,
+    mode: "full",
+    loosenings: "queue",
+    env: {},
+    output: { log: (message) => logs.push(message), error: () => {} },
+    harness: scripted([
+      reply({
+        tools: [{ name: "host_customers_list", risk: "read", evidence: "select().from(customers)" }],
+        narrative: "one read",
+      }),
+      reply({ verdicts: [{ name: "host_customers_list", field: "risk", verdict: "uphold" }] }),
+    ]),
+  };
+  const result = await runJudgmentPass(options);
+  expect(result.status).toBe("judged");
+  return { logs, root };
+}
+
+describe("the judgment receipt", () => {
+  it("names the file the grades landed in, and the merge that makes tools.json still say ungraded", async () => {
+    const { logs, root } = await judgeOne();
+    const said = logs.join("\n");
+    expect(said).toContain(`grades written to ${join(".vendo", "judgments.json")}`);
+    expect(said).toContain("tools.json keeps the raw scan; the runtime merges both");
+
+    // Both halves of the claim are literally true on disk: the grade is in
+    // judgments.json, and tools.json is untouched by it.
+    const judgments = JSON.parse(await readFile(join(root, ".vendo", "judgments.json"), "utf8")) as {
+      tools: Record<string, { fields?: { risk?: string } }>;
+    };
+    expect(judgments.tools["host_customers_list"]?.fields?.risk).toBe("read");
+    const tools = JSON.parse(await readFile(join(root, ".vendo", "tools.json"), "utf8")) as {
+      tools: Array<{ risk: string }>;
+    };
+    expect(tools.tools[0]?.risk).toBe("ungraded");
+  });
+
+  it("tells the developer to restart the dev server, which is the only way a running one sees them", async () => {
+    const { logs } = await judgeOne();
+    expect(logs.join("\n")).toContain("restart your dev server to pick up the new grades");
+  });
+});

--- a/packages/vendo/tests/cli/pretty.test.ts
+++ b/packages/vendo/tests/cli/pretty.test.ts
@@ -471,10 +471,10 @@ describe("createPrettyOutput (visual system)", () => {
     pretty.log("\n  Without it, nothing on the page can reach Vendo.");
     pretty.log(rule);
     const plain = out.plain();
-    expect(plain).toContain("docs.vendo.run/quickstart#the-client-mount — exact wording for layout.tsx and _app.tsx");
+    expect(plain).toContain("docs.vendo.run/product/mount-the-surface#the-provider — exact wording for layout.tsx and _app.tsx");
     // Right under the wrap line it explains, and dim.
-    expect(plain.indexOf("</VendoProvider>")).toBeLessThan(plain.indexOf("docs.vendo.run/quickstart"));
-    expect(out.raw()).toContain(`${ESC}[2mdocs.vendo.run/quickstart#the-client-mount`);
+    expect(plain.indexOf("</VendoProvider>")).toBeLessThan(plain.indexOf("docs.vendo.run/product/mount-the-surface"));
+    expect(out.raw()).toContain(`${ESC}[2mdocs.vendo.run/product/mount-the-surface#the-provider`);
   });
 
   it("prints the mount paste as real JSX, with a dim … for the app tree already there", () => {
@@ -501,7 +501,7 @@ describe("createPrettyOutput (visual system)", () => {
     // The app tree is a dim PLACEHOLDER, not code to paste…
     expect(out.raw()).toContain(`${ESC}[2m…${ESC}[22m`);
     // …which is exactly what the docs pointer under it exists to resolve.
-    expect(plain.indexOf("│    </VendoProvider>")).toBeLessThan(plain.indexOf("docs.vendo.run/quickstart"));
+    expect(plain.indexOf("│    </VendoProvider>")).toBeLessThan(plain.indexOf("docs.vendo.run/product/mount-the-surface"));
   });
 
   it("keeps the real JSX when the host is a pages `_app` — the child expression differs, the shape does not", () => {

--- a/packages/vendo/tests/hosted-store-notice.test.ts
+++ b/packages/vendo/tests/hosted-store-notice.test.ts
@@ -1,5 +1,5 @@
 import type { LanguageModel } from "ai";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createVendo } from "../src/server.js";
 import { fakeConsole } from "@vendoai/store/test-util";
 
@@ -7,9 +7,34 @@ import { fakeConsole } from "@vendoai/store/test-util";
  * Self-serve audit F7: the hosted-store automations notice is a boot fact, but
  * a Next dev server recomposes on nearly every request — the paragraph landed
  * in the host's log 29 times in one short session. It is latched per PROCESS.
+ *
+ * "Per process" is the whole claim, and a MODULE-scoped `let` does not make it:
+ * Next's dev server re-instantiates the module graph too, so the latch was reborn
+ * every couple of seconds and the notice — and the `vendo ready` block beside it —
+ * came back with it. The first test below could never see that: it composes three
+ * times through ONE module instance, which is exactly the case a module-scoped
+ * latch already handles. The second test is the one that reproduces a dev-server
+ * reload, and both latches now live on `globalThis`, which is the only thing in
+ * the process that survives one.
  */
 
+/** The two process-wide latches, by the registered symbols their modules use. */
+const LATCHES = [
+  Symbol.for("vendo.compose-store.hosted-notice"),
+  Symbol.for("vendo.boot-summary.announced"),
+];
+
+const HOSTED_NOTICE = "Vendo Cloud is the hosted store for this deployment";
+const READY_BLOCK = "[vendo] ready";
+
 const cleanups: Array<() => Promise<void>> = [];
+
+/** A latch that outlives the module also outlives the TEST, so each case clears
+ *  it — which is itself the proof it is not module-scoped any more. */
+beforeEach(() => {
+  for (const latch of LATCHES) delete (globalThis as unknown as Record<symbol, unknown>)[latch];
+});
+
 afterEach(async () => {
   for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
   vi.unstubAllEnvs();
@@ -17,23 +42,57 @@ afterEach(async () => {
   vi.restoreAllMocks();
 });
 
-function compose(): void {
-  const vendo = createVendo({ models: { default: {} as LanguageModel }, principal: async () => null });
+type Compose = typeof createVendo;
+
+function composeWith(create: Compose): void {
+  const vendo = create({ models: { default: {} as LanguageModel }, principal: async () => null });
   cleanups.push(async () => { await vendo.store.close(); });
+}
+
+function hostedEnv(): void {
+  vi.stubEnv("VENDO_API_KEY", "vnd_hosted_key");
+  vi.stubEnv("VENDO_CLOUD_URL", "https://cloud-notice.test");
+  vi.stubGlobal("fetch", fakeConsole().handler as unknown as typeof fetch);
+}
+
+/** Every console line either latch can produce, whatever level it rode. */
+function said(spies: Array<{ mock: { calls: unknown[][] } }>, needle: string): unknown[] {
+  return spies.flatMap((spy) => spy.mock.calls.flat()).filter((message) => String(message).includes(needle));
 }
 
 describe("the hosted-store automations notice", () => {
   it("prints once per process, however many compositions there are", async () => {
-    vi.stubEnv("VENDO_API_KEY", "vnd_hosted_key");
-    vi.stubEnv("VENDO_CLOUD_URL", "https://cloud-notice.test");
-    vi.stubGlobal("fetch", fakeConsole().handler as unknown as typeof fetch);
+    hostedEnv();
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-    for (let index = 0; index < 3; index += 1) compose();
+    for (let index = 0; index < 3; index += 1) composeWith(createVendo);
 
-    const printed = warn.mock.calls
-      .flat()
-      .filter((message) => String(message).includes("Vendo Cloud is the hosted store for this deployment"));
-    expect(printed).toHaveLength(1);
+    expect(said([warn], HOSTED_NOTICE)).toHaveLength(1);
+  });
+
+  it("stays latched across a module re-instantiation — the dev-server reload", async () => {
+    hostedEnv();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    // Its OWN module graph to start from, so the count below is this test's
+    // alone — the case above already used the one this file imported.
+    vi.resetModules();
+    const booted = await import("../src/server.js");
+    composeWith(booted.createVendo);
+    expect(said([warn], HOSTED_NOTICE)).toHaveLength(1);
+    expect(said([warn, log], READY_BLOCK)).toHaveLength(1);
+
+    // A FRESH module graph, which is what Next hands a reloaded dev server: the
+    // modules holding the latches are constructed again from scratch.
+    vi.resetModules();
+    const reloaded = await import("../src/server.js");
+    expect(reloaded.createVendo).not.toBe(booted.createVendo);
+    composeWith(reloaded.createVendo);
+
+    // Still once. A module-scoped latch says twice here, every ~2 seconds, for as
+    // long as the dev server is polling.
+    expect(said([warn], HOSTED_NOTICE)).toHaveLength(1);
+    expect(said([warn, log], READY_BLOCK)).toHaveLength(1);
   });
 });


### PR DESCRIPTION
The install-DX repairs from the real-world audit of published 0.28.0. Fourteen
findings, each one approved individually; nothing else.

## What changed, per item

**1 — Non-TTY init requires `--yes`.** A CLI run that cannot ask now prints the
defaults it *would* take — each naming the flag that answers it — and exits 1;
`--yes` proceeds and still says what it settled. What counts as "unanswered" is
`initQuestions`' own list, so the guard and `--agent`'s relay can never disagree
about what a person owns. Only the CLI is guarded (`options.output === undefined`
is the same seam the renderer is selected by); `--agent` relays instead.
*Proven:* `init-install-dx.test.ts` "a run that cannot ask stops instead of
answering for you" (3 cases, driven through the real console). Revert-check: 2 red.

**2 — `--agent` always runs the AI grading step.** The mode is the consent
(`ai: true` unless `--no-ai`); the `delegated` option and its "Judgment:
delegated to you" line are gone. With no engine on the machine, the receipt hands
back `{ status: "delegated", checklist }` and the run prints
`judgment: REQUIRED, not done — …`. `cli.ts` no longer rejects `--ai`/`--engine`
with `--agent`. *Proven:* "agent mode grades" (scripted harness → `graded`, and a
`confirm` seam that throws if consent is ever asked) + "hands the grading back as
required work when no engine resolves". Revert-check: 1 red.

**3 — Loop detection drives the use-case recommendation.** `runsAgentLoop` is now
exported from `@vendoai/actions/sync` — the *same* marker the route scanner
excludes on, so the recommendation and the exclusion cannot drift — and
`detectAgentLoopRoute` (framework.ts) finds the host's own API-route loop. When
one is found, `agent-loop` is first (index 0 is what a select defaults to, so
ordering *is* the recommendation) and carries its reason, in both the interactive
select and the `--agent` question form. The unattended DEFAULT stays `embedded`.
*Proven:* 3 cases in "the use-case recommendation reads the loop detection".
Revert-check: 2 red.

**4 — `--agent` auth question gets detection + recommendation.** Nothing detected
→ `none` is recommended and the option says why. One family → that family (as
before). Several → the full list with no recommendation, deliberately: two
matches is ambiguous, and naming one hides the other (the same reason interactive
shows its picker). *Proven:* 2 cases. Revert-check: 1 red.

**5 — Re-run false alarm.** `planMcp` refused with "nothing MCP was written"
whenever `authWired === null` — which a re-run always is, because init never
re-decides auth for a composition it did not write. `composedAuthPreset` reads
the file, and the planner only refuses when auth genuinely is not wired.
*Proven:* "does not refuse a host whose existing composition already wires auth",
plus the control that an anonymous composition is still refused. Revert-check: 2 red.

**6 — `VENDO_SERVICE_KEY` is reused.** A well-formed existing key is reused and
nothing is written; anything else is replaced. The old path reminted on every
re-run and overwrote `.env.local`, so every backend already exchanging the key
started failing. *Proven:* 2 cases. Revert-check: 1 red.

**7 — Generated-import dependency guard.** After planning, every package the
generated CODE files import must be a declared host dependency;
`ensureGeneratedImports` installs what is missing through the same mechanism
`ensureProviderDeps` uses, and degrades to the exact manual command. The `vendoai`
alias satisfies `@vendoai/vendo`; a host that has installed nothing yet is skipped,
the same rule `ensureVendoPackage` already states. *Proven:* 3 cases (fires for the
backend path's manifest, silent for both declared spellings, names the command on
failure). Revert-check: 2 red.

**8 — Stale-grades restart hint + reload investigation.** (a) The judgment receipt
now always prints `restart your dev server to pick up the new grades` when grades
were written. (b) **Message only — the cheap reload is not cheap.** See "Item 8
decision" below.

**9 — Judgment receipt names its file.** `grades written to .vendo/judgments.json —
tools.json keeps the raw scan; the runtime merges both`. *Proven:*
`judge/receipt.test.ts` asserts the line AND that both halves are literally true
on disk (grade in judgments.json, `risk: "ungraded"` still in tools.json).

**10 — Route scan recognises `@vendoai/agents`.** Added to the recognised imports,
and `.respond(` / `.run(` now match on any receiver — `support.respond(…)` is what
a host writes, never `vendo.respond(…)`. The escape hatch is unchanged (emitted
`disabled: true` with the reason; `"disabled": false` in overrides.json puts it
back). *Proven:* `route-exclusions.agents.test.ts` (3 cases). Revert-check: 3 red.

**11 — Init tail fixes.**
- (a) No `<VendoProvider>`/`<VendoOverlay>` paste for `agent-loop`/`mcp` — the
  rule doctor already grades by. Express/custom keep their server-side line.
- (b) Both loop snippets declare the `principal` they pass: resolved from the
  preset the composition wires (with the 401 the non-nullable type requires), or
  the same anonymous literal the composition itself resolves.
- (c) `<your-agent>` resolves to the Mastra agent file the host has; the
  placeholder stays when there is none.
- (d) The chat-route path comes off the src-aware `appDirectory`.
*Proven:* 5 cases across "the agent-loop paste compiles as printed" and "the mount
paste is gated on the use case". Revert-checks: 2 red and 1 red.

**12 — Stale URLs + link test.** `existing-agents/{ai-sdk,mastra}` →
`existing-agent/*`; `quickstart#the-client-mount` →
`product/mount-the-surface#the-provider`; `agents/verify?v=…#E-CODE` →
`production/troubleshooting/e-code?v=…` (a code in a fragment never reaches the
server, so it could not select a page); `existing-agents/mcp` ×2 →
`outside-agents/quickstart`. `docs-links.test.ts` extracts every
`docs.vendo.run` URL in `src/cli/` — plus every `doctorFixRef(code)`, which is
built at runtime — and requires each to resolve DIRECTLY to a file under
`docs-site/`. Redirects are deliberately not accepted: all five stale URLs had
one, so a redirect-following check greens a CLI that has printed retired paths
for a year. *Proven:* re-breaking one URL turns it red (see the log in the
review notes). That strictness also surfaced two more CLI URLs
(`connect/act-as-presets` in `init-auth.ts` and `init-scaffolds.ts` →
`production/auth`), fixed with it.

**13 — Banner latch.** Both latches moved to `globalThis` under
`Symbol.for(…)`. Next's dev server re-instantiates the module graph, so a
module-scoped `let` was reborn every couple of seconds and both the `vendo ready`
block and the hosted-store notice flooded the log.
`hosted-store-notice.test.ts` gained a module-re-instantiation case (approved
edit); against the old code it fails with `expected [ …(2) ] to have a length of 1
but got 2`.

**14 — `VENDO_BASE_URL` verify-and-fix.** Root condition below.

## Item 8 decision: message only

A dev-mode re-read is not a trivial mtime check on access.
`loadHost()` (`packages/actions/src/runtime/registry.ts:859`) memoizes
`hostPromise` for the registry's lifetime, and the registry is created by the
module-level `createVendo` in `lib/vendo.ts`. Next's dev watcher watches source,
not `.vendo/`, so writing `judgments.json` invalidates nothing and the cached
instance keeps its memoized read — which is exactly the reported symptom.

Making it re-read would need, all together:
- a new stat seam exported from `#actions/host-files` in BOTH conditions
  (`host-files.ts` and the workerd `host-files-edge.ts`);
- an environment read inside `registry.ts`, which is a pure runtime module today;
- an `fs.stat` on the hot path — `loadHost()` is awaited by `buildRegistry`,
  `loadoutSeed` and `surfaceMenu`, i.e. every tool listing of every turn;
- invalidation for `tools.json` and `overrides.json` too, because a reload that
  picks up grades but not disables is worse than none: `overrides.json` carries
  disables and audience exclusions and is a fail-CLOSED surface.

That is a new cross-condition fs seam plus an env gate plus hot-path I/O plus a
three-file invalidation contract in a security-relevant loader — a watcher-class
change, not a one-liner. Shipping 8(a) only.

## Item 14 root condition

`captureDevBaseUrl` derived its ask from init's run-wide `interactive` flag, and
that flag folds in `invokedByPackageScript()` (`init.ts:1994-96`) — which is true
for **every** `npm run …`, because npm sets `npm_lifecycle_event` to the script
name. `npx vendo init` sets it to `"npx"`, which the helper excludes. So the same
person, in the same terminal, was asked and got a `VENDO_BASE_URL` from
`npx vendo init` and was never asked and got nothing through any wrapper script.
That is the conflicting pair of audit observations.

The question now has its own posture: it asks whether there is a TERMINAL, not
whether a package script launched init. `invokedByPackageScript()` stays in the
run-wide flag, where it exists so a `prebuild` hook can never block on a prompt.

**Still open, and a decision for Yousef:** `--yes` and a genuinely non-TTY run
still write nothing. That is a deliberate documented law with a test on it
("never asks and never writes .env.local on an unattended run": a guessed origin
is worse than an absent one). But item 1 now makes `--yes` the only way to do an
unattended install, so every unattended install ends with no `VENDO_BASE_URL` —
which contradicts the docs' promise. Changing it inverts that law and its test, so
it is not in this PR.

## Existing tests changed (and why each was unavoidable)

Each of these pinned the exact behaviour an approved item reverses:
- `init.test.ts`: agent-mode delegation → grading (item 2); agent-loop step counts
  2→1 and 3→2 (item 11a); `act-as-presets` URL → `production/auth` (item 12); the
  `agentRun` helper now passes `harnesses: []` so agent runs do not probe the
  developer's own machine and spend a real model call per test (item 2).
- `doctor-codes.test.ts`, `doctor.test.ts`, `doctor-store-persistence.test.ts`:
  the `fix_ref` URL (item 12).
- `pretty.test.ts` ×2: the mount docs URL (item 12).
- `cli.test.ts`: `--ai`/`--engine` are no longer refused with `--agent` (item 2).
- `hosted-store-notice.test.ts`: extended per the brief's explicit approval (item 13).
- `doctor-tenant-connectors.test.ts`: same `fix_ref` fragment→path swap, on a test that
  landed on main after this branch was cut (found during the rebase below).

## Pre-existing failures in this worktree (NOT from this change)

`tests/cli/init-mcp.test.ts` (1) and `tests/your-agent-docs.docs.test.ts` (2) fail
with `ENOENT … /Cool%20Code/…`: both derive paths via `new URL(...).pathname`,
which percent-encodes the space in this checkout's path. Proven pre-existing by
running them with this change stashed — identical failures. CI paths have no
space, so CI is unaffected.

## Rebase onto main (2026-08-18)

Rebased onto `5fa346d2` (#1473, #1480, #1477, #1481, #1483 landed after this branch
was cut). **One conflict**, in `packages/vendo/src/cli/framework.ts`: #1473 refactored
`wiresSupabaseAuth` onto a new shared `hostSourceMatches` helper and added
`wiresTenantConnectors` and `composesOwnStore` in the same place this branch added
`detectAgentLoopRoute`. Resolved by keeping BOTH — main's three functions verbatim,
this branch's route probe after them, with a note on why the probe does not ride
`hostSourceMatches` (it needs a narrower file filter and the PATH, not a boolean).

#1480's docs edits touched only pages that already existed (`existing-agent/ai-sdk`,
`existing-agent/mastra`, `outside-agents/quickstart`, …) — nothing renamed or removed —
so the link test still resolves every URL directly. #1477/#1481/#1483 are `packages/ui`
and `packages/apps`, with no overlap here.
