### PR TITLE
fix(core): a tenant's connectors survive a Cloud-hosted store (#1497)

### DIFF
--- a/.changeset/tenant-connectors-engine-allowlist.md
+++ b/.changeset/tenant-connectors-engine-allowlist.md
@@ -1,0 +1,20 @@
+---
+"@vendoai/core": patch
+---
+
+`vendo_tenant_connectors` joins the engine allowlist. The collection tenant
+connectors write their registrations to (`packages/vendo/src/tenant-connectors.ts`)
+was never added to `ENGINE_COLLECTION_REGISTRY`, so a deployment on a
+Cloud-hosted store — the posture a Cloud host gets by leaving the store slot
+unset — had its first registration refused with `collection
+"vendo_tenant_connectors" is not an engine collection`, which left `register`,
+`list`, `test` and every tenant's own tools dead on a live deployment while the
+suite stayed green: every tenant-connector test composes a local store, and a
+local store has no allowlist in front of it. Exactly the miss the text channel's
+three collections shipped with. The name is added with the `file:line` comment
+each entry in that list carries, `ENGINE_ALLOWLIST_VERSION` moves 5 → 6 as that
+constant's contract requires, and a new seam test drives
+`createTenantConnectors` through `hostedStore`, `hostedStoreOps` and the fake
+console — which serves the same gate as the live door precisely so a fake cannot
+bless a collection production refuses. If your BYO store pins the allowlist
+version, bump it.

--- a/packages/core/src/engine-collections.ts
+++ b/packages/core/src/engine-collections.ts
@@ -3,10 +3,9 @@ import { VendoError } from "./errors.js";
 /** Named in every refusal so a caller can tell "this name was never an engine
     collection" from "this build's list is older than yours". Bump it whenever
     ENGINE_COLLECTIONS or ENGINE_COLLECTION_PATTERNS changes. */
-// 5, not 3 (ours) or 4 (main's): both sides added a collection, so the merged
-// list is a list neither version ever named. A refusal quoting v3 or v4 would be
-// describing a build that never existed.
-export const ENGINE_ALLOWLIST_VERSION = 5;
+// 6: v5's list plus `vendo_tenant_connectors`, which shipped missing from it. A
+// refusal still quoting v5 would be describing a build without that entry.
+export const ENGINE_ALLOWLIST_VERSION = 6;
 
 /** What a collection HOLDS. `knowledge` is the retrieval corpus — documents and
     the chunks an engine mints from them; everything else is `storage`.
@@ -19,7 +18,7 @@ export type CollectionKind = "storage" | "knowledge";
 export interface EngineCollectionSpec {
   kind: CollectionKind;
   /** The fields an `engine.list` watermark may bound, because THIS collection
-      keeps them indexed. Absent for the 37 collections with nothing to walk
+      keeps them indexed. Absent for the 38 collections with nothing to walk
       forward through: an unindexed bound is a full table scan wearing a filter's
       clothes, so it is refused rather than served slowly. */
   indexed?: readonly string[];
@@ -97,6 +96,7 @@ export const ENGINE_COLLECTION_REGISTRY = {
   vendo_channel_links: { kind: "storage" }, // LINK_COLLECTION, packages/vendo/src/channel-links.ts:22
   vendo_channel_events: { kind: "storage" }, // EVENT_COLLECTION, packages/vendo/src/channel-links.ts:25
   vendo_channel_asks: { kind: "storage" }, // ASK_COLLECTION, packages/vendo/src/channel-links.ts:33
+  vendo_tenant_connectors: { kind: "storage" }, // COLLECTION, packages/vendo/src/tenant-connectors.ts:78
 } as const satisfies Record<string, EngineCollectionSpec>;
 
 export type EngineCollection = keyof typeof ENGINE_COLLECTION_REGISTRY;

