### PR TITLE
feat(agents,harnesses): an agent answers in one line, and a turn that needs a yes stops asking you to run it again

### DIFF
--- a/packages/agents/src/agent.ts
+++ b/packages/agents/src/agent.ts
@@ -30,7 +30,8 @@ import { createStore, hostedStore, storeFiles, type VendoStore } from "@vendoai/
 import type { LanguageModel, UIMessage } from "ai";
 import { randomUUID } from "node:crypto";
 import { declareAutomation, type OnOptions } from "./automations.js";
-import { startRun, type AgentRun, type RunOptions } from "./away.js";
+import { startRun, type RunOptions } from "./away.js";
+import { startChat, type ChatOptions, type Turn } from "./turn.js";
 import { resolveDoor, type DoorConfig } from "./door.js";
 import { withEgress, type EgressConfig } from "./egress.js";
 import { PERMISSIONS_PATH, schemaReadyPrincipal, type AgentPrincipal } from "./permissions.js";
@@ -94,20 +95,27 @@ export interface AgentConfig {
 export interface VendoAgent {
   readonly name: string;
   /**
-   * ONE lane per shape of caller. `respond` answers a person: one turn, an
-   * AI-SDK UI-message-stream `Response` to return from your route, with the
-   * conversation's id on `x-vendo-thread-id`. `run` answers code: no screen, a
-   * report at the end.
+   * ONE turn of a conversation — the answer, not a stream. Bare, the agent talks
+   * as itself; `as` names the user it is acting for. Venue "chat", presence
+   * "present", so it sees the whole present-user tool surface — and a call the
+   * guard wants a person for ENDS the turn as `interrupted` rather than blocking
+   * on it, with `resume()` to carry on once they answer.
+   */
+  chat(message: string, options?: ChatOptions): Turn;
+  /**
+   * `respond` answers a person over HTTP: one turn, an AI-SDK UI-message-stream
+   * `Response` to return from your route, with the conversation's id on
+   * `x-vendo-thread-id`.
    *
    * It is exactly `session(subject, options)` followed by `stream(message)` —
    * reach for `session()` when you want the object (approval events, several
    * turns on one thread), and this when you want the Response.
    */
   respond(subject: string, message: string | UIMessage, options?: RespondOptions): Promise<Response>;
-  /** One unattended run: no screen, an {@link AgentRun} whose report says what
-   *  happened. Venue "automation", presence "away", non-interactive — so a tool
-   *  the guard wants a person for parks, and `refs.approvals` is who to ask. */
-  run<T = never>(task: string, options?: RunOptions<T>): AgentRun<T>;
+  /** One unattended run: no screen, the same {@link Turn} `chat` answers with.
+   *  Venue "automation", presence "away" — so every ask parks and a run that
+   *  needed consent answers `interrupted`, carrying the cards to answer. */
+  run<T = void>(task: string, options?: RunOptions<T>): Turn<T>;
   /**
    * Declare an automation this agent runs unattended. A bare string is a cron
    * expression; the other four shapes are `{ every }`, `{ at }`, `{ event }` and
@@ -381,6 +389,7 @@ export function agent(config: AgentConfig): VendoAgent {
 
   const built: VendoAgent = {
     name: config.name,
+    chat: (message, options) => startChat(deps, message, options),
     async respond(subject, message, options = {}) {
       await requireModel();
       const session = await createSession(deps, subject, options);

--- a/packages/agents/src/away.ts
+++ b/packages/agents/src/away.ts
@@ -1,138 +1,45 @@
 /**
- * The AWAY lane — one non-interactive harness run, in two faces.
+ * The AWAY lane — one unattended turn, in two faces.
  *
- * `run()` is the one a host calls: a task in, an {@link AgentRun} out (the
- * report to await, the thread id to hand a person, the events to watch).
- * {@link awayRunner} is the same run behind core's `AgentRunner` seam (01-core
- * §13), for the automations engine and the delegation tool that already speak it.
- * ONE implementation ({@link runTurn}) — the two faces only differ in who names
- * the ctx.
+ * `run()` is the one a host calls: a task in, a {@link Turn} out (the id to hand
+ * a person, the events to watch, and the same `TurnResult` a chat turn answers
+ * with). {@link awayRunner} is the same turn behind core's `AgentRunner` seam
+ * (01-core §13), for the automations engine and the delegation tool that already
+ * speak `AgentRunReport`. ONE implementation — `runTurn` in ./turn.ts, shared
+ * with the chat lane; the faces differ only in the ctx they name and the shape
+ * they answer in.
  *
- * One run is one non-interactive harness run: `interactive: false`, a
- * `RunContext` at venue "automation" and presence "away" (an engine firing
- * carries its trigger's id too — the guard's away-grant lookup matches on it),
- * the sponsor's durable workspace mounted, and the caller's guard-bound registry
- * as the whole tool surface. Everything else — approvals as §1.4's wait-or-fail
- * (here: fail, with the card left standing, which is what `refs.approvals`
- * reports), the audit row, the transcript, the view channel — is the runtime's
- * and the guard's, inherited rather than rebuilt. There is no resume: a person
- * answers the cards, and the caller runs again.
+ * An away turn is a `RunContext` at venue "automation" and presence "away" (an
+ * engine firing carries its trigger's id too — the guard's away-grant lookup
+ * matches on it), the sponsor's durable workspace mounted, and the caller's
+ * guard-bound registry as the whole tool surface. Everything else — the audit
+ * row, the transcript, the view channel — is the runtime's and the guard's,
+ * inherited rather than rebuilt.
  *
- * The report is assembled from the three things the run really leaves behind: the
- * shipped tool bridge's own `onCall`/`gate` rails (the calls and the outcomes the
- * guard returned), the persisted assistant message (the summary, read back
- * through the real read path and narrowed to the model's closing account), and
- * the harness's own `error` event.
+ * `AgentRunReport`'s `summary` is the one narrowing left in this file: it is
+ * rendered VERBATIM in the automations panel's run row, so it is a reading
+ * budget. `TurnResult.text` — what `run()` answers with — is the whole reply.
  */
-import {
-  VendoError,
-  createTurnSkills,
-  hostSkillFiles,
-  type AgentRunner,
-  type AgentRunReport,
-  type FilesAdapter,
-  type Guard,
-  type Harness,
-  type HarnessEvent,
-  type Json,
-  type JsonSchema,
-  type Skill,
-  type RunContext,
-  type SeatModels,
-  type ThreadId,
-  type ToolCall,
-  type ToolOutcome,
-  type ToolRegistry,
-  type Turn,
-} from "@vendoai/core";
-import { wrapWorkspaceForRender } from "@vendoai/apps";
-import { addUsage, createHarnessRuntime, type HarnessRuntimeDeps, type UsageTotals } from "@vendoai/harnesses";
-import { storeFiles, threadMessageStore, workspaceStore, type VendoStore } from "@vendoai/store";
-import { asSchema, type FlexibleSchema, type LanguageModel, type Schema, type UIMessage } from "ai";
+import { mintTurnId, type AgentRunner, type AgentRunReport, type Json, type ThreadId } from "@vendoai/core";
+import type { FlexibleSchema } from "ai";
 import { randomUUID } from "node:crypto";
-import { resolveSystem, type SystemPromptHook } from "./prompt.js";
-import { asUserMessage, openThread } from "./session.js";
+import {
+  DEFAULT_MAX_TOOL_CALLS,
+  openingThread,
+  runTurn,
+  startTurn,
+  type AgentDeps,
+  type RecordedCall,
+  type TurnDeps,
+  type TurnRecord,
+  type Turn,
+} from "./turn.js";
 
-/** What a caller with no budget gets. The automations engine always passes its
- *  own (50), so this only bounds a host driving the seam directly. */
-const DEFAULT_MAX_TOOL_CALLS = 20;
+/** The composition an away turn runs on — a turn's composition, under the name
+ *  the `AgentRunner` seam already exports. */
+export type AwayRunnerDeps = TurnDeps;
 
-/** What a call past the run's budget gets. Two rails answer with it: `preflight`
- *  rules the call out before the guard can park it, and `gate` — the rail whose
- *  outcome reaches the model — repeats it for that same call. */
-const BUDGET_EXHAUSTED: ToolOutcome = {
-  status: "error",
-  error: { code: "budget-exhausted", message: "Tool-call budget exhausted" },
-};
-
-export interface AwayRunnerDeps {
-  /** The brain, with its knobs already bound. */
-  harness: Harness<unknown>;
-  store: VendoStore;
-  guard: Guard;
-  /** Where workspace blobs land; unset → the store's own rows. */
-  files?: FilesAdapter;
-  /** Projected into the read-only `/host/skills` mount, as in a session. */
-  skills?: readonly Skill[];
-  /** The host's prompt block. */
-  instructions?: string;
-  /**
-   * The run's system prompt, for a composition that already has one. Handed this
-   * package's own assembly (`instructions`, the ctx's situation data, and the
-   * guard's directions); a returned string is used verbatim, `undefined` is that
-   * default — never a promptless run.
-   *
-   * It exists because the prompt is VENUE-GATED and carries the guard's
-   * directions, so it needs the ctx: the umbrella assembles a chat turn's brief
-   * per turn, and an away firing that thought with a different brief than a chat
-   * turn would be a second agent wearing the same name.
-   */
-  system?: SystemPromptHook;
-  /** The seats a harness that does NOT bring its own brain reads (`vendo()`). */
-  models?: SeatModels<LanguageModel>;
-  liveTurn?: HarnessRuntimeDeps["liveTurn"];
-}
-
-interface RecordedCall {
-  call: ToolCall;
-  outcome: ToolOutcome["status"];
-}
-
-/** What a caller can watch a run do while it runs. The harness's own vocabulary
- *  for what it SAYS (`text`/`status`/`error`, straight off the runtime's
- *  `observe` tap) plus the two things it DOES, off the same bridge rails the
- *  report is assembled from. */
-export type RunEvent =
-  | { type: "text"; delta: string }
-  | { type: "status"; label: string }
-  | { type: "error"; message: string }
-  | { type: "tool-call"; id: string; tool: string; args: Json }
-  | { type: "tool-result"; id: string; tool: string; outcome: ToolOutcome["status"] };
-
-export interface AgentReport<T = never> extends AgentRunReport {
-  refs: {
-    threadId: string;
-    /** Approvals this run parked. Non-empty means a person has to answer them
-     *  before the work can happen — the run itself finished honestly, which is
-     *  why the status is still `ok`. There is no resume: show these, then call
-     *  `run()` again. */
-    approvals: readonly string[];
-  };
-  /** Present only when `output` was asked for AND the model filled it in. */
-  output?: T;
-  usage: UsageTotals;
-}
-
-export interface AgentRun<T = never> extends PromiseLike<AgentReport<T>> {
-  /** Available before the run starts, so a caller can show it (or hand it back
-   *  as `run({ threadId })`) without waiting for the report. */
-  readonly threadId: string;
-  /** Read ONCE, while the run runs: nothing is kept for a reader that never
-   *  attaches, and a second reader alongside the first throws. */
-  readonly events: AsyncIterable<RunEvent>;
-}
-
-export interface RunOptions<T = never> {
+export interface RunOptions<T = void> {
   /** Whose run this is — the subject every grant, workspace and audit row is
    *  scoped to. Unset, the agent runs as itself. */
   as?: string;
@@ -147,139 +54,6 @@ export interface RunOptions<T = never> {
   signal?: AbortSignal;
   /** Continue a conversation this subject already owns, instead of a fresh one. */
   threadId?: string;
-}
-
-/** The run's return channel. Named, rather than parsed back out of prose,
- *  because the args the model already assembled ARE the answer. */
-const RESULT_TOOL = "vendo_result";
-
-/**
- * The typed-output surface: one synthetic tool on THIS run's registry, whose
- * args are validated against the caller's schema.
- *
- * Deliberately OUTSIDE the guard binding. It reaches nothing — no network, no
- * host API, no file — so there is nothing for a person to approve, and an
- * unattended run whose result channel parked on an approval card would be a
- * typed run that can never return.
- */
-function withResultTool(
-  tools: ToolRegistry,
-  schema: Schema<unknown>,
-  capture: (value: unknown) => void,
-): ToolRegistry {
-  return {
-    async descriptors(ctx) {
-      return [...await tools.descriptors(ctx), {
-        name: RESULT_TOOL,
-        description: "Report this run's result. Call this once, with the finished answer.",
-        inputSchema: schema.jsonSchema as JsonSchema,
-        risk: "read",
-      }];
-    },
-    async execute(call, ctx) {
-      if (call.tool !== RESULT_TOOL) return tools.execute(call, ctx);
-      const checked = await schema.validate?.(call.args) ?? { success: true as const, value: call.args };
-      if (!checked.success) {
-        // Back to the MODEL, in its own error channel, so it can fix the shape
-        // and call again rather than the run failing on a fixable mistake.
-        return { status: "error", error: { code: "validation", message: checked.error.message } };
-      }
-      capture(checked.value);
-      return { status: "ok", output: { recorded: true } };
-    },
-  };
-}
-
-/** One buffer, one waiter — everything an `AsyncIterable` fed from callbacks
- *  needs. Nothing is buffered unless a reader is attached: a run whose events
- *  nobody reads is the common case, and buffering for it grew without a bound. */
-function eventQueue<T>(): { push: (item: T) => void; close: () => void; iterable: AsyncIterable<T> } {
-  const buffered: T[] = [];
-  let wake: (() => void) | undefined;
-  let closed = false;
-  let reading = false;
-  const nudge = (): void => {
-    wake?.();
-    wake = undefined;
-  };
-  return {
-    push: (item) => {
-      if (!reading) return;
-      buffered.push(item);
-      nudge();
-    },
-    close: () => {
-      closed = true;
-      nudge();
-    },
-    iterable: {
-      async *[Symbol.asyncIterator]() {
-        if (reading) throw new VendoError("validation", "run.events is single-reader — it is already being read.");
-        reading = true;
-        try {
-          while (true) {
-            while (buffered.length > 0) yield buffered.shift() as T;
-            if (closed) return;
-            await new Promise<void>((resolve) => {
-              wake = resolve;
-            });
-          }
-        } finally {
-          // A reader that LEFT is no reader at all — `break` gets here through
-          // `.return()`. What it did not take is dropped and nothing more is
-          // kept, or a cancelled read leaves the buffer growing forever, which
-          // is the whole growth this queue exists to avoid. Its seat goes back
-          // only while the run is still going: single-reader is there so two
-          // consumers cannot split ONE live stream, and a finished run has
-          // nothing left to hand a replacement, so reading it again stays the
-          // named error rather than a silently empty stream.
-          buffered.length = 0;
-          if (!closed) reading = false;
-        }
-      },
-    },
-  };
-}
-
-function fallbackSummary(status: AgentRunReport["status"], calls: readonly RecordedCall[]): string {
-  if (status === "error") return "The run could not be completed.";
-  if (status === "stopped") return "The run stopped before it was finished.";
-  return `The run completed with ${calls.length} tool call${calls.length === 1 ? "" : "s"}.`;
-}
-
-/**
- * Watch the harness's own closed vocabulary for a failure, without taking
- * anything away from the runtime.
- *
- * A harness `error` event reaches the SCREEN's error channel and never the
- * transcript (runtime.ts), so it is invisible to a caller that only reads the
- * persisted turn — and "the nightly digest failed" reported as a successful run is
- * the failure this whole seam exists to avoid. A throw is left to propagate: the
- * runtime's own handler already puts its plain sentence in the transcript, so only
- * the STATUS is missing here.
- *
- * Wrapping is safe: the adapter slots a harness reads (`harnessAdapters`) are
- * keyed on the object its own factory closed over, never on the value handed to
- * the runtime.
- */
-function watchForFailure(
-  harness: Harness<unknown>,
-  onFailure: (message?: string) => void,
-): Harness<unknown> {
-  return {
-    ...harness,
-    async *run(turn: Turn<unknown>): AsyncGenerator<HarnessEvent, void, void> {
-      try {
-        for await (const event of harness.run(turn)) {
-          if (event.type === "error") onFailure(event.message);
-          yield event;
-        }
-      } catch (error) {
-        onFailure();
-        throw error;
-      }
-    },
-  };
 }
 
 /**
@@ -342,354 +116,83 @@ function conciseSummary(spoken: string): string {
   return capped((chosen ?? spoken).trim());
 }
 
-/** The assistant's own words for the turn, read back through the real read path. */
-function spokenSummary(messages: readonly UIMessage[]): string {
-  const reply = [...messages].reverse().find((message) => message.role === "assistant");
-  if (reply === undefined) return "";
-  return conciseSummary(reply.parts
-    .filter((part): part is { type: "text"; text: string } => part.type === "text")
-    .map((part) => part.text)
-    .join("")
-    .trim());
-}
-
-/** What one run needs beyond the composition it runs on. The two faces below
- *  differ only in how they fill this. */
-interface RunTurnInput {
-  prompt: string;
-  /** The whole tool surface for this run — guard-bound already. */
-  tools: ToolRegistry;
-  ctx: RunContext;
-  threadId: ThreadId;
-  /** The id came from the caller: reopen it (ownership-checked) rather than mint. */
-  reopen: boolean;
-  maxToolCalls: number;
-  signal?: AbortSignal;
-  output?: FlexibleSchema<unknown>;
-  emit?: (event: RunEvent) => void;
-}
-
-/** ONE non-interactive harness run. Everything both faces share lives here. */
-async function runTurn(deps: AwayRunnerDeps, input: RunTurnInput): Promise<AgentReport<unknown>> {
-  const cap = input.maxToolCalls;
-  if (!Number.isInteger(cap) || cap < 1) {
-    throw new VendoError("validation", "maxToolCalls must be a positive integer");
-  }
-  // Read through a call, never inline: `AbortSignal.aborted` is a readonly
-  // boolean, so a narrowing here would have the compiler believe the answer
-  // below cannot change — and the whole point of a signal is that it does.
-  const aborted = (): boolean => input.signal?.aborted === true;
-  // Cancelled before it began: no thread, no workspace, no harness. The signal
-  // is the only way to stop a run, and a run stopped before its first I/O has
-  // nothing to report but the stop.
-  if (aborted()) {
-    return {
-      status: "stopped",
-      summary: fallbackSummary("stopped", []),
-      toolCalls: [],
-      refs: { threadId: input.threadId, approvals: [] },
-      usage: { inputTokens: 0, outputTokens: 0 },
-    };
-  }
-  // Everything the caller put on the ctx rides through untouched — the sponsor,
-  // the venue, the appId, the firing trigger's id, the asserted memberships.
-  // Only presence is asserted, for a caller that came in without it.
-  const awayCtx: RunContext = { ...input.ctx, presence: "away" };
-  const principal = awayCtx.principal;
-
-  /** One entry per call the harness attempted, in order, each carrying the last
-   *  thing known about it. `error` is the opening value only for a call whose
-   *  outcome hook never fires at all. */
-  const recorded: RecordedCall[] = [];
-  /** Calls whose final outcome has already reached `events`. */
-  const reported = new Set<string>();
-  const emitResult = (entry: RecordedCall): void => {
-    reported.add(entry.call.id);
-    input.emit?.({ type: "tool-result", id: entry.call.id, tool: entry.call.tool, outcome: entry.outcome });
-  };
-  const attempted = (call: ToolCall): RecordedCall => {
-    const existing = recorded.find((entry) => entry.call.id === call.id);
-    if (existing !== undefined) return existing;
-    const entry: RecordedCall = { call, outcome: "error" };
-    recorded.push(entry);
-    input.emit?.({ type: "tool-call", id: call.id, tool: call.tool, args: call.args });
-    return entry;
-  };
-  let startedCalls = 0;
-  let budgetRefused = false;
-  /** Calls the budget already refused, by id: the two rails below are two halves
-   *  of ONE decision, and the second must answer for exactly the call the first
-   *  ruled out — never for the call that spent the last of the budget. */
-  const overBudget = new Set<string>();
-  let failed = false;
-  let usage: UsageTotals | undefined;
-  let output: unknown;
-  /** The harness's own sentence for the failure, when it gave one. */
-  let failureMessage: string | undefined;
-  /** Every approval this run parked, in the order the guard minted them. Scoped
-   *  to THIS run: the guard is shared, so a sibling run's card is not this
-   *  report's to show. */
-  const approvals: string[] = [];
-  /** The guard's OWN per-run key (packages/guard/src/guard.ts:1104), so a card is
-   *  matched the way the guard counts it: an engine firing keys on its runId,
-   *  `run()` on the thread it minted. An undefined key matches NOTHING — two
-   *  ctxs that both name no run are not the same run, and matching them would
-   *  hand one firing's cards to another. Typed wider than `RunContext` declares
-   *  on purpose: `sessionId` is required in the type and the automations engine
-   *  does not set it, so the undefined case is real however the type reads. */
-  const runKey: string | undefined = awayCtx.trigger?.runId ?? awayCtx.sessionId;
-
-  await deps.store.ensureSchema();
-  const transcript = threadMessageStore<UIMessage>(deps.store);
-  const { threadId } = input;
-  await openThread(deps.store, principal, threadId, input.reopen);
-  // The SPONSOR's durable workspace, with the same `/host/skills` projection and
-  // the same org mounts (§9.7) a session gets — the ctx carries the memberships
-  // the caller asserted for this run.
-  const workspace = await workspaceStore(deps.store, { files: deps.files ?? storeFiles(deps.store) })
-    .open(principal, {
-      host: hostSkillFiles(deps.skills ?? []),
-      ...(awayCtx.memberships === undefined ? {} : { memberships: awayCtx.memberships }),
-    });
-
-  const schema = input.output === undefined ? undefined : asSchema(input.output);
-
-  const runtime = createHarnessRuntime({
-    // THE CALLER's registry, never one of this runner's own choosing: the caller
-    // decides an unattended run's tool surface, and it is already guard-bound —
-    // so §12's unattended projection is what answers `list()` here.
-    tools: schema === undefined
-      ? input.tools
-      : withResultTool(input.tools, schema, (value) => {
-        output = value;
-      }),
-    guard: deps.guard,
-    skills: createTurnSkills(workspace),
-    transcript,
-    // `harnessState` is left unset on purpose — the runtime's per-run memory is
-    // the whole truth for a fresh thread, so there is nothing to carry and
-    // nothing to write.
-    // §1.6 — the render seam, on the runtime's generic `wrapWorkspace` slot:
-    // an away run's hot-path commit paints too (the part persists, so the
-    // sponsor's thread shows the screen the run built). BARE — no floor, no
-    // app half — because this standalone runtime composes no apps runtime to
-    // fill them; the umbrella's composition does.
-    wrapWorkspace: (turnWorkspace, opts) => wrapWorkspaceForRender(turnWorkspace, {
-      turnId: opts.turnId,
-      emit: opts.emit,
-    }),
-    bridge: {
-      // Every call the harness ATTEMPTS, before the guard sees it — and the one
-      // rail EVERY away call passes, which is why the budget is spent here. A
-      // call the preview parks (`interactive: false` and nobody there to
-      // approve) is denied without ever reaching `execute`, so `gate` and
-      // `onCall` below never see it: charged there alone, the budget bounded
-      // nothing away and a looping model minted one approval card per attempt.
-      // Recording the attempt here is what keeps the run record honest too —
-      // the automation asked, and it is waiting on a person.
-      preflight: async (call) => {
-        attempted(call);
-        if (startedCalls >= cap) {
-          budgetRefused = true;
-          overBudget.add(call.id);
-          // Returned BEFORE the guard is consulted: nothing past the bound is
-          // worth a person's card, and `gate` speaks this to the model.
-          return BUDGET_EXHAUSTED;
-        }
-        startedCalls += 1;
-        // The result channel takes the same pre-guard short-circuit an
-        // unconnected service does. It reaches nothing — it validates its args
-        // and hands them to a closure in this function: no network, no store,
-        // no host API, no file — and it pays the call budget just above. It is
-        // here ONLY because an away run parks every call it cannot trace to a
-        // grant, READS INCLUDED (packages/guard/src/guard.ts:1051), which would
-        // strand every typed run on a card nobody can answer. DELETE THIS
-        // BRANCH once the pending guard change lands and a reaches-nothing read
-        // no longer parks unattended.
-        return call.tool === RESULT_TOOL ? { status: "ok", output: {} } : undefined;
-      },
-      // The other half of the budget decision: the refusal, at the one place an
-      // outcome reaches the model — nothing runs past the bound.
-      gate: (call) => (overBudget.has(call.id) ? BUDGET_EXHAUSTED : undefined),
-      onCall: (call) => {
-        const entry = attempted(call);
-        return (outcome) => {
-          entry.outcome = outcome.status;
-          emitResult(entry);
-        };
-      },
-    },
-    ...(deps.liveTurn === undefined ? {} : { liveTurn: deps.liveTurn }),
-  });
-
-  const system = await resolveSystem(deps, awayCtx);
-  // The result channel is NAMED in the ask, not merely listed among the tools: a
-  // model that never calls it returns prose where the caller asked for a shape,
-  // and there is no second model call here to recover one.
-  const message = asUserMessage(schema === undefined
-    ? input.prompt
-    : `${input.prompt}\n\nWhen you are done, call ${RESULT_TOOL} with the result.`);
-
-  // Reopening means CONTINUING: the thread's own turns come back with it, read
-  // through the same path a session's do. A fresh thread has none.
-  const persisted = input.reopen ? await transcript.list(principal, threadId) : [];
-
-  // Subscribed as LATE as possible and torn down in `finally`: the guard holds
-  // its callbacks in a set forever, so a throw between the subscribe and the
-  // teardown would leak one — and a foreign `threadId` is a rejection a caller
-  // can repeat at will.
-  const unsubscribe = deps.guard.onApprovalRequested?.((request) => {
-    if (runKey !== undefined && (request.ctx.trigger?.runId ?? request.ctx.sessionId) === runKey) {
-      approvals.push(request.id);
-    }
-    // A parked call never reaches `onCall`, so this is the only moment the run
-    // learns one parked — and it is the HONEST one: a guard that threw while
-    // parking mints no request, so its call keeps the opening `error` instead of
-    // telling the host to wait on a card nobody has. Matched on the tool call's
-    // own id (minted per call, uuid-backed), so a sibling run's card cannot mark
-    // this run's call whatever the run key says.
-    const parked = recorded.find((entry) => entry.call.id === request.call.id);
-    if (parked !== undefined) parked.outcome = "pending-approval";
-  });
-  try {
-    const response = await runtime.run({
-      harness: watchForFailure(deps.harness, (message) => {
-        failed = true;
-        failureMessage = message;
-      }),
-      threadId,
-      messages: [...persisted, message],
-      ctx: awayCtx,
-      workspace,
-      interactive: false,
-      system,
-      // The harness's own vocabulary, forwarded as the runtime routes it: the
-      // metering fold every caller needs, and the three things a watching caller
-      // wants to see while they happen.
-      observe: (event) => {
-        if (event.type === "usage") usage = addUsage(usage, event);
-        else if (event.type === "text") input.emit?.({ type: "text", delta: event.delta });
-        else if (event.type === "status") input.emit?.({ type: "status", label: event.label });
-        else if (event.type === "error") input.emit?.({ type: "error", message: event.message });
-      },
-      ...(deps.models === undefined ? {} : { models: deps.models }),
-      ...(input.signal === undefined ? {} : { signal: input.signal }),
-    });
-    // Drained, not discarded: the stream's `onFinish` is what persists the turn
-    // and writes its audit row, and it only fires on consumption.
-    await response.text();
-  } catch {
-    failed = true;
-  } finally {
-    unsubscribe?.();
-  }
-  // A call the guard parked never reaches `onCall`, so its outcome has no live
-  // moment to be announced in. Announced here instead, so the event stream ends
-  // agreeing with the report rather than silently short of it.
-  for (const entry of recorded) if (!reported.has(entry.call.id)) emitResult(entry);
-
-  const stopped = aborted() || budgetRefused;
-  const status: AgentRunReport["status"] = stopped
-    ? "stopped"
-    : failed ? "error" : "ok";
-  // A summary is worth a lost turn, never a lost run: an unreadable transcript
-  // falls back to the counted sentence rather than failing a finished run.
-  const spoken = failureMessage
-    ?? spokenSummary(await transcript.list(principal, threadId).catch(() => []));
-  return {
-    status,
-    summary: spoken === "" ? fallbackSummary(status, recorded) : spoken,
-    toolCalls: recorded,
-    refs: { threadId, approvals },
-    ...(output === undefined ? {} : { output }),
-    usage: usage ?? { inputTokens: 0, outputTokens: 0 },
-  };
-}
-
-/** What `run()` needs beyond {@link AwayRunnerDeps}; `agent()` fills both. */
-export interface RunDeps extends AwayRunnerDeps {
-  /** Attribution when the caller names no subject of their own. */
-  name: string;
-  /** The agent's guard-bound registry — an unattended run's whole tool surface. */
-  tools: ToolRegistry;
-  /** Awaited before the turn opens anything — `agent()`'s model check, so a run
-   *  with no model rejects for the same reason `respond()` does, and writes no
-   *  thread on the way. */
-  assertModel?: () => Promise<void>;
-  /** A loopback door still binding its port, exactly as `createSession` awaits
-   *  it (session.ts). Without this a `claudeCode()` run can start while the
-   *  door's origin is still undefined, and the box dials a URL that is not
-   *  there yet. */
-  doorReady?: Promise<void>;
+function fallbackSummary(status: AgentRunReport["status"], calls: readonly RecordedCall[]): string {
+  if (status === "error") return "The run could not be completed.";
+  if (status === "stopped") return "The run stopped before it was finished.";
+  return `The run completed with ${calls.length} tool call${calls.length === 1 ? "" : "s"}.`;
 }
 
 /**
- * `agent.run(task)` — one unattended run, for code rather than a screen.
+ * One turn as core's `AgentRunner` reads it.
  *
- * Returned rather than awaited so the thread id is readable immediately (show
- * it, or hand it back as `run({ threadId })`) and `events` can be read while the
- * run is still going. Cancellation is the `signal` the caller passes; there is
- * no second way to stop a run.
+ * A turn that PARKED still reports `ok`: the run itself finished honestly, and a
+ * card standing for a person is not a failed automation. That is why this face
+ * has three statuses where a `TurnResult` has four.
  */
-export function startRun<T>(deps: RunDeps, task: string, options: RunOptions<T> = {}): AgentRun<T> {
-  const threadId = (options.threadId ?? `thr_${randomUUID()}`) as ThreadId;
-  const queue = eventQueue<RunEvent>();
-  // Both gates a turn has to clear before it opens anything, in the one place a
-  // run begins: the model check, and the door still binding its port —
-  // `createSession` awaits the same two.
-  const settled = Promise.all([deps.assertModel?.(), deps.doorReady]).then(() => runTurn(deps, {
+function asReport(record: TurnRecord): AgentRunReport {
+  const status: AgentRunReport["status"] = record.stopped !== undefined
+    ? "stopped"
+    : record.failed !== undefined ? "error" : "ok";
+  const spoken = record.failed?.message ?? conciseSummary(record.text);
+  return {
+    status,
+    summary: spoken === "" ? fallbackSummary(status, record.toolCalls) : spoken,
+    toolCalls: record.toolCalls,
+  };
+}
+
+/**
+ * `agent.run(task)` — one unattended turn, for code rather than a screen.
+ *
+ * Returned rather than awaited so the ids are readable immediately (show the
+ * thread, or hand it back as `run({ threadId })`) and `events` can be read while
+ * the run is still going. Cancellation is the `signal` the caller passes.
+ *
+ * Every ask PARKS — nobody is there to tap — so a run that needed consent
+ * answers `interrupted`, with the cards on it and `resume()` to carry on.
+ */
+export function startRun<T = void>(deps: AgentDeps, task: string, options: RunOptions<T> = {}): Turn<T> {
+  const opening = openingThread(options);
+  return startTurn<T>(deps, {
+    ...opening,
     prompt: task,
-    tools: deps.tools,
     ctx: {
       // Unset, the agent runs as ITSELF — the subject its own audit rows are
       // attributed to, never a borrowed user.
       principal: { kind: "user", subject: options.as ?? `vendo:agent:${deps.name}` },
       venue: "automation",
       presence: "away",
-      sessionId: threadId,
+      sessionId: opening.threadId,
       ...(options.user === undefined ? {} : { user: options.user }),
       ...(options.context === undefined ? {} : { context: options.context }),
     },
-    threadId,
-    reopen: options.threadId !== undefined,
+    turnId: mintTurnId(),
     maxToolCalls: options.maxToolCalls ?? DEFAULT_MAX_TOOL_CALLS,
     ...(options.signal === undefined ? {} : { signal: options.signal }),
     ...(options.output === undefined ? {} : { output: options.output as FlexibleSchema<unknown> }),
-    emit: queue.push,
-  })).finally(() => {
-    queue.close();
   });
-  // The doc above invites reading `threadId` and never awaiting, so a failed run
-  // nobody asked about must not take the host process down (node ≥15 exits on an
-  // unhandled rejection). This handler is on a DERIVED promise: `settled` itself
-  // is untouched, so a caller who does await still gets the error.
-  settled.catch(() => {});
-  return {
-    threadId,
-    events: queue.iterable,
-    then: (onFulfilled, onRejected) => settled.then(onFulfilled as never, onRejected),
-  };
 }
 
 /**
- * The same run behind core's `AgentRunner` seam (01-core §13) — the shape the
+ * The same turn behind core's `AgentRunner` seam (01-core §13) — the shape the
  * automations engine and the delegation tool already speak. Prefer
- * {@link startRun} (`agent.run`) for anything new: it is this run with the
- * thread id, the live events, the usage and the typed output attached.
+ * {@link startRun} (`agent.run`) for anything new: it is this turn with the ids,
+ * the live events, the usage, the typed output and the interruptions attached.
  *
  * `AgentComposition` (what `agentComposition(agent)` returns) satisfies these deps
  * structurally, so a host that already built an `agent()` can hand its composition
  * straight in.
  */
 export function awayRunner(deps: AwayRunnerDeps): AgentRunner {
-  return (task, ctx) => runTurn(deps, {
+  return async (task, ctx) => asReport(await runTurn(deps, {
     prompt: task.prompt,
     tools: task.tools,
-    ctx,
+    // Only presence is asserted, for an engine that came in without it.
+    ctx: { ...ctx, presence: "away" },
     threadId: `thr_${randomUUID()}` as ThreadId,
+    turnId: mintTurnId(),
     reopen: false,
     maxToolCalls: task.budget?.maxToolCalls ?? DEFAULT_MAX_TOOL_CALLS,
     ...(task.abortSignal === undefined ? {} : { signal: task.abortSignal }),
-  });
+  }));
 }
-

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -22,14 +22,9 @@ export {
   agentAutomations,
   type OnOptions,
 } from "./automations.js";
-export {
-  awayRunner,
-  type AgentReport,
-  type AgentRun,
-  type AwayRunnerDeps,
-  type RunEvent,
-  type RunOptions,
-} from "./away.js";
+export { awayRunner, type AwayRunnerDeps, type RunOptions } from "./away.js";
+/** The turn a verb hands back, and the two shapes a caller writes against it. */
+export type { ChatOptions, RunEvent, Turn } from "./turn.js";
 export { DOOR_PATH, type DoorConfig } from "./door.js";
 export { PERMISSIONS_PATH, type AgentPrincipal } from "./permissions.js";
 export { assemblePrompt, type PromptInput, type SystemPromptHook } from "./prompt.js";
@@ -48,16 +43,19 @@ export type { EgressConfig } from "./egress.js";
 export type { RunContext } from "@vendoai/core";
 /** The turn contract, from the one package a host installed. It is DEFINED in
  *  `@vendoai/core` — one definition, every block speaks it — and re-exported
- *  here so nobody has to add a second dependency to name what a turn returned. */
+ *  here so nobody has to add a second dependency to name what a turn returned.
+ *  `TurnResult` is the exception, and only because core cannot name the `Turn`
+ *  its `resume()` hands back: turn.ts binds that one parameter and nothing
+ *  else. */
 export type {
   Decision,
   Decisions,
   Interruption,
   Question,
   ResumeOptions,
-  TurnResult,
   TurnUsage,
 } from "@vendoai/core";
+export type { TurnResult } from "./turn.js";
 export { decisionSchema, decisionsSchema, interruptionSchema, questionSchema } from "@vendoai/core";
 /** The header `respond()` and `session.stream()` return the conversation's id
  *  on, and the one `@vendoai/ui` reads it from. Named, not spelled out, so a

--- a/packages/agents/src/session.ts
+++ b/packages/agents/src/session.ts
@@ -131,7 +131,7 @@ export interface SessionDeps {
   doorReady?: Promise<void>;
 }
 
-const toHeaderRecord = (
+export const toHeaderRecord = (
   headers: Record<string, string> | Headers | undefined,
 ): Record<string, string> | undefined => {
   if (headers === undefined) return undefined;

--- a/packages/agents/src/turn.ts
+++ b/packages/agents/src/turn.ts
@@ -1,0 +1,790 @@
+/**
+ * ONE turn, in both venues — the object a caller holds while it runs, and the
+ * assembly that runs it.
+ *
+ * `chat()` and `run()` are the same turn wearing two contexts: a present user's
+ * conversation and an unattended run differ in venue, in presence, and in
+ * whether the answer has a declared shape — and in nothing else. So there is one
+ * {@link runTurn} here rather than one per lane. `session()`/`respond()` are NOT
+ * this lane: they hand back a streaming `Response` and BLOCK on an approval, and
+ * they are untouched.
+ *
+ * DRAINER OF RECORD. The turn executes and persists whether or not anyone reads
+ * `events` and whether or not anyone awaits it: `await response.text()` below is
+ * what fires the stream's `onFinish`, and `onFinish` is what writes the
+ * transcript and the audit row. `events` is an INDEPENDENT tap on the same run —
+ * a turn nobody taps still happens, in full.
+ *
+ * A PARK ENDS THE TURN. Every turn here runs `interactive: false`, so a call the
+ * guard wants a person for refuses on the spot instead of blocking on the 90s
+ * approval waiter: `await turn` answers `interrupted` in the time the turn took,
+ * never in a minute and a half. Presence is the CTX's and is untouched by that
+ * flag (`ToolListingContext`), so a chat turn still runs `presence: "present"`
+ * and still sees the whole present-user tool surface.
+ */
+import {
+  VendoError,
+  createTurnSkills,
+  hostSkillFiles,
+  mintTurnId,
+  type ApprovalRequest,
+  type Decisions,
+  type FilesAdapter,
+  type Guard,
+  type Harness,
+  type HarnessEvent,
+  type Json,
+  type JsonSchema,
+  type ResumeOptions,
+  type RunContext,
+  type SeatModels,
+  type Skill,
+  type ThreadId,
+  type ToolCall,
+  type ToolOutcome,
+  type ToolRegistry,
+  type Turn as HarnessTurn,
+  type TurnId,
+  type TurnResult as CoreTurnResult,
+} from "@vendoai/core";
+import { wrapWorkspaceForRender } from "@vendoai/apps";
+import type { VendoGuard } from "@vendoai/guard";
+import { addUsage, createHarnessRuntime, type HarnessRuntimeDeps, type UsageTotals } from "@vendoai/harnesses";
+import {
+  harnessStateStore,
+  storeFiles,
+  threadMessageStore,
+  workspaceStore,
+  type VendoStore,
+} from "@vendoai/store";
+import { asSchema, type FlexibleSchema, type LanguageModel, type Schema, type UIMessage } from "ai";
+import { randomUUID } from "node:crypto";
+import { resolveSystem, type SystemPromptHook } from "./prompt.js";
+import { asUserMessage, openThread, toHeaderRecord } from "./session.js";
+
+/** The union, with the AGENTS-level `Turn` bound into the arm that resumes.
+ *  Core owns the definition; this only names the loop core cannot. */
+export type TurnResult<T = void> = CoreTurnResult<T, Turn<T>>;
+
+/**
+ * A turn in flight.
+ *
+ * Returned rather than awaited so `threadId` and `turnId` are readable
+ * immediately — show them, hand the thread back on the next call, or join the
+ * turn's audit rows — and so `events` can be read while the turn is still going.
+ */
+export interface Turn<T = void> extends PromiseLike<TurnResult<T>> {
+  readonly threadId: ThreadId;
+  readonly turnId: TurnId;
+  /** Read ONCE, while the turn runs: nothing is kept for a reader that never
+   *  attaches, and a second reader alongside the first throws. */
+  readonly events: AsyncIterable<RunEvent>;
+}
+
+/** What a caller can watch a turn do while it runs. The harness's own vocabulary
+ *  for what it SAYS (`text`/`status`/`error`, straight off the runtime's
+ *  `observe` tap) plus the two things it DOES, off the same bridge rails the
+ *  result is assembled from. */
+export type RunEvent =
+  | { type: "text"; delta: string }
+  | { type: "status"; label: string }
+  | { type: "error"; message: string }
+  | { type: "tool-call"; id: string; tool: string; args: Json }
+  | { type: "tool-result"; id: string; tool: string; outcome: ToolOutcome["status"] };
+
+export interface ChatOptions {
+  /** Whose turn this is — the subject every grant, workspace and audit row is
+   *  scoped to. Unset, the agent talks as itself. */
+  as?: string;
+  /** Server-trust identity facts, model-visible (`[User]`). */
+  user?: Record<string, Json>;
+  /** Guard/tools context: functions run at check-time, data survives parking. */
+  context?: Record<string, unknown>;
+  /** Present-user auth forwarding — the request's own headers. Per call, never
+   *  bound: request-lifetime authority does not outlive the request. */
+  headers?: Record<string, string> | Headers;
+  /** Continue a conversation this subject already owns instead of starting one.
+   *  Omit it for a new thread; see {@link openingThread} for why passing an
+   *  explicit `undefined` is refused. */
+  threadId?: string;
+  signal?: AbortSignal;
+}
+
+/** The composition ONE turn runs on. */
+export interface TurnDeps {
+  /** The brain, with its knobs already bound. */
+  harness: Harness<unknown>;
+  store: VendoStore;
+  guard: Guard;
+  /** Where workspace blobs land; unset → the store's own rows. */
+  files?: FilesAdapter;
+  /** Projected into the read-only `/host/skills` mount, as in a session. */
+  skills?: readonly Skill[];
+  /** The host's prompt block. */
+  instructions?: string;
+  /**
+   * The turn's system prompt, for a composition that already has one. Handed this
+   * package's own assembly (`instructions`, the ctx's situation data, and the
+   * guard's directions); a returned string is used verbatim, `undefined` is that
+   * default — never a promptless turn.
+   *
+   * It exists because the prompt is VENUE-GATED and carries the guard's
+   * directions, so it needs the ctx: the umbrella assembles a chat turn's brief
+   * per turn, and an away firing that thought with a different brief than a chat
+   * turn would be a second agent wearing the same name.
+   */
+  system?: SystemPromptHook;
+  /** The seats a harness that does NOT bring its own brain reads (`vendo()`). */
+  models?: SeatModels<LanguageModel>;
+  liveTurn?: HarnessRuntimeDeps["liveTurn"];
+}
+
+/** What `agent()` composed, as {@link startTurn} needs it: the agent's own name
+ *  and tool surface, the two gates a turn clears before it opens anything, and
+ *  the guard in its full form — deciding an approval on resume is a
+ *  `VendoGuard` verb. */
+export interface AgentDeps extends TurnDeps {
+  /** Attribution when the caller names no subject of their own. */
+  name: string;
+  /** The agent's guard-bound registry — the turn's whole tool surface. */
+  tools: ToolRegistry;
+  guard: VendoGuard;
+  /** Awaited before the turn opens anything — `agent()`'s model check, so a turn
+   *  with no model fails for the same reason `respond()` does, and writes no
+   *  thread on the way. */
+  assertModel?: () => Promise<void>;
+  /** A loopback door still binding its port, exactly as `createSession` awaits
+   *  it (session.ts). Without this a `claudeCode()` turn can start while the
+   *  door's origin is still undefined, and the box dials a URL that is not
+   *  there yet. */
+  doorReady?: Promise<void>;
+}
+
+/**
+ * The thread this call MEANT.
+ *
+ * Omitted is a new conversation. Present and explicitly `undefined` is a
+ * mistake, and it is refused rather than quietly forked: `{ threadId:
+ * thread?.id }` on a value that was not there is the one way a caller loses a
+ * conversation without ever being told. Detected with `in`, because `undefined`
+ * and absent are the two cases that have to be told apart.
+ *
+ * It THROWS where a foreign id rejects, and the difference is the point: a
+ * malformed call is wrong before anything opens, an unowned thread is a lookup
+ * that failed.
+ */
+export function openingThread(options: { threadId?: string }): { threadId: ThreadId; reopen: boolean } {
+  if ("threadId" in options && options.threadId === undefined) {
+    throw new VendoError(
+      "validation",
+      "threadId was passed as undefined. Omit it to start a new conversation, or pass the id the "
+      + "last turn returned — an undefined id would silently start a second conversation and lose the first.",
+    );
+  }
+  return options.threadId === undefined
+    ? { threadId: `thr_${randomUUID()}` as ThreadId, reopen: false }
+    : { threadId: options.threadId as ThreadId, reopen: true };
+}
+
+/** One entry per call the harness attempted, in order, each carrying the last
+ *  thing known about it. */
+export interface RecordedCall {
+  call: ToolCall;
+  outcome: ToolOutcome["status"];
+}
+
+/** What ONE turn left behind, before either face shapes it: {@link startTurn}
+ *  reads it into a {@link TurnResult}, `awayRunner` into core's
+ *  `AgentRunReport`. */
+export interface TurnRecord {
+  /** The assistant's OWN words for this turn, in full — never a narrowing. */
+  text: string;
+  toolCalls: RecordedCall[];
+  usage: UsageTotals;
+  /** Every approval this turn parked, in the order the guard minted them. */
+  parked: ApprovalRequest[];
+  /** Something outside the turn called time on it. */
+  stopped?: "aborted" | "maxToolCalls";
+  /** The turn broke; the harness's own sentence for it when it gave one. */
+  failed?: { message?: string };
+  /** Present only when `output` was asked for AND the model filled it in. */
+  output?: unknown;
+}
+
+/** What one turn needs beyond the composition it runs on. */
+export interface TurnInput {
+  prompt: string;
+  /** The whole tool surface for this turn — guard-bound already. */
+  tools: ToolRegistry;
+  ctx: RunContext;
+  threadId: ThreadId;
+  turnId: TurnId;
+  /** The id came from the caller: reopen it (ownership-checked) rather than mint. */
+  reopen: boolean;
+  maxToolCalls: number;
+  signal?: AbortSignal;
+  output?: FlexibleSchema<unknown>;
+  emit?: (event: RunEvent) => void;
+  /** Interruptions a caller answered, settled before the model thinks again. The
+   *  guard rides along because deciding an approval is a `VendoGuard` verb while
+   *  a turn's composition is typed on core's narrower `Guard`. */
+  resume?: { guard: VendoGuard; parked: readonly ApprovalRequest[]; decisions: Decisions };
+}
+
+/** The turn's return channel for a declared answer. Named, rather than parsed
+ *  back out of prose, because the args the model already assembled ARE the
+ *  answer. */
+const RESULT_TOOL = "vendo_result";
+
+/** What a caller with no budget gets. The automations engine always passes its
+ *  own (50), so this only bounds a host driving a turn directly. */
+export const DEFAULT_MAX_TOOL_CALLS = 20;
+
+/** What a call past the turn's budget gets. Two rails answer with it: `preflight`
+ *  rules the call out before the guard can park it, and `gate` — the rail whose
+ *  outcome reaches the model — repeats it for that same call. */
+const BUDGET_EXHAUSTED: ToolOutcome = {
+  status: "error",
+  error: { code: "budget-exhausted", message: "Tool-call budget exhausted" },
+};
+
+/** What a turn LEFT UNSAID when it broke. `text` is empty on the error arm by
+ *  contract, so the sentence has to live in the error. */
+const TURN_FAILED = "The turn could not be completed.";
+
+/**
+ * The typed-output surface: one synthetic tool on THIS turn's registry, whose
+ * args are validated against the caller's schema.
+ *
+ * Deliberately OUTSIDE the guard binding. It reaches nothing — no network, no
+ * host API, no file — so there is nothing for a person to approve, and an
+ * unattended turn whose result channel parked on an approval card would be a
+ * typed run that can never return.
+ */
+function withResultTool(
+  tools: ToolRegistry,
+  schema: Schema<unknown>,
+  capture: (value: unknown) => void,
+): ToolRegistry {
+  return {
+    async descriptors(ctx) {
+      return [...await tools.descriptors(ctx), {
+        name: RESULT_TOOL,
+        description: "Report this run's result. Call this once, with the finished answer.",
+        inputSchema: schema.jsonSchema as JsonSchema,
+        risk: "read",
+      }];
+    },
+    async execute(call, ctx) {
+      if (call.tool !== RESULT_TOOL) return tools.execute(call, ctx);
+      const checked = await schema.validate?.(call.args) ?? { success: true as const, value: call.args };
+      if (!checked.success) {
+        // Back to the MODEL, in its own error channel, so it can fix the shape
+        // and call again rather than the turn failing on a fixable mistake.
+        return { status: "error", error: { code: "validation", message: checked.error.message } };
+      }
+      capture(checked.value);
+      return { status: "ok", output: { recorded: true } };
+    },
+  };
+}
+
+/** One buffer, one waiter — everything an `AsyncIterable` fed from callbacks
+ *  needs. Nothing is buffered unless a reader is attached: a turn whose events
+ *  nobody reads is the common case, and buffering for it grew without a bound. */
+function eventQueue<T>(): { push: (item: T) => void; close: () => void; iterable: AsyncIterable<T> } {
+  const buffered: T[] = [];
+  let wake: (() => void) | undefined;
+  let closed = false;
+  let reading = false;
+  const nudge = (): void => {
+    wake?.();
+    wake = undefined;
+  };
+  return {
+    push: (item) => {
+      if (!reading) return;
+      buffered.push(item);
+      nudge();
+    },
+    close: () => {
+      closed = true;
+      nudge();
+    },
+    iterable: {
+      async *[Symbol.asyncIterator]() {
+        if (reading) throw new VendoError("validation", "run.events is single-reader — it is already being read.");
+        reading = true;
+        try {
+          while (true) {
+            while (buffered.length > 0) yield buffered.shift() as T;
+            if (closed) return;
+            await new Promise<void>((resolve) => {
+              wake = resolve;
+            });
+          }
+        } finally {
+          // A reader that LEFT is no reader at all — `break` gets here through
+          // `.return()`. What it did not take is dropped and nothing more is
+          // kept, or a cancelled read leaves the buffer growing forever, which
+          // is the whole growth this queue exists to avoid. Its seat goes back
+          // only while the turn is still going: single-reader is there so two
+          // consumers cannot split ONE live stream, and a finished turn has
+          // nothing left to hand a replacement, so reading it again stays the
+          // named error rather than a silently empty stream.
+          buffered.length = 0;
+          if (!closed) reading = false;
+        }
+      },
+    },
+  };
+}
+
+/**
+ * Watch the harness's own closed vocabulary for a failure, without taking
+ * anything away from the runtime.
+ *
+ * A harness `error` event reaches the SCREEN's error channel and never the
+ * transcript (runtime.ts), so it is invisible to a caller that only reads the
+ * persisted turn — and "the nightly digest failed" reported as a successful turn
+ * is the failure this whole seam exists to avoid. A throw is left to propagate:
+ * the runtime's own handler already puts its plain sentence in the transcript,
+ * so only the STATUS is missing here.
+ *
+ * Wrapping is safe: the adapter slots a harness reads (`harnessAdapters`) are
+ * keyed on the object its own factory closed over, never on the value handed to
+ * the runtime.
+ */
+function watchForFailure(
+  harness: Harness<unknown>,
+  onFailure: (message?: string) => void,
+): Harness<unknown> {
+  return {
+    ...harness,
+    async *run(turn: HarnessTurn<unknown>): AsyncGenerator<HarnessEvent, void, void> {
+      try {
+        for await (const event of harness.run(turn)) {
+          if (event.type === "error") onFailure(event.message);
+          yield event;
+        }
+      } catch (error) {
+        onFailure();
+        throw error;
+      }
+    },
+  };
+}
+
+/** The assistant's own words for the turn, read back through the real read path. */
+function spokenText(messages: readonly UIMessage[]): string {
+  const reply = [...messages].reverse().find((message) => message.role === "assistant");
+  if (reply === undefined) return "";
+  return reply.parts
+    .filter((part): part is { type: "text"; text: string } => part.type === "text")
+    .map((part) => part.text)
+    .join("")
+    .trim();
+}
+
+/**
+ * Answer the interruptions the caller decided, and say what came of them.
+ *
+ * An approved call is RE-DISPATCHED byte for byte — the exact `ToolCall` the
+ * guard parked, through the same guard-bound registry — because a fresh call id
+ * misses the guard's approved replay (`sameParkedCall`, guard.ts) and would only
+ * park a second time. Asking the model to call it again is therefore not a
+ * resume; re-dispatching it is, and the guard's one-shot receipt is what keeps
+ * it from running twice.
+ *
+ * What comes back is the resumed turn's ask. The model was told its call needed
+ * approval, so the honest next thing it reads is what the person said and what
+ * happened. It rides a user message because the transcript has no other channel
+ * a fact enters a turn through, and it is durable on purpose: a reload has to
+ * show the approved call, not a gap where one was.
+ */
+async function settleInterruptions(
+  resume: NonNullable<TurnInput["resume"]>,
+  tools: ToolRegistry,
+  ctx: RunContext,
+  ran: (call: ToolCall, outcome: ToolOutcome) => void,
+): Promise<string> {
+  const lines: string[] = [];
+  for (const request of resume.parked) {
+    const decision = resume.decisions[request.id];
+    if (decision === undefined) continue;
+    const approve = decision === "approve";
+    await resume.guard.approvals.decide([request.id], { approve }, ctx.principal);
+    if (!approve) {
+      lines.push(`- ${request.call.tool}: turned down. It did not run.`);
+      continue;
+    }
+    const outcome = await tools.execute(request.call, ctx);
+    ran(request.call, outcome);
+    lines.push(`- ${request.call.tool}: approved, and it has now run — ${JSON.stringify(outcome)}`);
+  }
+  return `[Resumed] The approvals this conversation was waiting on have been answered.\n${lines.join("\n")}`
+    + "\n\nPick up from there and tell me how it went.";
+}
+
+/** ONE harness turn — everything both venues share. */
+export async function runTurn(deps: TurnDeps, input: TurnInput): Promise<TurnRecord> {
+  const cap = input.maxToolCalls;
+  if (!Number.isInteger(cap) || cap < 1) {
+    throw new VendoError("validation", "maxToolCalls must be a positive integer");
+  }
+  // Read through a call, never inline: `AbortSignal.aborted` is a readonly
+  // boolean, so a narrowing here would have the compiler believe the answer
+  // below cannot change — and the whole point of a signal is that it does.
+  const aborted = (): boolean => input.signal?.aborted === true;
+  // Cancelled before it began: no thread, no workspace, no harness. The signal
+  // is the only way to stop a turn, and a turn stopped before its first I/O has
+  // nothing to report but the stop.
+  if (aborted()) {
+    return { text: "", toolCalls: [], usage: { inputTokens: 0, outputTokens: 0 }, parked: [], stopped: "aborted" };
+  }
+  // Everything the caller put on the ctx rides through untouched — the sponsor,
+  // the venue, the presence, the appId, the firing trigger's id, the asserted
+  // memberships. The turn's own id joins it, so every audit row, mirrored call
+  // and painted view this turn produces names the turn a caller is holding.
+  const ctx: RunContext = { ...input.ctx, turnId: input.turnId };
+  const principal = ctx.principal;
+
+  const recorded: RecordedCall[] = [];
+  /** Calls whose final outcome has already reached `events`. */
+  const reported = new Set<string>();
+  const emitResult = (entry: RecordedCall): void => {
+    reported.add(entry.call.id);
+    input.emit?.({ type: "tool-result", id: entry.call.id, tool: entry.call.tool, outcome: entry.outcome });
+  };
+  const attempted = (call: ToolCall): RecordedCall => {
+    const existing = recorded.find((entry) => entry.call.id === call.id);
+    if (existing !== undefined) return existing;
+    const entry: RecordedCall = { call, outcome: "error" };
+    recorded.push(entry);
+    input.emit?.({ type: "tool-call", id: call.id, tool: call.tool, args: call.args });
+    return entry;
+  };
+  let startedCalls = 0;
+  let budgetRefused = false;
+  /** Calls the budget already refused, by id: the two rails below are two halves
+   *  of ONE decision, and the second must answer for exactly the call the first
+   *  ruled out — never for the call that spent the last of the budget. */
+  const overBudget = new Set<string>();
+  let failed = false;
+  let usage: UsageTotals | undefined;
+  let output: unknown;
+  /** The harness's own sentence for the failure, when it gave one. */
+  let failureMessage: string | undefined;
+  const parked: ApprovalRequest[] = [];
+  /** The guard's OWN per-run key (packages/guard/src/guard.ts:1104), so a card is
+   *  matched the way the guard counts it: an engine firing keys on its runId,
+   *  everything else on the thread it is on. An undefined key matches NOTHING —
+   *  two ctxs that both name no run are not the same run, and matching them would
+   *  hand one firing's cards to another. Typed wider than `RunContext` declares
+   *  on purpose: `sessionId` is required in the type and the automations engine
+   *  does not set it, so the undefined case is real however the type reads. */
+  const runKey: string | undefined = ctx.trigger?.runId ?? ctx.sessionId;
+
+  await deps.store.ensureSchema();
+  const transcript = threadMessageStore<UIMessage>(deps.store);
+  const { threadId } = input;
+  await openThread(deps.store, principal, threadId, input.reopen);
+  // The SPONSOR's durable workspace, with the same `/host/skills` projection and
+  // the same org mounts (§9.7) a session gets — the ctx carries the memberships
+  // the caller asserted for this turn.
+  const workspace = await workspaceStore(deps.store, { files: deps.files ?? storeFiles(deps.store) })
+    .open(principal, {
+      host: hostSkillFiles(deps.skills ?? []),
+      ...(ctx.memberships === undefined ? {} : { memberships: ctx.memberships }),
+    });
+
+  const schema = input.output === undefined ? undefined : asSchema(input.output);
+
+  const runtime = createHarnessRuntime({
+    // THE CALLER's registry, never one of this turn's own choosing: the caller
+    // decides the tool surface, and it is already guard-bound — so §12's
+    // projection is what answers `list()` here.
+    tools: schema === undefined
+      ? input.tools
+      : withResultTool(input.tools, schema, (value) => {
+        output = value;
+      }),
+    guard: deps.guard,
+    skills: createTurnSkills(workspace),
+    transcript,
+    // The same door a session keeps: a turn that CONTINUES a thread has to carry
+    // what the harness remembered on it, and a fresh thread has nothing stored,
+    // so wiring it costs the fresh case nothing.
+    harnessState: harnessStateStore(deps.store),
+    // §1.6 — the render seam, on the runtime's generic `wrapWorkspace` slot: a
+    // commit that lands `app.tsx` paints (the part persists, so the thread shows
+    // the screen the turn built). BARE — no floor, no app half — because this
+    // standalone runtime composes no apps runtime to fill them; the umbrella's
+    // composition does.
+    wrapWorkspace: (turnWorkspace, opts) => wrapWorkspaceForRender(turnWorkspace, {
+      turnId: opts.turnId,
+      emit: opts.emit,
+    }),
+    bridge: {
+      // Every call the harness ATTEMPTS, before the guard sees it — and the one
+      // rail EVERY call passes, which is why the budget is spent here. A call the
+      // preview parks is refused without ever reaching `execute`, so `gate` and
+      // `onCall` below never see it: charged there alone, the budget bounded
+      // nothing away and a looping model minted one approval card per attempt.
+      // Recording the attempt here is what keeps the record honest too — the turn
+      // asked, and it is waiting on a person.
+      preflight: async (call) => {
+        attempted(call);
+        if (startedCalls >= cap) {
+          budgetRefused = true;
+          overBudget.add(call.id);
+          // Returned BEFORE the guard is consulted: nothing past the bound is
+          // worth a person's card, and `gate` speaks this to the model.
+          return BUDGET_EXHAUSTED;
+        }
+        startedCalls += 1;
+        // The result channel takes the same pre-guard short-circuit an
+        // unconnected service does. It reaches nothing — it validates its args
+        // and hands them to a closure in this function: no network, no store,
+        // no host API, no file — and it pays the call budget just above. It is
+        // here ONLY because an away turn parks every call it cannot trace to a
+        // grant, READS INCLUDED (packages/guard/src/guard.ts:1051), which would
+        // strand every typed run on a card nobody can answer. DELETE THIS
+        // BRANCH once the pending guard change lands and a reaches-nothing read
+        // no longer parks unattended.
+        return call.tool === RESULT_TOOL ? { status: "ok", output: {} } : undefined;
+      },
+      // The other half of the budget decision: the refusal, at the one place an
+      // outcome reaches the model — nothing runs past the bound.
+      gate: (call) => (overBudget.has(call.id) ? BUDGET_EXHAUSTED : undefined),
+      onCall: (call) => {
+        const entry = attempted(call);
+        return (outcome) => {
+          entry.outcome = outcome.status;
+          emitResult(entry);
+        };
+      },
+    },
+    ...(deps.liveTurn === undefined ? {} : { liveTurn: deps.liveTurn }),
+  });
+
+  const system = await resolveSystem(deps, ctx);
+
+  // Subscribed as LATE as possible and torn down in `finally`: the guard holds
+  // its callbacks in a set forever, so a throw between the subscribe and the
+  // teardown would leak one — and a foreign `threadId` is a rejection a caller
+  // can repeat at will.
+  const unsubscribe = deps.guard.onApprovalRequested?.((request) => {
+    if (runKey !== undefined && (request.ctx.trigger?.runId ?? request.ctx.sessionId) === runKey) {
+      parked.push(request);
+    }
+    // A parked call never reaches `onCall`, so this is the only moment the turn
+    // learns one parked — and it is the HONEST one: a guard that threw while
+    // parking mints no request, so its call keeps the opening `error` instead of
+    // telling the host to wait on a card nobody has. Matched on the tool call's
+    // own id (minted per call, uuid-backed), so a sibling turn's card cannot mark
+    // this turn's call whatever the run key says.
+    const waiting = recorded.find((entry) => entry.call.id === request.call.id);
+    if (waiting !== undefined) waiting.outcome = "pending-approval";
+  });
+  try {
+    // The answered interruptions land BEFORE the model thinks again, so what it
+    // reads is already true.
+    const ask = input.resume === undefined
+      ? input.prompt
+      : await settleInterruptions(input.resume, input.tools, ctx, (call, outcome) => {
+        attempted(call).outcome = outcome.status;
+      });
+    // The result channel is NAMED in the ask, not merely listed among the tools:
+    // a model that never calls it returns prose where the caller asked for a
+    // shape, and there is no second model call here to recover one.
+    const message = asUserMessage(schema === undefined
+      ? ask
+      : `${ask}\n\nWhen you are done, call ${RESULT_TOOL} with the result.`);
+    // Reopening means CONTINUING: the thread's own turns come back with it, read
+    // through the same path a session's do. A fresh thread has none.
+    const persisted = input.reopen ? await transcript.list(principal, threadId) : [];
+
+    const response = await runtime.run({
+      harness: watchForFailure(deps.harness, (failure) => {
+        failed = true;
+        failureMessage = failure;
+      }),
+      threadId,
+      messages: [...persisted, message],
+      ctx,
+      workspace,
+      // A park ENDS this turn: nobody is blocked on the 90s waiter, and the card
+      // stands for `resume()`. See this file's header.
+      interactive: false,
+      system,
+      // The harness's own vocabulary, forwarded as the runtime routes it: the
+      // metering fold every caller needs, and the three things a watching caller
+      // wants to see while they happen.
+      observe: (event) => {
+        if (event.type === "usage") usage = addUsage(usage, event);
+        else if (event.type === "text") input.emit?.({ type: "text", delta: event.delta });
+        else if (event.type === "status") input.emit?.({ type: "status", label: event.label });
+        else if (event.type === "error") input.emit?.({ type: "error", message: event.message });
+      },
+      ...(deps.models === undefined ? {} : { models: deps.models }),
+      ...(input.signal === undefined ? {} : { signal: input.signal }),
+    });
+    // Drained, not discarded: the stream's `onFinish` is what persists the turn
+    // and writes its audit row, and it only fires on consumption. THIS is the
+    // drainer-of-record property — nothing a client does or fails to do changes
+    // whether the turn happened.
+    await response.text();
+  } catch {
+    failed = true;
+  } finally {
+    unsubscribe?.();
+  }
+  // A call the guard parked never reaches `onCall`, so its outcome has no live
+  // moment to be announced in. Announced here instead, so the event stream ends
+  // agreeing with the result rather than silently short of it.
+  for (const entry of recorded) if (!reported.has(entry.call.id)) emitResult(entry);
+
+  // A turn's words are worth a lost read, never a lost turn: an unreadable
+  // transcript answers with nothing rather than failing a finished turn.
+  return {
+    text: spokenText(await transcript.list(principal, threadId).catch(() => [])),
+    toolCalls: recorded,
+    usage: usage ?? { inputTokens: 0, outputTokens: 0 },
+    parked,
+    ...(aborted() ? { stopped: "aborted" as const } : budgetRefused ? { stopped: "maxToolCalls" as const } : {}),
+    ...(failed ? { failed: failureMessage === undefined ? {} : { message: failureMessage } } : {}),
+    ...(output === undefined ? {} : { output }),
+  };
+}
+
+/**
+ * One turn's four ends, out of what it left behind.
+ *
+ * Order is the answer to "what actually ended this": something outside it called
+ * time, or it broke, or it is waiting on a person, or it finished. A turn asked
+ * for a shaped answer that never reported one is an ERROR, never a silent `ok`
+ * with nothing in it.
+ */
+function shape<T>(deps: AgentDeps, input: Omit<TurnInput, "tools" | "emit">, record: TurnRecord): TurnResult<T> {
+  const ran = {
+    text: record.text,
+    threadId: input.threadId,
+    turnId: input.turnId,
+    toolCalls: record.toolCalls,
+    usage: record.usage,
+  };
+  // `unavailable` is the honest code for every one of these: the turn broke on
+  // the SERVER's side of the seam, so running it again verbatim is the right
+  // next move. A refusal a caller could fix would have thrown before the turn
+  // ever opened (see {@link openingThread}).
+  const broke = (message: string): TurnResult<T> => ({
+    status: "error",
+    text: "",
+    threadId: input.threadId,
+    turnId: input.turnId,
+    error: { code: "unavailable", message },
+  });
+  if (record.stopped !== undefined) return { ...ran, status: "stopped", reason: record.stopped };
+  if (record.failed !== undefined) {
+    return broke(record.failed.message ?? (record.text === "" ? TURN_FAILED : record.text));
+  }
+  if (record.parked.length > 0) {
+    return {
+      ...ran,
+      status: "interrupted",
+      interruptions: record.parked.map((request) => ({
+        id: request.id,
+        type: "approval",
+        toolCall: request.call,
+      })),
+      // The SAME turn, carrying on: one turn id across park and resume, so the
+      // thing a caller answered is the thing they get an answer about.
+      resume: (decisions, options) => startTurn<T>(deps, {
+        ...input,
+        reopen: true,
+        ctx: resumedContext(input.ctx, options),
+        resume: { guard: deps.guard, parked: record.parked, decisions },
+      }),
+    };
+  }
+  if (input.output !== undefined && record.output === undefined) {
+    return broke("The run finished without reporting the result it was asked for.");
+  }
+  return { ...ran, status: "ok", output: record.output as T };
+}
+
+/** The ctx a resumed turn runs on. Authority comes from the RESUMING call and
+ *  never from the dead one: the parked turn's request headers were
+ *  request-lifetime and that request is over, so they are DROPPED unless this
+ *  call brings its own. Its context wins over what the parked turn carried. */
+const resumedContext = (ctx: RunContext, options: ResumeOptions | undefined): RunContext => {
+  const { requestHeaders, ...carried } = ctx;
+  const headers = toHeaderRecord(options?.headers);
+  return {
+    ...carried,
+    ...(headers === undefined ? {} : { requestHeaders: headers }),
+    ...(options?.context === undefined ? {} : { context: { ...ctx.context, ...options.context } }),
+  };
+};
+
+/**
+ * Start one turn and hand back the object it runs behind.
+ *
+ * The gates a turn clears before it opens anything are here, in the one place a
+ * turn begins: the model check, and a door still binding its port —
+ * `createSession` awaits the same two.
+ */
+export function startTurn<T = void>(deps: AgentDeps, input: Omit<TurnInput, "tools" | "emit">): Turn<T> {
+  const queue = eventQueue<RunEvent>();
+  const settled = Promise.all([deps.assertModel?.(), deps.doorReady])
+    .then(() => runTurn(deps, { ...input, tools: deps.tools, emit: queue.push }))
+    .finally(() => {
+      queue.close();
+    })
+    .then((record) => shape<T>(deps, input, record));
+  // The doc above invites reading `threadId` and never awaiting, so a turn that
+  // failed before it began and nobody asked about must not take the host process
+  // down (node ≥15 exits on an unhandled rejection). This handler is on a DERIVED
+  // promise: `settled` itself is untouched, so a caller who does await still gets
+  // the error.
+  settled.catch(() => {});
+  return {
+    threadId: input.threadId,
+    turnId: input.turnId,
+    events: queue.iterable,
+    then: (onFulfilled, onRejected) => settled.then(onFulfilled as never, onRejected),
+  };
+}
+
+/**
+ * `agent.chat(message)` — one turn of a conversation, for code that wants the
+ * answer rather than a stream.
+ *
+ * No output schema by design: a chat turn's answer is what the assistant SAID.
+ * `run()` is the lane with a declared shape.
+ */
+export function startChat(deps: AgentDeps, message: string, options: ChatOptions = {}): Turn {
+  const opening = openingThread(options);
+  const headers = toHeaderRecord(options.headers);
+  return startTurn(deps, {
+    ...opening,
+    prompt: message,
+    ctx: {
+      // Unset, the agent talks as ITSELF — the subject its own audit rows are
+      // attributed to, never a borrowed user. The same default `run()` takes.
+      principal: { kind: "user", subject: options.as ?? `vendo:agent:${deps.name}` },
+      venue: "chat",
+      presence: "present",
+      // The thread this turn is on: the guard scopes a parked card by it, and
+      // `resume()` finds the card again through the same key.
+      sessionId: opening.threadId,
+      ...(headers === undefined ? {} : { requestHeaders: headers }),
+      ...(options.user === undefined ? {} : { user: options.user }),
+      ...(options.context === undefined ? {} : { context: options.context }),
+    },
+    turnId: mintTurnId(),
+    maxToolCalls: DEFAULT_MAX_TOOL_CALLS,
+    ...(options.signal === undefined ? {} : { signal: options.signal }),
+  });
+}

--- a/packages/agents/tests/run.test.ts
+++ b/packages/agents/tests/run.test.ts
@@ -2,14 +2,15 @@
  * The code lane — `agent.run(task)`. Real embedded store, real guard, real
  * runtime; only the thinker is scripted (CLAUDE.md: test the SEAM).
  */
-import { VendoError, agentRunReportSchema } from "@vendoai/core";
+import { VendoError } from "@vendoai/core";
 import type { VendoGuard } from "@vendoai/guard";
 import { defineHarness } from "@vendoai/harnesses";
 import { createStore, threadStore } from "@vendoai/store";
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
 import { agent } from "../src/agent.js";
-import { startRun, type RunEvent } from "../src/away.js";
+import { startRun } from "../src/away.js";
+import type { RunEvent } from "../src/turn.js";
 import { tool } from "../src/tools.js";
 
 let stores = 0;
@@ -28,9 +29,9 @@ const readTool = () => tool({
  *
  * The REAL guard parks every away call it cannot trace to an app-bound
  * automation grant (guard.ts:1052) — which is its own test below, and is the
- * whole reason `refs.approvals` exists. The rails under test here (the budget
- * gate, the event lane, the report) sit on the far side of that decision, so
- * they need a run where calls actually execute.
+ * whole reason the `interrupted` arm exists. The rails under test here (the
+ * budget gate, the event lane, the result) sit on the far side of that
+ * decision, so they need a run where calls actually execute.
  */
 const permissive = (): VendoGuard => ({
   check: async () => ({ action: "run", decidedBy: "grant" }),
@@ -56,7 +57,7 @@ const collect = async (events: AsyncIterable<RunEvent>): Promise<RunEvent[]> => 
 };
 
 describe("run()", () => {
-  it("reports what the run left behind: the core report, the thread, the calls and the usage", async () => {
+  it("reports what the run left behind: what it said, the ids, the calls and the usage", async () => {
     const store = memoryStore();
     const support = agent({
       name: "support",
@@ -74,18 +75,21 @@ describe("run()", () => {
     });
 
     const running = support.run("Check the invoices.", { as: "u_42" });
-    // Readable BEFORE the report — a caller can show it or hand it back.
+    // Readable BEFORE the result — a caller can show them or hand them back.
     expect(running.threadId).toMatch(/^thr_/);
-    const report = await running;
+    expect(running.turnId).toMatch(/^trn_/);
+    const result = await running;
 
-    expect(agentRunReportSchema.parse(report)).toBeTruthy();
-    expect(report.status).toBe("ok");
-    expect(report.summary).toBe("Two invoices are outstanding.");
-    expect(report.toolCalls.map(({ call, outcome }) => [call.tool, outcome]))
+    expect(result).toMatchObject({
+      status: "ok",
+      text: "Two invoices are outstanding.",
+      threadId: running.threadId,
+      turnId: running.turnId,
+      usage: { inputTokens: 11, outputTokens: 7, model: "fake-1" },
+      output: undefined,
+    });
+    expect(result.status === "ok" && result.toolCalls.map(({ call, outcome }) => [call.tool, outcome]))
       .toEqual([["invoices_list", "ok"]]);
-    expect(report.refs).toEqual({ threadId: running.threadId, approvals: [] });
-    expect(report.usage).toEqual({ inputTokens: 11, outputTokens: 7, model: "fake-1" });
-    expect(report.output).toBeUndefined();
     // The thread is real and belongs to the subject that ran.
     expect(await threadStore(store).get({ kind: "user", subject: "u_42" }, running.threadId as never))
       .not.toBeNull();
@@ -237,7 +241,7 @@ describe("run()", () => {
     expect(await replacement).toEqual([{ type: "text", delta: "Two invoices." }]);
   });
 
-  it("a run nobody was there to approve finishes ok, with the cards a person has to answer", async () => {
+  it("a run nobody was there to approve is INTERRUPTED, carrying the calls to answer for", async () => {
     const store = memoryStore();
     const support = agent({
       name: "support",
@@ -253,12 +257,14 @@ describe("run()", () => {
     });
 
     // No grant: the guard wants a person, and nobody is here.
-    const report = await support.run("Check the invoices.", { as: "u_42" });
+    const result = await support.run("Check the invoices.", { as: "u_42" });
 
-    expect(report.status).toBe("ok");
-    expect(report.refs.approvals).toHaveLength(1);
-    expect(report.refs.approvals[0]).toMatch(/^apr_/);
-    expect(report.toolCalls.map(({ outcome }) => outcome)).toEqual(["pending-approval"]);
+    expect(result.status).toBe("interrupted");
+    if (result.status !== "interrupted") return;
+    expect(result.interruptions).toHaveLength(1);
+    expect(result.interruptions[0]).toMatchObject({ type: "approval", toolCall: { tool: "invoices_list" } });
+    expect(result.interruptions[0]?.id).toMatch(/^apr_/);
+    expect(result.toolCalls.map(({ outcome }) => outcome)).toEqual(["pending-approval"]);
   });
 
   it("fills a typed output from the schema, and hands a bad shape back to the model", async () => {
@@ -277,12 +283,12 @@ describe("run()", () => {
       store,
     });
 
-    const report = await support.run("Count the overdue invoices.", {
+    const result = await support.run("Count the overdue invoices.", {
       as: "u_42",
       output: z.object({ overdue: z.number() }),
     });
 
-    expect(report.output).toEqual({ overdue: 2 });
+    expect(result).toMatchObject({ status: "ok", output: { overdue: 2 } });
     expect(attempts[0]).toMatchObject({ status: "error" });
     expect(attempts[1]).toMatchObject({ status: "ok" });
   });
@@ -327,10 +333,10 @@ describe("run()", () => {
       store,
     });
 
-    const report = await support.run("Loop.", { as: "u_42" });
+    const result = await support.run("Loop.", { as: "u_42" });
 
     expect(attempted).toBe(20);
-    expect(report.status).toBe("stopped");
+    expect(result).toMatchObject({ status: "stopped", reason: "maxToolCalls" });
   });
 
   it("honors an explicit maxToolCalls", async () => {
@@ -353,10 +359,10 @@ describe("run()", () => {
       store,
     });
 
-    const report = await support.run("Loop.", { as: "u_42", maxToolCalls: 2 });
+    const result = await support.run("Loop.", { as: "u_42", maxToolCalls: 2 });
 
     expect(attempted).toBe(2);
-    expect(report.status).toBe("stopped");
+    expect(result).toMatchObject({ status: "stopped", reason: "maxToolCalls" });
   });
 
   it("stops on the caller's AbortSignal — the only way to stop a run", async () => {
@@ -374,10 +380,9 @@ describe("run()", () => {
       store: memoryStore(),
     });
 
-    const report = await support.run("Stop me.", { as: "u_42", signal: controller.signal });
+    const result = await support.run("Stop me.", { as: "u_42", signal: controller.signal });
 
-    expect(report.status).toBe("stopped");
-    expect(report.summary.trim()).not.toBe("");
+    expect(result).toMatchObject({ status: "stopped", reason: "aborted" });
   });
 
   it("continues a thread this subject owns, and refuses one they do not", async () => {

--- a/packages/agents/tests/turn.test.ts
+++ b/packages/agents/tests/turn.test.ts
@@ -1,0 +1,334 @@
+/**
+ * The turn contract — `chat()` and `run()` answering the one `TurnResult`.
+ *
+ * Real embedded store, real guard, real `createHarnessRuntime`; only the thinker
+ * is scripted, because the thinker is not what is under test (CLAUDE.md: test
+ * the SEAM). Everything a caller is promised about a turn is proved through the
+ * real write path and read back through the real read path.
+ */
+import { VendoError, type ToolResult } from "@vendoai/core";
+import { createGuard } from "@vendoai/guard";
+import { APPROVAL_WAIT_MS, defineHarness } from "@vendoai/harnesses";
+import { createStore, threadMessageStore, type VendoStore } from "@vendoai/store";
+import type { UIMessage } from "ai";
+import { describe, expect, it } from "vitest";
+import { agent, type VendoAgent } from "../src/agent.js";
+import type { RunEvent } from "../src/turn.js";
+import { tool } from "../src/tools.js";
+
+let stores = 0;
+const memoryStore = (): VendoStore => createStore({ dataDir: `memory://agents-turn-${stores++}` });
+
+/** Ungraded/destructive is the one thing a guard with no rules at all still
+ *  wants a person for (`#defaultPosture`), in either venue — so this is how a
+ *  turn parks without a rule set standing in for the guard. */
+const refundTool = (ran: { count: number }) => tool({
+  name: "refund",
+  description: "Refund an invoice",
+  risk: "destructive",
+  inputSchema: { type: "object" },
+  execute: () => {
+    ran.count += 1;
+    return { refunded: true };
+  },
+});
+
+const owner = (subject: string) => ({ kind: "user" as const, subject });
+
+/** The whole transcript, through the same read path a reload takes. */
+const transcriptOf = (store: VendoStore, subject: string, threadId: string): Promise<UIMessage[]> =>
+  threadMessageStore<UIMessage>(store).list(owner(subject), threadId as never);
+
+const collect = async (events: AsyncIterable<RunEvent>): Promise<RunEvent[]> => {
+  const seen: RunEvent[] = [];
+  for await (const event of events) seen.push(event);
+  return seen;
+};
+
+const speaker = (text: string) => defineHarness({
+  name: "speaker",
+  async *run() {
+    yield { type: "text" as const, delta: text };
+  },
+});
+
+describe("the turn is the drainer of record", () => {
+  it("persists a turn nobody awaited and nobody tapped", async () => {
+    const store = memoryStore();
+    const support = agent({ name: "support", harness: speaker("Filed under done."), store });
+
+    // Neither awaited nor read: exactly what a caller who only wanted the work
+    // done writes. The turn still has to happen, in full.
+    const turn = support.chat("File the report.", { as: "u_42" });
+
+    await expect.poll(
+      async () => (await transcriptOf(store, "u_42", turn.threadId)).map((message) => message.role),
+      { timeout: 20_000, interval: 25 },
+    ).toEqual(["user", "assistant"]);
+    const transcript = await transcriptOf(store, "u_42", turn.threadId);
+    expect(JSON.stringify(transcript.at(-1)?.parts)).toContain("Filed under done.");
+  }, 20_000);
+
+  it("refuses a second reader, and finishes for a turn whose events nobody reads", async () => {
+    const support = agent({ name: "support", harness: speaker("done"), store: memoryStore() });
+
+    const turn = support.chat("go", { as: "u_42" });
+    expect(await collect(turn.events)).toContainEqual({ type: "text", delta: "done" });
+    await turn;
+    const second = await collect(turn.events).catch((error: unknown) => error);
+
+    expect(second).toBeInstanceOf(VendoError);
+    expect((second as VendoError).code).toBe("validation");
+
+    const unread = support.chat("go again", { as: "u_42" });
+    expect(await unread).toMatchObject({ status: "ok", text: "done" });
+  });
+});
+
+describe("a turn's ids", () => {
+  it("are readable before it completes, and are the ones the result carries", async () => {
+    const support = agent({ name: "support", harness: speaker("done"), store: memoryStore() });
+
+    const turn = support.chat("go", { as: "u_42" });
+    expect(turn.threadId).toMatch(/^thr_/);
+    expect(turn.turnId).toMatch(/^trn_/);
+
+    expect(await turn).toMatchObject({ status: "ok", threadId: turn.threadId, turnId: turn.turnId });
+  });
+
+  it("are on the arm a broken turn answers with too", async () => {
+    const support = agent({
+      name: "support",
+      harness: defineHarness({
+        name: "breaks",
+        async *run() {
+          yield { type: "error" as const, message: "The ledger is unreachable." };
+        },
+      }),
+      store: memoryStore(),
+    });
+
+    const turn = support.chat("go", { as: "u_42" });
+    const result = await turn;
+
+    expect(result).toMatchObject({
+      status: "error",
+      // §1.5: a turn that broke never spoke, so the sentence lives in the error.
+      text: "",
+      threadId: turn.threadId,
+      turnId: turn.turnId,
+      error: { message: "The ledger is unreachable." },
+    });
+  });
+
+  it("names the turn on the rows the turn wrote, so a caller can join them", async () => {
+    const store = memoryStore();
+    const guard = createGuard({ store });
+    const turn = agent({
+      name: "support",
+      // Spend is what mints the turn's run row (`runAuditEvent`), so the thinker
+      // has to meter something for there to be a row to join.
+      harness: defineHarness({
+        name: "meters",
+        async *run() {
+          yield { type: "usage" as const, inputTokens: 3, outputTokens: 1 };
+          yield { type: "text" as const, delta: "done" };
+        },
+      }),
+      guard,
+      store,
+    }).chat("go", { as: "u_42" });
+    await turn;
+
+    const { events } = await guard.audit.query({ principal: owner("u_42") });
+    expect(events.map((event) => event.turnId)).toContain(turn.turnId);
+  });
+});
+
+describe("the thread a turn runs on", () => {
+  const peeker = (seen: { messages: number }) => defineHarness({
+    name: "peek",
+    async *run(turn) {
+      seen.messages = turn.messages.length;
+      yield { type: "text" as const, delta: "ok" };
+    },
+  });
+
+  it("is new when the id is omitted, and the same one when it is handed back", async () => {
+    const seen = { messages: 0 };
+    const support = agent({ name: "support", harness: peeker(seen), store: memoryStore() });
+
+    const first = support.chat("first", { as: "u_42" });
+    await first;
+    const fresh = support.chat("second", { as: "u_42" });
+    await fresh;
+    expect(fresh.threadId).not.toBe(first.threadId);
+    expect(seen.messages).toBe(1);
+
+    await support.chat("carry on", { as: "u_42", threadId: first.threadId });
+    expect(seen.messages).toBe(3); // user, assistant, user
+  });
+
+  it("refuses an explicitly-undefined id rather than quietly forking the conversation", () => {
+    const support = agent({ name: "support", harness: speaker("ok"), store: memoryStore() });
+    // What a host actually writes: an id read off a record that was not there.
+    const remembered: { threadId?: string } = {};
+
+    const forked = (): unknown => support.chat("go", { as: "u_42", threadId: remembered.threadId });
+
+    expect(forked).toThrow(VendoError);
+    expect(forked).toThrow(/threadId was passed as undefined/);
+  });
+});
+
+describe("a park ENDS the turn", () => {
+  /** A thinker that asks for the refund on its first turn and reports on its
+   *  second — which is exactly what a resumed turn is. */
+  const refunder = (asked: { reason: string }) => {
+    let turns = 0;
+    return defineHarness({
+      name: "refunder",
+      async *run(turn) {
+        turns += 1;
+        if (turns > 1) {
+          yield { type: "text" as const, delta: "The refund went through." };
+          return;
+        }
+        const result: ToolResult = await turn.tools.call("refund", {});
+        asked.reason = result.status === "denied" ? result.reason : result.status;
+        yield { type: "text" as const, delta: "I have asked for approval." };
+      },
+    });
+  };
+
+  const parking = (store: VendoStore, ran: { count: number }, asked: { reason: string }): VendoAgent =>
+    agent({ name: "support", harness: refunder(asked), tools: [refundTool(ran)], store });
+
+  it("answers interrupted with the parked call, without waiting out the approval clock", async () => {
+    const ran = { count: 0 };
+    const asked = { reason: "" };
+    const support = parking(memoryStore(), ran, asked);
+
+    const startedAt = Date.now();
+    const result = await support.chat("Refund invoice 7.", { as: "u_42" });
+    const elapsed = Date.now() - startedAt;
+
+    expect(result.status).toBe("interrupted");
+    if (result.status !== "interrupted") return;
+    expect(result.interruptions).toHaveLength(1);
+    expect(result.interruptions[0]).toMatchObject({ type: "approval", toolCall: { tool: "refund" } });
+    expect(result.text).toBe("I have asked for approval.");
+    expect(ran.count).toBe(0);
+    // The whole point of not blocking: the answer is the turn's own duration,
+    // never the 90-second closed-tab bound.
+    expect(elapsed).toBeLessThan(APPROVAL_WAIT_MS / 3);
+  });
+
+  it("tells a PRESENT user's agent that the ask is pending, not that nobody is around", async () => {
+    const asked = { reason: "" };
+    await parking(memoryStore(), { count: 0 }, asked).chat("Refund invoice 7.", { as: "u_42" });
+
+    expect(asked.reason).not.toMatch(/nobody is here/);
+    expect(asked.reason).toMatch(/needs approval/i);
+  });
+
+  it("still tells an AWAY run that nobody is there — because nobody is", async () => {
+    // A READ tool, because §12 withholds a destructive one from an unattended
+    // run outright: away parks every call it cannot trace to a grant, reads
+    // included (guard.ts:1051), so this is what parking away looks like.
+    const asked = { reason: "" };
+    const support = agent({
+      name: "support",
+      harness: defineHarness({
+        name: "lister",
+        async *run(turn) {
+          const result: ToolResult = await turn.tools.call("invoices_list", {});
+          asked.reason = result.status === "denied" ? result.reason : result.status;
+          yield { type: "text" as const, delta: "asked" };
+        },
+      }),
+      tools: [tool({
+        name: "invoices_list",
+        description: "List invoices",
+        risk: "read",
+        inputSchema: { type: "object" },
+        execute: () => ({ invoices: 2 }),
+      })],
+      store: memoryStore(),
+    });
+
+    await support.run("List the invoices.", { as: "u_42" });
+
+    expect(asked.reason).toBe("This needs your approval, and nobody is here to give it.");
+  });
+});
+
+describe("resume", () => {
+  it("re-dispatches the approved call byte for byte and carries the turn on", async () => {
+    const store = memoryStore();
+    const ran = { count: 0 };
+    const asked = { reason: "" };
+    let turns = 0;
+    const support = agent({
+      name: "support",
+      harness: defineHarness({
+        name: "refunder",
+        async *run(turn) {
+          turns += 1;
+          if (turns > 1) {
+            yield { type: "text" as const, delta: "The refund went through." };
+            return;
+          }
+          const result: ToolResult = await turn.tools.call("refund", {});
+          asked.reason = result.status === "denied" ? result.reason : result.status;
+          yield { type: "text" as const, delta: "I have asked for approval." };
+        },
+      }),
+      tools: [refundTool(ran)],
+      store,
+    });
+
+    const parked = support.chat("Refund invoice 7.", { as: "u_42" });
+    const result = await parked;
+    expect(result.status).toBe("interrupted");
+    if (result.status !== "interrupted") return;
+
+    const resumed = result.resume({ [result.interruptions[0]!.id]: "approve" });
+    const answered = await resumed;
+
+    // The exact call the person saw ran, once — a fresh call would have missed
+    // the guard's approved replay and parked all over again.
+    expect(ran.count).toBe(1);
+    expect(answered).toMatchObject({ status: "ok", text: "The refund went through." });
+    // One turn across the park: what was answered is what the answer is about.
+    expect(resumed.turnId).toBe(parked.turnId);
+    expect(resumed.threadId).toBe(parked.threadId);
+    // And it is all one conversation, read back the way a reload reads it.
+    expect((await transcriptOf(store, "u_42", parked.threadId)).map((message) => message.role))
+      .toEqual(["user", "assistant", "user", "assistant"]);
+  });
+
+  it("runs nothing for an interruption the caller turned down", async () => {
+    const ran = { count: 0 };
+    const asked = { reason: "" };
+    const support = agent({
+      name: "support",
+      harness: defineHarness({
+        name: "refunder",
+        async *run(turn) {
+          const result: ToolResult = await turn.tools.call("refund", {});
+          asked.reason = result.status === "denied" ? result.reason : result.status;
+          yield { type: "text" as const, delta: "asked" };
+        },
+      }),
+      tools: [refundTool(ran)],
+      store: memoryStore(),
+    });
+
+    const result = await support.chat("Refund invoice 7.", { as: "u_42" });
+    if (result.status !== "interrupted") throw new Error(`expected interrupted, got ${result.status}`);
+    await result.resume({ [result.interruptions[0]!.id]: "deny" });
+
+    expect(ran.count).toBe(0);
+  });
+});

--- a/packages/agents/tests/unattended.test.ts
+++ b/packages/agents/tests/unattended.test.ts
@@ -6,7 +6,8 @@
  * as "waiting on a person". Real embedded store, real guard, real runtime; only
  * the thinker is scripted (CLAUDE.md: test the SEAM).
  */
-import type { Guard, ToolDescriptor, ToolRegistry } from "@vendoai/core";
+import type { ToolDescriptor, ToolRegistry } from "@vendoai/core";
+import type { VendoGuard } from "@vendoai/guard";
 import { defineHarness } from "@vendoai/harnesses";
 import { createStore, threadStore } from "@vendoai/store";
 import { describe, expect, it } from "vitest";
@@ -49,13 +50,14 @@ describe("run() — the budget bounds a run whose calls PARK", () => {
       store,
     });
 
-    const report = await support.run("Loop.", { as: "u_42", maxToolCalls: 2 });
+    const result = await support.run("Loop.", { as: "u_42", maxToolCalls: 2 });
 
     // Two cards for two attempts the budget allowed — never one per attempt.
-    expect(report.refs.approvals).toHaveLength(2);
-    expect(report.toolCalls.map(({ outcome }) => outcome))
+    // The budget is what ENDED this run, so it stops rather than interrupts:
+    // answering the two cards would not give the run its budget back.
+    expect(result).toMatchObject({ status: "stopped", reason: "maxToolCalls" });
+    expect(result.status === "stopped" && result.toolCalls.map(({ outcome }) => outcome))
       .toEqual(["pending-approval", "pending-approval", "error", "error", "error"]);
-    expect(report.status).toBe("stopped");
   });
 });
 
@@ -118,9 +120,9 @@ describe("run() — an already-aborted signal", () => {
     controller.abort();
 
     const running = support.run("Stop me.", { as: "u_42", signal: controller.signal });
-    const report = await running;
+    const result = await running;
 
-    expect(report.status).toBe("stopped");
+    expect(result).toMatchObject({ status: "stopped", reason: "aborted" });
     expect(thought).toBe(false);
     expect(await threadStore(store).get({ kind: "user", subject: "u_42" }, running.threadId as never))
       .toBeNull();
@@ -140,20 +142,32 @@ describe("run() — a guard that fails while parking", () => {
   };
   /** Fails closed the way the shipped preview does: it wants a person, and it
    *  minted nothing for anyone to answer. */
-  const brokenGuard = (): Guard => ({
+  const brokenGuard = (): VendoGuard => ({
     check: async () => {
+      throw new Error("the guard is down");
+    },
+    previewCheck: async () => {
       throw new Error("the guard is down");
     },
     report: async () => {},
     directions: async () => [],
     onApprovalDecision: () => () => {},
     onApprovalRequested: () => () => {},
+    bind: (tools) => tools,
+    approvals: { parkedCallTtlMs: 0, pending: async () => [], decide: async () => {}, revoke: async () => {} },
+    freeze: async () => {},
+    unfreeze: async () => {},
+    frozen: async () => false,
+    grants: { list: async () => [], revoke: async () => {} },
+    audit: { query: async () => ({ events: [] }), export: async function* () {} },
+    status: () => ({ posture: "unconfigured" }),
   });
 
-  // "pending-approval" with `refs.approvals: []` tells the host to wait on a
-  // person who has nothing to answer — the run is stuck, silently, forever.
+  // "pending-approval" with nothing to answer tells the host to wait on a person
+  // who has no card — the run is stuck, silently, forever. So the turn is an
+  // ordinary finished one whose call ERRORED, never an interrupted one.
   it("reports the failure, not a card nobody has", async () => {
-    const report = await startRun({
+    const result = await startRun({
       name: "support",
       store: memoryStore(),
       guard: brokenGuard(),
@@ -161,8 +175,8 @@ describe("run() — a guard that fails while parking", () => {
       harness: looper(1),
     }, "read the invoices", { as: "u_42" });
 
-    expect(report.refs.approvals).toEqual([]);
-    expect(report.toolCalls.map(({ call, outcome }) => [call.tool, outcome]))
+    expect(result.status).toBe("ok");
+    expect(result.status === "ok" && result.toolCalls.map(({ call, outcome }) => [call.tool, outcome]))
       .toEqual([["invoices_list", "error"]]);
   });
 });

--- a/packages/harnesses/src/runtime.ts
+++ b/packages/harnesses/src/runtime.ts
@@ -287,11 +287,15 @@ export function createHarnessRuntime(deps: HarnessRuntimeDeps): HarnessRuntime {
 
   return {
     async run<Options>(started: TurnRunInput<Options>): Promise<Response> {
-      // The turn's identity, minted here because here is where a turn begins. It
-      // rides the CTX rather than a second parameter, so every guarded call,
-      // audit row and painted view below is joinable to this exchange for free —
-      // and the rest of this function reads `input` exactly as it always did.
-      const turnId = mintTurnId();
+      // The turn's identity, minted here because here is where a turn begins —
+      // unless the caller already named one, which is how a caller that hands the
+      // id out BEFORE the turn resolves (`agent.chat().turnId`) stays joinable to
+      // the rows this turn writes. There is still exactly one id per turn; the
+      // only question is who minted it. It rides the CTX rather than a second
+      // parameter, so every guarded call, audit row and painted view below is
+      // joinable to this exchange for free — and the rest of this function reads
+      // `input` exactly as it always did.
+      const turnId = started.ctx.turnId ?? mintTurnId();
       const input: TurnRunInput<Options> = { ...started, ctx: { ...started.ctx, turnId } };
       // §1.3: what the harness may remember depends on how the history moved.
       // A prefix truncation is a native rewind, so its session survives; an

--- a/packages/harnesses/src/turn-tools.ts
+++ b/packages/harnesses/src/turn-tools.ts
@@ -356,10 +356,19 @@ export function createTurnTools(options: TurnToolsOptions): RuntimeTurnTools {
             waiter.raise(approvalId, { standing: !options.interactive });
           }
           if (!options.interactive) {
-            // Nobody is here to tap, so the run fails loudly and the card stands
-            // as the grant "Grant & re-run" will collect.
+            // Nobody is WAITING on this call, so it fails loudly here and the
+            // card stands as the grant "Grant & re-run" (or `turn.resume()`)
+            // will collect.
+            //
+            // Whether anybody is THERE is a different question, and it is the
+            // ctx's: an away run has nobody, but a turn at presence "present" has
+            // a person who simply answers on their own clock rather than inside
+            // this call. Telling that model nobody is around would have the agent
+            // say so to the very person it just asked.
             return refused(
-              "This needs your approval, and nobody is here to give it.",
+              options.ctx.presence === "present"
+                ? "This needs approval and it has been asked for. Stop here and say so — you will be told the answer."
+                : "This needs your approval, and nobody is here to give it.",
               approvalId === undefined ? undefined : { kind: "approval", approvalId },
             );
           }

--- a/packages/harnesses/tests/stale-approvals.test.ts
+++ b/packages/harnesses/tests/stale-approvals.test.ts
@@ -396,7 +396,10 @@ describe("3 — a refusal nobody was asked about leaves a transcript the next tu
         }),
         threadId: THREAD,
         messages: [userMessage("m1", "pay")],
-        ctx: ctx(),
+        // Presence follows the case: an unattended turn is one nobody is AT, and
+        // the refusal it speaks says so — a present turn that merely does not
+        // block gets a different sentence (turn-tools.ts).
+        ctx: ctx({ presence: options.interactive ? "present" : "away" }),
         workspace: testWorkspace(),
         models: unusedModels(),
         interactive: options.interactive,


### PR DESCRIPTION
## What changes

`chat()` and `run()` now return the same thing — one `Turn`, resolving to one `TurnResult`:

```ts
const turn = user.chat("refund invoice #7", { threadId });
turn.threadId; turn.turnId;          // readable before it finishes
const result = await turn;           // ok | interrupted | stopped | error
```

Two things a caller could not do before:

- **A turn that hits an approval now ENDS and says so** (`status: "interrupted"`, carrying the parked calls) instead of holding the connection open for 90 seconds hoping someone taps. The away lane's old advice — "show these, then call `run()` again" — is retired along with `refs.approvals`.
- **The turn is the drainer of record.** It executes and persists whether or not anyone reads `events` and whether or not anyone awaits it. `events` is an independent single-reader tap, not the thing that makes the turn happen.

`respond()` is untouched and undeprecated — it stays the one-liner for an existing route.

## How

The chat lane and the away lane turned out to be one turn assembled twice, so this is mostly a deletion: **`away.ts` goes from 696 lines to 198**, keeping only `RunOptions`, the away ctx, the summary narrowing, and `awayRunner`'s `AgentRunReport` mapping (which the automations engine consumes and which is NOT retired). Everything else — the turn, the event queue, the typed-output tool, the failure watch, the thread/id/gate opening — is now one implementation in `turn.ts`.

`session.stream()` stays as it is: it is the blocking streaming-`Response` lane, and unifying it would have broken `respond()`.

## Notable

- **`turnId` is minted once.** One line in `packages/harnesses/src/runtime.ts:294` now honours a ctx that already carries a turn id instead of overwriting it. Without it, "readable before completion" would have meant two ids per turn and a `TurnResult.turnId` joined to nothing. Nobody sets it before `runtime.run` today, so it is behaviour-identical for every existing caller.
- **A park's refusal now depends on who is there.** Previously every early-ended turn told the model "nobody is here to give it" — true for a 3am automation, false in a live chat where the person is right there and answering asynchronously. 12 lines in `turn-tools.ts` pick on `ctx.presence`; the away wording is byte-identical to today's. In production `!interactive` and `presence === "away"` were equivalent until this PR, so no shipped path changes what it says.
- **Explicit-`undefined` `threadId` throws synchronously** (anti-fork), while a foreign thread still rejects as `not-found`.
- `turnId` is stable across park→resume, so PR3's `turns.resume(turnId)` addresses one turn.

## Retired-behaviour test edits

Listed in full because the law requires it: `tests/run.test.ts` (6 assertions moved off `AgentReport`/`refs.approvals` onto `TurnResult`), `tests/unattended.test.ts` (3, same retirement), and one line in `packages/harnesses/tests/stale-approvals.test.ts` where a test double's ctx said `present` while asserting the away wording. `away.test.ts`, `session.test.ts` and `respond.test.ts` pass unchanged.

## Gate

`build` · `typecheck` (42/42) · `lint` (dependency-guard OK; portability-gate all 9 legs green) · `packages/agents` 166 · `packages/harnesses` 568 · `packages/core` 800 — all EXIT=0.

Stacked on #1494.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies `chat()` and `run()` under one turn contract so both return a `Turn` that resolves to a single `TurnResult`. Turns that need approval no longer block or ask you to run again; they end as `interrupted` and carry the parked calls.

- The turn is the drainer of record. It executes and persists even if no one reads `events` or awaits it. `threadId` and `turnId` are readable immediately and match what gets written.
- Old: away runs held the connection ~90s and required a second `run()` after approvals via `refs.approvals`. New: the first turn ends `interrupted` and can be resumed; `refs.approvals` is gone.
- `respond()` and `session.stream()` stay the blocking streaming lane and are unchanged.

**Review notes**
- Most logic is new in `packages/agents/src/turn.ts`. `packages/agents/src/away.ts` deletes duplicate turn code and delegates to the shared turn.
- `packages/harnesses/src/runtime.ts` now honors a pre-set `turnId` in ctx (keeps one id per turn; enables “readable before completion”).
- `packages/harnesses/src/turn-tools.ts` adjusts refusal text based on `ctx.presence` (away vs present).
- Public API: `packages/agents/src/index.ts` stops exporting `AgentRun`/`AgentReport`; adds `Turn`, `RunEvent`, `ChatOptions`. `awayRunner` remains and maps to `AgentRunReport` for automations.

**Migration**
- Update callers of `agent.chat()` and `agent.run()` to handle a `Turn`:
  - Read `turn.threadId`/`turn.turnId` immediately; `await turn` for `{ status: "ok" | "interrupted" | "stopped" | "error" }`.
  - Replace `report.refs.approvals` with `result.status === "interrupted"` and read parked calls from the result. Do not call `run()` again to continue; plan to resume the same `turnId`.
- Do not pass `threadId: undefined`. Omit `threadId` or pass a valid id; explicit `undefined` now throws synchronously.
- Treat `events` as an optional, single-reader tap; do not rely on it to drive execution.

<sup>Written for commit f94b34f6a15779a56ba45c7b2b7f8de6bce5085d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

