### PR TITLE
fix(ui,knowledge): the agent says "the docs" to end users, never "knowledge base"

### DIFF
--- a/packages/knowledge/src/prompt-note.ts
+++ b/packages/knowledge/src/prompt-note.ts
@@ -31,7 +31,7 @@ export function knowledgeIndexSummary(status: KnowledgeStatus, config?: Knowledg
     `- Answer product and how-it-works questions with the ${VENDO_KNOWLEDGE_SEARCH_TOOL} tool instead of guessing; cite what you find.`,
     "- Set lookup:true for an exact glossary or API term lookup.",
     "- Pass readMore:{docId} to read the full document behind a hit when its snippet is not enough.",
-    "- On an insufficient-evidence outcome say you don't know; on unavailable say the knowledge base cannot be checked right now.",
+    `- On an insufficient-evidence outcome say you don't know; on unavailable say the docs cannot be checked right now. When you mention this to the user call it "the docs" — never "knowledge base".`,
   ].join("\n");
 }
 

--- a/packages/ui/src/chrome/thread/turn-citations.tsx
+++ b/packages/ui/src/chrome/thread/turn-citations.tsx
@@ -219,8 +219,7 @@ export function TurnCitations({ message }: { message: UIMessage }) {
             <path d="M12 3l10 18H2L12 3z" /><path d="M12 10v5" /><path d="M12 18.2v.1" />
           </svg>
           <span>
-            I couldn&apos;t check the docs just now — the knowledge base is temporarily
-            unreachable, so this answer isn&apos;t verified against the documentation.
+            I couldn&apos;t check the docs just now, so this isn&apos;t verified against them.
           </span>
         </div>
       ) : null}
@@ -229,7 +228,7 @@ export function TurnCitations({ message }: { message: UIMessage }) {
           <svg width="12.5" height="12.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
             <circle cx="11" cy="11" r="7" /><path d="M21 21l-4.5-4.5" />
           </svg>
-          Searched the knowledge base — no matching documentation
+          Searched the docs — no answer for this one
         </div>
       ) : null}
     </>

--- a/packages/ui/test/chrome/knowledge-citations.test.tsx
+++ b/packages/ui/test/chrome/knowledge-citations.test.tsx
@@ -106,7 +106,7 @@ describe("knowledge citations in the thread (Knowledge K1)", () => {
 
     const line = document.querySelector("[data-vendo-knowledge-searched]");
     expect(line).toBeTruthy();
-    expect(line?.textContent).toContain("Searched the knowledge base — no matching documentation");
+    expect(line?.textContent).toContain("Searched the docs — no answer for this one");
     expect(document.querySelector("[data-vendo-citations]")).toBeNull();
     expect(document.querySelector("[data-vendo-knowledge-unavailable]")).toBeNull();
   });
@@ -116,7 +116,7 @@ describe("knowledge citations in the thread (Knowledge K1)", () => {
 
     const flag = document.querySelector("[data-vendo-knowledge-unavailable]");
     expect(flag).toBeTruthy();
-    expect(flag?.textContent).toContain("knowledge base is temporarily unreachable");
+    expect(flag?.textContent).toContain("I couldn't check the docs just now, so this isn't verified against them.");
     expect(document.querySelector("[data-vendo-knowledge-searched]")).toBeNull();
   });
 


### PR DESCRIPTION
## What changed

"Knowledge base" is our internal word for the retrieval corpus. It was leaking
into two lines an end user actually reads, and into the guidance the model
follows when it has to tell the user it could not check. Consumer-facing copy
now says "the docs".

### The three new strings, verbatim

1. `packages/ui/src/chrome/thread/turn-citations.tsx` — structured-refusal line
   (`data-vendo-knowledge-searched`):

   > Searched the docs — no answer for this one

2. `packages/ui/src/chrome/thread/turn-citations.tsx` — engine-outage line
   (`data-vendo-knowledge-unavailable`):

   > I couldn't check the docs just now, so this isn't verified against them.

3. `packages/knowledge/src/prompt-note.ts` — the guidance bullet:

   > - On an insufficient-evidence outcome say you don't know; on unavailable say the docs cannot be checked right now. When you mention this to the user call it "the docs" — never "knowledge base".

## Test files edited (stated explicitly)

- `packages/ui/test/chrome/knowledge-citations.test.tsx` — two assertions bound
  to the old copy verbatim and move with it:
  - line 109 (refusal line) now expects `Searched the docs — no answer for this one`
  - line 119 (outage flag) now expects `I couldn't check the docs just now, so this isn't verified against them.`

Both assertions were changed *first* and observed failing against the old
source, then observed passing after the copy change (red → green).

## Scope left alone

Code identifiers, internal comments, operator-facing logs, README/docs prose and
test names were not touched. Two model-facing prompt strings still say
"knowledge base" and were deliberately left (they are instruction text the model
reads, not text it is told to echo, and change 3 now explicitly forbids echoing
the term):

- `packages/knowledge/src/prompt-note.ts:30` — the index summary line
- `packages/knowledge/src/agent-tools.ts:69` — the `vendo_knowledge_search` tool description

Also left, per the change's scope: `docs-site/customize/knowledge.mdx` (~lines
123, 126-127) quotes the two retired UI strings verbatim and is now stale — it
needs a follow-up docs pass.

## Gate

`pnpm build` ✅ · `pnpm typecheck` ✅ (42/42) · `pnpm lint` ✅ (4/4) ·
`pnpm test:affected` — touched packages green (`@vendoai/ui` 1379/1379,
`@vendoai/knowledge` 104/104). `@vendoai/vendo` has 3 failures that are
pre-existing on `origin/main` and unrelated to this change: they come from
`new URL(...).pathname` not decoding percent-escapes, and this worktree's path
contains a space (`Cool%20Code` → ENOENT). Verified by stashing this diff and
re-running the same two files on a clean tree — identical failures. CI runs on a
space-free path.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace all user-facing mentions of “knowledge base” with “the docs” in UI copy and agent guidance to match consumer language. Previously, users saw “knowledge base” in two thread notices; now they see “the docs,” and the agent is instructed to use the same term.

- UI: `packages/ui/src/chrome/thread/turn-citations.tsx`
  - Structured refusal: “Searched the docs — no answer for this one”
  - Engine outage: “I couldn't check the docs just now, so this isn't verified against them.”
- Guidance: `packages/knowledge/src/prompt-note.ts` tells the agent to say “the docs” and never “knowledge base” when lookups are unavailable.
- Tests: `packages/ui/test/chrome/knowledge-citations.test.tsx` updated to assert the new copy.
- Migration: Update any downstream tests or snapshots that asserted the old “knowledge base” strings.
- Intentional non-changes: Internal identifiers and two model-facing prompt strings still use “knowledge base.”

<sup>Written for commit 321aa1f75f59df2f489e94f71a97aba8e0938969. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

