### PR TITLE
feat: arming an automation is one page and one yes

### DIFF
--- a/.changeset/expiry-is-not-a-refusal.md
+++ b/.changeset/expiry-is-not-a-refusal.md
@@ -1,0 +1,20 @@
+---
+"@vendoai/automations": patch
+---
+
+An expired arming ask no longer turns the automation off. Live 2026-08-18 on
+production Maple, automation atm_d50cd48e: 33 arming asks were created at 11:26,
+all 33 were denied at 12:27 — createdAt plus exactly the parked-call TTL — and
+the record flipped to armed=false at 12:27:37, with not one human decision ever
+recorded. The person's automation turned itself off an hour after they set it up,
+silently.
+
+The guard's hour-long sweep denies an abandoned ask as `"system"`, and the
+decision subscriber read any deny as a person's "no" and disarmed a consent
+moment that had granted nothing. It now reads WHO said no off the approval row —
+the provenance the guard already stamps, and which the decision callback (id,
+approved) cannot carry — and disarms only for a human. The guard already draws
+this line for standing denials, where it enforces only `deniedBy: "human"`; this
+was the one place that did not. A guard that stamps nothing keeps today's
+behaviour, and a human NO still disarms, so the text channel's "Okay — I turned
+it off." stays true.

--- a/.changeset/job-shaped-arming-consent.md
+++ b/.changeset/job-shaped-arming-consent.md
@@ -1,0 +1,41 @@
+---
+"@vendoai/automations": minor
+"@vendoai/vendo": minor
+"@vendoai/core": patch
+"@vendoai/guard": patch
+"@vendoai/apps": patch
+---
+
+Arming an automation is ONE page and ONE yes. Live 2026-08-18 on production
+Maple: a user armed "check my checking balance every 15 minutes and text me"
+entirely over iMessage, their YES to the job landed — and arming then minted four
+MORE per-tool asks (Text me, knowledge search, request a connection, list
+connections). Three were reads nobody needs a second opinion about, and the
+fourth was literally in the sentence they had just typed. Consent was framed
+per-tool while the person was thinking per-job.
+
+The authoring call's own approval now NAMES what the automation will hold, and
+that one yes mints all of it. The powers ride on the approval record
+(`ApprovalRequest.powers`, additive and optional, human titles only), computed
+once at park time by the composition and rendered verbatim by whoever reads it —
+the text channel today, any other surface without further work. They are grouped
+the way a person reads them: the tools that DO something named one by one, and
+every read folded into a single trailing "Read-only access to your data", because
+naming reads individually is exactly what turned a yes to a job into a wall of
+tool names.
+
+What an automation is granted has NOT changed, and neither has how it runs. The
+surface is as wide as it ever was, every away call is still grant-backed, and 05
+§6's away authority is untouched — the guard's law suites pass unmodified. Two
+kinds are excluded from standing powers because a grant could never satisfy them
+and the card would be promising what the run will not honour: `destructive` and
+`ungraded` (§12's pair, now closed on the two branches that leaked — a steps
+record's declared destructive tool, and a connector slug the risk resolver grades
+destructive), and `confirmEach`, which needs a person every time.
+
+Minting is gated on a person having actually been asked. `enable()` takes the
+authoring call (`armedBy`); when the host's policy would have asked about it, the
+call reaching the engine proves the ask was answered, so the powers are minted on
+the spot. When policy would have run it unasked — `vendo_make` is read-graded —
+nobody saw a powers page, so nothing is minted and each power is captured as a
+pending ask exactly as before, delivered by the grant-set text.

--- a/examples/demo-bank/tests/vendo/away-drill.test.ts
+++ b/examples/demo-bank/tests/vendo/away-drill.test.ts
@@ -282,6 +282,27 @@ async function enableAndApprove(stack: Stack, subject: string, record: Automatio
   }
 }
 
