### PR TITLE
docs: "building on a file" says there is nothing to wire, then walks the five steps

### DIFF
--- a/docs-site/customize/user-data.mdx
+++ b/docs-site/customize/user-data.mdx
@@ -116,108 +116,33 @@ it.
 
 ## Building on a file
 
-**There is nothing to wire here.** No API to call, no option to set, no flag to
-turn on. Once a file can get in, your users have this — it is the agent using
-the read tools it already has, and the only code involved is the code that puts
-the file there in the first place.
+**There is nothing to wire here.** Once your users can drop files (the upload
+door above), everything in this section happens on its own — no API to call, no
+configuration. This is what the agent does with a file, automatically.
 
-So the way to understand it is to watch it. This is a real run against Maple,
-the demo bank.
+The whole flow, as your user experiences it:
 
-A user drops `store_sales.csv` on the thread and asks about it:
-
-```text
-Here is my store sales export. Using ONLY this file: how many units did the
-Hakodate store sell, and what is the total units_sold across every store?
-
-    Read a file you shared
-
-Hakodate (S-103): 6,094 units sold
-Total units_sold across all stores:
-4,173 + 2,856 + 6,094 + 1,287 + 3,521 = 17,931 units
-```
-
-The upload saved the file on the way in; the agent read it to answer. Nothing
-about that turn was configured. Then they ask for an app:
-
-```text
-Make me a dashboard app of that store sales file — one row per store showing
-the city, units sold and revenue, with the totals.
-
-    Building your view…
-
-    ┌──────────────────────────────────────────────┐
-    │ Store sales                 Pin to dashboard │
-    │ TOTAL UNITS SOLD   17,931                    │
-    │ CITY          UNITS SOLD   REVENUE           │
-    │ Reykjavik          4,173   $318,492.00       │
-    │ Valparaiso         2,856   $201,377.00       │
-    │ Hakodate           6,094   $447,015.00       │
-    │ Trondheim          1,287   $93,664.00        │
-    │ Ouagadougou        3,521   $259,830.00       │
-    └──────────────────────────────────────────────┘
-
-Your store sales dashboard is on your screen — one row per store with city,
-units sold, and revenue, plus totals across all five stores.
-```
-
-Those five rows are now the app's **own saved items**. Saved items are the app's
-own storage, not a second window onto the drawer: an app keeps only the
-collections it declares, each one apart from every other app's, and the agent is
-what reads and writes them. The drawer is untouched by any of it — the agent can
-list and read a user's files, and has no tool that writes one.
-
-That copy is a **snapshot, not a live link**. The app does not read the user's
-files afterwards, and nothing re-reads them on its behalf. Which is what makes
-the next turn the interesting one. Months later, a new export — same name, six
-stores now instead of five:
-
-```text
-I just updated that same file — here is the new version. Read it again, tell me
-how many units Hakodate sold NOW, list the file names you have for me, and then
-refresh the dashboard you built.
-
-    See the files you shared · 1 file
-    Read a file you shared
-
-Hakodate now sold 7,776 units (Q4, up from 6,094 in Q3).
-The only file I have on record for you is store_sales.csv — 6 stores now, a
-new Montevideo store was added.
-
-    Make you a screen
-
-Dashboard refreshed — it now shows all 6 stores for Q4.
-```
-
-Two things changed, and both are storage. The drawer's `store_sales.csv` **is**
-the new file — same name, last write wins. And the dashboard's saved items are
-the new six rows, replacing the five it was built from. The agent reports both
-in the reply, which is how the user knows it happened.
+1. **They drop `sales-2026.csv`** into the chat and ask: *"make me a dashboard of this."*
+2. **The agent reads the file and builds an app.** The rows it needs are copied into the app's own saved items — the app's private storage, separate from the user's files. The dashboard renders from those saved rows.
+3. **The file and the app now live separately.** The copy is a snapshot, not a live link — the app doesn't read the user's files afterward, and nothing re-reads them on its behalf.
+4. **In December they drop the updated `sales-2026.csv`.** Same name, so it replaces the old copy — no duplicates. The dashboard still shows what it was built from —
+5. **— until they ask.** *"Refresh my dashboard."* The agent reads the new file, rewrites the app's saved items, and says what it did: file replaced, app updated.
 
 <Note>
-  **Refresh is the agent's job, never a background sync.** Send a newer
-  `sales-2026.csv` and the agent recognises it, says the file was replaced, and
-  updates what it built from the new contents — on that turn, because the person
-  asked. There is no watcher, no polling, and no automatic rebuild anywhere in
-  this design. A file sitting in the drawer changes nothing until someone talks
-  to the agent about it.
+  No watcher, no polling, no background sync — a file sitting in the drawer
+  changes nothing until the user talks to the agent. That's deliberate:
+  everything the agent does is visible in the conversation.
 </Note>
+
+What *is* yours to wire is already above on this page: the upload door
+(`POST /files`), `client.files.upload` in your UI, and `putUserFile` from your
+backend. The agent's two read tools ship with every deployment.
 
 <Warning>
   In this release a PDF or an image **lands in the drawer and can be read about,
   but does not reach an app**. Only tabular data is copied into an app. Putting a
   document into an app's own file storage is a follow-up.
 </Warning>
-
-Everything in that run is the agent's. The parts that are **yours** are the ones
-above it, and they are the whole integration:
-
-| To do this | Use |
-| --- | --- |
-| Let a browser you did not build push a file | [`POST /files`](#where-files-go) |
-| Upload from your own UI | [`client.files.upload`](#from-the-browser) |
-| Put a file at a user from your server | [`putUserFile`](#from-your-own-code) |
-| Let the agent find and read them | [nothing — the two tools ship](#what-the-agent-does-with-it) |
 
 ## Size
 


### PR DESCRIPTION
Docs-only, one file: `docs-site/customize/user-data.mdx`. Follow-up to #1490 and #1492.

This is the author's **approved section text, applied verbatim**. The section now opens with the thing that explains why it used to read as empty — there is no dev surface in this flow at all — and then walks the five steps a user experiences: drop `sales-2026.csv`, the agent builds an app over a copy of the rows, the file and the app live separately, the December re-drop replaces the file by name, and the refresh happens when the user asks for it.

Step 5 says the agent reads the new file, rewrites the app's saved items, and says what it did. Nothing on the page claims a background rebuild, and nothing claims a card repaints in the conversation.

Both callouts are Mintlify components, matching the page: the no-background-sync `<Note>`, and the existing PDF `<Warning>` kept at the end.

Verified against source before applying — snapshot-not-live-link, same-name-replaces, no watcher, and the three host surfaces (`POST /files`, `client.files.upload`, `putUserFile`) all match shipped behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the “Building on a file” section to state there’s nothing to wire and to walk the five-step user flow. This sets correct expectations: apps snapshot file rows into saved items, same-name uploads replace the file, and refresh happens only when the user asks.

- Single file: `docs-site/customize/user-data.mdx`.
- Keeps Mintlify callouts: a note on no background sync and the existing PDF/image warning.
- Names the three upload surfaces for wiring: `POST /files`, `client.files.upload`, and `putUserFile`; the agent’s read tools are built-in.
- Explicitly documents snapshot-not-live-link behavior, same-name replacement, and no watcher/polling; agent refresh is user-initiated and reported in the conversation.
- Docs-only; no API or runtime changes and no migration required.

<sup>Written for commit fe411505af0e469140478fe0b34014915039b01f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1501?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

