### PR TITLE
feat(core,agents): a turn's answer has one shape, and a tool must say what it does

### DIFF
--- a/packages/agents/README.md
+++ b/packages/agents/README.md
@@ -12,8 +12,9 @@ import { claudeCode } from "@vendoai/harnesses/claude-code";
 const support = agent({
   name: "support",
   harness: claudeCode({ model: "claude-sonnet-5" }),
-  // `outputSchema` is optional: the result shape the model is told to expect.
-  tools: [api(), tool({ name: "refund", risk: "write", inputSchema, outputSchema, execute })],
+  // `description` is required — it is all the model reads to decide to call the
+  // tool. `outputSchema` is optional: the result shape the model is told to expect.
+  tools: [api(), tool({ name: "refund", description, risk: "write", inputSchema, outputSchema, execute })],
   mcp: [{ url: "https://mcp.example.com", headers: { authorization: "…" } }],
   skills: ["./skills/product-docs"],
   egress: ["api.stripe.com"],

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -32,6 +32,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
+    },
+    "./claude-code": {
+      "types": "./dist/claude-code.d.ts",
+      "default": "./dist/claude-code.js"
     }
   },
   "files": [

--- a/packages/agents/src/claude-code.ts
+++ b/packages/agents/src/claude-code.ts
@@ -1,0 +1,11 @@
+/**
+ * `@vendoai/agents/claude-code` — the builder engine, from the one package a
+ * host installed.
+ *
+ * A subpath rather than a root export for the reason it is one in
+ * `@vendoai/harnesses`: the Claude Agent SDK reaches Node built-ins, and the
+ * root barrel is bundled for Worker targets through `packages/vendo/src/server.ts`
+ * (portability-gate.mjs). Everything here is a re-export — one definition, in
+ * harnesses.
+ */
+export { claudeCode, type ClaudeCodeOptions } from "@vendoai/harnesses/claude-code";

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -1,8 +1,8 @@
 /**
  * `@vendoai/agents` — spawn a governed, harness-grade agent in any Node
  * backend in a few lines. One runtime, always host-run; a Vendo Cloud key
- * fills the sandbox slot when it is left unset. Harness factories live in
- * `@vendoai/harnesses` (`claudeCode`, `vendo`).
+ * fills the sandbox slot when it is left unset. The engines are DEFINED in
+ * `@vendoai/harnesses` and re-exported here, so a host installs one package.
  */
 export {
   agent,
@@ -41,13 +41,33 @@ export {
   type HostTool,
   type McpServerConfig,
   type ToolConfig,
+  type ToolInput,
   type ToolSource,
 } from "./tools.js";
 export type { EgressConfig } from "./egress.js";
 export type { RunContext } from "@vendoai/core";
+/** The turn contract, from the one package a host installed. It is DEFINED in
+ *  `@vendoai/core` — one definition, every block speaks it — and re-exported
+ *  here so nobody has to add a second dependency to name what a turn returned. */
+export type {
+  Decision,
+  Decisions,
+  Interruption,
+  Question,
+  ResumeOptions,
+  TurnResult,
+  TurnUsage,
+} from "@vendoai/core";
+export { decisionSchema, decisionsSchema, interruptionSchema, questionSchema } from "@vendoai/core";
 /** The header `respond()` and `session.stream()` return the conversation's id
  *  on, and the one `@vendoai/ui` reads it from. Named, not spelled out, so a
  *  host and the browser cannot drift onto two literals. */
 export { THREAD_ID_HEADER, type UsageTotals } from "@vendoai/harnesses";
+/** The default engine, from the one package a host installed — DEFINED in
+ *  `@vendoai/harnesses`, re-exported here, never a second copy. `claudeCode()`
+ *  is its own subpath (`@vendoai/agents/claude-code`) for the reason it is one
+ *  in harnesses: its SDK needs Node built-ins, and this barrel is bundled for
+ *  Worker targets through `packages/vendo/src/server.ts` (portability-gate.mjs). */
+export { vendo, type VendoHarnessOptions } from "@vendoai/harnesses";
 
 export { createGuard, type GuardLike, type VendoGuard } from "@vendoai/guard";

--- a/packages/agents/src/tools.ts
+++ b/packages/agents/src/tools.ts
@@ -19,40 +19,78 @@ import {
   type ToolOutcome,
   type ToolRegistry,
 } from "@vendoai/core";
+import { asSchema, type FlexibleSchema, type InferSchema } from "ai";
 
-export interface ToolConfig {
+/** What `execute` is handed. A zod (or any standard-schema) `inputSchema` types
+ *  it; a raw JSON Schema cannot, because JSON Schema is data — there is nothing
+ *  in it for TypeScript to read — so that branch stays `Json`, as it always was. */
+export type ToolInput<TSchema> = [InferSchema<TSchema>] extends [never] ? Json : InferSchema<TSchema>;
+
+export interface ToolConfig<TSchema = JsonSchema> {
   name: string;
-  description?: string;
+  /** What this tool does and when to reach for it. REQUIRED: it is the only
+   *  thing the model reads when deciding whether to call it. */
+  description: string;
   /** The dev's label is FINAL; unlabeled = ungraded = asks at call time. */
   risk?: RiskLabel;
-  inputSchema: JsonSchema;
+  /** A zod schema — which also types `execute`'s `input` — or a raw JSON
+   *  Schema for a host that has one already. */
+  inputSchema: TSchema;
   /** The tool's DECLARED result shape. Surfaces print it, so generated UI can
    *  bind to fields before any call; nothing validates a result against it, so a
    *  stale schema never fails a working tool. */
   outputSchema?: JsonSchema;
-  execute(input: Json, ctx: RunContext, call: ToolCall): Promise<Json> | Json;
+  execute(input: ToolInput<TSchema>, ctx: RunContext, call: ToolCall): Promise<Json> | Json;
 }
 
 /** One host-authored tool, ready for `agent({ tools: [...] })`. */
 export interface HostTool {
   descriptor: ToolDescriptor;
-  execute: ToolConfig["execute"];
+  execute(input: Json, ctx: RunContext, call: ToolCall): Promise<Json> | Json;
 }
 
 export type ToolSource = HostTool | ToolRegistry;
 
-export function tool(config: ToolConfig): HostTool {
+/**
+ * A descriptor carries JSON Schema and nothing else — it crosses the wire to a
+ * model, a box and a browser, none of which can run a validator — so a zod
+ * schema is converted ONCE, here, rather than at every reader.
+ *
+ * The two branches are told apart by what the AI SDK itself keys on: zod (v3.25+
+ * and v4 alike) and every standard schema carry `~standard`, an `asSchema`
+ * result carries `jsonSchema`, and a lazy schema is a function. A raw JSON
+ * Schema is a plain object with none of those, and is passed through untouched.
+ */
+const isJsonSchema = (schema: JsonSchema | FlexibleSchema): schema is JsonSchema =>
+  typeof schema === "object" && !("~standard" in schema) && !("jsonSchema" in schema);
+
+const toJsonSchema = (schema: JsonSchema | FlexibleSchema): JsonSchema =>
+  isJsonSchema(schema)
+    ? schema
+    // `asSchema`'s `jsonSchema` is only a promise for a DEFERRED schema; zod's
+    // is built synchronously, which is why a descriptor can be minted here.
+    : asSchema(schema).jsonSchema as JsonSchema;
+
+export function tool<TSchema extends JsonSchema | FlexibleSchema>(config: ToolConfig<TSchema>): HostTool {
   if (!TOOL_NAME_PATTERN.test(config.name)) {
     throw new VendoError(
       "validation",
       `tool name "${config.name}" must match ${String(TOOL_NAME_PATTERN)}`,
     );
   }
+  if ((config.description ?? "").trim() === "") {
+    throw new VendoError(
+      "validation",
+      `tool "${config.name}" needs a description. It is the only thing the model reads when it `
+      + "decides whether to call this tool, so without one the tool is effectively invisible — "
+      + "write a sentence saying what it does and when to use it.",
+    );
+  }
   return {
     descriptor: {
       name: config.name,
-      description: config.description ?? "",
-      inputSchema: config.inputSchema,
+      description: config.description,
+      inputSchema: toJsonSchema(config.inputSchema),
       ...(config.outputSchema === undefined ? {} : { outputSchema: config.outputSchema }),
       risk: config.risk ?? "ungraded",
     },

--- a/packages/agents/tests/agent.test.ts
+++ b/packages/agents/tests/agent.test.ts
@@ -92,7 +92,7 @@ describe("agent() boot", () => {
   });
 
   it("two tools claiming one name is a boot error", () => {
-    const same = { name: "x", inputSchema: { type: "object" as const }, execute: () => ({}) };
+    const same = { name: "x", description: "X", inputSchema: { type: "object" as const }, execute: () => ({}) };
     expect(() =>
       agent({ name: "support", harness: inert(), store: memoryStore(), tools: [tool(same), tool(same)] }),
     ).toThrow(/claim the name/);

--- a/packages/agents/tests/door.test.ts
+++ b/packages/agents/tests/door.test.ts
@@ -138,6 +138,7 @@ const jsonRpcBody = async (response: Response): Promise<string> => response.text
 
 const refund = tool({
   name: "refund_invoice",
+  description: "Refund an invoice",
   risk: "write",
   inputSchema: { type: "object" as const },
   execute: () => ({ ok: true }),

--- a/packages/agents/tests/index.test.ts
+++ b/packages/agents/tests/index.test.ts
@@ -1,5 +1,6 @@
 /** The public surface, pinned — what the spec promises a host can import. */
 import { describe, expect, it } from "vitest";
+import { claudeCode } from "../src/claude-code.js";
 import * as agents from "../src/index.js";
 import { mcpSources } from "../src/tools.js";
 
@@ -12,6 +13,13 @@ describe("the package surface", () => {
     expect(agents.e2b).toBeTypeOf("function");
     expect(agents.postgres).toBeTypeOf("function");
     expect(agents.provideCloudAdapters).toBeTypeOf("function");
+  });
+
+  it("exports both engines, so a host installs one package", () => {
+    expect(agents.vendo).toBeTypeOf("function");
+    // `claudeCode` rides a subpath, not the barrel: its SDK reaches Node
+    // built-ins and this barrel is bundled for Worker targets.
+    expect(claudeCode).toBeTypeOf("function");
   });
 
   it("exports the type a host writes its `system` hook against", () => {

--- a/packages/agents/tests/respond.test.ts
+++ b/packages/agents/tests/respond.test.ts
@@ -212,6 +212,7 @@ describe("respond()", () => {
       }),
       tools: [tool({
         name: "peek",
+        description: "Peek at the run context",
         risk: "read",
         inputSchema: { type: "object" },
         execute: (_input, ctx) => {

--- a/packages/agents/tests/session.test.ts
+++ b/packages/agents/tests/session.test.ts
@@ -222,6 +222,7 @@ describe("session", () => {
     let seen: RunContext | undefined;
     const probe = tool({
       name: "probe",
+      description: "Probe the run context",
       risk: "read",
       inputSchema: { type: "object" },
       execute: (_input, ctx) => {
@@ -324,6 +325,7 @@ describe("session", () => {
     const guard = createGuard({ store, policy: "cautious" });
     const writer = tool({
       name: "writer",
+      description: "Write something",
       risk: "write",
       inputSchema: { type: "object" },
       execute: () => ({ done: true }),

--- a/packages/agents/tests/tools.test.ts
+++ b/packages/agents/tests/tools.test.ts
@@ -1,8 +1,9 @@
 import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import type { RunContext, ToolRegistry } from "@vendoai/core";
-import { afterEach, describe, expect, it } from "vitest";
+import type { Json, RunContext, ToolRegistry } from "@vendoai/core";
+import { afterEach, describe, expect, expectTypeOf, it } from "vitest";
+import { z } from "zod";
 import { api, mergeSources, tool } from "../src/tools.js";
 
 const ctx: RunContext = {
@@ -28,26 +29,66 @@ const registryOf = (...names: string[]): ToolRegistry => ({
 
 describe("tool()", () => {
   it("unlabeled = ungraded — the guard asks; it is never invented as a grade", () => {
-    const t = tool({ name: "lookup", inputSchema: { type: "object" }, execute: () => ({}) });
+    const t = tool({ name: "lookup", description: "Look one up", inputSchema: { type: "object" }, execute: () => ({}) });
     expect(t.descriptor.risk).toBe("ungraded");
   });
 
   it("keeps the dev's label — it is final", () => {
-    const t = tool({ name: "wipe", risk: "destructive", inputSchema: { type: "object" }, execute: () => ({}) });
+    const t = tool({ name: "wipe", description: "Wipe it", risk: "destructive", inputSchema: { type: "object" }, execute: () => ({}) });
     expect(t.descriptor.risk).toBe("destructive");
   });
 
   it("carries the declared result shape, and has no key at all without one", () => {
     const outputSchema = { type: "object" as const, properties: { balance: { type: "number" } } };
-    const declared = tool({ name: "balance", inputSchema: { type: "object" }, outputSchema, execute: () => ({}) });
+    const declared = tool({ name: "balance", description: "Read the balance", inputSchema: { type: "object" }, outputSchema, execute: () => ({}) });
     expect(declared.descriptor.outputSchema).toEqual(outputSchema);
-    const silent = tool({ name: "ping", inputSchema: { type: "object" }, execute: () => ({}) });
+    const silent = tool({ name: "ping", description: "Ping", inputSchema: { type: "object" }, execute: () => ({}) });
     expect("outputSchema" in silent.descriptor).toBe(false);
   });
 
   it("rejects a name the registry could never carry", () => {
-    expect(() => tool({ name: "not a name!", inputSchema: { type: "object" }, execute: () => ({}) }))
+    expect(() => tool({ name: "not a name!", description: "Nope", inputSchema: { type: "object" }, execute: () => ({}) }))
       .toThrow(/must match/);
+  });
+
+  it("refuses a tool with nothing to tell the model, and says what to write", () => {
+    // As an untyped host would call it — the type says required, this says so at runtime too.
+    const missing: unknown = { name: "lookup", inputSchema: { type: "object" }, execute: () => ({}) };
+    expect(() => tool(missing as Parameters<typeof tool>[0]))
+      .toThrow(/needs a description[\s\S]*write a sentence/);
+    expect(() => tool({ name: "lookup", description: "   ", inputSchema: { type: "object" }, execute: () => ({}) }))
+      .toThrow(/needs a description/);
+  });
+
+  it("takes a zod schema: `execute` is typed by it, and the descriptor carries its JSON Schema", () => {
+    const refund = tool({
+      name: "refund",
+      description: "Refund an order in full.",
+      inputSchema: z.object({ orderId: z.string(), note: z.string().optional() }),
+      execute: (input) => {
+        expectTypeOf(input).toEqualTypeOf<{ orderId: string; note?: string | undefined }>();
+        return { refunded: input.orderId };
+      },
+    });
+    expect(refund.descriptor.inputSchema).toMatchObject({
+      type: "object",
+      properties: { orderId: { type: "string" }, note: { type: "string" } },
+      required: ["orderId"],
+    });
+  });
+
+  it("takes a raw JSON Schema unchanged — and then `input` is only Json", () => {
+    const inputSchema = { type: "object" as const, properties: { orderId: { type: "string" } } };
+    const refund = tool({
+      name: "refund_raw",
+      description: "Refund an order in full.",
+      inputSchema,
+      execute: (input) => {
+        expectTypeOf(input).toEqualTypeOf<Json>();
+        return {};
+      },
+    });
+    expect(refund.descriptor.inputSchema).toBe(inputSchema);
   });
 });
 
@@ -108,8 +149,8 @@ describe("mergeSources", () => {
   it("executes a host tool and wraps its output / its throw", async () => {
     const merged = mergeSources(
       [
-        tool({ name: "ok", risk: "read", inputSchema: { type: "object" }, execute: (input) => ({ echoed: input }) }),
-        tool({ name: "boom", risk: "read", inputSchema: { type: "object" }, execute: () => { throw new Error("nope"); } }),
+        tool({ name: "ok", description: "Echo the input", risk: "read", inputSchema: { type: "object" }, execute: (input) => ({ echoed: input }) }),
+        tool({ name: "boom", description: "Throw", risk: "read", inputSchema: { type: "object" }, execute: () => { throw new Error("nope"); } }),
       ],
       [],
     );
@@ -121,7 +162,7 @@ describe("mergeSources", () => {
 
   it("routes across sources by name and answers not-found honestly", async () => {
     const merged = mergeSources(
-      [tool({ name: "mine", risk: "read", inputSchema: { type: "object" }, execute: () => ({}) }), registryOf("theirs")],
+      [tool({ name: "mine", description: "Mine", risk: "read", inputSchema: { type: "object" }, execute: () => ({}) }), registryOf("theirs")],
       [],
     );
     expect((await merged.execute({ id: "c1", tool: "theirs", args: {} }, ctx)).status).toBe("ok");
@@ -129,14 +170,14 @@ describe("mergeSources", () => {
   });
 
   it("two tool() names colliding is a boot error, synchronously", () => {
-    const a = tool({ name: "same", inputSchema: { type: "object" }, execute: () => ({}) });
-    const b = tool({ name: "same", inputSchema: { type: "object" }, execute: () => ({}) });
+    const a = tool({ name: "same", description: "Same name", inputSchema: { type: "object" }, execute: () => ({}) });
+    const b = tool({ name: "same", description: "Same name", inputSchema: { type: "object" }, execute: () => ({}) });
     expect(() => mergeSources([a, b], [])).toThrow(/claim the name "same"/);
   });
 
   it("a dynamic source colliding throws on the first projection — before any call can shadow", async () => {
     const merged = mergeSources(
-      [tool({ name: "same", inputSchema: { type: "object" }, execute: () => ({}) }), registryOf("same")],
+      [tool({ name: "same", description: "Same name", inputSchema: { type: "object" }, execute: () => ({}) }), registryOf("same")],
       [],
     );
     await expect(merged.descriptors()).rejects.toThrow(/claim the name "same"/);
@@ -144,7 +185,7 @@ describe("mergeSources", () => {
 
   it("projects every source's descriptors together", async () => {
     const merged = mergeSources(
-      [tool({ name: "a", inputSchema: { type: "object" }, execute: () => ({}) }), registryOf("b", "c")],
+      [tool({ name: "a", description: "A", inputSchema: { type: "object" }, execute: () => ({}) }), registryOf("b", "c")],
       [],
     );
     expect((await merged.descriptors()).map((d) => d.name).sort()).toEqual(["a", "b", "c"]);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -59,6 +59,7 @@ export * from "./engine-over-adapter.js";
 export * from "./stream-parts.js";
 export * from "./tool-envelopes.js";
 export * from "./tools.js";
+export * from "./turn-result.js";
 export * from "./url.js";
 export * from "./version.js";
 export * from "./genui/tree-node.js";

--- a/packages/core/src/turn-result.ts
+++ b/packages/core/src/turn-result.ts
@@ -1,0 +1,127 @@
+import { z } from "zod";
+import type { VendoErrorCode } from "./errors.js";
+import type { ThreadId, TurnId } from "./ids.js";
+import { toolCallSchema, type ToolCall, type ToolOutcome } from "./tools.js";
+
+/**
+ * The metering figures a turn reports.
+ *
+ * Field for field the `UsageTotals` a harness already hands the runtime
+ * (`@vendoai/harnesses`), restated here because core may not depend on
+ * harnesses and a turn's answer is core's shape. Identical on purpose: either
+ * side's value is the other's, with no adapter between them.
+ */
+export interface TurnUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
+  model?: string;
+}
+
+/** What every turn that RAN reports, whatever ended it. `text` is the
+ *  assistant's own words — the one channel a person reads (§1.5) — and
+ *  `toolCalls` pairs each call with how it ended, the same pair
+ *  `AgentRunReport` carries so one reader serves both. */
+interface TurnRun {
+  text: string;
+  threadId: ThreadId;
+  turnId: TurnId;
+  toolCalls: Array<{ call: ToolCall; outcome: ToolOutcome["status"] }>;
+  usage: TurnUsage;
+}
+
+/** One thing a person has to answer before the turn can go on. `id` is what a
+ *  {@link Decisions} map is keyed by, so an answer can never be applied to the
+ *  wrong interruption. */
+export type Interruption =
+  | { id: string; type: "approval"; toolCall: ToolCall }
+  /** Wire-defined now, EMITTED post-v1: `ask_user` ends the turn in v1 and the
+   *  answer arrives as the next message, so nothing mints this arm yet. It is
+   *  frozen here anyway because `@vendoai/ui` and the resume route both parse
+   *  this union, and a shape added later is a shape two shipped readers reject. */
+  | { id: string; type: "input"; questions: Question[] };
+
+/** One question inside an `input` interruption. Same vocabulary as the
+ *  `ask_user` door (a question, and optionally the fixed choices it accepts);
+ *  free text when `choices` is absent. */
+export interface Question {
+  id: string;
+  text: string;
+  choices?: string[];
+}
+
+/** How a caller answers ONE interruption: a verdict for an approval, the
+ *  answers for a set of questions. */
+export type Decision = "approve" | "deny" | { answers: Record<string, string | string[]> };
+
+/** Every interruption's answer, keyed by {@link Interruption.id}. */
+export type Decisions = Record<string, Decision>;
+
+/** The per-resume knobs, the same two a session already takes: the request's
+ *  own headers to forward, and the guard/tools context. */
+export interface ResumeOptions {
+  headers?: Record<string, string> | Headers;
+  context?: Record<string, unknown>;
+}
+
+/** The wire half. `Interruption`, `Question` and `Decision` all cross a wire —
+ *  `@vendoai/ui` renders them and `POST /turns/:id/resume` accepts them — so
+ *  each one has a schema, per core's rule that a shape crossing a wire or a
+ *  store is parsed, never trusted. */
+export const questionSchema = z.object({
+  id: z.string(),
+  text: z.string().min(1),
+  choices: z.array(z.string()).optional(),
+}).passthrough() satisfies z.ZodType<Question>;
+
+export const interruptionSchema = z.discriminatedUnion("type", [
+  z.object({ id: z.string(), type: z.literal("approval"), toolCall: toolCallSchema }).passthrough(),
+  z.object({ id: z.string(), type: z.literal("input"), questions: z.array(questionSchema) }).passthrough(),
+]) satisfies z.ZodType<Interruption>;
+
+export const decisionSchema = z.union([
+  z.literal("approve"),
+  z.literal("deny"),
+  z.object({ answers: z.record(z.union([z.string(), z.array(z.string())])) }).passthrough(),
+]) satisfies z.ZodType<Decision>;
+
+export const decisionsSchema = z.record(decisionSchema) satisfies z.ZodType<Decisions>;
+
+/**
+ * What ONE turn answered.
+ *
+ * Four ends and no fifth: it finished (`ok`), it needs a person before it can
+ * go on (`interrupted`), something outside it called time (`stopped`), or it
+ * broke (`error`). A caller reads `status` once and every field it then
+ * touches is there — which is the whole reason this is a discriminated union
+ * and not one wide record of optionals.
+ *
+ * `TTurn` exists because `resume()` hands back the AGENTS-level `Turn`, and
+ * core is the layer everything else depends on, so it cannot name one.
+ * `@vendoai/agents` binds it (`TurnResult<T, Turn<T>>`). There is ONE
+ * definition of this union and this is it — nothing re-declares it.
+ *
+ * Deliberately NOT schema-ised: the interrupted arm carries a live closure, and
+ * a function is not a wire value. The pieces that DO cross the wire — the
+ * interruptions and the decisions answering them — have their schemas above.
+ */
+export type TurnResult<T = void, TTurn = unknown> =
+  | (TurnRun & { status: "ok"; output: T })
+  | (TurnRun & {
+    status: "interrupted";
+    interruptions: Interruption[];
+    /** Answer them and carry on. The turn resumes byte-for-byte from where it
+     *  parked — a denied call is a refusal the model reads, never a rerun. */
+    resume(decisions: Decisions, options?: ResumeOptions): TTurn;
+  })
+  | (TurnRun & { status: "stopped"; reason: "aborted" | "maxToolCalls" })
+  | {
+    status: "error";
+    /** Empty, always: a turn that broke never spoke, and putting an internal
+     *  failure in the assistant's voice is exactly what §1.5 forbids. */
+    text: "";
+    threadId: ThreadId;
+    turnId: TurnId;
+    error: { code: VendoErrorCode; message: string };
+  };

--- a/packages/core/tests/turn-result.test.ts
+++ b/packages/core/tests/turn-result.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, expectTypeOf, it } from "vitest";
+import {
+  decisionSchema,
+  decisionsSchema,
+  interruptionSchema,
+  questionSchema,
+  type TurnResult,
+} from "../src/turn-result.js";
+
+const toolCall = { id: "call_1", tool: "refund_invoice", args: { id: "inv_7" } };
+
+describe("interruptionSchema", () => {
+  it("accepts both arms and preserves unknown keys", () => {
+    expect(interruptionSchema.safeParse({ id: "int_1", type: "approval", toolCall }).success).toBe(true);
+    expect(
+      interruptionSchema.parse({
+        id: "int_2",
+        type: "input",
+        questions: [{ id: "q1", text: "Which account?", choices: ["checking", "savings"] }],
+        note: "extra",
+      }),
+    ).toMatchObject({ note: "extra" });
+  });
+
+  it("rejects a type nothing renders, and an arm missing its payload", () => {
+    expect(interruptionSchema.safeParse({ id: "int_3", type: "consent", toolCall }).success).toBe(false);
+    expect(interruptionSchema.safeParse({ id: "int_4", type: "approval" }).success).toBe(false);
+    expect(interruptionSchema.safeParse({ id: "int_5", type: "input" }).success).toBe(false);
+  });
+});
+
+describe("questionSchema", () => {
+  it("takes free text without choices, and rejects an empty question", () => {
+    expect(questionSchema.safeParse({ id: "q1", text: "What is the reason?" }).success).toBe(true);
+    expect(questionSchema.safeParse({ id: "q1", text: "" }).success).toBe(false);
+  });
+});
+
+describe("decisionSchema", () => {
+  it("accepts the two verdicts and an answers object, single- or multi-valued", () => {
+    expect(decisionSchema.safeParse("approve").success).toBe(true);
+    expect(decisionSchema.safeParse("deny").success).toBe(true);
+    expect(decisionSchema.safeParse({ answers: { q1: "checking", q2: ["a", "b"] } }).success).toBe(true);
+  });
+
+  it("rejects anything that is neither verdict nor answers", () => {
+    expect(decisionSchema.safeParse("maybe").success).toBe(false);
+    expect(decisionSchema.safeParse({ approved: true }).success).toBe(false);
+    expect(decisionSchema.safeParse({ answers: { q1: 42 } }).success).toBe(false);
+  });
+
+  it("keys a decisions map by interruption id", () => {
+    expect(decisionsSchema.safeParse({ int_1: "approve", int_2: { answers: { q1: "x" } } }).success).toBe(true);
+    expect(decisionsSchema.safeParse({ int_1: "maybe" }).success).toBe(false);
+  });
+});
+
+describe("TurnResult", () => {
+  type Result = TurnResult<{ refunded: string }, { id: string }>;
+
+  it("narrows on status: each arm carries its own fields and only its own", () => {
+    expectTypeOf<Extract<Result, { status: "ok" }>["output"]>().toEqualTypeOf<{ refunded: string }>();
+    expectTypeOf<Extract<Result, { status: "stopped" }>["reason"]>().toEqualTypeOf<"aborted" | "maxToolCalls">();
+    expectTypeOf<Extract<Result, { status: "error" }>["text"]>().toEqualTypeOf<"">();
+    // Nothing ran, so there is no work to report.
+    expectTypeOf<Extract<Result, { status: "error" }>>().not.toHaveProperty("toolCalls");
+  });
+
+  it("hands `resume` back whatever the second parameter binds — core never names a Turn", () => {
+    expectTypeOf<ReturnType<Extract<Result, { status: "interrupted" }>["resume"]>>()
+      .toEqualTypeOf<{ id: string }>();
+  });
+});


### PR DESCRIPTION
PR1 of the `@vendoai/agents` v1 DX stack. It builds no feature — it freezes the
contracts PR2–PR7 code against.

## What changed

**One shape for what a turn answered.** `packages/core/src/turn-result.ts` (new)
declares `TurnResult`: a turn finished (`ok`), needs a person (`interrupted`),
was called time on (`stopped`), or broke (`error`). A caller reads `status` once
and every field it then touches is present. `Interruption`, `Question`,
`Decision` and `Decisions` come with it, each with a zod schema, because those
four cross a wire (`@vendoai/ui` renders them, `POST /turns/:id/resume` accepts
them). `TurnResult` itself has no schema: the interrupted arm carries a live
`resume()` closure, and a function is not a wire value.

The interrupted arm's `resume()` returns the agents-level `Turn`, which core may
not import, so the union carries a second type parameter agents binds
(`TurnResult<T, Turn<T>>`). There is ONE definition of this union; nothing
re-declares it. `turnId`/`threadId` reuse the existing ids, `toolCalls` reuses
the `{ call, outcome }` pair `AgentRunReport` already carries, and `TurnUsage`
is field-for-field the `UsageTotals` a harness hands the runtime — restated in
core only because core may not depend on `@vendoai/harnesses`; harnesses' copy
is untouched.

The `input` interruption arm is wire-defined now and **emitted post-v1**: v1's
`ask_user` still ends the turn and the answer arrives as the next message.
It is frozen anyway so a shape added later is not a shape two shipped readers
reject.

**A tool must say what it does.** `tool()` now requires a non-empty
`description`, validated beside the existing name check. The reason is in the
error message, not a comment: the description is the only thing the model reads
when it decides whether to call the tool, so an undescribed tool is effectively
invisible.

**`tool()` infers `execute`'s input from zod.** `inputSchema` now takes a zod
schema as well as a raw JSON Schema; a zod one types `execute`'s `input`, and
the schema is converted to JSON Schema once, at `tool()` time, because a
descriptor crosses the wire to a model, a box and a browser, none of which can
run a validator. A raw JSON Schema is passed through byte-identical, and `input`
stays `Json` there — JSON Schema is data, with nothing in it for TypeScript to
read.

> **Type inference only — NOT runtime validation.** Nothing new checks arguments
> before `execute` runs. What reaches an existing host's tool is exactly what
> reached it before.

**One install.** `@vendoai/agents` re-exports `vendo()` from its root and the
turn-contract types from `@vendoai/core`, so a host names a turn's answer without
adding a dependency.

## The one forced amendment to the spec

The spec's hello-world reads
`import { agent, tool, claudeCode } from "@vendoai/agents"`. `claudeCode` could
not go on the root barrel: `packages/vendo/src/server.ts` imports that barrel and
must bundle for a Worker, and the Claude Agent SDK reaches `readline` /
`async_hooks`. On the barrel it broke two `portability-gate.mjs` legs (server
entry, workerd fixture boot) — which is exactly why `claudeCode` is a subpath in
`@vendoai/harnesses` and `vendo()` is not.

So it is a subpath here too — `@vendoai/agents/claude-code` — and the import
splits over two lines. The spec's actual promise, "install one package", is
intact. Escalated separately.

## Retired-behaviour test edits (called out explicitly)

`tool()` accepting a missing or empty `description` is retired, so every call
site that relied on it had to gain one. Source and docs: `packages/agents/README.md`.
Tests, all mechanical — a `description` added, no assertion changed:
`tests/agent.test.ts:95`, `tests/door.test.ts:139`, `tests/respond.test.ts:213`,
`tests/session.test.ts:223`, `tests/session.test.ts:325`, and ten call sites in
`tests/tools.test.ts`. Every pre-existing assertion in those files (name pattern,
risk default, `outputSchema` passthrough, collision detection) still passes
unmodified.

New tests live beside them: `tests/tools.test.ts` covers the missing and the
whitespace description (and that the message names the fix), zod inference plus
the JSON Schema it produces, and raw JSON Schema passthrough;
`packages/core/tests/turn-result.test.ts` covers each schema's valid and invalid
wire values — an unknown `Interruption.type`, a `Decision` that is neither
literal nor an answers object — and pins each `TurnResult` arm's narrowing.

## Gates

`build` · `typecheck` · `lint` (dependency-guard, portability-gate, eslint) ·
`packages/core` suite (800 tests) · `packages/agents` suite (154 tests) — all
green. The full affected cone is CI's job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies a turn’s return contract as `TurnResult` and makes `tool()` descriptions mandatory so models can discover tools. Also adds zod-powered `inputSchema` typing and exposes both engines from `@vendoai/agents` with `claudeCode` via a subpath for Worker portability.

- `@vendoai/core`: New `TurnResult` discriminated union (`ok` | `interrupted` | `stopped` | `error`). `Interruption`, `Question`, and `Decision` have zod schemas for wire safety; the `interrupted` arm carries a live `resume()` closure and stays schema-less. The `input` interruption shape is defined now but not emitted in v1 (freezes the wire for post-v1).
- `@vendoai/agents`: `tool()` now requires a non-empty `description` (old: optional/empty allowed). `inputSchema` accepts zod or raw JSON Schema; zod types `execute(input)` and is converted once to JSON Schema in the descriptor. No new runtime validation is introduced. Root re-exports `vendo()` and core turn-contract types; `claudeCode` moves to `@vendoai/agents/claude-code` to keep the barrel Worker-safe. Tests pin the new contracts and error messages.

**Migration**
- Add a meaningful `description` to every `tool({...})`. Calls without one now throw at boot.
- Import the Claude builder from `@vendoai/agents/claude-code` instead of the root barrel.
- Optional: switch `inputSchema` to a zod schema to get typed `execute(input)`; raw JSON Schema continues to work unchanged.

<sup>Written for commit 2bd396f1acfff3c7cca8504954309873cf46070f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

