### PR TITLE
docs: an app keeps a copy, a resolver holds the per-user credential, and a tenant's token is the org's

### DIFF
--- a/docs-site/capabilities/connectors.mdx
+++ b/docs-site/capabilities/connectors.mdx
@@ -116,3 +116,19 @@ The resolver receives `principal`, `presence` (`present` or `away`), and `grant`
 </Warning>
 
 An MCP connector with a resolver also keeps one protocol session per subject, so a server that binds auth to the session can never mix two users up.
+
+## Which layer holds the credential
+
+Three separate things can put a credential on a call, and two of them are this page.
+
+| Layer | Who sets it up | Whose credential runs the call |
+| --- | --- | --- |
+| A connector's static `headers` | You, once, at boot | Yours — the whole deployment shares it |
+| A connector's [headers resolver](#one-credential-per-user) | You, once, at boot | Whatever you hand back for that principal |
+| [Connected accounts](/capabilities/connected-accounts) | Each user, through one OAuth popup | Theirs — the broker holds it and runs the call |
+
+The resolver is the per-user path for the connectors on this page: `openApiConnector` and `mcpConnector` both take one, it runs on every call with the acting principal in hand, and what it returns is that call's headers. So a host can send a different token for every user without a broker in the way.
+
+<Warning>
+  **[Tenant connectors](/capabilities/tenant-connectors) have no per-user path in this release.** The token an org pastes at registration is vaulted once for that org and rides static headers, so every member of that org calls with the same credential. The resolver above is not reachable from a tenant registration.
+</Warning>

--- a/docs-site/capabilities/tenant-connectors.mdx
+++ b/docs-site/capabilities/tenant-connectors.mdx
@@ -68,6 +68,92 @@ await vendo.tenantConnectors.register({
 });
 ```
 
+## How you wire it
+
+The screen is yours and so is the route behind it. Vendo supplies the registration API and nothing else — who may administer an org is a question your own auth answers.
+
+Start with a form that has no `org` field, because the org is not the browser's to name:
+
+```tsx app/settings/connectors/page.tsx
+export default function AddConnector() {
+  return (
+    <form action="/api/tenant-connectors" method="post">
+      <input name="name" placeholder="billing" required />
+      <select name="kind">
+        <option value="mcp">MCP server</option>
+        <option value="openapi">OpenAPI spec</option>
+      </select>
+      <input name="url" placeholder="https://mcp.acme.example/sse" />
+      <textarea name="spec" placeholder="Paste an OpenAPI document" />
+      <input name="token" type="password" placeholder="Paste the token" />
+      <button type="submit">Add</button>
+    </form>
+  );
+}
+```
+
+The route behind it does three things, in this order: authorize the caller with your own auth, read the org off the session, then register.
+
+```ts app/api/tenant-connectors/route.ts
+import { auth } from "@/auth";
+import { vendo } from "@/vendo";
+
+export async function POST(request: Request) {
+  // Your auth, not ours: Vendo never decides who may administer an org.
+  const session = await auth();
+  if (!session?.user.orgAdmin) return new Response("forbidden", { status: 403 });
+
+  // The org is a fact about the session.
+  const org = session.user.orgId;
+
+  const form = await request.formData();
+  const url = form.get("url");
+  const spec = form.get("spec");
+  const token = form.get("token");
+
+  const result = await vendo.tenantConnectors.register({
+    org,
+    name: String(form.get("name")),
+    kind: form.get("kind") === "openapi" ? "openapi" : "mcp",
+    ...(url ? { url: String(url) } : {}),
+    ...(spec ? { spec: String(spec) } : {}),
+    ...(token ? { token: String(token) } : {}),
+  });
+
+  if (result.status === "error") {
+    return Response.json({ code: result.error.code, message: result.error.message }, { status: 400 });
+  }
+  return Response.json({ tools: result.tools.map((tool) => tool.name) });
+}
+```
+
+Render both branches. A refusal is the other half of this API: the org pasted a URL that does not answer, or a spec that is not usable, and the admin who pasted it is the only person who can fix either.
+
+<Warning>
+  **Take `org` from the session, never from the request body.** A body field any
+  signed-in user can set lets that user register a connector against an org they
+  do not belong to — the token they paste is then vaulted under that org and
+  handed to its members on their next request.
+</Warning>
+
+Nothing binds until your deployment asserts memberships: a registration reaches only a request whose `memberships` seam names the org that owns it.
+
+```ts app/api/vendo/[...vendo]/route.ts
+import { createVendo } from "@vendoai/vendo/server";
+import { authJs } from "@vendoai/vendo/auth/auth-js";
+
+export const vendo = createVendo({
+  auth: authJs({
+    memberships: async ({ subject }) => {
+      const rows = await db.membership.findMany({ where: { userId: subject } });
+      return rows.map((row) => ({ org: row.orgId }));
+    },
+  }),
+});
+```
+
+See [Orgs & memberships](/users-orgs/orgs-and-memberships) for the rest of that seam.
+
 ## Who sees what
 
 Visibility follows the orgs your host asserts for the request — the same `memberships` seam the rest of Vendo reads. A run that asserts `acme` is served a registry carrying your tools plus Acme's; a run that asserts nothing is served the shared registry, unchanged.

--- a/docs-site/capabilities/tenant-connectors.mdx
+++ b/docs-site/capabilities/tenant-connectors.mdx
@@ -176,7 +176,17 @@ await vendo.tenantConnectors.list("acme");
 
 The vault belongs to whichever store composes. If Vendo composes it, `VENDO_STORE_ENCRYPTION_KEY` (base64, 32 bytes) is what turns it on. If you pass your own store, you configure it there yourself — `createStore({ url, encryption: { key: ... } })` — because an explicitly passed store owns its own secrets config, and the environment variable never reaches it.
 
-Without one of those two, a registration carrying a token is refused in every environment, not just production. A tokenless registration is unaffected: it stores no secret, so it needs no vault.
+With no key at all, what happens next depends on which store composed, and the two answers differ.
+
+| No key, and the store is… | A registration carrying a token |
+| --- | --- |
+| composed by Vendo, in development | Written **in the clear**, behind one loud warning |
+| composed by Vendo, with `NODE_ENV=production` | Refused |
+| passed by you | Refused in **every** environment, development included |
+
+A store Vendo composes gets the development allowance automatically. A store you pass does not: it owns its own secrets config, so it refuses until you give it a key — or opt in explicitly with `createStore({ url, allowUnencryptedSecrets: true })`, which is a development convenience and nothing more.
+
+A tokenless registration is unaffected either way: it stores no secret, so it needs no vault.
 
 ## Checking and removing
 

--- a/docs-site/customize/user-data.mdx
+++ b/docs-site/customize/user-data.mdx
@@ -32,6 +32,7 @@ comes after it.
 ```http
 POST /api/vendo/files?name=sales-2026.csv
 Content-Type: text/csv