+/**
+ * The standing authority arming no longer mints, minted the one way left.
+ *
+ * `enable` captures nothing for `host_transferMoney`: it is destructive, THE LAW
+ * refuses a destructive away call whatever grant is held, and a card offering a
+ * standing power for one would offer what no firing honours. So the strongest
+ * authority that exists is bought at FIRE time — a firing meets a permission
+ * nobody granted, fails loud, and that ask, answered, mints the standing
+ * automation-bound automation-source grant. Which is the authority the law then
+ * has to beat.
+ */
+async function grantThroughTheRunsOwnAsk(stack: Stack, subject: string): Promise<void> {
+  const principal: Principal = { kind: "user", subject };
+  const [runId] = await stack.automations.emit("maple.payday", { requestedBy: "away-drill" }, principal);
+  expect((await stack.automations.runs.get(runId!, ownerCtx(subject)))?.error?.code).toBe("needs-permission");
+  const pending = (await stack.guard.approvals.pending(principal))
+    .filter((request) => request.call.tool === MONEY_TOOL);
+  expect(pending).toHaveLength(1);
+  await stack.guard.approvals.decide(pending.map((request) => request.id), { approve: true }, principal);
+}
+
 /** Read Maple's own API as `subject`, with a session minted the same way the
  *  away run's actAs mints one. This is the evidence channel, not the subject. */
 async function readAs(subject: string, tool: string, path: string): Promise<Response> {
@@ -463,10 +484,12 @@ describe("Maple away drill (ENG-260)", () => {
       const pay = await descriptorFor(stack, MONEY_TOOL);
       expect(pay.risk).toBe("destructive");
 
-      // Enable + approve while present: the ceremony sees the tool and mints the
-      // strongest authority that exists (automation-bound, automation-source).
-      // The law must beat it.
+      // Enable while present: the ceremony SEES the tool (no "unknown tool") and
+      // deliberately captures nothing for it, so the strongest authority that
+      // exists is minted through the run's own ask instead — see
+      // `grantThroughTheRunsOwnAsk`. The law must beat that.
       await enableAndApprove(stack, subject, paydayAutomation(automationId, subject));
+      await grantThroughTheRunsOwnAsk(stack, subject);
       const balanceBefore = await checkingBalance(subject);
 
       // 1. Not projected: an unattended run is never even offered the tool.

--- a/fixtures/automations-e2e/tests/agentic-consent.e2e.test.ts
+++ b/fixtures/automations-e2e/tests/agentic-consent.e2e.test.ts
@@ -13,9 +13,12 @@
  * has no place for the tool set an authored plan declares, so the card can no
  * longer be the plan's own width: EVERY goal record gets the fallback surface and
  * the narrowing is the person's, card by card. What still holds — and what this
- * pins — is that the fallback never asks for a standing away grant on a tool THE
- * LAW would refuse away. Asking to allow a thing that can never happen is a false
- * choice, not consent.
+ * pins — is that the fallback never asks for a standing away grant a firing could
+ * not run on. Asking to allow a thing that can never happen is a false choice, not
+ * consent, and there are two ways to be that: a tool THE LAW refuses away
+ * (`destructive`/`ungraded`), and a confirm-each tool, which needs a person EVERY
+ * time and which no grant may ever suppress. `host_invoices_send` is the first
+ * kind; `host_invoices_send_critical` is the second.
  */
 import { planAutomation, type HostToolInfo } from "@vendoai/apps";
 import { scriptedLanguageModel } from "@vendoai/apps/testing";
@@ -85,11 +88,13 @@ describe("goal consent surface", () => {
       expect(enabled.enabled).toBe(true);
       // The headline of the finding: no card for a thing this run can never do.
       expect(enabled.missing.every((request) => !withheldFromUnattended(request.descriptor))).toBe(true);
+      // …and none for a confirm-each tool either: a standing power that cannot
+      // suppress the ask it exists to answer is the same false choice.
+      expect(enabled.missing.every((request) => request.descriptor.confirmEach !== true)).toBe(true);
       expect(enabled.missing.map((request) => request.call.tool).sort()).toEqual([
         "host_invoices_create",
         "host_invoices_get",
         "host_invoices_list",
-        "host_invoices_send_critical",
         "host_invoices_update",
       ]);
       // ONE grant set, so a single decision settles the whole card.

--- a/fixtures/automations-e2e/tests/enable-capture.e2e.test.ts
+++ b/fixtures/automations-e2e/tests/enable-capture.e2e.test.ts
@@ -9,7 +9,13 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { createAutomation, createStack, ownerCtx, resetFixture, type Stack } from "../src/harness.js";
 import { ADA, BOB, approve } from "../src/support.js";
 
-const surface = ["host_invoices_list", "host_invoices_send"];
+/** Two tools a standing grant can really buy. Neither is destructive,
+ *  `ungraded`, or confirm-each on purpose: arming captures only the powers a
+ *  firing could hold, so `host_invoices_send` — which this record declared
+ *  until 2026-08-18 — is never carded and never granted, THE LAW refusing it
+ *  away whatever the owner answers. What a yes MINTS is this file's subject, so
+ *  the surface has to be two tools a yes can actually mint. */
+const surface = ["host_invoices_list", "host_invoices_update"];
 
 /** A disarmed steps record, so `enable` is what arms it and captures for it. */
 const stepsRecord = (event: string): CreateAutomationInput => ({
@@ -19,7 +25,7 @@ const stepsRecord = (event: string): CreateAutomationInput => ({
     kind: "steps",
     steps: [
       { id: "list", tool: "host_invoices_list" },
-      { id: "send", tool: "host_invoices_send", args: { id: "event.id" } },
+      { id: "update", tool: "host_invoices_update", args: { id: "event.id" } },
     ],
   },
   authoredBy: "chat",

--- a/fixtures/automations-e2e/tests/observability.e2e.test.ts
+++ b/fixtures/automations-e2e/tests/observability.e2e.test.ts
@@ -2,9 +2,46 @@
  * newest-first, owner-scoped on every door, plus dryRun — a preview that
  * executes nothing, on the store or on the live host.
  */
+import type { RunContext } from "@vendoai/core";
 import { beforeEach, describe, expect, it } from "vitest";
-import { createStack, ownerCtx, resetFixture } from "../src/harness.js";
+import { createStack, ownerCtx, resetFixture, type Stack } from "../src/harness.js";
 import { ADA, BOB, approve, enableAndApprove, fixtureInvoices, tableCount } from "../src/support.js";
+
+/**
+ * The standing automation grant a yes can no longer mint, written directly.
+ *
+ * `host_invoices_send` is destructive, so arming captures nothing for it — THE
+ * LAW refuses a destructive away call whatever grant is held, and a card
+ * promising one would promise what no firing honours. A PREVIEW still has to
+ * say what a fully granted pipeline looks like, so the row is seeded here
+ * through the guard's own mint, off the very descriptor `dryRun` hashes its
+ * grant lookup against — a hand-built one would silently not match.
+ */
+async function grantStanding(
+  stack: Stack,
+  automationId: string,
+  tool: string,
+  ctx: RunContext,
+): Promise<void> {
+  const descriptor = (await stack.bound.descriptors(ctx)).find((entry) => entry.name === tool);
+  if (descriptor === undefined) throw new Error(`${tool} is not bound`);
+  // Optional on the `VendoGuard` seam, so feature-detected the way the engine
+  // itself detects it — this stack composes the real guard, which has it.
+  if (stack.guard.mintGrant === undefined) throw new Error("the composed guard offers no grant mint");
+  await stack.guard.mintGrant({
+    request: {
+      id: `apr_seed_${tool}`,
+      call: { id: `call_seed_${tool}`, tool, args: {} },
+      descriptor,
+      inputPreview: `Allow ${tool} while you're away`,
+      ctx: { principal: ctx.principal, venue: "automation", presence: "present" },
+      createdAt: new Date().toISOString(),
+    },
+    remember: { duration: "standing" },
+    source: "automation",
+    automationId,
+  });
+}
 
 describe("run observability and dry-run", () => {
   beforeEach(resetFixture);
@@ -91,6 +128,8 @@ describe("run observability and dry-run", () => {
       expect(await tableCount(stack, "vendo_approvals")).toBe(approvalsBefore);
 
       await approve(stack, enabled.missing);
+      // …and the one arming never asked about, seeded (see `grantStanding`).
+      await grantStanding(stack, created.id, "host_invoices_send", ctx);
       const postGrant = await stack.automations.dryRun(created.id, ctx, {
         items: [{ id: "inv_0002" }, { id: "inv_0005" }],
       });
@@ -159,6 +198,10 @@ describe("run observability and dry-run", () => {
         authoredBy: "chat",
       }, ctx);
       await enableAndApprove(stack, created.id, ctx);
+      // "even when granted" is the whole point of this preview, and the send is
+      // the half arming no longer captures — so its grant is seeded (see
+      // `grantStanding`) and the pipeline really is fully granted.
+      await grantStanding(stack, created.id, "host_invoices_send", ctx);
       const runsBefore = await tableCount(stack, "vendo_runs");
 
       const plan = await stack.automations.dryRun(created.id, ctx, {});

--- a/fixtures/integration/tests/away-park-revoke.e2e.test.ts
+++ b/fixtures/integration/tests/away-park-revoke.e2e.test.ts
@@ -203,10 +203,21 @@ describe("J5: away capture, fail-loud, re-run, revoke through the composed wire"
     const automationId = await automationFor("j5.revoke", [
       { id: "send", tool: SEND, args: { id: "event.id" } },
     ]);
-    const missing = await enableMissing(automationId);
-    expect((await decideApprovals(stack, missing.map((request) => request.id), { approve: true }, ADA)).status).toBe(200);
+    // Arming captures NOTHING for a destructive tool: a standing grant could
+    // never authorize `host_invoices_send` away (THE LAW refuses it per fire),
+    // so a card promising one would promise what no run honours. The way this
+    // record comes to HOLD the grant this leg revokes is therefore the run's
+    // own ask — the first fire meets a permission nobody granted, fails loud,
+    // and the person answers THAT. Same standing, automation-bound,
+    // automation-source grant leg 1 above pins; a different door to it.
+    expect(await enableMissing(automationId)).toEqual([]);
+    const [primingRun] = await stack.vendo.emit("j5.revoke", { id: "inv_0003" }, ADA);
+    expect((await readRun(primingRun!)).error?.code).toBe("needs-permission");
+    const sendAsk = await pendingAway(SEND);
+    expect(sendAsk).toBeDefined();
+    expect((await decideApprovals(stack, [sendAsk!.id], { approve: true }, ADA)).status).toBe(200);
 
-    // First run: the standing grant does NOT authorize the away send. THE LAW
+    // The next run: the standing grant does NOT authorize the away send. THE LAW
     // (§12) "refuses a standing grant, rule, judge, or default authorizing an
     // irreversible action with nobody watching" — and `host_invoices_send` is
     // declared destructive (the dev's label is final; two-vote grading removed).
@@ -292,27 +303,16 @@ describe("J5: away capture, fail-loud, re-run, revoke through the composed wire"
       [DELETE],
     )).toEqual([{ source: "chat", app_id: null, duration: "standing" }]);
 
-    // --- The automation references the same tool; deny its capture --------
+    // --- The automation references the same tool, and arming grants it nothing --
+    // `host_invoices_delete` is destructive, so arming captures nothing for it:
+    // a standing grant could never authorize it away, and a card promising one
+    // would promise what no firing honours. The record therefore arms holding
+    // no automation authority at all — which is exactly the state this leg
+    // needs, and it arrives without anyone having to refuse anything.
     const automationId = await automationFor("j5.chatgrant", [
       { id: "delete", tool: DELETE, args: { id: "event.id" } },
     ]);
-    const missing = await enableMissing(automationId);
-    expect((await decideApprovals(stack, missing.map((request) => request.id), { approve: false }, ADA)).status).toBe(200);
-
-    // Grant sets (demo-live-readiness): a consent moment refused WHOLESALE
-    // (every capture denied, nothing granted) disarms the automation in the
-    // same decision — the row must not sit enabled-but-ungranted. GET /automations
-    // is a FLAT list of records now, and `armed` is the field that says so.
-    const listed = (await (await stack.wireFetch("/automations", {}, ADA)).json()) as Array<{
-      id: string;
-      armed: boolean;
-    }>;
-    expect(listed.find((entry) => entry.id === automationId)?.armed).toBe(false);
-
-    // Re-arm; the re-minted capture ask stays UNDECIDED — an open ask leaves
-    // the automation armed and the ungranted step fails loud at fire time, the
-    // moment this leg actually exercises.
-    await enableMissing(automationId);
+    expect(await enableMissing(automationId)).toEqual([]);
 
     // --- Fire: the away run fails loud; the chat grant does not carry across --
     expect(await invoice("inv_0002")).toBeDefined(); // exists before

--- a/fixtures/integration/tests/law-presence-predicate.e2e.test.ts
+++ b/fixtures/integration/tests/law-presence-predicate.e2e.test.ts
@@ -9,13 +9,23 @@
  * about the very tools it exists to ask about, which breaks the law's own
  * prescribed prepare-then-human-sends path.
  *
- * This is the narrow regression pin: enable a destructive host tool, get a
- * consent card for it, and the card is addressed to a PRESENT person.
+ * This is the narrow regression pin: enable an automation declaring a
+ * destructive host tool and the ceremony goes THROUGH — the 200 is what proves
+ * it saw the tool — and the cards it does mint are addressed to a PRESENT
+ * person.
+ *
+ * The destructive tool itself is deliberately not among them. Arming captures
+ * only what a standing grant could satisfy, and THE LAW refuses a destructive
+ * away call whatever anyone answered, so a card for `host_invoices_send` would
+ * promise something no firing will honour. Hence the second declared step: a
+ * read the ceremony really does card, which is what carries the present-person
+ * assertion the old predicate could not represent.
  */
 import { afterEach, describe, expect, it } from "vitest";
 import { ADA, createAutomation, createStack, resetFixture, type Stack } from "../src/harness.js";
 
 const SEND = "host_invoices_send";
+const LIST = "host_invoices_list";
 
 let stack: Stack;
 afterEach(async () => {
@@ -29,7 +39,13 @@ describe("THE LAW: the enable ceremony sees the tools it asks about", () => {
     const { id } = await createAutomation(stack, {
       owner: ADA,
       when: { event: "law.predicate" },
-      task: { kind: "steps", steps: [{ id: "send", tool: SEND, args: { id: "event.id" } }] },
+      task: {
+        kind: "steps",
+        steps: [
+          { id: "list", tool: LIST },
+          { id: "send", tool: SEND, args: { id: "event.id" } },
+        ],
+      },
     });
 
     const response = await stack.wireFetch(`/automations/${id}/enable`, { method: "POST" }, ADA);
@@ -44,7 +60,12 @@ describe("THE LAW: the enable ceremony sees the tools it asks about", () => {
     expect(response.status).toBe(200);
     expect(body.enabled).toBe(true);
 
-    const card = body.missing?.find((request) => request.call.tool === SEND);
+    // The ceremony SAW the destructive tool — the 200 above is that proof — and
+    // still mints no card for it: a standing grant could never authorize it
+    // away, so asking would be a question with no true answer.
+    expect(body.missing?.some((request) => request.call.tool === SEND)).toBe(false);
+
+    const card = body.missing?.find((request) => request.call.tool === LIST);
     expect(card).toBeDefined();
     // The ceremony is a ceremony: the card it mints is addressed to a person who
     // is present, in the automation venue. That pair is legal, and it is the

--- a/fixtures/redteam/tests/away-authority.e2e.test.ts
+++ b/fixtures/redteam/tests/away-authority.e2e.test.ts
@@ -329,9 +329,22 @@ describe("away runs reach a connector only through a granted service action", ()
         [{ id: "send", slug: "GMAIL_SEND_EMAIL" }],
         ctx,
       );
-      const asks = await enableAndApprove(stack, automation.id, ctx);
+      // Arming captures nothing here: the resolver grades GMAIL_SEND_EMAIL
+      // destructive, and a standing grant could never authorize a destructive
+      // call away — so a card offering one would offer what no firing honours.
+      // The door that IS left to such a grant is the run's own ask: the first
+      // firing meets a permission nobody granted, fails loud, and answering
+      // that ask mints the standing per-slug grant. Which is exactly the grant
+      // this test needs to exist, so it can be beaten.
+      expect(await enableAndApprove(stack, automation.id, ctx)).toEqual([]);
+      const [priming] = await stack.automations.emit("service.away.destructive", {}, ADA);
+      await waitForRun(stack, priming!, ctx, "error");
+      const ask = (await stack.guard.approvals.pending(ADA)).find(
+        (entry) => entry.ctx.presence === "away" && entry.ctx.trigger?.automationId === automation.id,
+      );
       // The grant is real, standing, automation-bound, and for this exact slug…
-      expect(asks[0]?.descriptor.risk).toBe("destructive");
+      expect(ask?.descriptor.risk).toBe("destructive");
+      await approve(stack, [ask!]);
       expect((await stack.guard.grants.list(ADA)).map((grant) => grant.scope)).toEqual([
         { kind: "service-tool", slug: "GMAIL_SEND_EMAIL" },
       ]);

--- a/packages/apps/src/server/doors/automate-tool.ts
+++ b/packages/apps/src/server/doors/automate-tool.ts
@@ -137,7 +137,13 @@ export const runAutomateTool = async (
   // Grant capture, the same flow every other authoring door runs: what the owner
   // still has to allow is said HERE, in the line the model reads out, rather
   // than discovered by the first away run failing.
-  const armed = await seam.enable(record.id, ctx);
+  //
+  // THIS call rides along (07 §3): its own approval ask is where the powers this
+  // automation will hold were named, so under a policy that asks about arming,
+  // the yes already given mints them and there is no second per-tool ceremony.
+  // Under a policy that runs arming unasked, nobody saw a powers line and the
+  // engine captures each one as a pending ask exactly as before.
+  const armed = await seam.enable(record.id, ctx, { armedBy: call });
   const next = nextRunAt(record.when, record.timezone ?? "UTC");
   const ref: VendoAutomationRef = {
     kind: VENDO_AUTOMATION_REF_KIND,

--- a/packages/apps/src/server/runtime/types.ts
+++ b/packages/apps/src/server/runtime/types.ts
@@ -79,7 +79,11 @@ export interface AutomationsSeam {
   create: CreateAutomation;
   /** `automations.enable` — the 07 §3 grant-capture flow. `missing` is what the
    *  owner still has to allow before an away run can complete unattended. */
-  enable(id: AutomationId, ctx: RunContext): Promise<{ enabled: boolean; missing: ApprovalRequest[] }>;
+  enable(
+    id: AutomationId,
+    ctx: RunContext,
+    options?: { armedBy?: ToolCall },
+  ): Promise<{ enabled: boolean; missing: ApprovalRequest[] }>;
   /** The kill switch (`automations.disable`). */
   disable(id: AutomationId, ctx: RunContext): Promise<void>;
   /** The records these ids still name, dead ids dropped. */

--- a/packages/automations/src/arming-surface.ts
+++ b/packages/automations/src/arming-surface.ts
@@ -9,6 +9,7 @@ import type { ConsentAccess } from "./consent.js";
 import type { EngineBase } from "./engine-context.js";
 import type { GrantsAccess } from "./grants.js";
 import type { AutomationsEngine, RunPlan } from "./index.js";
+import { powerTitles } from "./messages.js";
 import { currentIntentHash, declaredSurface, markSponsored, writeSponsorship } from "./sponsorship.js";
 import { evaluate, stepArgs, validateForEachItems } from "./steps.js";
 
@@ -20,14 +21,17 @@ export type ArmingSurfaceDeps = {
 };
 
 /** 07 §3's arm/disarm pair. */
-const createArmDoors = (deps: ArmingSurfaceDeps): Pick<AutomationsEngine, "enable" | "disable"> => {
+const createArmDoors = (
+  deps: ArmingSurfaceDeps,
+): Pick<AutomationsEngine, "enable" | "disable" | "armingPowers"> => {
   const { base: { engine, iso }, automations, grants, consent } = deps;
-  const enable: AutomationsEngine["enable"] = async (automationId, ctx) => {
+  const enable: AutomationsEngine["enable"] = async (automationId, ctx, options) => {
     const found = await automations.owned(automationId, ctx);
     const { missing, grantSetId } = await consent.captureGrants(
       found.row,
       await grants.descriptors(ctx),
       ctx,
+      options?.armedBy,
     );
     // §9.9 — enabling is what names the sponsor: the person arming an automation
     // is the person it runs as, bound to the intent they just saw. A re-enable
@@ -66,7 +70,13 @@ const createArmDoors = (deps: ArmingSurfaceDeps): Pick<AutomationsEngine, "enabl
     await automations.write({ ...found.row, armed: false, disarmedBy: "user", updatedAt: iso() });
   };
 
-  return { enable, disable };
+  /** 07 §3 — the powers an arming would hold, named for a person, before any
+   *  record exists to read them off. Titles, never identifiers (design §3's voice
+   *  law): the whole point is that a surface renders them verbatim. */
+  const armingPowers: AutomationsEngine["armingPowers"] = async (ctx) =>
+    powerTitles(await consent.goalArmingPowers(await grants.descriptors(ctx), ctx));
+
+  return { enable, disable, armingPowers };
 };
 
 /** Preview: what a record would run, nothing executes. */
@@ -135,5 +145,5 @@ const createDryRunDoor = (
 
 export const createArmingSurface = (
   deps: ArmingSurfaceDeps,
-): Pick<AutomationsEngine, "enable" | "disable" | "dryRun"> =>
+): Pick<AutomationsEngine, "enable" | "disable" | "dryRun" | "armingPowers"> =>
   ({ ...createArmDoors(deps), ...createDryRunDoor(deps) });

--- a/packages/automations/src/consent.ts
+++ b/packages/automations/src/consent.ts
@@ -175,7 +175,27 @@ const createDecisionSubscriber = (
         if (await spendApproval(approval)) await grants.mintGrant(data.request, parsed.automationId);
       }
       await engine.delete(CAPTURES, approvalId);
-      if (!approved) {
+      // A MACHINE deny is not an answer. The guard stamps who said no on the row
+      // (`#decideApprovals`), and only `"human"` is a person: `"system"` is the
+      // hour-long TTL sweep or an abandoned ask. The decision callback carries just
+      // (id, approved), so the provenance can only be read here, off the row.
+      //
+      // Live 2026-08-18 on production Maple, automation atm_d50cd48e: 33 arming
+      // asks were created at 11:26 and all 33 were denied by the sweep at 12:27 —
+      // createdAt plus exactly the parked-call TTL — and the record flipped to
+      // armed=false at 12:27:37. Nobody ever decided anything. The person's
+      // automation turned itself off an hour after they set it up, silently,
+      // because an expiry read as a refusal. The guard already draws this exact
+      // line for standing denials (it enforces only `deniedBy: "human"`); this was
+      // the one place that did not, and it is the same hazard class the supersede
+      // path below is already careful about.
+      //
+      // A guard that stamps nothing keeps today's behaviour, so no BYO guard
+      // regresses; a human NO still disarms, so the channel's "Okay — I turned it
+      // off." stays true.
+      const deniedBySystem = approval !== null
+        && approvalRowSchema.safeParse(approval.data).data?.deniedBy === "system";
+      if (!approved && !deniedBySystem) {
         // Deny is transactional at the DECISION (criterion 19, deny half), but
         // disarms ONLY a consent moment that ended with NOTHING granted: no
         // capture asks left pending for the record and no live automation-source

--- a/packages/automations/src/consent.ts
+++ b/packages/automations/src/consent.ts
@@ -6,6 +6,7 @@
 import {
   approvalRecordRefs,
   descriptorHash,
+  projectableForRun,
   serviceToolPhrase,
   serviceToolSlug,
   USE_SERVICE_TOOL,
@@ -16,6 +17,7 @@ import {
   type AutomationRecord,
   type RunContext,
   type Step,
+  type ToolCall,
   type ToolDescriptor,
   type VendoRecord,
 } from "@vendoai/core";
@@ -38,6 +40,11 @@ import {
   type InternalRunRecord,
 } from "./types.js";
 
+/** One thing a person may have to allow, already graded the way the firing will
+ *  grade it and already carrying the synthetic call the grade was resolved from —
+ *  so nothing downstream re-derives either and gets a different answer. */
+export type ArmingPower = { item: ConsentItem; descriptor: ToolDescriptor; call: ToolCall };
+
 export type ConsentDeps = {
   base: EngineBase;
   automations: AutomationRowsAccess;
@@ -56,13 +63,24 @@ export interface ConsentAccess {
   spendApproval(record: VendoRecord): Promise<boolean>;
   /** The guard's decision subscriber: mint, clear, and disarm on a bare no. */
   handleDecision(approvalId: string, approved: boolean): Promise<void>;
-  /** The tools a consent moment covers. */
-  consentSurface(record: AutomationRecord, byName: Map<string, ToolDescriptor>): Promise<ConsentItem[]>;
+  /** Every tool a task could reach away, before policy has been consulted. */
+  candidateSurface(record: AutomationRecord, byName: Map<string, ToolDescriptor>): Promise<ConsentItem[]>;
+  /** 07 §3 — the tools this record's arming has to NAME to a person: graded as the
+   *  firing will grade them, minus everything policy runs away unasked. */
+  armingSurface(
+    record: AutomationRecord,
+    byName: Map<string, ToolDescriptor>,
+    ctx: RunContext,
+  ): Promise<ArmingPower[]>;
+  /** The same, for a GOAL arming whose record does not exist yet — the ask parks
+   *  before `vendo_automate` runs. */
+  goalArmingPowers(byName: Map<string, ToolDescriptor>, ctx: RunContext): Promise<ArmingPower[]>;
   /** 07 §3 — the asks arming has to raise for this subject. */
   captureGrants(
     record: AutomationRecord,
     byName: Map<string, ToolDescriptor>,
     ctx: RunContext,
+    armedBy?: ToolCall,
   ): Promise<{ missing: ApprovalRequest[]; grantSetId: string }>;
   /** A step met a permission nobody has granted. The run ends HERE, loudly. */
   needsPermission(
@@ -246,10 +264,14 @@ const createDecisionSubscriber = (
 };
 
 /** What a consent moment COVERS, before anything is asked. */
-const createConsentSurface = (): Pick<ConsentAccess, "consentSurface"> => {
-  /** The tools a consent moment covers. Steps DECLARE their surface; a goal
-   *  declares nothing, so it falls back to every bound descriptor THE LAW would
-   *  still let it reach away.
+const createConsentSurface = (
+  deps: Pick<ConsentDeps, "base">,
+): Pick<ConsentAccess, "candidateSurface" | "armingSurface" | "goalArmingPowers"> => {
+  const { base: { config } } = deps;
+
+  /** Every tool a task could reach away, before policy has been consulted. Steps
+   *  DECLARE their surface; a goal declares nothing, so it falls back to every
+   *  bound descriptor THE LAW would still let it reach away.
    *
    *  The connector dispatcher never enters as ITSELF, whichever kind of task
    *  this is: a tool-wide grant on it would be consent to the broker's whole
@@ -257,21 +279,11 @@ const createConsentSurface = (): Pick<ConsentAccess, "consentSurface"> => {
    *  ACTION it names. Anything either one reaches beyond that parks at fire time
    *  like any ungranted away call, and its approval accretes the per-slug
    *  grant. */
-  const consentSurface = async (
+  const candidateSurface = async (
     record: AutomationRecord,
     byName: Map<string, ToolDescriptor>,
   ): Promise<ConsentItem[]> => {
-    if (record.task.kind === "goal") {
-      // The fallback is wide, but it is not DISHONEST: a tool §12 withholds from
-      // every unattended run can never be the thing this grant permits, so
-      // "allow this while you're away" is a question with no true answer. The
-      // predicate is core's own `withheldFromUnattended` — the SAME one
-      // `projectableForRun` filters the firing through — so the card and the run
-      // cannot disagree about what may never happen away.
-      return [...byName.values()]
-        .filter((descriptor) => descriptor.name !== USE_SERVICE_TOOL && !withheldFromUnattended(descriptor))
-        .map(({ name }) => ({ tool: name }));
-    }
+    if (record.task.kind === "goal") return goalCandidates(byName);
     const items = new Map<string, ConsentItem>();
     for (const tool of declaredSurface(record)) {
       if (tool !== USE_SERVICE_TOOL) items.set(tool, { tool });
@@ -285,16 +297,135 @@ const createConsentSurface = (): Pick<ConsentAccess, "consentSurface"> => {
     return [...items.values()];
   };
 
-  return { consentSurface };
+  /**
+   * The tools this record's arming COVERS: its candidates, graded the way the
+   * firing will grade them, minus the ones a standing grant could never satisfy.
+   *
+   * The surface itself is as wide as it has always been, and deliberately so —
+   * an automation runs on captured grants, so everything it may touch away has to
+   * be granted here or the firing meets a permission nobody holds. What changed
+   * on 2026-08-18 is not WHAT gets granted but what a person is made to do about
+   * it: live on production Maple, a user armed "check my checking balance every
+   * 15 minutes and text me" over iMessage, their YES to the job landed, and
+   * arming then minted FOUR more per-tool asks — `vendo_text_me`,
+   * `vendo_knowledge_search`, `request_connection`, `list_connections`. Three are
+   * reads nobody needs a second opinion about, and the fourth was literally in the
+   * sentence they typed. Consent was framed per-tool while the person was thinking
+   * per-job. So the whole surface is now named ONCE, on the arming ask itself
+   * (`powerTitles` groups it for reading), and one yes mints all of it.
+   *
+   * Graded through `withResolvedRisk` first, because that is the descriptor the
+   * guard will see at fire time: the dispatcher's own label is `ungraded` and the
+   * broker's per-slug tag arrives through the resolver. Grading here is what makes
+   * the card show the real grade, makes the minted grant's `descriptorHash` the one
+   * the guard recomputes on the away call, and keeps the card and the run from
+   * disagreeing.
+   *
+   * Two kinds never get a standing power, because a grant could not satisfy them
+   * anyway and the card would be promising what the run will not honour:
+   *  - `destructive` and `ungraded` (§12's pair). The guard refuses them away
+   *    regardless of any grant, so they park per fire. This is where the goal path
+   *    always filtered them and the other two never did: a STEPS record that
+   *    declares a destructive tool, and a connector slug the risk resolver grades
+   *    destructive, both used to receive a standing grant that could not work.
+   *  - `confirmEach`. Governance, not severity: it needs a person EVERY time and
+   *    no grant may suppress it (05 §2), so a standing power for one is dead on
+   *    arrival.
+   */
+  const armingSurface = async (
+    record: AutomationRecord,
+    byName: Map<string, ToolDescriptor>,
+    ctx: RunContext,
+  ): Promise<ArmingPower[]> => await graded(await candidateSurface(record, byName), byName, ctx);
+
+  /** The same, for a GOAL arming that has no record yet — the arming ask parks
+   *  before `vendo_automate` runs, so the powers it names are computed from the
+   *  bound surface alone. Sound because a goal's candidates never depended on the
+   *  record in the first place. */
+  const goalArmingPowers = async (
+    byName: Map<string, ToolDescriptor>,
+    ctx: RunContext,
+  ): Promise<ArmingPower[]> => await graded(goalCandidates(byName), byName, ctx);
+
+  const graded = async (
+    candidates: readonly ConsentItem[],
+    byName: Map<string, ToolDescriptor>,
+    ctx: RunContext,
+  ): Promise<ArmingPower[]> => {
+    const powers: ArmingPower[] = [];
+    for (const item of candidates) {
+      const { tool, slug } = item;
+      const authored = byName.get(tool);
+      if (authored === undefined) throw new VendoError("validation", `unknown tool in automation: ${tool}`);
+      const call: ToolCall = { id: id("call_"), tool, args: slug === undefined ? {} : { slug } };
+      const descriptor = slug === undefined
+        ? authored
+        : withResolvedRisk(authored, await config.resolveRisk?.(call, authored, ctx));
+      // Never a standing power — see the block comment above.
+      if (withheldFromUnattended(descriptor) || descriptor.confirmEach === true) continue;
+      powers.push({ item, descriptor, call });
+    }
+    return powers;
+  };
+
+  return { candidateSurface, armingSurface, goalArmingPowers };
 };
+
+/**
+ * A goal's candidates: every bound descriptor THE LAW would really hand a firing,
+ * minus the dispatcher itself.
+ *
+ * Through `projectableForRun` — core's own §12 projection, the SAME function the
+ * firing's tool listing is filtered by — rather than a hand-rolled copy of half of
+ * it. The copy this replaces checked only `withheldFromUnattended` and so named
+ * powers a firing can never hold: the presence-only tools, whose whole effect is
+ * on a person's screen and which the projection drops from every unattended run.
+ * A card promising "Pin the app to your page" to an automation is a card that
+ * lies, and the person allowing it would never find out.
+ */
+const goalCandidates = (byName: Map<string, ToolDescriptor>): ConsentItem[] =>
+  projectableForRun([...byName.values()], { venue: "automation", presence: "away" })
+    .filter((descriptor) => descriptor.name !== USE_SERVICE_TOOL)
+    .map(({ name }) => ({ tool: name }));
 
 /** 07 §3's arming half: the asks enable() has to raise for this subject. */
 const createGrantCapture = (
   deps: Pick<ConsentDeps, "base" | "grants">
     & Pick<CaptureRows, "writeCapture" | "pendingCaptures">
-    & Pick<ConsentAccess, "consentSurface">,
+    & Pick<ConsentAccess, "armingSurface">,
 ): Pick<ConsentAccess, "captureGrants"> => {
-  const { base: { config, engine, iso }, grants, writeCapture, pendingCaptures, consentSurface } = deps;
+  const { base: { config, engine, iso }, grants, writeCapture, pendingCaptures, armingSurface } = deps;
+
+  /**
+   * Did a person actually SEE this arming and say yes?
+   *
+   * The arming ask is the guard's own ask about the authoring call, and it names
+   * the powers before anything is armed (`ApprovalRequest.powers`). So if the
+   * host's policy would ASK about that call, the call reaching us at all is proof
+   * the ask was answered yes — the guard does not let an unanswered ask through.
+   * That yes is what licenses minting the standing powers on the spot, with no
+   * second per-tool ceremony.
+   *
+   * If policy would RUN the authoring call, nobody was asked anything. That is
+   * not a theoretical case: `vendo_make` is read-graded (it arms the schedule half
+   * of "build me the board and refresh it every Monday"), so under an
+   * asks-on-writes policy it runs unasked. Minting standing away powers off a call
+   * nobody was asked about would be a silent consent regression, so those keep the
+   * per-tool captures they have always had, and the set ask delivers them.
+   */
+  const armingWasAsked = async (
+    armedBy: ToolCall | undefined,
+    byName: Map<string, ToolDescriptor>,
+    ctx: RunContext,
+  ): Promise<boolean> => {
+    if (armedBy === undefined) return false;
+    const descriptor = byName.get(armedBy.tool);
+    if (descriptor === undefined) return false;
+    // The ctx the authoring call was MADE in, unchanged: the question is whether
+    // policy asked a person there, in that venue, at that moment.
+    return await config.guard.policyOutcome?.(armedBy, descriptor, ctx) === "ask";
+  };
+
   /** The tools a consent moment has to ask THIS subject about: the automation's
    *  surface minus whatever they already hold a live standing grant for.
    *
@@ -304,10 +435,12 @@ const createGrantCapture = (
     record: AutomationRecord,
     byName: Map<string, ToolDescriptor>,
     ctx: RunContext,
+    armedBy?: ToolCall,
   ): Promise<{ missing: ApprovalRequest[]; grantSetId: string }> => {
     const automationId = record.id;
     const subject = ctx.principal.subject;
-    const surface = await consentSurface(record, byName);
+    const surface = await armingSurface(record, byName, ctx);
+    const consented = await armingWasAsked(armedBy, byName, ctx);
     // One grant SET per RECORD: re-enables reuse that record's still-pending
     // asks (and their set id) instead of minting duplicates for the same
     // (automation, tool); a fresh set id is minted only when nothing is pending.
@@ -321,22 +454,8 @@ const createGrantCapture = (
       .find((value) => value !== undefined) ?? id("gset_");
     const name = automationName(record);
     const missing: ApprovalRequest[] = [];
-    for (const item of surface) {
+    for (const { item, descriptor } of surface) {
       const { tool, slug } = item;
-      const authored = byName.get(tool);
-      if (authored === undefined) throw new VendoError("validation", `unknown tool in automation: ${tool}`);
-      // The descriptor the GUARD will see at fire time, not the authored one:
-      // the dispatcher's own label is `ungraded` and the broker's per-slug tag
-      // arrives through the risk resolver. Grading it here is what makes the
-      // consent card show the real grade AND makes the minted grant's
-      // descriptorHash the one the guard recomputes on the away call — hash the
-      // authored label instead and the grant is invalidated on first use.
-      const descriptor = slug === undefined
-        ? authored
-        : withResolvedRisk(
-            authored,
-            await config.resolveRisk?.({ id: id("call_"), tool, args: { slug } }, authored, ctx),
-          );
       if (await grants.liveGrant(subject, automationId, descriptor, slug)) continue;
       const pending = pendingHere.get(consentKey(item));
       if (pending !== undefined) {
@@ -382,6 +501,15 @@ const createGrantCapture = (
         },
         createdAt: iso(),
       };
+      // ONE yes, already given. The arming ask named these powers and the person
+      // approved it, so the grant is minted here and now — no pending capture, no
+      // second ask, nothing left for any surface to chase. The request above is
+      // built either way because it is what `mintGrant` derives the grant's scope
+      // and descriptor hash from; it is simply never persisted as an ask.
+      if (consented) {
+        await grants.mintGrant(request, automationId);
+        continue;
+      }
       await engine.put(APPROVALS, {
         id: request.id,
         data: { request, status: "pending", sessionId: ctx.sessionId },
@@ -524,7 +652,7 @@ const createPermissionMiss = (
 
 export const createConsent = (deps: ConsentDeps): ConsentAccess => {
   const captures = createCaptureRows(deps);
-  const surface = createConsentSurface();
+  const surface = createConsentSurface(deps);
   return {
     ...captures,
     ...surface,

--- a/packages/automations/src/index.ts
+++ b/packages/automations/src/index.ts
@@ -24,6 +24,7 @@ import type {
   RunId,
   StoreAdapter,
   StoreOps,
+  ToolCall,
   ToolOutcome,
   ToolRegistry,
   TriggerSource,
@@ -43,7 +44,7 @@ export type { ReconcileAutomations } from "./create-surface.js";
  *  channel names automations at someone too (`channel-turn.ts`), and design §3's
  *  voice law only holds if every surface says the same name — a second spelling
  *  is how one of them starts printing a tool identifier. */
-export { automationName } from "./messages.js";
+export { automationName, powerTitles, READ_ONLY_POWER } from "./messages.js";
 export { UNATTENDED_IRREVERSIBILITY_RULE, unattendedIrreversibilityCheck } from "./law.js";
 
 /** 07 §1 — createAutomations config. */
@@ -141,11 +142,28 @@ export interface AutomationsEngine {
   /** The kill switch. `enable` runs grant capture; `missing` is what the owner
    *  still has to allow, and `grantSetId` names the ONE set so a single decision
    *  settles them all. `disable` stamps `disarmedBy: "user"`, which is what makes
-   *  it survive every redeploy. */
+   *  it survive every redeploy.
+   *
+   *  `armedBy` is the authoring TOOL CALL, when an agent's call is what armed
+   *  this: 07 §3 names the standing powers on that call's own approval ask, so a
+   *  call the host's policy asked about arrives here already consented and its
+   *  powers are minted on the spot rather than asked for a second time. Omit it —
+   *  as the wire's own turn-it-on route does — and every power is captured as a
+   *  pending ask exactly as before. */
   enable(
     id: AutomationId,
     ctx: RunContext,
+    options?: { armedBy?: ToolCall },
   ): Promise<{ enabled: boolean; missing: ApprovalRequest[]; grantSetId?: string }>;
+  /** 07 §3 — the human titles of the standing powers arming a GOAL automation in
+   *  this ctx would hold: the tools whose fire-time policy outcome needs a person.
+   *
+   *  Exists for the ONE surface that has to name them before there is a record to
+   *  read: the arming ask parks while `vendo_automate` is still deciding whether to
+   *  run, so the composition asks this and rides the answer on the approval
+   *  (`ApprovalRequest.powers`). Every surface then renders the same set from the
+   *  same computation. */
+  armingPowers(ctx: RunContext): Promise<string[]>;
   disable(id: AutomationId, ctx: RunContext): Promise<void>;
 
   /** INVARIANT: idempotent. Due-ness comes from the engine's own schedule

--- a/packages/automations/src/messages.ts
+++ b/packages/automations/src/messages.ts
@@ -58,3 +58,37 @@ export const IDENTITY_UNAVAILABLE = (name: string): string =>
  *  named and nobody would ever find out. */
 export const NO_SUCH_RUNNER = (name: string): string =>
   `stopped: no agent named "${name}" is registered in this deployment — nothing ran`;
+
+/**
+ * The one phrase every read an automation may make is named by, together.
+ *
+ * Reads are the bulk of any automation's surface and the least interesting thing
+ * about it: naming them one by one is what turned a person's yes to a JOB into a
+ * wall of tool names they could not act on (live 2026-08-18 — three of the four
+ * follow-up asks were reads). They still get granted, they are simply not worth a
+ * line each. Deliberately generic and deliberately not a list: it says what the
+ * automation can SEE, in the words someone would use about their own account,
+ * with no tool identifier anywhere near it.
+ */
+export const READ_ONLY_POWER = "Read-only access to your data";
+
+/**
+ * What a person is told an automation will hold, in the order they should read
+ * it: the tools that DO something, each by its own human title, then every read
+ * folded into {@link READ_ONLY_POWER}.
+ *
+ * Titles, never identifiers (design §3's voice law) — a descriptor with no title
+ * falls back to its name, which is the same fallback every other consent surface
+ * makes. The list is what rides on the arming approval (`ApprovalRequest.powers`),
+ * so it is a plain array of finished phrases: every surface renders it verbatim
+ * and none of them has to know this rule.
+ */
+export const powerTitles = (
+  powers: ReadonlyArray<{ descriptor: { name: string; title?: string; risk: string } }>,
+): string[] => {
+  const acts = powers
+    .filter(({ descriptor }) => descriptor.risk !== "read")
+    .map(({ descriptor }) => descriptor.title ?? descriptor.name);
+  const reads = powers.some(({ descriptor }) => descriptor.risk === "read");
+  return reads ? [...acts, READ_ONLY_POWER] : acts;
+};

--- a/packages/automations/src/types.ts
+++ b/packages/automations/src/types.ts
@@ -43,6 +43,13 @@ export const approvalRowSchema = z.object({
   decidedAt: z.string().optional(),
   consumedAt: z.string().optional(),
   voidedAt: z.string().optional(),
+  /** WHO said no. The guard stamps it on every deny (`#decideApprovals`), and the
+   *  distinction is load-bearing here rather than cosmetic: `"system"` is an
+   *  expiry sweep or an abandoned ask, never a person's answer. Read by the
+   *  decision subscriber, which must not disarm an automation nobody said no to.
+   *  Optional because the decision callback carries only (id, approved) — the
+   *  provenance lives on the row and nowhere else. */
+  deniedBy: z.enum(["human", "system"]).optional(),
 }).passthrough();
 
 export const captureSchema = z.object({

--- a/packages/automations/tests/arming-consent.test.ts
+++ b/packages/automations/tests/arming-consent.test.ts
@@ -1,0 +1,476 @@
+/**
+ * 07 §3 — arming covers the WHOLE job, and one yes is what pays for it.
+ *
+ * The incident behind every case here (2026-08-18, production Maple): a user
+ * armed "check my checking balance every 15 minutes and text me" over iMessage,
+ * their YES to the job landed, and arming then minted FOUR MORE per-tool asks —
+ * `vendo_text_me`, `vendo_knowledge_search`, `request_connection`,
+ * `list_connections`. Three of those are read-grade tools a live chat runs
+ * without asking anybody, and the fourth was literally in the sentence they
+ * typed. Consent was framed per-tool while the person was thinking per-job.
+ *
+ * What that did NOT change is the SURFACE. An automation runs on captured
+ * grants, so everything it may touch away still has to be granted at arming or
+ * the firing meets a permission nobody holds — the surface here is as wide as it
+ * has always been, minus only the two kinds a standing grant could never satisfy.
+ * What changed is what a person is made to DO about it: the whole surface is
+ * named once, on the arming ask, and one yes mints all of it.
+ *
+ * The harness (descriptors, `ctx`, `create`, `GuardDouble`, `registry`, `flush`)
+ * is engine.test.ts's, verbatim; only the optional seams no case here scripts are
+ * left out, and `policyOutcome` is added as one more scripted-per-test seam
+ * beside the ones the double already carries.
+ */
+import {
+  serviceToolSlug,
+  USE_SERVICE_TOOL,
+  type ApprovalId,
+  type AutomationRecord,
+  type CreateAutomationInput,
+  type Guard,
+  type GuardDecision,
+  type RiskLabel,
+  type RunContext,
+  type StoreAdapter,
+  type ToolCall,
+  type ToolDescriptor,
+  type ToolOutcome,
+  type ToolRegistry,
+} from "@vendoai/core";
+import { memoryStoreAdapter } from "@vendoai/core/conformance";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  automationsInternals,
+  createAutomations,
+  powerTitles,
+  READ_ONLY_POWER,
+  type AutomationsEngine,
+} from "../src/index.js";
+
+const NOW = new Date("2026-07-12T12:00:00.000Z");
+
+const readTool: ToolDescriptor = {
+  name: "read_data",
+  description: "Read data",
+  inputSchema: { type: "object" },
+  risk: "read",
+};
+
+const writeTool: ToolDescriptor = {
+  name: "write_data",
+  description: "Write data",
+  inputSchema: { type: "object" },
+  risk: "write",
+};
+
+/** Destructive and NOTHING else. `criticalTool` in engine.test.ts is destructive
+ *  AND `confirmEach`, which cannot tell the two filters apart — and telling them
+ *  apart is the whole point of the pair of cases below. */
+const wipeTool: ToolDescriptor = {
+  name: "wipe_data",
+  description: "Wipe data",
+  inputSchema: { type: "object" },
+  risk: "destructive",
+};
+
+/** `confirmEach` on a WRITE, so severity is not what drops it: only governance
+ *  (05 §2 — a person, every time, and no grant may suppress it) is. */
+const signTool: ToolDescriptor = {
+  name: "sign_off",
+  description: "Sign something off",
+  inputSchema: { type: "object" },
+  risk: "write",
+  confirmEach: true,
+};
+
+/** The connector dispatcher, `ungraded` by construction: its real grade arrives
+ *  per SLUG through the risk resolver, never off this label. */
+const dispatcher: ToolDescriptor = {
+  name: USE_SERVICE_TOOL,
+  description: "Use a connected service's tool",
+  inputSchema: { type: "object" },
+  risk: "ungraded",
+};
+
+/** The two authoring calls the armedBy gate turns on. `vendo_automate` is
+ *  write-graded, so an asks-on-writes policy asked a person about it — the call
+ *  reaching enable() at all is that person's yes. `vendo_make` is read-graded, so
+ *  the same policy RAN it and nobody was asked anything. */
+const automateTool: ToolDescriptor = {
+  name: "vendo_automate",
+  description: "Arm an automation",
+  inputSchema: { type: "object" },
+  risk: "write",
+};
+
+const makeTool: ToolDescriptor = {
+  name: "vendo_make",
+  description: "Build a screen",
+  inputSchema: { type: "object" },
+  risk: "read",
+};
+
+const ctx = (subject = "user_a"): RunContext => ({
+  principal: { kind: "user", subject },
+  venue: "chat",
+  presence: "present",
+  sessionId: `session_${subject}`,
+});
+
+/** The ONE create op, with this suite's defaults: a code-authored record the
+ *  calling ctx speaks for. There is no public create — every authoring door
+ *  goes through `automationsInternals`, so the tests do too. */
+const create = async (
+  engine: AutomationsEngine,
+  input: Omit<CreateAutomationInput, "owner" | "authoredBy"> & Partial<CreateAutomationInput>,
+  runCtx: RunContext = ctx(),
+): Promise<AutomationRecord> =>
+  await automationsInternals(engine).create(
+    { owner: runCtx.principal, authoredBy: "code", ...input },
+    runCtx,
+  );
+
+class GuardDouble implements Guard {
+  /** The optional policy probe, scripted. Left unset by default because a guard
+   *  that cannot answer is read as "nobody was asked" — the conservative answer,
+   *  and the last case of the armedBy gate below. */
+  policyOutcome?: (
+    call: ToolCall,
+    descriptor: ToolDescriptor,
+    ctx: RunContext,
+  ) => Promise<GuardDecision["action"]>;
+  private readonly callbacks = new Set<(id: ApprovalId, approved: boolean) => void>();
+
+  async check(): Promise<{ action: "run"; decidedBy: "default" }> {
+    return { action: "run", decidedBy: "default" };
+  }
+
+  async report(): Promise<void> {}
+
+  async directions(): Promise<string[]> { return []; }
+
+  onApprovalDecision(callback: (id: ApprovalId, approved: boolean) => void): () => void {
+    this.callbacks.add(callback);
+    return () => this.callbacks.delete(callback);
+  }
+
+  decide(id: string, approved: boolean): void {
+    for (const callback of this.callbacks) callback(id, approved);
+  }
+}
+
+const registry = (
+  descriptors: ToolDescriptor[] = [],
+  execute: (call: ToolCall, runCtx: RunContext) => Promise<ToolOutcome> = async () => ({ status: "ok", output: {} }),
+): ToolRegistry => ({
+  async descriptors() { return descriptors; },
+  execute,
+});
+
+const flush = async (): Promise<void> => {
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+};
+
+/** A host policy that asks about exactly these grades and runs everything else.
+ *  It is consulted about ONE call — the one that armed the automation — and
+ *  never about the surface: the surface is the law's business, not policy's. */
+const asksOn = (...risks: RiskLabel[]) =>
+  async (_call: ToolCall, descriptor: ToolDescriptor): Promise<GuardDecision["action"]> =>
+    risks.includes(descriptor.risk) ? "ask" : "run";
+
+const tools = (result: { records: Array<{ data: unknown }> }): unknown[] =>
+  result.records.map((row) => (row.data as { tool: string }).tool);
+
+describe("what arming covers: everything but what a standing grant could not satisfy", () => {
+  let store: StoreAdapter;
+
+  beforeEach(() => {
+    store = memoryStoreAdapter();
+  });
+
+  /**
+   * The STEPS branch of the destructive filter, which is the branch that did not
+   * exist before: only the goal path narrowed its candidates, so a steps record
+   * that DECLARED a destructive tool got a standing-grant ask for it — an ask
+   * promising authority the guard refuses away no matter what is granted. A card
+   * that lies, and a grant row nobody can spend.
+   */
+  it("never names a destructive tool a STEPS record declares, and mints no standing grant for it", async () => {
+    const guard = new GuardDouble();
+    const engine = createAutomations({
+      tools: registry([writeTool, wipeTool]), guard, store, now: () => NOW,
+    });
+    const record = await create(engine, {
+      id: "atm_steps_destructive",
+      when: { event: "go" },
+      task: { kind: "steps", steps: [
+        { id: "write", tool: writeTool.name },
+        { id: "wipe", tool: wipeTool.name },
+      ] },
+    });
+
+    const { missing } = await engine.enable(record.id, ctx());
+
+    expect(missing.map(({ call }) => call.tool)).toEqual([writeTool.name]);
+
+    guard.decide(missing[0]!.id, true);
+    await flush();
+
+    // …and the only standing grant this consent moment can ever mint is the
+    // write's: with nothing named for the wipe there is no ask to answer yes to.
+    expect(tools(await store.records("vendo_grants").list())).toEqual([writeTool.name]);
+  });
+
+  /**
+   * The CONNECTOR SLUG branch of the same filter, and the reason the surface is
+   * graded through `withResolvedRisk` at all: the authored dispatcher is
+   * `ungraded`, and the real grade arrives per slug from the broker through the
+   * resolver. The send surviving is what proves the resolver ran — the authored
+   * `ungraded` would have dropped BOTH steps — and the delete is gone on its
+   * RESOLVED grade, which the authored label never mentions.
+   */
+  it("never names a connector slug the risk resolver grades destructive, whatever the dispatcher's own label says", async () => {
+    const guard = new GuardDouble();
+    const engine = createAutomations({
+      tools: registry([dispatcher]),
+      guard,
+      store,
+      now: () => NOW,
+      resolveRisk: async (call) => serviceToolSlug(call) === "GMAIL_DELETE_MESSAGE" ? "destructive" : "write",
+    });
+    const record = await create(engine, {
+      id: "atm_slug_destructive",
+      when: { event: "go" },
+      task: { kind: "steps", steps: [
+        { id: "send", tool: USE_SERVICE_TOOL, args: { slug: "'GMAIL_SEND_EMAIL'" } },
+        { id: "delete", tool: USE_SERVICE_TOOL, args: { slug: "'GMAIL_DELETE_MESSAGE'" } },
+      ] },
+    });
+
+    const { missing } = await engine.enable(record.id, ctx());
+
+    expect(missing.map(({ call }) => serviceToolSlug(call))).toEqual(["GMAIL_SEND_EMAIL"]);
+    // The card states the grade the call will really run under, not `ungraded`.
+    expect(missing[0]?.descriptor.risk).toBe("write");
+
+    guard.decide(missing[0]!.id, true);
+    await flush();
+
+    const grants = (await store.records("vendo_grants").list()).records;
+    expect(grants).toHaveLength(1);
+    // Keyed on the SLUG: one name stands in for a whole third-party catalog, so
+    // a tool-wide grant here would be consent to all of it behind one card.
+    expect(grants[0]?.data).toMatchObject({
+      tool: USE_SERVICE_TOOL,
+      scope: { kind: "service-tool", slug: "GMAIL_SEND_EMAIL" },
+    });
+  });
+
+  /** Governance, not severity — which is why this tool is write-graded, so the
+   *  destructive filter is provably not what drops it. `confirmEach` needs a
+   *  person EVERY time and no grant may suppress it (05 §2), so a standing power
+   *  for one is dead on arrival: naming it would be a card promising something
+   *  the run will not honour. */
+  it("never names a confirmEach tool, though it is otherwise an ordinary write", async () => {
+    const guard = new GuardDouble();
+    const engine = createAutomations({
+      tools: registry([writeTool, signTool]), guard, store, now: () => NOW,
+    });
+    const record = await create(engine, {
+      id: "atm_confirm_each",
+      when: { event: "go" },
+      task: { kind: "steps", steps: [
+        { id: "write", tool: writeTool.name },
+        { id: "sign", tool: signTool.name },
+      ] },
+    });
+
+    const { missing } = await engine.enable(record.id, ctx());
+
+    expect(missing.map(({ call }) => call.tool)).toEqual([writeTool.name]);
+
+    guard.decide(missing[0]!.id, true);
+    await flush();
+
+    expect(tools(await store.records("vendo_grants").list())).toEqual([writeTool.name]);
+  });
+});
+
+/**
+ * The armedBy gate: ONE yes, or none.
+ *
+ * The arming ask is the guard's own ask about the AUTHORING call, and it names
+ * the powers before anything is armed. So a call the policy would ask about
+ * reaching enable() at all is proof a person answered that ask yes — and that
+ * yes is what licenses minting the standing powers on the spot, with no second
+ * per-tool ceremony. A call the policy RUNS proves nothing, and minting off it
+ * would be a silent consent regression in the other direction.
+ *
+ * Same record, same policy, four doors — only the arming call differs.
+ */
+describe("the armedBy gate", () => {
+  const ID = "atm_armed_by";
+  let store: StoreAdapter;
+  let guard: GuardDouble;
+  let engine: AutomationsEngine;
+
+  beforeEach(async () => {
+    store = memoryStoreAdapter();
+    guard = new GuardDouble();
+    guard.policyOutcome = asksOn("write");
+    engine = createAutomations({
+      tools: registry([readTool, writeTool, automateTool, makeTool]), guard, store, now: () => NOW,
+    });
+    await create(engine, {
+      id: ID,
+      when: "*/15 * * * *",
+      task: { kind: "steps", steps: [
+        { id: "read", tool: readTool.name },
+        { id: "write", tool: writeTool.name },
+      ] },
+    });
+  });
+
+  const armedBy = (tool: string): ToolCall => ({ id: `call_${tool}`, tool, args: {} });
+
+  /**
+   * THE case, and the whole reshape in one assertion: the yes covers the JOB, so
+   * BOTH powers are live standing grants the instant arming returns — the read
+   * included. Naming the read separately is what the person on Maple was made to
+   * do four extra times, three of them for reads a live chat never asks about.
+   *
+   * Liveness is read back through the engine's own grant lookup rather than off
+   * the row: a second arming finds every power already held and asks nothing, so
+   * the rows are grants the firing will actually accept, not just rows that look
+   * like grants.
+   */
+  it("mints the WHOLE surface — the read as well as the write — when the arming call is one policy ASKED about", async () => {
+    const result = await engine.enable(ID, ctx(), { armedBy: armedBy(automateTool.name) });
+
+    // Nothing left for any surface to chase: the person already answered.
+    expect(result.missing).toEqual([]);
+    const grants = (await store.records("vendo_grants").list()).records;
+    // Sorted: which order a store hands its rows back in is the store's business,
+    // and the claim here is that BOTH powers are held, not that they were written
+    // in surface order.
+    expect(tools({ records: grants }).sort()).toEqual([readTool.name, writeTool.name]);
+    for (const grant of grants) {
+      expect(grant.data).toMatchObject({
+        subject: "user_a",
+        scope: { kind: "tool" },
+        duration: "standing",
+        source: "automation",
+        automationId: ID,
+      });
+    }
+    // No pending ask and no capture row — those are what the incident's four
+    // extra cards were made of.
+    expect((await store.records("automations:captures").list()).records).toEqual([]);
+    expect((await store.records("vendo_approvals").list()).records).toEqual([]);
+
+    const again = await engine.enable(ID, ctx());
+
+    expect(again.missing).toEqual([]);
+    expect((await store.records("vendo_grants").list()).records).toHaveLength(2);
+  });
+
+  /** `vendo_make` is read-graded — it arms the schedule half of "build me the
+   *  board and refresh it every Monday" — so under this policy it runs unasked.
+   *  Minting standing away powers off a call nobody was asked about would be the
+   *  silent regression in the other direction; the per-tool captures stay, and
+   *  the set ask delivers them. */
+  it("mints nothing and parks one ask per power when the arming call is one policy RUNS", async () => {
+    const result = await engine.enable(ID, ctx(), { armedBy: armedBy(makeTool.name) });
+
+    expect(result.missing.map(({ call }) => call.tool)).toEqual([readTool.name, writeTool.name]);
+    expect((await store.records("vendo_grants").list()).records).toEqual([]);
+    expect((await store.records("automations:captures").get(result.missing[0]!.id))?.data)
+      .toMatchObject({ automationId: ID, subject: "user_a", tool: readTool.name });
+    expect((await store.records("automations:captures").get(result.missing[1]!.id))?.data)
+      .toMatchObject({ automationId: ID, subject: "user_a", tool: writeTool.name });
+  });
+
+  /** The wire's own turn-it-on route passes no `armedBy` at all, and an absent
+   *  arming call can never be read as an answered one. */
+  it("mints nothing and parks one ask per power when nothing armed it", async () => {
+    const result = await engine.enable(ID, ctx());
+
+    expect(result.missing.map(({ call }) => call.tool)).toEqual([readTool.name, writeTool.name]);
+    expect((await store.records("vendo_grants").list()).records).toEqual([]);
+    expect((await store.records("automations:captures").list()).records).toHaveLength(2);
+  });
+
+  /** The safe fallback for a host's custom Guard: a guard that cannot say what
+   *  its policy would do is read as "nobody was asked", so the powers fall back
+   *  to pending asks — exactly the behaviour that predates the gate. A guard that
+   *  cannot answer must never be read as a guard that said yes on someone's
+   *  behalf. */
+  it("mints nothing when the guard has no policyOutcome to say whether anybody was asked", async () => {
+    const silent = new GuardDouble();
+    const other = createAutomations({
+      tools: registry([readTool, writeTool, automateTool, makeTool]), guard: silent, store, now: () => NOW,
+    });
+
+    const result = await other.enable(ID, ctx(), { armedBy: armedBy(automateTool.name) });
+
+    expect(result.missing.map(({ call }) => call.tool)).toEqual([readTool.name, writeTool.name]);
+    expect((await store.records("vendo_grants").list()).records).toEqual([]);
+    expect((await store.records("automations:captures").list()).records).toHaveLength(2);
+  });
+});
+
+/**
+ * How the surface READS once it is all named at once.
+ *
+ * Naming every power on one card is only an improvement if the card is
+ * readable: the incident's wall of four tool identifiers is not fixed by
+ * printing all of them together. Writes are the part a person can act on, so
+ * they keep a line each; reads are the bulk and the least interesting thing
+ * about any automation, so they collapse into one phrase about the account
+ * rather than a list of identifiers nobody asked for.
+ */
+describe("powerTitles", () => {
+  const power = (descriptor: { name: string; title?: string; risk: string }) => ({ descriptor });
+
+  it("names each write by its title and folds every read into one trailing phrase", () => {
+    const titles = powerTitles([
+      power({ ...readTool, title: "Read your balances" }),
+      power({ ...writeTool, title: "Send you a text" }),
+      power({ ...readTool, name: "read_more", title: "Search your knowledge" }),
+      power({ ...signTool, title: "Sign a document" }),
+    ]);
+
+    // The read phrase is LAST and appears exactly once however many reads there
+    // are: it is the closing "…and it can see your data", not an item competing
+    // with the actions for the person's attention.
+    expect(titles).toEqual(["Send you a text", "Sign a document", READ_ONLY_POWER]);
+    expect(titles.at(-1)).toBe(READ_ONLY_POWER);
+    expect(titles.filter((title) => title === READ_ONLY_POWER)).toHaveLength(1);
+    // Design §3's voice law: an identifier on a consent card is the engine
+    // talking to itself in front of a person who cannot act on it.
+    expect(titles.join(" ")).not.toContain("_");
+  });
+
+  it("says only the read phrase when everything the automation holds is a read", () => {
+    expect(powerTitles([
+      power({ ...readTool, title: "Read your balances" }),
+      power({ ...readTool, name: "read_more", title: "Search your knowledge" }),
+    ])).toEqual([READ_ONLY_POWER]);
+  });
+
+  /** The other end: an automation that only acts must not be told it can also
+   *  see things. The phrase is claim about the surface, so it is only true when
+   *  a read is actually in it. */
+  it("never says the read phrase when the surface holds no read at all", () => {
+    expect(powerTitles([power({ ...writeTool, title: "Send you a text" })]))
+      .toEqual(["Send you a text"]);
+    expect(powerTitles([])).toEqual([]);
+  });
+
+  /** Titles, never identifiers — but a descriptor with no title still has to
+   *  render as something, and the name is the same fallback every other consent
+   *  surface makes. Silently dropping the power would be worse than an ugly one. */
+  it("falls back to the tool's own name when a write has no title", () => {
+    expect(powerTitles([power(writeTool)])).toEqual([writeTool.name]);
+  });
+});

--- a/packages/core/src/grants.ts
+++ b/packages/core/src/grants.ts
@@ -145,6 +145,23 @@ export interface ApprovalRequest {
   call: ToolCall;
   descriptor: ToolDescriptor;
   inputPreview: string;
+  /**
+   * The standing powers ONE yes to this ask mints — human tool TITLES, never
+   * identifiers.
+   *
+   * Present only on an ask that is a consent moment for work nobody has asked
+   * for yet: arming an automation (07 §3), where the yes authorizes calls the
+   * agent will make at 2am. That ask parks BEFORE the record exists, so the set
+   * is computed at park time and rides here — which is the whole point of
+   * putting it on the request rather than in a renderer. Every surface (a text,
+   * a card, a console feed) names the same powers because there is one
+   * computation, and a surface that has not learned to render them simply shows
+   * the ask it always showed.
+   *
+   * Absent on every ordinary ask, where the call in hand IS the whole of what is
+   * being allowed.
+   */
+  powers?: string[];
   invalidatedGrant?: {
     id: GrantId;
     grantedAt: IsoDateTime;
@@ -170,6 +187,7 @@ export const approvalRequestSchema = z.object({
   call: toolCallSchema,
   descriptor: toolDescriptorSchema,
   inputPreview: z.string(),
+  powers: z.array(z.string()).optional(),
   invalidatedGrant: z.object({
     id: grantIdSchema,
     grantedAt: isoDateTimeSchema,

--- a/packages/core/src/guard.ts
+++ b/packages/core/src/guard.ts
@@ -92,4 +92,33 @@ export interface Guard extends GuardLike {
    *  the one caller today; packages/agent tools.ts). Callers feature-detect;
    *  a guard that omits it is used exactly as `check()` always was. */
   previewCheck?(call: ToolCall, descriptor: ToolDescriptor, ctx: RunContext): Promise<GuardDecision>;
+  /**
+   * What the host POLICY alone says about this call — its ordered rules, then
+   * `policy.code`, then the guard's own default posture — with NO grant lookup,
+   * no judge, no breaker spend, no parked approval, and no audit row. Nothing
+   * about asking it changes any state, which is what separates it from
+   * `previewCheck`: an "ask" there PARKS a real approval, so it cannot be used
+   * to ask a hypothetical question.
+   *
+   * ONE caller (07 §3): the automations engine asking, about the AUTHORING call
+   * that armed an automation, "was a person actually asked about this?". A call
+   * the policy would ASK about can only have reached the engine by being
+   * approved — the guard does not let an unanswered ask through — and that yes is
+   * what licenses minting the automation's standing powers on the spot instead of
+   * asking again per tool. A call the policy RUNS was never put to anybody, so
+   * nothing may be minted off it.
+   *
+   * The judge is deliberately NOT consulted: it is a per-call judgment with a
+   * model behind it, and the question here is about the host's stated posture, not
+   * about one call's circumstances.
+   *
+   * Callers feature-detect. A guard without it is read as "nobody was asked",
+   * which is the conservative answer — the powers fall back to being captured as
+   * pending asks, exactly as they were before this existed.
+   */
+  policyOutcome?(
+    call: ToolCall,
+    descriptor: ToolDescriptor,
+    ctx: RunContext,
+  ): Promise<GuardDecision["action"]>;
 }

--- a/packages/guard/src/guard.ts
+++ b/packages/guard/src/guard.ts
@@ -1422,31 +1422,8 @@ class GuardImplementation implements VendoGuard {
     const withInvalidated = (metadata: DecisionMetadata): DecisionMetadata =>
       invalidated.length === 0 ? metadata : { ...metadata, invalidatedGrants: invalidated };
 
-    const rules = await this.#policy.rules();
-    for (const rule of rules) {
-      if (!ruleMatches(rule, call.tool, descriptor.risk, ctx.venue, ctx.presence)) continue;
-      if (rule.action === "block") {
-        return withInvalidated({
-          decision: { action: "block", reason: rule.note ?? "blocked by policy rule", decidedBy: "rule" },
-        });
-      }
-      return withInvalidated({ decision: { action: rule.action, decidedBy: "rule" } });
-    }
-
-    const code = this.#policyConfig?.code;
-    if (code !== undefined) {
-      try {
-        const decision = code(call, descriptor, ctx);
-        if (decision !== undefined) {
-          return withInvalidated({ decision: normalizeCodeDecision(decision) });
-        }
-      } catch (error) {
-        return withInvalidated({
-          decision: { action: "ask", decidedBy: "rule" },
-          rationale: errorMessage(error),
-        });
-      }
-    }
+    const spoken = await this.#policySays(call, descriptor, ctx);
+    if (spoken !== undefined) return withInvalidated(spoken);
 
     if (this.#config.judge !== undefined) {
       const directions = await this.#policy.directions();
@@ -1493,10 +1470,73 @@ class GuardImplementation implements VendoGuard {
     // list is the point: §12 refuses them where there is nobody to ask, and this
     // asks where there is — the halves cannot drift apart into a default that
     // silently ran what the unattended law refuses.
-    if (withheldFromUnattended(descriptor)) {
-      return withInvalidated({ decision: { action: "ask", decidedBy: "default" } });
+    return withInvalidated({ decision: this.#defaultPosture(descriptor) });
+  }
+
+  /**
+   * The POLICY tier of `#pipeline`, on its own: the host's ordered rules, then
+   * `policy.code`. `undefined` means policy did not speak, and the caller falls
+   * through to whatever comes next (the judge, then the default posture).
+   *
+   * Extracted so `policyOutcome` below evaluates the SAME rules by the SAME
+   * precedence rather than a second copy of them — a second copy is how an arming
+   * card starts naming tools the firing would have run, and vice versa.
+   */
+  async #policySays(
+    call: ToolCall,
+    descriptor: ToolDescriptor,
+    ctx: RunContext,
+  ): Promise<DecisionMetadata | undefined> {
+    for (const rule of await this.#policy.rules()) {
+      if (!ruleMatches(rule, call.tool, descriptor.risk, ctx.venue, ctx.presence)) continue;
+      if (rule.action === "block") {
+        return { decision: { action: "block", reason: rule.note ?? "blocked by policy rule", decidedBy: "rule" } };
+      }
+      return { decision: { action: rule.action, decidedBy: "rule" } };
     }
-    return withInvalidated({ decision: { action: "run", decidedBy: "default" } });
+    const code = this.#policyConfig?.code;
+    if (code === undefined) return undefined;
+    try {
+      const decision = code(call, descriptor, ctx);
+      return decision === undefined ? undefined : { decision: normalizeCodeDecision(decision) };
+    } catch (error) {
+      return { decision: { action: "ask", decidedBy: "rule" }, rationale: errorMessage(error) };
+    }
+  }
+
+  /**
+   * Nothing spoke. `ungraded` is a tool nobody has graded — no human, no judge,
+   * no protocol fact — and `destructive` is one whose effect cannot be taken
+   * back; both need a PERSON, so neither is hidden behind a run here.
+   * Guard-level on purpose, so a hand-wired server with no policy config at all
+   * gets it too. A host that consciously wants these to run says so in writing,
+   * with a matching `risk` rule.
+   *
+   * `withheldFromUnattended` is the same two grades, and reading them off ONE
+   * list is the point: §12 refuses them where there is nobody to ask, and this
+   * asks where there is — the halves cannot drift apart into a default that
+   * silently ran what the unattended law refuses.
+   */
+  #defaultPosture(descriptor: ToolDescriptor): DraftDecision {
+    return withheldFromUnattended(descriptor)
+      ? { action: "ask", decidedBy: "default" }
+      : { action: "run", decidedBy: "default" };
+  }
+
+  /** 07 §3's arm-time probe — see `Guard.policyOutcome` in core for the contract
+   *  and for why `previewCheck` cannot answer this question. Pure: it reads the
+   *  policy and nothing else, writes nothing, and parks nothing. */
+  async policyOutcome(
+    call: ToolCall,
+    descriptor: ToolDescriptor,
+    ctx: RunContext,
+  ): Promise<GuardDecision["action"]> {
+    // `confirmEach` outranks rules in `#pipeline` and no grant can suppress it,
+    // so it outranks them here too: a tool that needs a person EVERY time is one
+    // a standing power could never satisfy.
+    if (descriptor.confirmEach === true) return "ask";
+    const spoken = await this.#policySays(call, descriptor, ctx);
+    return (spoken?.decision ?? this.#defaultPosture(descriptor)).action;
   }
 
   async #judgeWithTimeout(
@@ -1957,11 +1997,23 @@ class GuardImplementation implements VendoGuard {
     ctx: RunContext,
     invalidatedGrant?: PermissionGrant,
   ): Promise<ApprovalRequest> {
+    // What ONE yes to this ask mints beyond the call in hand. Composition
+    // answers, because arming an automation is the only ask whose yes authorizes
+    // calls nobody has made yet and the guard cannot know which those are. A
+    // failure here is swallowed on purpose: an ask a person needs to see must
+    // never fail to park because a label could not be computed.
+    let powers: readonly string[] | undefined;
+    try {
+      powers = await this.#config.describePowers?.(call, ctx);
+    } catch {
+      powers = undefined;
+    }
     const request: ApprovalRequest = {
       id: makeId("apr_") as ApprovalId,
       call: cloneJson(call),
       descriptor: cloneJson(descriptor),
       inputPreview: inputPreview(call),
+      ...(powers === undefined || powers.length === 0 ? {} : { powers: [...powers] }),
       ...(invalidatedGrant === undefined
         ? {}
         : {

--- a/packages/guard/src/types.ts
+++ b/packages/guard/src/types.ts
@@ -237,6 +237,20 @@ export interface CreateGuardConfig extends GuardRules {
    *  record doors, which is what a host's BYO `StoreAdapter` gets. */
   ops?: StoreOps;
   resolveRisk?: RiskResolver;
+  /**
+   * The standing powers one yes to a parked ask would mint, for
+   * `ApprovalRequest.powers`.
+   *
+   * Composition supplies it because the guard cannot know: arming an automation
+   * is the one ask whose yes authorizes calls NOBODY HAS MADE YET, and which
+   * tools those are is a question only the automations engine can answer. Asked
+   * once per park, for every ask — an implementation that has nothing to say
+   * about this call answers `undefined` and the request carries no `powers`.
+   *
+   * A throw or a rejection is swallowed: an ask that a person needs to see must
+   * never fail to park because a label could not be computed.
+   */
+  describePowers?: (call: ToolCall, ctx: RunContext) => Promise<readonly string[] | undefined>;
   /** Build contract §9.10 — the org-admin policy layer, resolved per check from
    *  the caller's asserted orgs (composition reads `/orgs/<orgId>/policy.json`
    *  and unions the rules). Applied as a post-pipeline strictness clamp that can

--- a/packages/vendo/src/channel-turn.ts
+++ b/packages/vendo/src/channel-turn.ts
@@ -166,7 +166,20 @@ function approvalText(request: ApprovalRequest): string {
       return `- ${argLabel(key, request.descriptor.inputSchema)}: ${shown}`;
     })
     : [];
-  const detail = lines.length > 0 ? lines : [request.inputPreview.trim()].filter(Boolean);
+  // What this yes hands over BEYOND the call itself, when the ask is one that
+  // authorizes future unattended work — arming an automation (07 §3). It reads as
+  // one more labelled line because that is what it is: another fact about what is
+  // being allowed, in the same voice as the arguments above it, human titles only.
+  //
+  // The set is computed at park time and rides on the approval, so this renders
+  // what it is given and decides nothing. That is the whole design: the powers are
+  // not a property of texting, and the web card reads the same field when it
+  // learns to.
+  const powers = request.powers ?? [];
+  const detail = [
+    ...(lines.length > 0 ? lines : [request.inputPreview.trim()].filter(Boolean)),
+    ...(powers.length === 0 ? [] : [`- Powers it will hold: ${powers.join(", ")}`]),
+  ];
   return [
     // "approval", never "OK" — the decider matches only YES/NO, and a header
     // that says OK teaches the one reply that will NOT decide it. The em dash

--- a/packages/vendo/src/compose-apps.ts
+++ b/packages/vendo/src/compose-apps.ts
@@ -284,7 +284,7 @@ const appsTailSeams = (composition: VendoComposition, seams: AppsSeams): Partial
           }
           return create(input, createCtx);
         },
-        enable: async (id, ctx) => composition.automations.enable(id, ctx),
+        enable: async (id, ctx, options) => composition.automations.enable(id, ctx, options),
         disable: async (id, ctx) => composition.automations.disable(id, ctx),
         // A list of NAMES, not foreign keys: an id nothing answers for is dropped
         // rather than raised, so deleting an automation is one fewer entry the

--- a/packages/vendo/src/compose-guard.ts
+++ b/packages/vendo/src/compose-guard.ts
@@ -4,7 +4,13 @@
  * layer), and the one-shot warning a present-mode host
  * tool call raises when its credentials cannot be forwarded.
  */
-import { RESERVED_SUBJECT_PREFIX, type RunContext, type ToolDescriptor } from "@vendoai/core";
+import {
+  RESERVED_SUBJECT_PREFIX,
+  VENDO_AUTOMATE_TOOL,
+  type RunContext,
+  type ToolCall,
+  type ToolDescriptor,
+} from "@vendoai/core";
 import {
   createGuard,
   isGuardInstance,
@@ -55,6 +61,31 @@ export const composeGuard = (composition: VendoComposition): Pick<VendoCompositi
   // label the guard never sees and is invalidated on first use.
   const resolveRisk: RiskResolver = async (call, _descriptor, ctx) =>
     (await composition.resolveAppToolRisk?.(call, ctx)) ?? await composition.serviceToolRisk(call);
+  /**
+   * 07 §3 — what ONE yes to a parked ask mints beyond the call in hand.
+   *
+   * Only `vendo_automate` has an answer: it is the ask whose yes authorizes calls
+   * nobody has made yet, so the powers the automation will hold are named on the
+   * ask itself (`ApprovalRequest.powers`) rather than asked for again per tool
+   * afterwards. Everything else answers `undefined` — an ordinary ask's call IS
+   * the whole of what is being allowed.
+   *
+   * Computed ONCE, here, and rendered by whichever surfaces know how: there is
+   * deliberately nothing channel-specific about it. The engine's own
+   * `armingPowers` is the single computation, shared with the mint that runs when
+   * the yes comes back, so the ask and the grants cannot name different tools.
+   *
+   * Late-bound through `composition`, the same way `resolveRisk` above reaches the
+   * apps runtime: the automations engine is composed after the guard, and this
+   * only ever runs inside a later park.
+   */
+  const describePowers = async (
+    call: ToolCall,
+    ctx: RunContext,
+  ): Promise<readonly string[] | undefined> => {
+    if (call.tool !== VENDO_AUTOMATE_TOOL) return undefined;
+    return await composition.automations?.armingPowers(ctx);
+  };
   // ADAPTER RULE, guard seam: a built VendoGuard is this deployment's choke
   // point verbatim; rules are completed here with the plumbing only a
   // composition can supply — the store, the app/service risk resolver, the
@@ -67,6 +98,7 @@ export const composeGuard = (composition: VendoComposition): Pick<VendoCompositi
     // route, not a downgrade.
     ...(ops === undefined ? {} : { ops }),
     resolveRisk,
+    describePowers,
     ...(guardRules.approvals === undefined ? {} : { approvals: guardRules.approvals }),
     ...(guardRules.breakers === undefined ? {} : { breakers: guardRules.breakers }),
     ...(configPolicy === undefined ? {} : { policy: configPolicy }),

--- a/packages/vendo/tests/automations-ttl-sweep.seam.test.ts
+++ b/packages/vendo/tests/automations-ttl-sweep.seam.test.ts
@@ -1,0 +1,129 @@
+/**
+ * AN EXPIRY IS NOT A REFUSAL.
+ *
+ * Live 2026-08-18 on production Maple, automation atm_d50cd48e: 33 arming asks
+ * were created at 11:26 and all 33 were denied at 12:27 — createdAt plus exactly
+ * the parked-call TTL — and the record flipped to armed=false at 12:27:37. Not one
+ * human decision was ever recorded. The person's automation turned itself off an
+ * hour after they set it up, silently, because the guard's expiry sweep denies as
+ * `"system"` and the automations decision subscriber read any deny as a person's
+ * "no".
+ *
+ * The provenance is the whole of the bug and it is why this test drives the REAL
+ * guard: `onApprovalDecision` carries only (id, approved), so `deniedBy` exists
+ * nowhere except on the persisted approval row. A double that reported its own
+ * denials could agree with the engine about a field the guard is the only writer
+ * of — the producer and the consumer have to be the real ones, over one real
+ * store, for this to prove anything.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { automationsInternals } from "@vendoai/automations";
+import type {
+  AutomationId,
+  Principal,
+  RunContext,
+  ToolDescriptor,
+  ToolRegistry,
+} from "@vendoai/core";
+import { createStore, type VendoStore } from "@vendoai/store";
+import type { LanguageModel } from "ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { createVendo, type Vendo } from "../src/server.js";
+
+const principal: Principal = { kind: "user", subject: "user_ttl_sweep" };
+const ctx: RunContext = { principal, venue: "chat", presence: "present", sessionId: "session_ttl_sweep" };
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+const readAccounts: ToolDescriptor = {
+  name: "host_read_accounts",
+  description: "Read the accounts",
+  inputSchema: { type: "object" },
+  risk: "read",
+};
+
+const host: ToolRegistry = {
+  async descriptors() {
+    return [readAccounts];
+  },
+  async execute() {
+    return { status: "ok", output: {} };
+  },
+};
+
+/** An automation with arming asks still OUTSTANDING — the state the live record
+ *  was in when the sweep reached it. The policy asks about the one tool, and
+ *  `enable` is called with no authoring call, so nothing is consented and every
+ *  power is captured as a pending ask (the leftover path). */
+async function armedWithPendingAsks(): Promise<{ vendo: Vendo; id: AutomationId; askIds: string[] }> {
+  const dataDir = await mkdtemp(join(tmpdir(), "vendo-ttl-sweep-"));
+  const store: VendoStore = createStore({ dataDir });
+  cleanups.push(async () => {
+    await store.close();
+    await rm(dataDir, { recursive: true, force: true });
+  });
+  const vendo = createVendo({
+    models: { default: {} as LanguageModel },
+    principal: async () => principal,
+    store,
+    guard: { policy: { rules: [{ match: { risk: "read" }, action: "ask" }] } },
+  });
+  vendo.actions.add(host);
+  await store.ensureSchema();
+  const record = await automationsInternals(vendo.automations).create({
+    owner: principal,
+    when: { event: "go" },
+    task: { kind: "steps", steps: [{ id: "read", tool: readAccounts.name }] },
+    authoredBy: "chat",
+    armed: false,
+  }, ctx);
+  const armed = await vendo.automations.enable(record.id, ctx);
+  expect(armed.enabled).toBe(true);
+  expect(armed.missing.length).toBeGreaterThan(0);
+  expect(await vendo.automations.get(record.id, ctx)).toMatchObject({ armed: true });
+  return { vendo, id: record.id, askIds: armed.missing.map((ask) => ask.id) };
+}
+
+describe.sequential("CHECK: the TTL sweep never disarms an automation nobody said no to", () => {
+  it("leaves the record ARMED when the hour-long sweep expires its arming asks", async () => {
+    const { vendo, id, askIds } = await armedWithPendingAsks();
+
+    // The sweep, exactly as compose-sweep drives it in production: every pending
+    // approval older than the TTL, denied as `"system"`, as its own principal.
+    // Feature-detected the same way `compose-sweep.ts` does — a guard without it
+    // never sweeps, so there would be nothing here to prove.
+    const sweep = vendo.guard.sweepExpiredApprovals;
+    expect(sweep).toBeDefined();
+    const swept = await sweep!.call(vendo.guard, 60 * 60_000, Date.now() + 2 * 60 * 60_000);
+    expect(swept).toBe(askIds.length);
+
+    // THE POINT. The person set this up and answered nothing yet; an hour passing
+    // is not them saying no, so the automation they armed is still armed.
+    expect(await vendo.automations.get(id, ctx)).toMatchObject({ armed: true });
+
+    // And the asks really were settled — the sweep's job is to stop the queue
+    // accreting forever, which it still does. What is gone is only the silent
+    // disarm: the record stays on, holding no grant, so its next firing meets the
+    // permission it does not have and asks again there (05 §6, J5) instead of the
+    // automation having quietly ceased to exist.
+    const pending = await vendo.guard.approvals.pending(principal);
+    expect(pending.filter((ask) => askIds.includes(ask.id))).toEqual([]);
+  });
+
+  it("still disarms on a real person's NO, so the channel's receipt stays true", async () => {
+    const { vendo, id, askIds } = await armedWithPendingAsks();
+
+    // The mirror, and the reason this cannot be fixed by ignoring denials
+    // wholesale: a bare no over text means "turn it off", and the channel answers
+    // "Okay — I turned it off." That sentence has to remain true.
+    await vendo.guard.approvals.decide([...askIds], { approve: false }, principal);
+
+    expect(await vendo.automations.get(id, ctx)).toMatchObject({ armed: false });
+    expect(await vendo.guard.grants.list(principal)).toEqual([]);
+  });
+});

--- a/packages/vendo/tests/channel-arming-consent.e2e.test.ts
+++ b/packages/vendo/tests/channel-arming-consent.e2e.test.ts
@@ -1,0 +1,415 @@
+import { createServer, type Server } from "node:http";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AddressInfo } from "node:net";
+import {
+  VENDO_AUTOMATE_TOOL,
+  type AutomationRecord,
+  type Principal,
+  type RunContext,
+  type ToolDescriptor,
+  type ToolRegistry,
+} from "@vendoai/core";
+import { defineHarness } from "@vendoai/harnesses";
+import { createStore, type VendoStore } from "@vendoai/store";
+import type { LanguageModel } from "ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { channelInboundSecret } from "../src/channels.js";
+import { createVendo, guard, type Vendo } from "../src/server.js";
+import { READ_ONLY_POWER } from "@vendoai/automations";
+import { VENDO_TEXT_ME_TOOL } from "../src/text-me.js";
+
+/**
+ * JOB-SHAPED ARMING CONSENT, END TO END OVER THE CHANNEL THAT EXPOSED IT.
+ *
+ * The failure, live 2026-08-18 on production Maple: a user armed "check my
+ * checking balance every 15 minutes and text me" entirely over iMessage. Their
+ * YES to the job landed — and arming then minted FOUR more per-tool asks
+ * (`vendo_text_me`, `vendo_knowledge_search`, `request_connection`,
+ * `list_connections`). Three are read-grade tools a live chat runs without asking
+ * anyone, and the fourth was literally in the sentence they typed. Consent was
+ * framed per-tool while the person was thinking per-job.
+ *
+ * What this pins is the whole rule in one flow: the arming ask NAMES the powers
+ * that need a human and nothing else, ONE yes mints exactly those, and the reads
+ * the host's policy already runs need no grant at all — they simply run at 2am.
+ *
+ * Nothing is stubbed between the halves: real `createVendo`, real guard, real
+ * automations engine, one real PGlite store, the real `cloudTextChannel` client,
+ * and an HTTP console standing in for the one half this repo does not own. The
+ * grants are read back through the path that actually gates a firing, because a
+ * grant row the guard would not honour proves nothing — and the ungranted read is
+ * read back the same way, because a read that parks proves the opposite.
+ */
+
+const API_KEY = "vk_live_arming_consent";
+const owner: Principal = { kind: "user", subject: "user_arming_consent" };
+const PHONE = "+15557770789";
+const CONVERSATION = "conv_arming_consent";
+const BALANCE_TOOL = "maple_accounts_balance";
+const BALANCE_TITLE = "Check an account balance";
+/** The goal an automation is armed with, and the phrase the probe brain keys the
+ *  firing branch off. */
+const GOAL = "check my checking balance and text me";
+const ARMING_HEADER = "Set this to run on its own — needs your approval";
+const POWERS_LINE = "- Powers it will hold: ";
+const SET_ASK_HEADER = "needs your permission to run on its own";
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+  vi.unstubAllEnvs();
+});
+
+interface FakeConsole {
+  baseUrl: string;
+  sent: Array<{ conversationId: string; text: string }>;
+}
+
+async function fakeConsole(): Promise<FakeConsole> {
+  const state: FakeConsole = { baseUrl: "", sent: [] };
+  const server: Server = createServer((req, res) => {
+    let body = "";
+    req.on("data", (chunk) => (body += String(chunk)));
+    req.on("end", () => {
+      res.setHeader("content-type", "application/json");
+      if (req.url === "/api/v1/channels/text/register") {
+        res.end(JSON.stringify({
+          identityId: "tid_arming_consent",
+          handle: "maple",
+          number: "+15550000000",
+          connectCommand: "connect @maple",
+        }));
+        return;
+      }
+      if (req.url === "/api/v1/channels/text/send") {
+        state.sent.push(JSON.parse(body) as { conversationId: string; text: string });
+        res.end(JSON.stringify({ ok: true }));
+        return;
+      }
+      res.statusCode = 404;
+      res.end("{}");
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  cleanups.push(async () => new Promise<void>((resolve) => server.close(() => resolve())));
+  const { port } = server.address() as AddressInfo;
+  state.baseUrl = `http://127.0.0.1:${port}`;
+  return state;
+}
+
+/** The host's own read, and the observable that says whether it really ran: a
+ *  firing that reaches it with no grant of any kind is the point of the change. */
+function bankingHost(): { tools: ToolRegistry; reads: number } {
+  const state = { reads: 0 };
+  const descriptor: ToolDescriptor = {
+    name: BALANCE_TOOL,
+    title: BALANCE_TITLE,
+    description: "Read the balance of one of the customer's accounts",
+    inputSchema: { type: "object" },
+    risk: "read",
+  };
+  return {
+    get reads() {
+      return state.reads;
+    },
+    tools: {
+      async descriptors() {
+        return [descriptor];
+      },
+      async execute() {
+        state.reads += 1;
+        return { status: "ok", output: { balance: 41_208 } };
+      },
+    },
+  };
+}
+
+/** The brain, on both sides of the same composition: it arms when asked to, and
+ *  on a firing it does what the goal says — reads the balance, then texts it. One
+ *  harness rather than two because the automation has to be armed by the SAME
+ *  deployment whose away run later fires it. */
+const probe = defineHarness({
+  name: "channel-arming-consent-probe",
+  async *run(turn) {
+    const said = (turn.messages.at(-1)?.parts ?? [])
+      .map((part) => (part.type === "text" ? part.text : ""))
+      .join(" ");
+    if (said.includes("arm:")) {
+      const armed = await turn.tools.call(VENDO_AUTOMATE_TOOL, {
+        when: "*/15 * * * *",
+        task: GOAL,
+      });
+      yield { type: "text", delta: armed.status === "ok" ? "Set — I'll keep an eye on it." : "I couldn't set that up." };
+      return;
+    }
+    if (said.includes("checking balance")) {
+      // The READ first — ungranted, and it has to run anyway — then the write the
+      // person actually allowed at arming.
+      const read = await turn.tools.call(BALANCE_TOOL, {});
+      if (read.status !== "ok") {
+        yield { type: "text", delta: `read blocked: ${read.status}` };
+        return;
+      }
+      const sent = await turn.tools.call(VENDO_TEXT_ME_TOOL, { text: "Your checking balance is $412.08." });
+      yield { type: "text", delta: sent.status === "ok" ? "Texted them." : "Could not text them." };
+      return;
+    }
+    yield { type: "text", delta: "Nothing else is due this week." };
+  },
+});
+
+async function tempStore(): Promise<VendoStore> {
+  const dataDir = await mkdtemp(join(tmpdir(), "vendo-arming-consent-"));
+  const store = createStore({ dataDir });
+  cleanups.push(async () => {
+    await store.close();
+    await rm(dataDir, { recursive: true, force: true });
+  });
+  return store;
+}
+
+async function waitFor(check: () => boolean): Promise<void> {
+  while (!check()) await new Promise((resolve) => setTimeout(resolve, 25));
+}
+
+/** `asksOnReads` is the policy-is-truth switch: the SAME deployment, the same
+ *  tools, one rule different. The host's policy is the only thing that decides
+ *  which tools the arming ask names. */
+async function compose(
+  cloud: FakeConsole,
+  host: { tools: ToolRegistry },
+  options: { asksOnReads?: boolean } = {},
+): Promise<Vendo> {
+  vi.stubEnv("VENDO_API_KEY", API_KEY);
+  vi.stubEnv("VENDO_CLOUD_URL", cloud.baseUrl);
+  vi.stubEnv("VENDO_BASE_URL", "https://maple.test");
+  const vendo: Vendo = createVendo({
+    models: { default: {} as LanguageModel },
+    principal: async () => owner,
+    store: await tempStore(),
+    harness: probe as never,
+    // Arming future unattended behaviour is a write, so `vendo_automate` itself
+    // earns a card — and THAT card is the one consent moment for the whole job.
+    guard: guard({
+      policy: {
+        rules: [
+          { match: { risk: "write" }, action: "ask" },
+          ...(options.asksOnReads === true ? [{ match: { risk: "read" as const }, action: "ask" as const }] : []),
+        ],
+      },
+    }),
+    channels: { text: true },
+  } as Parameters<typeof createVendo>[0]);
+  vendo.actions.add(host.tools);
+  return vendo;
+}
+
+const inbound = async (vendo: Vendo, eventId: string, text: string): Promise<Response> =>
+  vendo.handler(new Request("https://maple.test/api/vendo/channels/text/inbound", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${await channelInboundSecret(API_KEY)}`,
+    },
+    body: JSON.stringify({
+      eventId,
+      channel: "text",
+      from: PHONE,
+      text,
+      conversationId: CONVERSATION,
+      receivedAt: new Date().toISOString(),
+    }),
+  }));
+
+/** A linked, texting user — the code off the link page, then nothing else. */
+async function link(vendo: Vendo, cloud: FakeConsole): Promise<void> {
+  const page = await (await vendo.handler(
+    new Request("https://maple.test/api/vendo/channels/text/link", { headers: { "user-agent": "Macintosh" } }),
+  )).text();
+  await inbound(vendo, "evt_link", /connect @maple ([23456789A-Z]{6})/.exec(page)![1]!);
+  await waitFor(() => cloud.sent.length === 1);
+}
+
+/** Arm the automation the way the live user did: one text asking for it, then the
+ *  arming card. Stops BEFORE the yes so a test can inspect the ask itself. */
+async function armingAsk(vendo: Vendo, cloud: FakeConsole): Promise<string> {
+  await link(vendo, cloud);
+  await inbound(vendo, "evt_arm", `arm: ${GOAL} every 15 minutes`);
+  await waitFor(() => cloud.sent.length === 2);
+  return cloud.sent[1]!.text;
+}
+
+const ctxFor = (sessionId: string): RunContext =>
+  ({ principal: owner, venue: "chat", presence: "present", sessionId });
+
+/** Arm, then say YES. Returns the record and every text that went out. */
+async function armAndApprove(
+  vendo: Vendo,
+  cloud: FakeConsole,
+): Promise<{ record: AutomationRecord; ctx: RunContext; ask: string }> {
+  const ask = await armingAsk(vendo, cloud);
+  await inbound(vendo, "evt_arm_yes", "YES");
+  // The turn's own words. Nothing must follow them — see the no-second-ask test.
+  await waitFor(() => cloud.sent.length >= 3);
+  const ctx = ctxFor("sess_arming_consent");
+  const records = await vendo.automations.list({ owner: owner.subject }, ctx);
+  expect(records).toHaveLength(1);
+  return { record: records[0]!, ctx, ask };
+}
+
+describe.sequential("job-shaped arming consent, over the channel that armed it", () => {
+  it("names the powers on the arming ask itself: acts by name, reads as one phrase", async () => {
+    const cloud = await fakeConsole();
+    const host = bankingHost();
+    const vendo = await compose(cloud, host);
+    const ask = await armingAsk(vendo, cloud);
+
+    // The post-#1462 arming card, now carrying what the yes actually hands over.
+    // Pinned as WHOLE LINES, in order: this text is the consent boundary, and a
+    // `toContain` sweep would not notice the powers line drifting above the
+    // schedule or the reply instruction losing its place.
+    const lines = ask.split("\n");
+    expect(lines[0]).toBe(`${ARMING_HEADER}:`);
+    expect(lines[1]).toBe("- When it runs: every 15 minutes (*/15 * * * *)");
+    expect(lines[2]).toBe(`- What to do on every firing: ${GOAL}`);
+    expect(lines[3]!.startsWith(POWERS_LINE)).toBe(true);
+    expect(lines[4]).toBe("Reply YES to approve, or NO to cancel.");
+    expect(lines).toHaveLength(5);
+
+    const powers = lines[3]!;
+    // What the automation DOES, named one by one — including the thing the person
+    // asked for in their own sentence.
+    expect(powers).toContain("Text me");
+    // THE POINT. Every read it may make is ONE phrase, at the end. Naming reads
+    // individually is what turned a yes to a JOB into a wall of tool names the
+    // person could not act on — three of the four follow-up asks in the live
+    // incident were reads. They are still granted; they are not worth a line each.
+    expect(powers.endsWith(READ_ONLY_POWER)).toBe(true);
+    expect(powers).not.toContain(BALANCE_TITLE);
+    expect(ask).not.toContain(BALANCE_TITLE);
+    // Exactly one read phrase, however many reads the deployment has.
+    expect(powers.split(READ_ONLY_POWER)).toHaveLength(2);
+
+    // Design §3's voice law: no identifier and no machinery reaches the person.
+    expect(ask).not.toContain("vendo_");
+    expect(ask).not.toContain(BALANCE_TOOL);
+    expect(ask).not.toContain("gset_");
+  }, 120_000);
+
+  it("carries the named powers on the approval RECORD, not in any one surface", async () => {
+    const cloud = await fakeConsole();
+    const host = bankingHost();
+    const vendo = await compose(cloud, host);
+    const ask = await armingAsk(vendo, cloud);
+
+    // The universal seam: the set is computed once, at park time, and rides on the
+    // approval. The text renders it; every other surface reads the same field. A
+    // powers list that lived in the channel would be a promise only texting users
+    // could ever be shown.
+    const pending = await vendo.guard.approvals.pending(owner);
+    const arming = pending.find((request) => request.call.tool === VENDO_AUTOMATE_TOOL);
+    expect(arming).toBeDefined();
+    expect(arming!.powers).toBeDefined();
+    expect(arming!.powers).toContain("Text me");
+    expect(arming!.powers).not.toContain(BALANCE_TITLE);
+    // Titles, never identifiers — the field is rendered verbatim by whoever reads it.
+    for (const power of arming!.powers!) expect(power).not.toMatch(/^[a-z_]+_[a-z_]+$/);
+
+    // And the text said exactly what the record carries: one computation, so the
+    // card and the run cannot disagree.
+    const powers = ask.split("\n").find((line) => line.startsWith(POWERS_LINE))!;
+    expect(powers).toBe(`${POWERS_LINE}${arming!.powers!.join(", ")}`);
+  }, 120_000);
+
+  it("turns ONE yes into exactly those standing grants, with nothing left pending", async () => {
+    const cloud = await fakeConsole();
+    const host = bankingHost();
+    const vendo = await compose(cloud, host);
+    const { record } = await armAndApprove(vendo, cloud);
+
+    // Armed, and every named power is already a live standing grant the guard will
+    // honour away. No second ceremony happened.
+    expect(record.armed).toBe(true);
+    const grants = await vendo.guard.grants.list(owner);
+    const mine = grants.filter((grant) => grant.automationId === record.id);
+    expect(mine.length).toBeGreaterThan(0);
+    for (const grant of mine) {
+      expect(grant).toMatchObject({
+        subject: owner.subject,
+        automationId: record.id,
+        source: "automation",
+        duration: "standing",
+      });
+    }
+    // THE RESHAPE'S CORE CLAIM: one yes covers the whole JOB. The write the person
+    // asked for by name AND the read they never had to think about are both live
+    // standing grants now, so the firing holds everything it needs and nobody is
+    // asked a second time. Away execution is grant-backed exactly as it always was
+    // (05 §6 untouched) — what changed is that the person answers once.
+    expect(mine.map((grant) => grant.tool)).toContain(VENDO_TEXT_ME_TOOL);
+    expect(mine.map((grant) => grant.tool)).toContain(BALANCE_TOOL);
+
+    // NOTHING is pending for this automation — this is the live failure, inverted.
+    const pending = await vendo.guard.approvals.pending(owner);
+    expect(pending.filter((ask) => ask.ctx.trigger?.automationId === record.id)).toEqual([]);
+  }, 120_000);
+
+  it("never sends a follow-up permission text, however many turns go by", async () => {
+    const cloud = await fakeConsole();
+    const host = bankingHost();
+    const vendo = await compose(cloud, host);
+    await armAndApprove(vendo, cloud);
+
+    // An ordinary turn about something else entirely. After a normal arming there
+    // is nothing outstanding, so the set ask has nothing to offer and must stay
+    // silent — the second consent moment is gone, not merely shorter.
+    await inbound(vendo, "evt_later", "what did I spend on food?");
+    await waitFor(() => cloud.sent.at(-1)!.text === "Nothing else is due this week.");
+
+    expect(cloud.sent.filter((text) => text.text.includes(SET_ASK_HEADER))).toEqual([]);
+  }, 120_000);
+
+  it("really fires: the read and the text both land on grants that one yes minted", async () => {
+    const cloud = await fakeConsole();
+    const host = bankingHost();
+    const vendo = await compose(cloud, host);
+    const { record, ctx } = await armAndApprove(vendo, cloud);
+    const before = host.reads;
+    const landed = cloud.sent.length;
+
+    // THE POINT, at 2am. Both halves of the job run on standing grants the single
+    // arming YES minted — the read the person never had to think about, and the
+    // text they asked for by name. Away execution is grant-backed exactly as it has
+    // always been (05 §6 untouched); what changed is that nobody had to answer a
+    // second round of per-tool asks to get here.
+    const [fired] = await vendo.automations.tick(new Date(Date.now() + 30 * 60_000));
+    expect(fired).toBeDefined();
+    expect(await vendo.automations.runs.get(fired!, ctx)).toMatchObject({
+      automationId: record.id,
+      status: "ok",
+    });
+    expect(host.reads).toBe(before + 1);
+    expect(cloud.sent.slice(landed)).toEqual([
+      { conversationId: CONVERSATION, text: "Your checking balance is $412.08." },
+    ]);
+  }, 120_000);
+
+  it("folds EVERY read into the one phrase, whatever the host's policy says", async () => {
+    const cloud = await fakeConsole();
+    const host = bankingHost();
+    // A host that confirms reads in live chat. The grouping is not a policy
+    // decision — an automation runs on captured grants, so its reads are granted
+    // either way; what the person is shown is a property of the CARD, and a card
+    // that reads well under one policy must read the same under another.
+    const vendo = await compose(cloud, host, { asksOnReads: true });
+    const ask = await armingAsk(vendo, cloud);
+
+    const powers = ask.split("\n").find((line) => line.startsWith(POWERS_LINE))!;
+    expect(powers.endsWith(READ_ONLY_POWER)).toBe(true);
+    expect(powers.split(READ_ONLY_POWER)).toHaveLength(2);
+    expect(powers).not.toContain(BALANCE_TITLE);
+    expect(ask).not.toContain(BALANCE_TOOL);
+  }, 120_000);
+});

--- a/packages/vendo/tests/channel-grant-set.e2e.test.ts
+++ b/packages/vendo/tests/channel-grant-set.e2e.test.ts
@@ -20,16 +20,27 @@ import { createVendo, guard, type Vendo } from "../src/server.js";
 import { VENDO_TEXT_ME_TOOL } from "../src/text-me.js";
 
 /**
- * ARMING AN AUTOMATION FROM A PHONE, ALL THE WAY TO A FIRING THAT DELIVERS.
+ * AN OUTSTANDING GRANT SET, ASKED OVER TEXT, ALL THE WAY TO A FIRING THAT
+ * DELIVERS.
  *
  * The gap this pins, live 2026-08-18 on production Maple: a user armed "check my
- * checking balance every 15 minutes and text me" entirely over iMessage. The
- * arming approval worked — the card went out as a text and their YES decided it —
- * but arming ALSO minted four pending standing-grant captures, and those asks are
- * approval rows the engine writes during `vendo_automate`, not stream parts. They
- * had exactly one surface: the host app's web approvals feed. A text-only user
- * could never reach it, so every firing ran without the Text me grant and the
- * agent could only say "there are still some permissions pending approval".
+ * checking balance every 15 minutes and text me" entirely over iMessage, and
+ * arming minted pending standing-grant captures. Those asks are approval rows the
+ * engine writes during the authoring call, not stream parts, so they had exactly
+ * one surface: the host app's web approvals feed. A text-only user could never
+ * reach it, so every firing ran without the Text me grant and the agent could only
+ * say "there are still some permissions pending approval". This one text is how
+ * they get asked.
+ *
+ * WHAT CHANGED under it (job-shaped arming consent, same day): a normal arming no
+ * longer leaves anything pending. The powers are named on the authoring call's own
+ * approval and one yes mints them, so there is nothing for this text to offer —
+ * `channel-arming-consent.e2e.test.ts` pins that, including that no follow-up text
+ * is sent. The set ask is now the LEFTOVER path, and this file exercises the
+ * leftover that actually happens: an arming the host's policy ran WITHOUT asking
+ * anybody, which is `vendo_make`'s read-graded arming and any host whose policy
+ * lets authoring through. Nobody saw a powers line, so nothing may be minted off
+ * it, and each power is captured as a pending ask exactly as before.
  *
  * Nothing is stubbed between the two halves: real `createVendo`, real guard, real
  * automations engine, one real PGlite store, the real `cloudTextChannel` client,
@@ -48,6 +59,7 @@ const BALANCE_TOOL = "maple_accounts_balance";
  *  firing branch off. */
 const GOAL = "check my checking balance and text me";
 const SET_ASK_HEADER = "needs your permission to run on its own";
+const SET_ALLOWED_TEXT = "Done — it can run on its own now.";
 
 const cleanups: Array<() => Promise<void>> = [];
 afterEach(async () => {
@@ -159,9 +171,19 @@ async function compose(cloud: FakeConsole): Promise<Vendo> {
     principal: async () => owner,
     store: await tempStore(),
     harness: probe as never,
-    // Arming future unattended behaviour is a write, so `vendo_automate` itself
-    // earns a card — which is the flow the live incident got RIGHT.
-    guard: guard({ policy: { rules: [{ match: { risk: "write" }, action: "ask" }] } }),
+    // A host whose policy lets AUTHORING through without a card, but still wants
+    // its writes confirmed. That combination is the whole subject of this file:
+    // nobody was ever shown a powers line for this arming, so nothing may be
+    // minted off one, and every power the automation needs is left as a pending
+    // ask for the text below to deliver.
+    guard: guard({
+      policy: {
+        rules: [
+          { match: { tool: VENDO_AUTOMATE_TOOL }, action: "run" },
+          { match: { risk: "write" }, action: "ask" },
+        ],
+      },
+    }),
     channels: { text: true },
   } as Parameters<typeof createVendo>[0]);
   vendo.actions.add(bankingHost());
@@ -194,26 +216,25 @@ async function link(vendo: Vendo, cloud: FakeConsole): Promise<void> {
   await waitFor(() => cloud.sent.length === 1);
 }
 
-/** Arm the automation the way the live user did: one text asking for it, the
- *  arming card, and a YES. Answers the set ask that lands after the turn. */
+/** Arm the automation over text under a policy that does NOT card the authoring
+ *  call: one text asking for it, the turn's own words, and then the set ask for
+ *  everything still outstanding. No arming card, and nothing minted without one. */
 async function armOverText(
   vendo: Vendo,
   cloud: FakeConsole,
 ): Promise<{ record: AutomationRecord; ctx: RunContext; setAsk: string }> {
   await link(vendo, cloud);
   await inbound(vendo, "evt_arm", `arm: ${GOAL} every 15 minutes`);
-  // The arming card.
-  await waitFor(() => cloud.sent.length === 2);
-  expect(cloud.sent[1]!.text).toContain("Set this to run on its own — needs your approval");
-
-  await inbound(vendo, "evt_arm_yes", "YES");
-  // The turn's own words, and then the set ask behind them.
-  await waitFor(() => cloud.sent.length === 4);
+  // The turn's own words, and then the set ask behind them. The authoring call
+  // itself never parks here, so there is no card in between — which is exactly
+  // why the powers had to be captured instead of minted.
+  await waitFor(() => cloud.sent.length === 3);
+  expect(cloud.sent.every((text) => !text.text.includes("needs your approval"))).toBe(true);
 
   const ctx: RunContext = { principal: owner, venue: "chat", presence: "present", sessionId: "sess_grant_set" };
   const records = await vendo.automations.list({ owner: owner.subject }, ctx);
   expect(records).toHaveLength(1);
-  return { record: records[0]!, ctx, setAsk: cloud.sent[3]!.text };
+  return { record: records[0]!, ctx, setAsk: cloud.sent[2]!.text };
 }
 
 describe.sequential("an automation's grant set, asked over text", () => {
@@ -235,6 +256,10 @@ describe.sequential("an automation's grant set, asked over text", () => {
     // The one the live incident lost: without it the automation can never reach
     // the phone it was armed from.
     expect(setAsk).toContain("\n- Text me");
+    // The read is named here, one line of its own, and that is the leftover path
+    // showing its age: this text is a raw list of every outstanding capture,
+    // because nobody was shown a powers page for this arming at all. A chat arming
+    // gets the grouped one-line version instead (channel-arming-consent.e2e).
     expect(setAsk).toContain("\n- Check an account balance");
     expect(setAsk).toContain("Reply YES to allow all of these, or NO to cancel it.");
     // Design §3's voice law: no identifier, and no machinery, reaches the person.
@@ -306,6 +331,57 @@ describe.sequential("an automation's grant set, asked over text", () => {
     expect(await vendo.automations.get(record.id, ctx)).toMatchObject({ armed: false });
     expect(await vendo.guard.grants.list(owner)).toEqual([]);
     expect(cloud.sent.at(-1)!.text).toBe("Okay — I turned it off.");
+  }, 120_000);
+
+  it("asks again over text when a FIRING meets a power the automation no longer holds", async () => {
+    const cloud = await fakeConsole();
+    const vendo = await compose(cloud);
+    const { record } = await armOverText(vendo, cloud);
+
+    // Settle the set the ordinary way, and prove the automation really works.
+    await inbound(vendo, "evt_set_yes", "YES");
+    await waitFor(() => cloud.sent.at(-1)!.text === SET_ALLOWED_TEXT);
+    let landed = cloud.sent.length;
+    await vendo.emit("balance.checked", {}, owner);
+    expect(cloud.sent.slice(landed)).toEqual([
+      { conversationId: CONVERSATION, text: "Your checking balance is $412.08." },
+    ]);
+
+    // Then the person takes the Text me permission back. THE OTHER HALF of the
+    // leftover path: a firing that meets an ask-grade tool it holds no grant for
+    // does not quietly skip it — the guard parks the call and the ask it mints is
+    // an automation-venue row, so the next texted turn offers it as a set again.
+    // Nothing else closes that ask; before the set text existed, only the web feed
+    // could.
+    for (const grant of await vendo.guard.grants.list(owner)) {
+      if (grant.tool === VENDO_TEXT_ME_TOOL) await vendo.guard.grants.revoke(grant.id, owner);
+    }
+    landed = cloud.sent.length;
+    await vendo.emit("balance.checked", {}, owner);
+    // The firing reached the phone with nothing, because the permission is gone.
+    expect(cloud.sent.slice(landed)).toEqual([]);
+    const parked = (await vendo.guard.approvals.pending(owner))
+      .filter((ask) => ask.ctx.trigger?.automationId === record.id);
+    expect(parked.map((ask) => ask.call.tool)).toContain(VENDO_TEXT_ME_TOOL);
+
+    // And the next ordinary turn asks for it, by title, exactly as arming's set
+    // did. Scoped to what this turn sent: an earlier set ask is still in the
+    // history, and matching that one would prove nothing.
+    const mark = cloud.sent.length;
+    await inbound(vendo, "evt_after_revoke", "anything due this week?");
+    await waitFor(() => cloud.sent.slice(mark).some((text) => text.text.includes(SET_ASK_HEADER)));
+    expect(cloud.sent.slice(mark).find((text) => text.text.includes(SET_ASK_HEADER))!.text)
+      .toContain("\n- Text me");
+
+    // One more YES and the automation reaches the phone again — through the away
+    // authority check and the real console send, not a grant row nobody honours.
+    await inbound(vendo, "evt_regrant_yes", "YES");
+    await waitFor(() => cloud.sent.at(-1)!.text === SET_ALLOWED_TEXT);
+    landed = cloud.sent.length;
+    await vendo.emit("balance.checked", {}, owner);
+    expect(cloud.sent.slice(landed)).toEqual([
+      { conversationId: CONVERSATION, text: "Your checking balance is $412.08." },
+    ]);
   }, 120_000);
 
   it("never asks the same set twice, however many turns go by", async () => {


### PR DESCRIPTION
## One page, one yes

Arming an automation used to be two consent moments. The user said yes to the job, and then the engine asked again, per tool, for things nobody needed a second opinion about. This makes it one.

**Live 2026-08-18, production Maple.** A user armed *"check my checking balance every 15 minutes and text me"* entirely over iMessage. Their YES to the job landed — and arming then minted four *more* pending per-tool asks: `vendo_text_me`, `vendo_knowledge_search`, `request_connection`, `list_connections`. Three are reads nobody needs to be consulted about. The fourth was literally in the sentence they had just typed. Consent was framed per-tool while the person was thinking per-job.

**Before** — one card, a YES, then a second text listing every tool again, unanswerable for a user who only ever texts.

**After** — the authoring call's own approval names what the automation will hold, and that one yes mints all of it:

```
Set this to run on its own — needs your approval:
- When it runs: every 15 minutes (*/15 * * * *)
- What to do on every firing: check my checking balance and text me
- Powers it will hold: Set this to run on its own, Refresh a remixed piece, Save an item in the app, Remove an item from the app, Change when this runs, Text me, Read-only access to your data
Reply YES to approve, or NO to cancel.
```

Nothing is pending afterward, and no follow-up permission text is ever sent.

## What the powers line does

Tools that **do** something are named one by one, by their human title. Every **read** folds into a single trailing phrase — `Read-only access to your data` — because naming reads individually is exactly what turned a yes to a job into a wall of tool names the person could not act on. The reads are still granted; they are simply not worth a line each. No identifier, no JSON, no tool list.

The set rides on the approval record itself: `ApprovalRequest.powers?: string[]` (additive, optional, finished phrases). It is computed **once**, at park time, by the composition — a new optional `describePowers` guard config wired in `compose-guard.ts` to the automations engine's `armingPowers(ctx)`. The text channel renders it verbatim today; any other surface reads the same field with no further work. There is deliberately nothing channel-specific about it.

## The reshape story

The first cut of this went further: it narrowed the consent surface by asking the host's policy which tools would actually need a human, freed policy-run calls from needing a grant away, and added a sponsorship-derived credential so those freed calls could still authenticate. The composed-wire suites found the flaw — the away grant is doing **three** jobs at once, not one. It is consent, it is the `actAs` credential (`registry.ts:651-654` refuses any away host call without a grant), and it is the connector dispatcher's visibility key (§12 withholds `use_service_tool` from an away listing except for a firing that already holds a per-slug grant). Replacing only the consent job broke the other two, and each patch needed another mechanism.

So the away law is **deliberately untouched here.** 05 §6 is exactly as it is on main: every away call is grant-backed, credentialed, doors open. The consent surface is as wide as it has always been. What changed is only what a person is made to do about it — one page instead of a pile.

The proof is that the away-law suites pass **unmodified**: `packages/guard/test/pipeline-conformance.test.ts`, `app-venue-reads.test.ts`, and `security/away-code-hatch.test.ts` are byte-identical to main in this branch, as are `packages/core/src/run-context.ts` and `packages/automations/src/sponsorship-gate.ts`.

## Minting is gated on someone actually being asked

`enable()` takes the authoring call (`armedBy`). When the host's policy would have **asked** about that call, the call reaching the engine at all proves the ask was answered yes — the guard does not let an unanswered ask through — so the powers are minted on the spot. When policy would have **run** it unasked (`vendo_make` is read-graded, and arms the schedule half of "build me the board and refresh it every Monday"), nobody was shown a powers page, so nothing is minted and every power is captured as a pending ask exactly as before, delivered by #1469's grant-set text. A guard with no `policyOutcome` reads as "nobody was asked", which is the conservative fallback.

Two kinds never receive a standing power, because a grant could not satisfy them and the card would be promising what the run will not honour:
- `destructive` / `ungraded` (§12's pair) — now closed on the two branches that leaked: a **steps** record's declared destructive tool, and a **connector slug** the risk resolver grades destructive. Both used to receive a standing grant that could never work.
- `confirmEach` — needs a person every time; no grant may suppress it (05 §2).

## Also fixed: an expiry is not a refusal

Separate production root cause found in the same seam. Automation `atm_d50cd48e` on Maple: 33 arming asks created at 11:26, all 33 denied at 12:27 — createdAt plus exactly the parked-call TTL — and the record flipped `armed=false` at 12:27:37 with **zero** human decisions ever recorded. The person's automation turned itself off an hour after they set it up, silently.

The guard's hourly sweep denies an abandoned ask as `"system"`; the automations decision subscriber read any deny as a person's no and disarmed. It now reads the provenance off the approval row — the only place it exists, since the decision callback carries just `(id, approved)` — and disarms only for a human. The guard already enforces `deniedBy: "human"` for standing denials; this was the one place that did not. A guard that stamps nothing keeps today's behaviour, and a human NO still disarms, so the channel's "Okay — I turned it off." stays true.

## Tests

New:
- `packages/vendo/tests/channel-arming-consent.e2e.test.ts` (6) — real guard, real engine, real store, fake console door. The ask pinned as whole lines in order; acts named, reads as one phrase; the approval **record** carries the powers and the text matches it exactly; one YES mints the whole surface (read *and* write) with nothing pending; no follow-up permission text on later turns; a real firing where both halves land on those grants; and the read phrase holds whatever the host's policy says.
- `packages/automations/tests/arming-consent.test.ts` (11) — destructive excluded on the steps branch and the connector-slug branch; `confirmEach` excluded; the `armedBy` gate ×4 (asked ⇒ mints read *and* write; runs ⇒ captures; nothing ⇒ captures; no `policyOutcome` ⇒ captures); and `powerTitles` ×4 (writes by title, reads folded, reads-only, writes-only, name fallback).
- `packages/vendo/tests/automations-ttl-sweep.seam.test.ts` (2) — the sweep leaves the record armed; a human NO still disarms.

Changed:
- `packages/vendo/tests/channel-grant-set.e2e.test.ts` — #1469's set-ask tests now exercise the path they still serve (an arming the host's policy ran without asking, so nothing could be minted), plus a new fire-time case: revoke a power, fire, and the set ask redelivers it.
- Seven fixture/example tests across `fixtures/integration`, `fixtures/automations-e2e`, `fixtures/redteam` and `examples/demo-bank` — **setup only**. Each arranged its world by approving a capture for a destructive tool, which arming no longer mints; they now buy that grant the one way that still exists (the run's own away ask) or seed it through the guard's `mintGrant`. Every behavioural assertion is unchanged and still passes — THE LAW still blocks the destructive away call, revocation is still live, the away run still fails loud, `unknown tool` is still not thrown. Two assertions were *added* (`missing === []` pins, and a confirm-each invariant so the consent-surface test proves the rule rather than listing names).

One assertion was removed, and it is worth naming: `away-park-revoke` leg 4's "a consent moment refused wholesale disarms the automation". Its precondition was "there are captures to refuse", which cannot exist for a destructive-only automation. That behaviour is covered unchanged at `packages/vendo/tests/channel-grant-set.e2e.test.ts:331` (bare NO ⇒ `armed: false`, nothing minted, correct receipt) — I verified that directly rather than taking it on trust.

**Red-green, stated out loud.** Disabling the mint turns three tests red at once — no grants minted, the follow-up set-ask text reappears, and the firing neither reads nor texts (`expected +0 to be 1`); restored, green. Ignoring the deny provenance turns the TTL test red while the human-NO mirror stays green; restored, green. The automations suite was additionally mutation-proved per assertion.

## Follow-up, deliberately not here

`packages/ui/src/chrome/approval-card.tsx` renders `approval.call.args` and the descriptor, so the web card does not yet show the powers line. That render belongs behind the design/browser gate and is its own PR. Until then the web shows the job and correctly shows nothing pending; the data is already on the record for it to read.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Arming an automation now requires one approval, not two. Before: users approved the job and then received per‑tool permission prompts. After: the job’s approval lists the automation’s powers and one YES mints them; no follow‑up asks are sent. Also fixes a bug where expired arming asks disarmed automations; only a human NO now disarms.

- Adds `ApprovalRequest.powers` with human‑readable titles computed once at park time; writes are listed individually, all reads collapse to `Read-only access to your data` (`READ_ONLY_POWER`). Text rendering reads this field; other surfaces can render it without further work.
- Excludes powers that a standing grant cannot satisfy: destructive/ungraded and confirmEach. Away authority and grant requirements are unchanged.
- `enable(id, ctx, { armedBy })` mints powers only if host policy asked about the authoring call; if policy runs arming unasked, pending grant‑set capture continues as before.
- Guard adds a policy‑only check and stamps deny provenance; the decision subscriber reads `deniedBy` and ignores system expiries.
- New e2e and unit tests cover one‑page consent, minting rules, and TTL denial; existing away‑law suites pass unmodified. The web approval card does not yet render `powers` (data is present for a follow‑up).

**Migration**
- If you implement `AutomationsSeam.enable`, add the optional third parameter: `options?: { armedBy?: ToolCall }`.
- If you render approvals, optionally display `ApprovalRequest.powers`; no change is required if you do not.

<sup>Written for commit 0c42c4811062b539f5ccaae21bde6cdeec10f685. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

