### PR TITLE
fix(vendo): a granted power an away run cannot see is a power it does not have

### DIFF
--- a/.changeset/away-belt-keeps-text-me.md
+++ b/.changeset/away-belt-keeps-text-me.md
@@ -1,0 +1,32 @@
+---
+"@vendoai/vendo": patch
+---
+
+An away run keeps the powers the person granted it. Live 2026-08-19 on
+production Maple, the day after the arming fix: "check my balance and text me"
+was armed with all 33 standing grants, fired on time, read the balance — and
+then told the customer "I don't have a way to send a text message." The grant
+was real; the tool was not on the belt.
+
+Two mechanisms, one silence. The starting toolbelt is cut safest-first at 24
+tools, and Maple's away surface is 25 reads and 6 writes, so every WRITE was
+evicted — `vendo_text_me` with them. Everything past the belt is meant to be one
+`find_tools` search away, but the away and delegated briefs hardcoded
+`discovery: false` on the belief that an away run carries no discovery rails.
+It was never true: an away run thinks on the SAME composed `vendo()` a chat turn
+does, `find_tools` is one of that brain's own hands, and the model was simply
+never told it was holding one.
+
+Both halves are closed. `vendo_text_me` joins the always-active set, so a
+granted way to reach the person is never what the cap displaces — the first
+honoring of a contract the `loadout` docs have stated since ENG-252 ("Vendo's
+own `vendo_*` tools are always active") and nothing implemented; the rest of it
+waits for the loadout redesign. And the discovery rail is DERIVED from the
+harness that actually runs, in one place every path now shares, instead of being
+written four times with three of them hardcoded off — an uncurated surface is
+still told about nothing, because it still has nothing.
+
+The demo bank raises its own belt to 64 alongside this. The 24 default is sized
+for a 600-tool catalog; Maple's whole surface is ~31 tools, inside the 30-50
+band where selection accuracy is best, and the default's safest-first cut is
+what buried its writes twice in two days.

--- a/examples/demo-bank/src/vendo/server.ts
+++ b/examples/demo-bank/src/vendo/server.ts
@@ -178,6 +178,15 @@ export const vendo = createVendo({
     judge: vendoAutoJudge({ model: vendoModel("vendo-judge") }),
   }),
   limits: mapleLimits,
+  // The 24-tool default belt is sized for a 600-tool catalog (tool-search.ts):
+  // past it, everything is one `find_tools` away. Maple's whole surface is ~31
+  // tools, comfortably inside the 30-50 band that file cites as the accurate
+  // one — and the default cut it safest-first, which on 25 reads and 6 writes
+  // means every WRITE was evicted. Twice in two days that buried `vendo_text_me`
+  // and an armed automation told the customer it could not text them. Raised
+  // here rather than lowered in the block: the cap is right for the catalog it
+  // was written for, and wrong for a demo bank.
+  maxInitialTools: 64,
   mcp: mapleMcpConfig(),
   // Maple's customers can text the assistant: they link their phone from the
   // "Text with Maple" card on /settings (components/settings/text-channel-card.tsx

--- a/packages/vendo/src/compose-automations.ts
+++ b/packages/vendo/src/compose-automations.ts
@@ -22,7 +22,7 @@ import {
 import type { VendoComposition } from "./compose-context.js";
 import { cloudKeyOptions } from "./compose-selection.js";
 import { isHostedStore, reportHostedStoreOnce } from "./compose-store.js";
-import { assembleSystemPrompt } from "./prompt.js";
+import { assembleSystemPrompt, discoveryRail } from "./prompt.js";
 import { enrolForTicks } from "./tick-enrolment.js";
 
 /** How often a development process ticks its own scheduler. One minute is the
@@ -93,10 +93,24 @@ export const composeAutomations = (composition: VendoComposition): Pick<VendoCom
     models: inference.seats,
     // The SAME brief a chat turn thinks on, assembled for the FIRING ctx — so
     // the venue gate and the guard's directions are the away run's too, and the
-    // deployment does not have two agents wearing one name. No discovery
-    // section: an away run gets no discovery rails, and promising `find_tools`
-    // would name a tool that is not on its listing.
-    system: (ctx) => assembleSystemPrompt(guard, ctx, system, true, false),
+    // deployment does not have two agents wearing one name.
+    //
+    // Including the discovery section, which this line used to hardcode off on
+    // the belief that "an away run gets no discovery rails". It was never true:
+    // an away run thinks on the SAME composed `vendo()` a chat turn does, and
+    // `find_tools` is one of that brain's own hands. The cost was measured on
+    // production Maple (2026-08-19): an armed "check my balance and text me"
+    // read the balance, found no Text me on its 24-tool belt, and told the
+    // person it had no way to send a text — with the search that would have
+    // equipped it mounted and unmentioned. The rail is DERIVED now, from the
+    // harness that actually runs.
+    system: (ctx) => assembleSystemPrompt(
+      guard,
+      ctx,
+      system,
+      true,
+      discoveryRail(harness, composition.serviceCatalog),
+    ),
   });
   const automations = createAutomations({
     tools: boundTools,

--- a/packages/vendo/src/compose-harness.ts
+++ b/packages/vendo/src/compose-harness.ts
@@ -11,14 +11,33 @@ import type { VendoComposition } from "./compose-context.js";
 import { storeServesHarnessTurns } from "./compose-store.js";
 import { MCP_MOUNT } from "./door-paths.js";
 import { createHarnessTurns, type HarnessTurns } from "./harness-turn.js";
-import { assembleSystemPrompt } from "./prompt.js";
+import { assembleSystemPrompt, discoveryRail } from "./prompt.js";
 import { withAgentMenu } from "./surface-menu.js";
+import { VENDO_TEXT_ME_TOOL } from "./text-me.js";
 import { registerTurnSteer } from "./turn-liveness.js";
 
 /** The tools the OPERATING PROMPT teaches by name — product knowledge, declared
  *  here so the general harness carries none of it (tool-search.ts exempts only
- *  its own capability-miss hand). */
-const PROMPT_TAUGHT_TOOLS: readonly string[] = [VENDO_MAKE_TOOL, ...CONNECTOR_DISCOVERY_TOOLS];
+ *  its own capability-miss hand).
+ *
+ *  `vendo_text_me` is here for the OTHER reason, and it is the first honoring of
+ *  a contract nothing implemented: types.ts's `loadout` doc says "Vendo's own
+ *  `vendo_*` tools are always active" and no code ever made it so. Maple's away
+ *  surface is 25 reads and 6 writes, so the 24-tool safest-first slice evicts
+ *  EVERY write — twice in two days (2026-08-18/19) an automation armed with a
+ *  live Text me grant answered "I don't have a way to send a text message". A
+ *  granted power the belt hides is a lie the person who granted it cannot see.
+ *  Restoring the whole contract belongs to the loadout redesign; the one tool
+ *  that broke production does not wait for it.
+ *
+ *  A name with nothing behind it costs nothing: `computeInitialLoadout` filters
+ *  the turn's OWN listings through this set (tool-search.ts), so on a deployment
+ *  that never opted into texts it simply never matches — no `channels` gate. */
+const PROMPT_TAUGHT_TOOLS: readonly string[] = [
+  VENDO_MAKE_TOOL,
+  VENDO_TEXT_ME_TOOL,
+  ...CONNECTOR_DISCOVERY_TOOLS,
+];
 
 const withPromptTaughtTools = (
   toolSearch: VendoComposition["toolSearch"],
@@ -311,7 +330,7 @@ const harnessDoorFor = (composition: VendoComposition): HarnessTurns => {
  * their task. It says the real reason instead.
  */
 const delegateRunnerFor = (composition: VendoComposition): AgentRunner => {
-  const { store, harness, files, guard, capability, inference, system } = composition;
+  const { store, harness, files, guard, capability, inference, system, serviceCatalog } = composition;
   return storeServesHarnessTurns(store)
     ? awayRunner({
       harness,
@@ -320,10 +339,12 @@ const delegateRunnerFor = (composition: VendoComposition): AgentRunner => {
       guard,
       skills: capability.skills,
       models: inference.seats,
-      // The SAME brief a chat turn thinks on, assembled for the delegated ctx. No
-      // discovery section: a delegated run has no discovery rails, and promising
-      // `find_tools` would name a tool that is not on its listing.
-      system: (ctx) => assembleSystemPrompt(guard, ctx, system, true, false),
+      // The SAME brief a chat turn thinks on, assembled for the delegated ctx —
+      // discovery section included. A delegated run is this deployment's own
+      // brain on the same runtime, so it carries the same `find_tools` hand a
+      // chat turn does; the hardcoded `false` here told it otherwise, the same
+      // way the away run's did (compose-automations.ts).
+      system: (ctx) => assembleSystemPrompt(guard, ctx, system, true, discoveryRail(harness, serviceCatalog)),
       liveTurn: ({ threadId, ctx, tools, steer }) => {
         const unpublish = composition.turnCredentials.publish(threadId, { ctx, tools });
         const unregister = registerTurnSteer({ threadId, subject: ctx.principal.subject, steer });

--- a/packages/vendo/src/harness-turn.ts
+++ b/packages/vendo/src/harness-turn.ts
@@ -74,6 +74,7 @@ import {
 } from "@vendoai/harnesses";
 import type { VendoToolSearchConfig } from "@vendoai/harnesses/vendo";
 import { createUIMessageStream, createUIMessageStreamResponse, type LanguageModel, type UIMessage } from "ai";
+import { discoveryRail } from "./prompt.js";
 import { isUserFilePath, userFilePath } from "./user-files.js";
 import type { Limiter } from "./limits.js";
 
@@ -500,9 +501,7 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
       // paid the store's wait and the guard's `directions` wait end to end.
       // Started after the limiter gate, not before: a refused message must still
       // cost nothing.
-      const rail = config.harness.toolSurface?.curated !== false
-        ? "find-tools" as const
-        : config.connectorDiscovery === true ? "connectors" as const : false;
+      const rail = discoveryRail(config.harness, config.connectorDiscovery);
       const systemRead = config.system(input.ctx, { discovery: rail });
       // A rejection is delivered where the prompt is awaited below; this only
       // keeps a store-phase throw from turning it into an unhandled one.
@@ -877,9 +876,7 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
         transcript: { upsert: async () => {}, list: async () => [] },
         harnessState: { get: async () => undefined, set: async () => {}, clear: async () => {} },
       });
-      const rail = config.harness.toolSurface?.curated !== false
-        ? "find-tools" as const
-        : config.connectorDiscovery === true ? "connectors" as const : false;
+      const rail = discoveryRail(config.harness, config.connectorDiscovery);
       const system = await config.system(input.ctx, { discovery: rail });
       const response = await runtime.run<{ maxSteps: number; maxOutputTokens: number }>({
         harness: config.harness,

--- a/packages/vendo/src/prompt.ts
+++ b/packages/vendo/src/prompt.ts
@@ -5,7 +5,27 @@
  * catalog and the knowledge index. It rides the turn (`Turn.system`), so every
  * harness — the default one, a host's own — thinks on the same brief.
  */
-import { userPromptBlock, type Guard, type RunContext } from "@vendoai/core";
+import { userPromptBlock, type Guard, type Harness, type RunContext } from "@vendoai/core";
+
+/**
+ * Which discovery rail a turn's harness actually carries — ONE derivation, for
+ * every path that assembles a brief.
+ *
+ * It was written four times and three of them were a hardcoded `false`. The away
+ * automation run and the delegated run mount the composed `vendo()`, so they
+ * carry `find_tools` like any chat turn — and were told they carried nothing.
+ * Maple, 2026-08-19: an automation whose whole job was "check the balance and
+ * text me" read the balance and then said it had no way to send a text, because
+ * the belt had evicted `vendo_text_me` and the brief never mentioned the search
+ * that would have found it again. A rail nobody names is a rail nobody uses.
+ */
+export const discoveryRail = (
+  harness: Pick<Harness, "toolSurface">,
+  connectorDiscovery: boolean | undefined,
+): "find-tools" | "connectors" | false =>
+  harness.toolSurface?.curated !== false
+    ? "find-tools"
+    : connectorDiscovery === true ? "connectors" : false;
 
 const OPERATING_PROMPT = `You are Vendo's agent.
 Act through the host's available tools on behalf of the signed-in user.

--- a/packages/vendo/tests/away-run-tools.seam.test.ts
+++ b/packages/vendo/tests/away-run-tools.seam.test.ts
@@ -1,0 +1,192 @@
+/**
+ * WHAT AN AWAY RUN IS EQUIPPED WITH, AND WHAT IT IS TOLD ABOUT THE REST.
+ *
+ * Production Maple, 2026-08-19: "check my balance and text me" was armed with
+ * every standing grant it needed, fired on time, read the balance — and then told
+ * the customer "I don't have a way to send a text message." Two mechanisms, one
+ * silence. `computeInitialLoadout` cuts a large surface safest-first, so 25 reads
+ * filled the 24-tool belt and every WRITE was evicted, `vendo_text_me` included;
+ * and the away brief hardcoded `discovery: false`, so the model was never told
+ * that the `find_tools` its own harness was carrying could equip it again.
+ *
+ * Nothing is stubbed between the halves: a real `createVendo`, a real store, the
+ * real automations engine, the real composed `vendo()` brain and the real away
+ * runner. The belt is read off the MODEL CALL — the tools block as it crosses the
+ * provider seam — because a loadout the model was never handed proves nothing.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { automationsInternals } from "@vendoai/automations";
+import type { Harness, Principal, RunContext, ToolDescriptor, ToolRegistry } from "@vendoai/core";
+import { defineHarness } from "@vendoai/harnesses";
+import { createStore, type VendoStore } from "@vendoai/store";
+import type { LanguageModel } from "ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createVendo, type Vendo } from "../src/server.js";
+import { VENDO_TEXT_ME_TOOL } from "../src/text-me.js";
+
+const owner: Principal = { kind: "user", subject: "user_away_tools" };
+const ctx: RunContext = {
+  principal: owner,
+  venue: "chat",
+  presence: "present",
+  sessionId: "sess_away_tools",
+};
+const EVENT = "balance.checked";
+const GOAL = "check my checking balance and text me";
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+  vi.unstubAllEnvs();
+});
+
+/** Maple's arithmetic in miniature: enough graded READS to fill the default belt
+ *  on their own, so every write on the surface is a candidate for eviction —
+ *  which is the whole reason the person's granted Text me never reached it. */
+const READS = 30;
+
+const hostReads = (): ToolRegistry => {
+  const descriptors: ToolDescriptor[] = Array.from({ length: READS }, (_, index) => ({
+    name: `maple_read_${String(index).padStart(2, "0")}`,
+    title: `Read ${index}`,
+    description: "One of the bank's read-only lookups",
+    inputSchema: { type: "object" },
+    risk: "read",
+  }));
+  return {
+    async descriptors() {
+      return descriptors;
+    },
+    async execute() {
+      return { status: "ok", output: {} };
+    },
+  };
+};
+
+/** Every tool block the provider was handed, per call. */
+function recordingModel(seen: string[][]): LanguageModel {
+  return {
+    specificationVersion: "v2",
+    provider: "probe",
+    modelId: "probe-v1",
+    supportedUrls: {},
+    async doStream(call: { tools?: readonly { name?: string }[] }) {
+      seen.push((call.tools ?? []).map((entry) => String(entry.name)));
+      return {
+        stream: new ReadableStream({
+          start(controller) {
+            controller.enqueue({ type: "stream-start", warnings: [] });
+            controller.enqueue({ type: "text-start", id: "t1" });
+            controller.enqueue({ type: "text-delta", id: "t1", delta: "ok" });
+            controller.enqueue({ type: "text-end", id: "t1" });
+            controller.enqueue({
+              type: "finish",
+              finishReason: "stop",
+              usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+            });
+            controller.close();
+          },
+        }),
+      };
+    },
+  } as unknown as LanguageModel;
+}
+
+async function tempStore(): Promise<VendoStore> {
+  const dataDir = await mkdtemp(join(tmpdir(), "vendo-away-tools-"));
+  const store = createStore({ dataDir });
+  cleanups.push(async () => {
+    await store.close();
+    await rm(dataDir, { recursive: true, force: true });
+  });
+  return store;
+}
+
+async function compose(overrides: Record<string, unknown>): Promise<Vendo> {
+  const store = await tempStore();
+  const vendo = createVendo({
+    models: { default: {} as LanguageModel },
+    principal: async () => owner,
+    store,
+    ...overrides,
+  } as Parameters<typeof createVendo>[0]);
+  vendo.actions.add(hostReads());
+  await store.ensureSchema();
+  return vendo;
+}
+
+/** One armed agentic automation, fired. `emit` awaits the firing, so the away run
+ *  has already thought by the time it returns. */
+async function fire(vendo: Vendo): Promise<void> {
+  await automationsInternals(vendo.automations).create({
+    owner,
+    when: { event: EVENT },
+    task: { kind: "goal", prompt: GOAL },
+    authoredBy: "chat",
+  }, ctx);
+  await vendo.emit(EVENT, {}, owner);
+}
+
+describe.sequential("the belt an away firing is handed", () => {
+  it("keeps vendo_text_me on it however many reads crowd the surface", async () => {
+    // The channel is configured, so the tool is registered and the grant the
+    // person gave it is worth something. `VENDO_CLOUD_URL` points nowhere on
+    // purpose: this run never reaches the console, and a stray request must fail
+    // instantly rather than leave the test's tenant.
+    vi.stubEnv("VENDO_API_KEY", "vk_live_away_tools");
+    vi.stubEnv("VENDO_CLOUD_URL", "http://127.0.0.1:1");
+    const seen: string[][] = [];
+    const vendo = await compose({
+      models: { default: recordingModel(seen) },
+      channels: { text: true },
+      connectors: [],
+    });
+
+    await fire(vendo);
+
+    expect(seen.length, "the away run never reached the model").toBeGreaterThan(0);
+    const belt = seen[0]!;
+    // THE POINT: the power the person granted is on the belt the model was
+    // handed. Before this, it was the 25th read's turn and every write lost.
+    expect(belt).toContain(VENDO_TEXT_ME_TOOL);
+    // …and the cap really did bite, so the line above is a survivor and not an
+    // accident of a surface that fit whole.
+    expect(belt.filter((name) => name.startsWith("maple_read_")).length).toBeLessThan(READS);
+  }, 60_000);
+});
+
+describe.sequential("the brief an away firing thinks on", () => {
+  /** A harness that reports the brief it was handed and nothing else. */
+  const probe = (told: { system?: string }, toolSurface?: Harness["toolSurface"]) =>
+    defineHarness({
+      name: "away-brief-probe",
+      ...(toolSurface === undefined ? {} : { toolSurface }),
+      async *run(turn) {
+        told.system = turn.system ?? "";
+        yield { type: "text", delta: "ok" };
+      },
+    }) as never;
+
+  it("teaches the search budget when the away harness actually carries find_tools", async () => {
+    const told: { system?: string } = {};
+    await fire(await compose({ harness: probe(told) }));
+
+    // The away run mounts the composed brain, `find_tools` and all — the brief
+    // used to say `discovery: false` and leave the rail unmentioned.
+    expect(told.system).toContain("Discovery budget");
+    expect(told.system).toContain("find_tools");
+  }, 60_000);
+
+  it("still says nothing about a rail an uncurated away harness does not have", async () => {
+    const told: { system?: string } = {};
+    await fire(await compose({ harness: probe(told, { curated: false }) }));
+
+    // Derived, not hardcoded the other way: an uncurated surface has no
+    // `find_tools`, and with no searchable connector it has no pair either.
+    expect(told.system).not.toContain("Discovery budget");
+    expect(told.system).not.toContain("find_tools");
+    expect(told.system).not.toContain("find_service_tools");
+  }, 60_000);
+});


### PR DESCRIPTION
Live 2026-08-19 on production Maple, the day after the arming fix shipped: a user's armed **"check my balance and text me"** — all 33 standing grants live, `vendo_text_me` among them — fired on time, read the balance, and then told them *"I don't have a way to send a text message."* The grant was real. The tool was not on the belt.

## What was actually wrong

Two mechanisms, one silence.

**The belt.** `computeInitialLoadout` cuts the starting toolbelt safest-first at 24 tools (`packages/harnesses/src/vendo/tool-search.ts`). Maple's away surface is 25 reads and 6 writes, so the reads filled the belt on their own and **every write was evicted** — `vendo_text_me` with them.

**The brief.** Everything past the belt is meant to be one `find_tools` search away, and the away run really does mount `find_tools`: `compose-harness.ts` builds the composed `vendo()` with the tool-search strategy, and the away runner runs that same brain. But `compose-automations.ts` and the delegate runner both called `assembleSystemPrompt(…, false)` — a hardcoded "no discovery rails" — so the model was never told it was holding the one hand that could get the tool back. It was the second live instance of that exact mechanism in one day; `prompt.ts` already records the first.

## The three changes

1. **`vendo_text_me` becomes always-active** (`compose-harness.ts`). This is the first honoring of a contract the `loadout` docs have stated since ENG-252 — *"Vendo's own `vendo_*` tools are always active"* — and that nothing implemented. Full contract restoration is deliberately deferred to the loadout redesign; the one tool that broke production twice does not wait for it. No `channels` gate is needed: `computeInitialLoadout` filters the turn's own listings through the always-active set, so a name with nothing behind it simply never matches.

2. **The away and delegated briefs stop lying about discovery.** The rail is now DERIVED from the harness that actually runs, through one shared `discoveryRail` in `prompt.ts`. It was written four times with three of them hardcoded off; all four paths (chat, warm, away, delegate) share the one derivation now, so they cannot drift again. An uncurated surface is still told about nothing, because it still has nothing.

3. **Maple raises its own belt to 64** (`examples/demo-bank`). The 24 default is sized for a 600-tool catalog; Maple's whole surface is ~31 tools, comfortably inside the 30-50 band `tool-search.ts` cites as the accurate one, and the default's safest-first cut buried its writes twice in two days.

## Tests

`packages/vendo/tests/away-run-tools.seam.test.ts` drives a real `createVendo`, a real store, the real automations engine and the real away runner, then reads the belt **off the model call** — the tools block as it crosses the provider seam — because a loadout the model was never handed proves nothing. Two more cover the brief: the away run is taught the Discovery budget when its harness carries `find_tools`, and still told nothing when `toolSurface.curated === false`.

Both fixes were reverted to prove the tests can fail:

```
× keeps vendo_text_me on it however many reads crowd the surface
  → expected [ 'vendo_make', 'ask_user', …(25) ] to include 'vendo_text_me'
× teaches the search budget when the away harness actually carries find_tools
  → expected 'You are Vendo's agent.\nAct through …' to contain 'Discovery budget'
```

Local gate green on the touched scope (`build`, `typecheck`, `lint`, `test:affected`). Three pre-existing failures in `your-agent-docs.docs.test.ts` and `cli/init-mcp.test.ts` are the known `%20`-in-worktree-path artifact — reproduced identically on a pristine `origin/main` checkout in the same directory.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes away/delegated runs dropping granted texting power by keeping `vendo_text_me` on the belt and by deriving discovery rails from the running harness. Previously, away/delegated briefs hardcoded discovery off and the 24-tool cap evicted writes; now the brief includes discovery when available and the demo raises its cap to avoid write eviction.

- `vendo_text_me` is now always active in `@vendoai/vendo`, so a granted text channel stays on the belt even when many reads crowd the surface.
- Discovery rail is derived once in `prompt.ts` (`discoveryRail`) and used by chat, warm, away, and delegated runs. Away/delegated runs now advertise `find_tools` when the harness supports it; uncurated surfaces still get no discovery rail.
- Demo bank (`examples/demo-bank`) sets `maxInitialTools: 64` to keep writes available; the default remains 24 for large catalogs.
- A seam test asserts the model’s actual tool list and brief content during an away firing.

Migration notes:
- If you must preserve the old “no discovery for away/delegate” behavior, set `harness.toolSurface.curated === false` or ensure connector discovery is disabled. No action required otherwise.

<sup>Written for commit 1aa1f8f447bbfe7a78e7f657f577b317758f0e0c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

