### PR TITLE
perf(vendo): a texted turn's opening store calls go out together

### DIFF
--- a/.changeset/channel-opening-write-beside-read.md
+++ b/.changeset/channel-opening-write-beside-read.md
@@ -1,0 +1,15 @@
+---
+"@vendoai/vendo": patch
+---
+
+A texted turn's opening store calls now go out together. The user's message was
+written only after the turn's opening read came back, because on a web turn that
+read is what shapes the write — it decides whether the thread is being created,
+it supplies the listing title, and it is what `validateUpsert` checks a client's
+message against. None of that applies to a text: the message is built in-process
+from a delivery Cloud already authenticated, and the thread id comes off the link
+row, which only carries one because a turn already ran on that thread. So the
+channel path vouches for both facts and the write rides beside the read instead
+of behind it, taking one more round trip off the front of every reply. Web and
+API turns are untouched, and the marker that carries the vouch is a symbol that
+is not exported and cannot arrive on a JSON body.

--- a/packages/vendo/src/channel-turn.ts
+++ b/packages/vendo/src/channel-turn.ts
@@ -29,7 +29,7 @@ import type {
   ChannelLinkRepository,
 } from "./channel-links.js";
 import type { ChannelsService, InboundTextEvent } from "./channels.js";
-import type { HarnessTurns } from "./harness-turn.js";
+import { SERVER_AUTHORED, type HarnessTurns } from "./harness-turn.js";
 
 /** Texting humans reply on a human clock — they put the phone down, they drive,
  *  they come back. The web's 90s wait is a closed-tab bound and would time out
@@ -521,7 +521,12 @@ export async function runChannelTurn(
       parts: [{ type: "text", text: event.text }, { type: "text", text: TEXT_STYLE }],
     } as UIMessage;
     const response = await deps.harness.stream({
-      ...(threadId === undefined ? {} : { threadId }),
+      // Vouched for in the same breath as the thread id, because the two facts
+      // are one fact: a rolling thread exists only because a turn already ran on
+      // it, and `message` above was built HERE from a delivery Cloud
+      // authenticated — never posted by a client. Without a rolling thread there
+      // is nothing to vouch for, so the door reads before it writes as usual.
+      ...(threadId === undefined ? {} : { threadId, [SERVER_AUTHORED]: true as const }),
       message,
       ctx,
       approvalWaitMs: CHANNEL_APPROVAL_WAIT_MS,

--- a/packages/vendo/src/harness-turn.ts
+++ b/packages/vendo/src/harness-turn.ts
@@ -188,6 +188,24 @@ const withFileReferences = (messages: readonly UIMessage[]): UIMessage[] =>
     )),
   })) as UIMessage[];
 
+/**
+ * Composition's word that this turn's opening WRITE needs nothing from its
+ * opening read — which is what lets the two go out together instead of one
+ * behind the other.
+ *
+ * It asserts two things at once, and both have to hold: the message was authored
+ * by THIS process rather than posted by a client (so `validateUpsert` has no
+ * history to protect), and `threadId` came off a row that only carries one
+ * because a turn already ran on it (so the thread exists and already holds the
+ * title the append would otherwise have to derive from the read).
+ *
+ * A SYMBOL, and not exported from the package, because those two claims can only
+ * be made by code that watched them become true. `JSON.parse` cannot produce a
+ * symbol key, so no request body can carry it however a door is later written,
+ * and no host can reach it. The one caller is `runChannelTurn`.
+ */
+export const SERVER_AUTHORED = Symbol("vendo.turn.serverAuthored");
+
 export interface HarnessTurns {
   /** One turn. Mirrors `VendoAgent.stream`'s signature so the wire route reads
    *  the same either way — including the `x-vendo-thread-id` response header. */
@@ -200,6 +218,7 @@ export interface HarnessTurns {
      *  frozen APPROVAL_WAIT_MS (a web tab's bound); a turn served over a
      *  channel where the person answers on a human clock passes its own. */
     approvalWaitMs?: number;
+    readonly [SERVER_AUTHORED]?: true;
   }): Promise<Response>;
   /** Prompt-cache warming (sub-1s shipment): ONE degenerate turn through the
    *  normal assembly — same registry projection, same system prompt, same
@@ -511,6 +530,20 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
       // workspace to read. Unbatched, `resolve` mints exactly as it always did
       // — a fresh id must not cost a read for a row that cannot exist.
       const threadId = given ?? mintThreadId();
+      // The opening WRITE, in flight WITH the opening read rather than behind
+      // it. It is only ever sent here because SERVER_AUTHORED says the two
+      // things that make the read's answer irrelevant to it: no title to derive
+      // (the thread already has one) and no history to guard (nothing came from
+      // a client). The append itself still enforces ownership in its own
+      // statement, so a link pointing at another subject's thread is refused
+      // here exactly as it always was. Below the turn level there is no round
+      // trip worth saving, so the old order stands.
+      const opening = input[SERVER_AUTHORED] === true && given !== undefined && batched
+        ? sqlDoors().transcript.upsertMany?.(input.ctx.principal, given, [input.message], {})
+        : undefined;
+      // A rejection is delivered where it is awaited below; this only keeps a
+      // slow read from turning it into an unhandled one first.
+      void opening?.catch(() => {});
       const loaded = batched
         ? await config.store.ops!.turn!.load({
           thread: { id: threadId },
@@ -543,7 +576,11 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
       // found no row, and persist's first attempt can skip re-reading that
       // absence (its insert is guarded either way).
       const fresh = thread.messages.length === 0;
-      validateUpsert(thread.messages, input.message);
+      // Skipped only where it can protect nothing: an already-sent opening write
+      // carries a message this process authored, so there is no client copy to
+      // check it against — and a gate run after the write could only report a
+      // rewrite it had already let through.
+      if (opening === undefined) validateUpsert(thread.messages, input.message);
       upsertMessage(thread.messages, input.message);
 
       // Before the FIRST write, not after it. `threads.persist` goes through the
@@ -596,7 +633,9 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
         // existed, and unlike a bare `upsert` it still refreshes the listing
         // title and `updated_at`. So a turn on an older store is slower, not
         // broken.
-        fresh || batchAppend === undefined
+        // Already in flight since before the read, where it was allowed to be.
+        opening
+        ?? (fresh || batchAppend === undefined
           ? threads.persist(thread, [input.message], { fresh })
           // No position is passed: the store assigns one while it holds the
           // thread row, so two turns racing on this conversation cannot claim
@@ -607,7 +646,7 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
             thread.id,
             [input.message],
             { title: deriveTitle(thread.messages) },
-          ),
+          )),
         // §9.7 — the turn's façade mounts every org the wire asserted for this
         // request, so an agent turn can read and write the team's files at all.
         workspaces.open(input.ctx.principal, {

--- a/packages/vendo/tests/channel-turn-opening.test.ts
+++ b/packages/vendo/tests/channel-turn-opening.test.ts
@@ -1,0 +1,274 @@
+/**
+ * THE OPENING WRITE, BESIDE THE OPENING READ — and the two assertions that are
+ * allowed to put it there.
+ *
+ * A turn's first store call reads the thread and its second writes the user's
+ * message, and the second waits for the first because the FIRST one's answer
+ * shapes it: `fresh` picks a guarded create over an append, the listing title is
+ * derived from the messages that come back, and `validateUpsert` is the gate
+ * that stops a client rewriting stored history before the write lands.
+ *
+ * None of those hold for a texted turn. The message was built in this process
+ * from a delivery Cloud already authenticated, so there is no client to forge
+ * anything; and the thread id came off the link row, which only carries one
+ * because a turn already ran on it — so the row exists and already has its
+ * title. Composition says both things at once by passing SERVER_AUTHORED, and
+ * only composition can: it is a symbol, so it cannot arrive on a parsed JSON
+ * body, and it is not exported from the package.
+ *
+ * Both halves are pinned here, because either one alone is a dead feature: the
+ * door honouring a marker nobody sets, or composition setting a marker the door
+ * ignores.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  STORE_WIRE_TURN_OPS,
+  VENDO_STORE_WIRE_FORMAT,
+  type Principal,
+  type RecordInput,
+  type RecordQuery,
+  type RunContext,
+  type StoreOps,
+} from "@vendoai/core";
+import { defineHarness } from "@vendoai/harnesses";
+import { createStore, createStoreOps, type VendoStore } from "@vendoai/store";
+import type { LanguageModel, UIMessage } from "ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ChannelLink } from "../src/channel-links.js";
+import { runChannelTurn } from "../src/channel-turn.js";
+import { SERVER_AUTHORED } from "../src/harness-turn.js";
+import { createVendo, type CreateVendoConfig } from "../src/server.js";
+
+const principal: Principal = { kind: "user", subject: "user_opening" };
+const ctx: RunContext = { principal, venue: "chat", presence: "present", sessionId: "s_opening" };
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+/** Every op this handle serves, logged as it STARTS and again as it settles —
+ *  which is the only way to see two calls overlap rather than merely follow one
+ *  another. One op is one wire call for a hosted deployment. */
+function timedOps(real: StoreOps, log: string[]): StoreOps {
+  const timed = (name: string, fn: unknown, self: unknown): unknown =>
+    typeof fn !== "function" ? fn : async (...args: unknown[]) => {
+      log.push(`start:${name}`);
+      try {
+        return await (fn as (...a: unknown[]) => Promise<unknown>).apply(self, args);
+      } finally {
+        log.push(`end:${name}`);
+      }
+    };
+  const family = (name: string, target: Record<string, unknown>): unknown => new Proxy(target, {
+    get: (inner, verb) => timed(`${name}.${String(verb)}`, Reflect.get(inner, verb), inner),
+  });
+  return new Proxy(real, {
+    get(target, key) {
+      const name = String(key);
+      // The ONE handshake — answered without logging, so it never crowds the
+      // ordering the cases below read.
+      if (name === "status") {
+        return () => Promise.resolve({ format: VENDO_STORE_WIRE_FORMAT, ops: STORE_WIRE_TURN_OPS });
+      }
+      const value = Reflect.get(target, key) as unknown;
+      if (typeof value === "function") return timed(name, value, target);
+      if (value !== null && typeof value === "object") return family(name, value as Record<string, unknown>);
+      return value;
+    },
+  });
+}
+
+/** A store the way a hosted deployment presents one: no SQL handle, so every
+ *  door goes through the ops and every read costs a call. */
+function hostedShape(backing: VendoStore, log: string[]): VendoStore {
+  const ops = timedOps(createStoreOps(backing), log);
+  return {
+    ops,
+    records: (collection) => ({
+      get: (id) => ops.engine.get(collection, id),
+      put: (record: RecordInput) => ops.engine.put(collection, record),
+      delete: (id) => ops.engine.delete(collection, id),
+      list: (query?: RecordQuery) => ops.engine.list(collection, query),
+      atomic: {
+        insertIfAbsent: (record: RecordInput) => ops.engine.insertIfAbsent(collection, record),
+        compareAndSwap: (record: RecordInput, revision: string) =>
+          ops.engine.compareAndSwap(collection, record, revision),
+      },
+    }),
+    blobs: (namespace) => backing.blobs(namespace),
+    ensureSchema: () => backing.ensureSchema(),
+    async close() {},
+    raw() { throw new Error("a hosted store has no local database handle"); },
+  };
+}
+
+const replying = defineHarness({
+  name: "opening-probe",
+  // eslint-disable-next-line require-yield
+  async *run() {
+    yield { type: "text", delta: "ok" } as const;
+  },
+});
+
+const say = (id: string, text: string): UIMessage =>
+  ({ id, role: "user", parts: [{ type: "text", text }] }) as UIMessage;
+
+interface Deployment {
+  stream: (message: UIMessage, trusted: boolean) => Promise<void>;
+  titles: () => Promise<string[]>;
+  log: string[];
+}
+
+async function deploy(): Promise<Deployment> {
+  const dataDir = await mkdtemp(join(tmpdir(), "vendo-turn-opening-"));
+  const backing = createStore({ dataDir });
+  cleanups.push(async () => { await backing.close(); await rm(dataDir, { recursive: true, force: true }); });
+  await backing.ensureSchema();
+  const log: string[] = [];
+  const vendo = createVendo({
+    models: { default: {} as LanguageModel },
+    principal: async () => principal,
+    store: hostedShape(backing, log),
+    harness: replying as never,
+  } as CreateVendoConfig);
+
+  const threadId = "thr_opening";
+  return {
+    log,
+    async stream(message, trusted) {
+      const response = await vendo.harness.stream({
+        threadId,
+        message,
+        ctx,
+        ...(trusted ? { [SERVER_AUTHORED]: true } : {}),
+      });
+      await response.text();
+    },
+    titles: async () => (await vendo.harness.threads.list(ctx)).map((summary) => summary.title),
+  };
+}
+
+/** Did `write` go out while `read` was still outstanding? */
+const overlapped = (log: string[], write: string, read: string): boolean =>
+  log.indexOf(`start:${write}`) !== -1
+  && log.indexOf(`end:${read}`) !== -1
+  && log.indexOf(`start:${write}`) < log.indexOf(`end:${read}`);
+
+describe("a turn's opening store calls", () => {
+  it("sends the user's message BESIDE the envelope read when composition vouches for it", async () => {
+    const deployment = await deploy();
+    // Turn one creates the thread. Turn two is the representative warm turn: the
+    // row exists and carries its title, which is what the marker asserts.
+    await deployment.stream(say("m_first", "first"), false);
+
+    deployment.log.length = 0;
+    await deployment.stream(say("m_second", "second"), true);
+
+    expect(overlapped(deployment.log, "transcripts.appendMessages", "turn.load")).toBe(true);
+  });
+
+  it("keeps the web turn's write BEHIND its read, where validateUpsert still gates it", async () => {
+    const deployment = await deploy();
+    await deployment.stream(say("m_first", "first"), false);
+
+    deployment.log.length = 0;
+    await deployment.stream(say("m_second", "second"), false);
+
+    // THE CONTROL. Without the marker nothing moves: the write still waits for
+    // the read, because the read is what proves the client is not rewriting
+    // history. An unvouched turn must never take the fast path by accident.
+    expect(overlapped(deployment.log, "transcripts.appendMessages", "turn.load")).toBe(false);
+    expect(deployment.log).toContain("start:transcripts.appendMessages");
+  });
+
+  it("still names a thread the vouch was wrong about", async () => {
+    // The vouch can be wrong: a thread deleted between two texts is gone by the
+    // time the append reaches it, so the append CREATES the row — and it carries
+    // no title, because a warm append must never overwrite the one a thread
+    // already has. What names it is the turn's CLOSING commit, which derives the
+    // title from the whole transcript. Pinned here because if that ever stops
+    // being true, these rows list as "New thread" for good: every later text on
+    // the thread vouches exactly the same way and appends title-less again.
+    const deployment = await deploy();
+
+    await deployment.stream(say("m_only", "what did I spend on food?"), true);
+
+    expect(await deployment.titles()).toEqual(["what did I spend on food?"]);
+  });
+});
+
+const link: ChannelLink = {
+  id: "chl_open",
+  subject: "user_opening",
+  phone: "+15551230123",
+  linkedAt: "2026-08-17T10:22:10.710Z",
+};
+
+const event = {
+  eventId: "evt_open",
+  channel: "text" as const,
+  from: "+15551230123",
+  text: "what did I spend on food last month?",
+  conversationId: "conv_open",
+  receivedAt: "2026-08-17T10:22:11.211Z",
+};
+
+function turnDeps(captured: { input?: Record<PropertyKey, unknown> }) {
+  return {
+    harness: {
+      stream: vi.fn(async (input: Record<PropertyKey, unknown>) => {
+        captured.input = input;
+        return new Response("data: {\"type\":\"text-delta\",\"delta\":\"ok\"}\n\n", {
+          headers: { "content-type": "text/event-stream" },
+        });
+      }),
+    },
+    guard: {
+      onApprovalRequested: () => () => undefined,
+      approvals: { pending: async () => [], decide: async () => undefined },
+    },
+    channel: { send: vi.fn(async () => undefined) },
+    links: { rememberTurn: vi.fn(async () => undefined) },
+    asks: { ids: async () => [], add: vi.fn(async () => undefined), consume: vi.fn(async () => undefined) },
+  } as unknown as Parameters<typeof runChannelTurn>[0];
+}
+
+describe("what a texted turn vouches for", () => {
+  it("vouches for the message when the link names a thread a turn already ran on", async () => {
+    const captured: { input?: Record<PropertyKey, unknown> } = {};
+
+    await runChannelTurn(turnDeps(captured), {
+      event,
+      link: { ...link, threadId: "thr_rolling", lastTurnAt: new Date().toISOString() },
+    });
+
+    expect(captured.input?.["threadId"]).toBe("thr_rolling");
+    expect(captured.input?.[SERVER_AUTHORED]).toBe(true);
+  });
+
+  it("vouches for nothing when there is no live thread to append to", async () => {
+    const captured: { input?: Record<PropertyKey, unknown> } = {};
+
+    // No rolling thread — the row this turn opens may not exist yet, so the
+    // door has to read before it writes, exactly as a web turn does.
+    await runChannelTurn(turnDeps(captured), { event, link });
+
+    expect(captured.input?.["threadId"]).toBeUndefined();
+    expect(captured.input?.[SERVER_AUTHORED]).toBeUndefined();
+  });
+
+  it("vouches for nothing once the rolling thread has gone idle", async () => {
+    const captured: { input?: Record<PropertyKey, unknown> } = {};
+
+    await runChannelTurn(turnDeps(captured), {
+      event,
+      link: { ...link, threadId: "thr_stale", lastTurnAt: "2020-01-01T00:00:00.000Z" },
+    });
+
+    expect(captured.input?.["threadId"]).toBeUndefined();
+    expect(captured.input?.[SERVER_AUTHORED]).toBeUndefined();
+  });
+});


### PR DESCRIPTION
**Stacked on #1487** (`yousefh409/channel-open-envelope`) — review/merge that one first.

A turn's opening store calls are a read then a write: load the thread, then write
the user's message. The write waits because on a **web** turn the read's answer is
what shapes it — `fresh` decides between creating the thread and appending to it,
the listing title is derived from the messages that come back, and `validateUpsert`
checks the incoming message against stored history before anything lands.

None of those hold for a **text**. The message is built in this process from a
delivery Cloud already authenticated, so there is no client copy to guard against;
and the thread id comes off the link row, which only carries one because a turn
already ran on that thread — so the row exists and already has its title. The
channel path says both things at once and the write goes out beside the read.

One more round trip off the front of every reply, on top of #1487's.

### The marker cannot be forged

`SERVER_AUTHORED` is a **symbol**, so `JSON.parse` cannot produce it however a door
is later written, and it is not exported from the package — `dist/index.d.ts` and
`dist/index.js` contain zero occurrences. The only three `harness.stream()` call
sites are `runChannelTurn`, the wire door (which builds its input from named
fields, never a spread of the body), and a test util. Web and API turns keep
`validateUpsert` exactly where it is today.

### No wire change

The fold needed none, so there is no new op, no level bump, and **no console PR**.
The envelope contract's ban on chaining data between parts is untouched — this
moves a call the client already owned, it does not ask the server to do anything
new.

### Proven

`packages/vendo/tests/channel-turn-opening.test.ts` — real `createVendo`, real
PGlite rows, real `createStoreOps`, a store shaped like a hosted deployment (no SQL
handle, so every door costs a call). Ops are logged as they **start** and again as
they settle, which is the only way to see two calls overlap rather than merely
follow each other.

- vouched turn: the append starts while the load is still outstanding
- **control** — unvouched turn: it does not, so nothing takes the fast path by accident
- `runChannelTurn` vouches only when the link names a live rolling thread — not on
  a first text, not on an idle one
- a thread the vouch was wrong about (deleted between texts) still ends up named

Both behavioural tests were watched failing before the code existed, and the
concurrency test was re-checked red with the fast path disabled.

### One thing I removed

I first added a repair for the "vouch was wrong" case, assuming the title-less
append would leave the row listing as "New thread" forever. Measured it: the
turn's closing commit already names the row, so the repair was dead code and is
gone. The test stays, pinning the outcome.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sends a text turn’s opening write beside its opening read to remove one round trip per reply. Previously we loaded the thread then appended; now, when the channel path proves the message is server-authored and the link targets a live rolling thread, we append alongside the read. Web/API turns are unchanged.

- Introduces `SERVER_AUTHORED` (internal symbol) in harness turns. `runChannelTurn` sets it only for text events with a live rolling `threadId`; it is not exported by the package and cannot arrive via JSON.
- In `createHarnessTurns`, when the marker is present and the call is batched with a `threadId`, start `transcript.upsertMany` in parallel with `turn.load`. Skip `validateUpsert` only on this vouched path; ownership checks remain in the append. Fallback to the old order if unbatched or `upsertMany` is unavailable.
- No wire/console changes. Adds `channel-turn-opening.test.ts` proving overlap, the control (no marker), correct vouching conditions, and that a deleted-between-texts thread is still titled by the closing commit.

**Rollout**
- Patch release for `@vendoai/vendo`. No migrations or client changes.

<sup>Written for commit 4ed328856b49eb0874afe7f3ada34a5cd2c84800. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