--- a/packages/core/tests/engine-collections.test.ts
+++ b/packages/core/tests/engine-collections.test.ts
@@ -29,10 +29,10 @@ function messageOf(run: () => unknown): string {
 }
 
 describe("engine allowlist", () => {
-  it("holds 38 distinct static collections", () => {
-    expect(ENGINE_ALLOWLIST_VERSION).toBe(5);
-    expect(ENGINE_COLLECTIONS).toHaveLength(38);
-    expect(new Set(ENGINE_COLLECTIONS).size).toBe(38);
+  it("holds 39 distinct static collections", () => {
+    expect(ENGINE_ALLOWLIST_VERSION).toBe(6);
+    expect(ENGINE_COLLECTIONS).toHaveLength(39);
+    expect(new Set(ENGINE_COLLECTIONS).size).toBe(39);
   });
 
   it("admits one name from each group and refuses host/app data", () => {

--- a/packages/vendo/tests/tenant-connectors-hosted-store.test.ts
+++ b/packages/vendo/tests/tenant-connectors-hosted-store.test.ts
@@ -1,0 +1,153 @@
+import { createActions } from "@vendoai/actions";
+import { tenantConnectorSecret, type Principal, type RunContext } from "@vendoai/core";
+import { hostedStore, hostedStoreOps } from "@vendoai/store";
+import { fakeConsole } from "@vendoai/store/test-util";
+import { describe, expect, it } from "vitest";
+import { createTenantConnectors } from "../src/tenant-connectors.js";
+
+/**
+ * The tenant registrations against the HOSTED door — the seam that actually
+ * ships.
+ *
+ * WHY THIS FILE EXISTS: `tenant-connectors.seam.test.ts` composes a local store,
+ * and a local store has no engine allowlist in front of it. The hosted door does
+ * (`engine-collections.ts`), and a Cloud host leaves the store slot unset, so
+ * hosted is the posture the feature runs in. `vendo_tenant_connectors` shipped
+ * missing from that list: the suite was green, and the first registration on a
+ * live deployment answered
+ *   403 collection "vendo_tenant_connectors" is not an engine collection
+ * which made register, list, test and every tenant's tools dead on arrival —
+ * the same miss the channel's three collections shipped with (#1276).
+ *
+ * So these cases drive `createTenantConnectors` through `hostedStore` and
+ * `hostedStoreOps`, whose fake console serves the same gate the live door serves
+ * — deliberately, per the note at `hosted-store.test-util.ts`: a fake that
+ * answers a collection the real door refuses lets a wrong call pass every test
+ * and fail in production. Drop `vendo_tenant_connectors` from
+ * `ENGINE_COLLECTION_REGISTRY` and this file goes red.
+ */
+
+const ADA: Principal = { kind: "user", subject: "user_ada" };
+
+const runAs = (...orgs: string[]): RunContext => ({
+  principal: ADA,
+  venue: "chat",
+  presence: "present",
+  sessionId: `s_${orgs.join("|")}`,
+  memberships: orgs.map((org) => ({ org })),
+});
+
+/** The spec a tenant pastes. Parsed locally by `openApiConnector`, so the only
+ *  thing on the wire here is the store — which is the point of the file. */
+const LEDGER_SPEC = {
+  openapi: "3.1.0",
+  info: { title: "Acme Ledger", version: "1.0.0" },
+  servers: [{ url: "https://ledger.acme.test" }],
+  paths: {
+    "/accounts/{id}": {
+      get: {
+        operationId: "getAccount",
+        parameters: [{ name: "id", in: "path", required: true, schema: { type: "string" } }],
+        responses: {},
+      },
+    },
+  },
+};
+
+const REGISTRATION = {
+  org: "acme",
+  name: "ledger",
+  kind: "openapi",
+  url: "https://ledger.acme.test",
+  spec: LEDGER_SPEC,
+} as const;
+
+/** The whole seam over ONE fake console: the adapter the rows go through, the
+ *  op surface the token is vaulted through, and the same registry binding
+ *  compose-actions gives a tenant. */
+const tenants = (mount = fakeConsole()) => {
+  const options = {
+    apiKey: "vnd_secret",
+    baseUrl: "https://cloud.test",
+    fetch: mount.handler as unknown as typeof fetch,
+  };
+  return createTenantConnectors({
+    store: hostedStore(options),
+    ops: hostedStoreOps(options),
+    bind: (connectors) => createActions({ connectors }),
+  });
+};
+
+/** What a run asserting these orgs is really offered by the overlay. */
+const overlayTools = async (
+  connectors: ReturnType<typeof tenants>,
+  ...orgs: string[]
+): Promise<string[]> => {
+  const registries = await connectors.overlay(runAs(...orgs));
+  const names: string[] = [];
+  for (const registry of registries) {
+    for (const descriptor of await registry.descriptors(runAs(...orgs))) names.push(descriptor.name);
+  }
+  return names;
+};
+
+describe("tenant connectors on a Cloud-hosted store", () => {
+  it("registers, lists, tests and removes through the engine door", async () => {
+    const connectors = tenants();
+
+    const registered = await connectors.api.register({ ...REGISTRATION, token: "tok_acme_live" });
+    expect(registered.status).toBe("ok");
+    if (registered.status !== "ok") return;
+    expect(registered.tools.map((tool) => tool.name)).toEqual(["openapi_ledger_getAccount"]);
+
+    // Read back through the door a later turn uses.
+    expect(await connectors.api.list("acme")).toMatchObject([
+      { org: "acme", name: "ledger", kind: "openapi", url: REGISTRATION.url },
+    ]);
+    expect(await connectors.api.test("acme", "ledger")).toMatchObject({ status: "ok" });
+
+    await connectors.api.remove("acme", "ledger");
+    expect(await connectors.api.list("acme")).toEqual([]);
+    expect(await connectors.api.test("acme", "ledger")).toMatchObject({
+      status: "error",
+      error: { code: "not-found" },
+    });
+  });
+
+  it("grows the registering org's overlay, and ONLY that org's", async () => {
+    const connectors = tenants();
+    await connectors.api.register(REGISTRATION);
+
+    expect(await overlayTools(connectors, "acme")).toContain("openapi_ledger_getAccount");
+    expect(await overlayTools(connectors, "globex")).toEqual([]);
+  });
+
+  it("writes the row to the engine collection and keeps the token off it", async () => {
+    const mount = fakeConsole();
+    const connectors = tenants(mount);
+
+    // The door ACCEPTED it — recording the requests alone would pass just as
+    // well on a refusal, since `register` answers a refusal instead of throwing.
+    expect(await connectors.api.register({ ...REGISTRATION, token: "tok_acme_live" }))
+      .toMatchObject({ status: "ok" });
+
+    // The rows really crossed the gated engine door under the name the registry
+    // has to carry — not some other collection the fake would have waved through.
+    const collections = mount.requests
+      .map((request) => (request.json as { collection?: string } | undefined)?.collection)
+      .filter((collection): collection is string => collection !== undefined);
+    expect(collections).toContain("vendo_tenant_connectors");
+    expect(new Set(collections)).toEqual(new Set(["vendo_tenant_connectors"]));
+
+    // …and the credential travelled the secrets door, never a row.
+    const rowBodies = mount.requests.filter(
+      (request) => (request.json as { collection?: string } | undefined)?.collection !== undefined,
+    );
+    expect(JSON.stringify(rowBodies)).not.toContain("tok_acme_live");
+    expect(await hostedStoreOps({
+      apiKey: "vnd_secret",
+      baseUrl: "https://cloud.test",
+      fetch: mount.handler as unknown as typeof fetch,
+    }).secrets.get(tenantConnectorSecret("acme", "ledger"))).toBe("tok_acme_live");
+  });
+});


### PR DESCRIPTION
Fixes #1497.

## The bug

`vendo_tenant_connectors` — the collection tenant registrations are written to
(`packages/vendo/src/tenant-connectors.ts:78`) — was missing from
`ENGINE_COLLECTION_REGISTRY`. Against a Cloud-hosted store (the posture a host
with `VENDO_API_KEY` and no store slot gets) the engine door refused the first
write:

```
collection "vendo_tenant_connectors" is not an engine collection (engine allowlist v5)
```

`register`, `list`, `test` and every tenant's own tools were dead on arrival on
a live deployment. The suite stayed green because every existing
tenant-connector test composes a local store, and a local store has no
allowlist in front of it — the same class of miss the text channel's three
collections shipped with (#1276).

## The fix

One registry entry, in the generic-table section, with the `file:line` comment
every neighbour carries:

```ts
vendo_tenant_connectors: { kind: "storage" }, // COLLECTION, packages/vendo/src/tenant-connectors.ts:78
```

`ENGINE_ALLOWLIST_VERSION` moves 5 → 6, as that constant's contract requires;
the historical "5, not 3 or 4" note is replaced with one that tells the truth
about the new number. The stale "37 collections with nothing to walk forward
through" count becomes 38 — a direct consequence of the entry.

## The test

`packages/vendo/tests/tenant-connectors-hosted-store.test.ts` drives
`createTenantConnectors` through the real `hostedStore` + `hostedStoreOps` +
`fakeConsole`, whose gate is the live door's gate. No stub on either side.
Three cases: the register/list/test/remove round trip, per-org overlay
isolation, and a check that the row crossed the engine door under the right
collection name with the token on the secrets door only.

**Red-green-red proof** — remove ONLY the registry line, rebuild `@vendoai/core`:

| run | result |
|---|---|
| baseline | 3 passed |
| registry line removed | 3 **failed**, `collection "vendo_tenant_connectors" is not an engine collection (engine allowlist v6). App data belongs to the appData family…` |
| line restored | 3 passed |

## A trap for whoever writes the next test against this API

**Inspecting recorded wire REQUESTS proves nothing here. Assert the answer's
`status` first.**

The first draft of case 3 passed while the bug was still present. It watched the
requests the client recorded — and `register` does not throw when the door
refuses it, it RETURNS a refusal. So a 403 and a success produce the identical
request log, and the assertion could not tell them apart. A test that can only
ever be green is not a test.

It is the mocked-counterparty failure in a new costume: not a stub on either
side this time, but an observation point that sits upstream of the disagreement,
so producer and consumer still cannot contradict each other. This is the fifth
or sixth time this shape has surfaced in this codebase. The fix is the same
every time — observe the ANSWER, not the attempt. Case 3 now asserts
`status: "ok"` before it looks at anything else, and all three cases go red
together when the registry line is removed.

## Other tests checked

- `packages/core/tests/engine-collections.test.ts` hardcoded the version and the
  count — updated to 6 / 39.
- `packages/store/tests/engine-allowlist.test.ts` needs nothing: it mirrors only
  the reserved and dedicated collections, and this one is generic.

## Changeset

`@vendoai/core: patch`, matching the identical prior fix (85fc7329b, the
channel's collections joining this same allowlist). No new API — a broken thing
made to work.

## Gate

`pnpm build && pnpm test:affected && pnpm typecheck && pnpm lint` on the touched
scope. Build, typecheck and lint all exit 0. `test:affected` pulled in 45 tasks
(core changed, so nearly everything): 44 successful — `@vendoai/core` 53 files,
`@vendoai/vendo` 253 files / 2618 tests, `@vendoai/store` 63 files, and the rest
green. `demo-bank`'s `away-drill.test.ts` went red under load (one test took 92s
against a ~5s budget while three agents shared the box); re-run alone it is
4 passed in 25s. Unrelated to this change either way — it exercises unattended
automation runs, not the allowlist.

**Note for the same session:** Vendo Cloud's mirror of this list needs the entry
and the version bump too, per the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocks tenant connector registration on Cloud-hosted stores by adding `vendo_tenant_connectors` to the engine allowlist. Previously, hosted writes failed with “collection 'vendo_tenant_connectors' is not an engine collection,” so `register`, `list`, `test`, and tenant tools did not work; now the collection is admitted and credentials remain in secrets.

- Bumps `ENGINE_ALLOWLIST_VERSION` 5 → 6 and updates counts to 39 in `packages/core/tests/engine-collections.test.ts`.
- Adds `packages/vendo/tests/tenant-connectors-hosted-store.test.ts` to exercise `hostedStore`/`hostedStoreOps`, assert the row lands in `vendo_tenant_connectors`, and the token is stored via secrets.
- Migration: update the Cloud allowlist mirror to include `vendo_tenant_connectors` at version 6; bump pinned allowlist versions in BYO stores. No API changes; `@vendoai/core` patch release.

<sup>Written for commit e6c9e4300922d189ef0110c4c00a125b2d258170. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


