### PR TITLE
perf(vendo): an inbound text is claimed in one store round trip, not two

### DIFF
--- a/.changeset/channel-claim-one-round-trip.md
+++ b/.changeset/channel-claim-one-round-trip.md
@@ -1,0 +1,12 @@
+---
+"@vendoai/vendo": patch
+---
+
+An inbound text is claimed in one round trip, not two. The delivery log decided
+a claim by reading the row and then writing it, so every text on a hosted store
+waited through two serial store calls before anything else could start — and two
+genuinely concurrent copies of one delivery could each read the absence and both
+run the person's turn, with a second tool call and a second charge behind it.
+The claim is now the adapter's own guarded insert where there is one, which
+answers both. An adapter that omits `atomic` keeps the read-then-write it always
+had: slower, never different.

--- a/packages/vendo/src/channel-links.ts
+++ b/packages/vendo/src/channel-links.ts
@@ -394,12 +394,9 @@ async function deliveryRowId(eventId: string): Promise<string> {
  * that retry is a different instance — which would run the person's text a
  * SECOND time, with a second tool call and a second charge behind it.
  *
- * Read-then-write rather than a conditional insert, because the records door has
- * no create-if-absent. Retries are sequential by construction — one exists only
- * because the delivery before it did not answer — so a retry does not land in
- * the window between the read and the write. Two genuinely concurrent copies of
- * one delivery would still both run; closing that needs a conditional write at
- * the adapter layer.
+ * The claim IS the adapter's conditional insert wherever there is one, so the
+ * winner is decided by the store rather than by a read the next copy of the
+ * delivery could race.
  *
  * The row holds the event id and a timestamp, never the phone or the text, so
  * there is nothing here for `eraseStore().bySubject` to have to reach.
@@ -415,12 +412,23 @@ export class ChannelEventLog {
   /** True when this delivery is ours to run, false when it already ran. */
   async claim(eventId: string, conversationId: string): Promise<boolean> {
     const id = await deliveryRowId(eventId);
-    if (await this.records().get(id) !== null) return false;
-    await this.records().put({
+    const records = this.records();
+    const row = {
       id,
       data: { eventId, seenAt: new Date(Date.now()).toISOString() },
       refs: { conversation: conversationId },
-    });
+    };
+    // ONE guarded write where the adapter has one (01 §12). This claim is the
+    // first thing an inbound text waits on, and read-then-write cost a person two
+    // round trips to answer it — while leaving a window where two concurrent
+    // copies of one delivery each read the absence and both ran the turn. An
+    // adapter without `atomic` keeps that pair, which is what it always had.
+    if (records.atomic !== undefined) {
+      if (await records.atomic.insertIfAbsent(row) === null) return false;
+    } else {
+      if (await records.get(id) !== null) return false;
+      await records.put(row);
+    }
     if (Date.now() - (this.sweptAt.get(conversationId) ?? 0) >= PRUNE_INTERVAL_MS) {
       this.sweptAt.set(conversationId, Date.now());
       await this.prune(conversationId);

--- a/packages/vendo/tests/channel-hosted-store.test.ts
+++ b/packages/vendo/tests/channel-hosted-store.test.ts
@@ -1,4 +1,4 @@
-import type { ApprovalId } from "@vendoai/core";
+import { STORE_WIRE_PATHS, type ApprovalId } from "@vendoai/core";
 import { describe, expect, it } from "vitest";
 import { ChannelAskRepository, ChannelEventLog, ChannelLinkRepository } from "../src/channel-links.js";
 import { hostedStore } from "@vendoai/store";
@@ -24,11 +24,16 @@ import { fakeConsole } from "@vendoai/store/test-util";
  * `ENGINE_COLLECTIONS`, or this file goes red.
  */
 
-const hosted = () => hostedStore({
+const hosted = (mount = fakeConsole()) => hostedStore({
   apiKey: "vnd_secret",
   baseUrl: "https://cloud.test",
-  fetch: fakeConsole().handler as unknown as typeof fetch,
+  fetch: mount.handler as unknown as typeof fetch,
 });
+
+/** The wire ops a call spent, in order — one entry per ROUND TRIP, which is what
+ *  a person waiting on a reply actually waits through. */
+const roundTrips = (mount: ReturnType<typeof fakeConsole>): string[] =>
+  mount.requests.map((request) => new URL(request.url).pathname.replace("/api/v1/store", ""));
 
 const APPROVAL = "apr_33333333-3333-3333-3333-333333333333" as ApprovalId;
 
@@ -59,10 +64,23 @@ describe("the text channel on a Cloud-hosted store", () => {
     expect(await asks.ids("conv_hosted")).toEqual([]);
   });
 
-  it("claims a delivery through the engine door", async () => {
-    const log = new ChannelEventLog(hosted());
+  it("claims a delivery through the engine door, in ONE round trip", async () => {
+    const mount = fakeConsole();
+    const log = new ChannelEventLog(hosted(mount));
 
     expect(await log.claim("evt_hosted", "conv_hosted")).toBe(true);
+    // The claim is the first thing an inbound text waits on, so it is ONE
+    // guarded write rather than a read and then a write. The list behind it is
+    // the conversation's first delivery paying for its own sweep, once an hour.
+    expect(roundTrips(mount)).toEqual([
+      STORE_WIRE_PATHS["engine.insertIfAbsent"],
+      STORE_WIRE_PATHS["engine.list"],
+    ]);
+
+    // A retried delivery is still recognised as already claimed — and costs the
+    // same single call to say so.
+    mount.requests.length = 0;
     expect(await log.claim("evt_hosted", "conv_hosted")).toBe(false);
+    expect(roundTrips(mount)).toEqual([STORE_WIRE_PATHS["engine.insertIfAbsent"]]);
   });
 });

--- a/packages/vendo/tests/channel-links.test.ts
+++ b/packages/vendo/tests/channel-links.test.ts
@@ -238,6 +238,19 @@ describe("the delivery log", () => {
     expect(await log.claim("evt_2", "conv_1")).toBe(true);
   });
 
+  it("still gives it to exactly one caller on an adapter with no guarded write", async () => {
+    // 01 §12 makes `atomic` optional, so a BYO adapter may omit it. The claim
+    // then reads-then-writes, exactly as it always did — slower, never different.
+    const store = await freshStore();
+    const bare = store.records("vendo_channel_events");
+    vi.spyOn(store, "records").mockImplementation((collection: string) =>
+      collection === "vendo_channel_events" ? { ...bare, atomic: undefined } : store.records(collection));
+    const log = new ChannelEventLog(store);
+
+    expect(await log.claim("evt_bare", "conv_bare")).toBe(true);
+    expect(await log.claim("evt_bare", "conv_bare")).toBe(false);
+  });
+
   it("keeps a vendor's event id out of the row id, so two ids never collide", async () => {
     const store = await freshStore();
     const log = new ChannelEventLog(store);


### PR DESCRIPTION
An inbound text is the one place a person is literally watching the clock, and
the very first thing it waited on was two serial store calls that only ever
answered one question: *have we run this delivery before?*

`ChannelEventLog.claim` decided that by reading the row and then writing it. On a
Cloud-hosted store that is two round trips before anything else in the turn can
start. It also left a window open that the old comment admitted to: two genuinely
concurrent copies of one delivery could each read the absence and both run the
person's turn — a second tool call and a second charge behind it.

The claim is now the adapter's own guarded insert, which answers both at once.
An adapter that omits `atomic` (01 §12 makes it optional) keeps the
read-then-write it always had: slower, never different.

### Measured, through the real hosted client

`packages/vendo/tests/channel-hosted-store.test.ts` counts the actual HTTP calls
a claim spends, with the real `hostedStore` client on one side and the fake
console's engine door — the one that serves the same allowlist the live door
serves — on the other:

```
before   /engine/get   /engine/put   /engine/list
after    /engine/insertIfAbsent      /engine/list
```

(The `/engine/list` is the conversation's first delivery paying for its own
hourly sweep; it is untouched.)

That takes the channel turn's pre-model chain from four serial store calls to
three — the claim, then `turn.load`, then the user-message append.

### Test changes, stated out loud

- `channel-hosted-store.test.ts` — the existing "claims a delivery through the
  engine door" case now also pins the round trips it spends. Same behaviour
  asserted, pinned harder, so the fold cannot silently regress.
- `channel-links.test.ts` — one new case covering the no-`atomic` adapter, which
  had no coverage before. Verified it fails when the fallback branch is removed.

### What this deliberately does NOT do

It does not fold `turn.load` and the user-message append into one call. Those two
are serial for reasons that live above the wire, and no new wire field or op
removes them without changing shipped turn semantics:

- `turn.load`'s request needs `thread.id` and `index.owner`, and both come from
  the channel link row (`channel-turn.ts:391-394`, `channel-turn.ts:437`), which
  is read by `links.byPhone`. Chaining link → thread inside one envelope is a
  data dependency between parts, which is exactly what the turn envelope's
  contract rules out (`store-wire.ts:605-610`).
- The load's *answer* shapes the write: `fresh` picks a guarded create over an
  append, `deriveTitle(thread.messages)` is an argument to that append, and
  `validateUpsert` is the history-forgery gate that has to run before the write
  lands (`harness-turn.ts:545-546`, `harness-turn.ts:599-610`).

No wire change, so no console change: `engine.insertIfAbsent` on a generic
collection is already in the conformance kit the console is held to
(`packages/core/src/conformance/store-ops.ts:415-436`, including a four-way race)
and already ships in `automations/src/ingestion-surface.ts:279`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Claims an inbound text in one store round trip instead of two. Previously `ChannelEventLog.claim` read the delivery row and then wrote it; now it uses the adapter’s guarded insert to decide the winner and, where supported, close the concurrent delivery race.

- Hosted client now spends one HTTP call to `engine.insertIfAbsent` (plus the hourly sweep list), down from `engine.get` + `engine.put`.
- Adapters without `atomic` keep the read-then-write path. Behavior is unchanged; it’s just slower and does not close the concurrency window.
- Tests pin the exact wire calls for the hosted path and add coverage for adapters that omit `atomic`.
- No console changes or migrations. `engine.insertIfAbsent` already ships in the conformance kit.

<sup>Written for commit eebe2ebe536fa295a5e6b1a2800fa280d2c24fe1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1487?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