+x-vendo-upload: 1
 
 month,revenue
 jan,31000
@@ -43,6 +44,11 @@ jan,31000
 
 The body is the file's own raw bytes under its own media type — there is no
 multipart form to assemble, so the name rides the query string, percent-encoded.
+
+`x-vendo-upload` is required and its value is not read. A raw body cannot be
+`application/json`, so this door sits outside the wire's CSRF floor and asks for
+a header a cross-site form post cannot set. Without it the upload comes back a
+`400`. The client below sends it for you.
 
 <Note>
   **Same name replaces.** Upload `sales-2026.csv` again and the new file *is*

--- a/docs-site/customize/user-data.mdx
+++ b/docs-site/customize/user-data.mdx
@@ -113,8 +113,22 @@ it.
 Ask for a dashboard of a spreadsheet and the agent builds an app, copying what
 it needs — the rows of a table become the app's own saved items.
 
+Saved items are the app's **own** storage, not a second window onto the drawer.
+An app keeps only the collections it declares, each one apart from every other
+app's, and the agent is what reads and writes them. The drawer is untouched by
+any of it — the agent can list and read a user's files, and has no tool that
+writes one.
+
 That copy is a **snapshot, not a live link**. The app does not read the user's
 files afterwards, and nothing re-reads them on its behalf.
+
+Say a user drops `sales-2026.csv` — eleven rows, one per month through November
+— and asks for a dashboard. The agent builds one over those eleven. In December
+they upload `sales-2026.csv` again, now twelve rows: the drawer's copy is
+replaced, and the dashboard still holds the eleven it was built from. It holds
+them until the person asks for a refresh. The agent then reads the new file,
+rewrites the app's saved items to the twelve, and answers in words — the file
+was replaced, the app updated. What changed is the app and what it has saved.
 
 <Note>
   **Refresh is the agent's job, never a background sync.** Send a newer


### PR DESCRIPTION
Docs-only follow-up to #1464 and #1473. Three pages, no code.

**`customize/user-data.mdx` — "Building on a file"**
Says what the copied rows actually are: the app's **own saved items**, in the app's own storage, in the collections that app declares — not a second view of the user's drawer, and the agent has no tool that writes a user's file at all. Then a worked re-drop: eleven monthly rows build a dashboard, a twelve-row upload replaces the drawer copy, the dashboard keeps the eleven until someone asks, and the agent then rewrites the app's saved items and answers in words. The refresh is agent-mediated on the turn it is asked for; nothing here promises a repainted card. The 5 MB door cap, BYO files adapter, last-write-wins, and the PDF caveat are untouched.

**`capabilities/connectors.mdx` — "Which layer holds the credential"**
The page documented deployment-level connectors and a per-principal headers resolver but never related them to per-user connected accounts. A table now does, and a warning states plainly that tenant connectors have **no per-user path in this release**: one token is vaulted for the whole org and rides static headers, so every member calls with the same credential.

**`capabilities/tenant-connectors.mdx` — "How you wire it"**
The page documented the API but never showed a host using it. Adds the admin form (no `org` field), the route that authorizes with the host's own auth, reads `org` off the session, and renders **both** result branches, a warning about why `org` must never come off the request body, and the memberships seam without which nothing binds.

All three snippets typechecked against the built `@vendoai/*` packages in a scratch project. No changeset: `docs-site` is not a published package, matching every prior docs-only commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies that apps keep their own copy of user files, explains where credentials live for connectors, and shows host-side wiring for tenant connectors. Also fixes two accuracy gaps: the required file-upload header and the conditional behavior when the secrets vault key is missing.

- User data: Saved items are app-owned storage with snapshot semantics; the agent refreshes only when asked. Includes a re-upload example showing the app updates its saved items, not the user’s file.
- Credential layers: Adds “Which layer holds the credential” covering static headers, a per-principal headers resolver (per-user path for `openApiConnector` and `mcpConnector`), and connected accounts. States tenant connectors have no per-user path in this release.
- Tenant connectors: Shows an admin form without an org field and a route that authorizes with host auth, derives `org` from the session, and renders both success and error. Includes the `memberships` seam and a warning to never accept `org` from the request body.
- Uploads: `x-vendo-upload` is required on raw POST /files to mitigate CSRF; the client sends it automatically. Missing the header returns 400.
- Secrets vault: Clarifies no-key behavior. If Vendo composes the store, development writes in clear with a warning and production refuses; a host-passed store refuses in all environments until you provide an encryption key or explicitly opt in with `allowUnencryptedSecrets: true` for development.

<sup>Written for commit b631db38d6431fb3a2860321323daf946f64968e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

