### PR TITLE
fix(apps): ship the QuickJS engine WASM as a file, so generated screens render in a production build

### DIFF
--- a/.changeset/engine-wasm-as-a-file.md
+++ b/.changeset/engine-wasm-as-a-file.md
@@ -1,0 +1,16 @@
+---
+"@vendoai/apps": patch
+---
+
+Generated screens render in a production build again. The screen engine and
+`$expr` rode the SINGLE-FILE QuickJS build, which carries its WebAssembly as a
+raw binary string inside the JavaScript — and that string cannot survive a
+modern minifier: the WASM bytes contain a backtick, SWC re-quotes the string
+with backticks, and the chunk that comes out opens a template literal whose
+`\0` bytes are illegal octal escapes. Turbopack's server, SSR and browser
+chunks were all unparseable, so the VM never started and the checks floor
+correctly refused every screen. The bytes now travel as a FILE: the wasmfile
+build's ten-kilobyte loader, handed the module through `wasmBinary` — read off
+disk on Node, fetched as a bundler-emitted asset everywhere else. `@vendoai/apps`
+ships `quickjs.wasm` beside its `dist`, and the QuickJS it installs drops from
+3.1MB to 1.2MB.

--- a/.changeset/engine-wasm-as-a-file.md
+++ b/.changeset/engine-wasm-as-a-file.md
@@ -14,3 +14,11 @@ build's ten-kilobyte loader, handed the module through `wasmBinary` — read off
 disk on Node, fetched as a bundler-emitted asset everywhere else. `@vendoai/apps`
 ships `quickjs.wasm` beside its `dist`, and the QuickJS it installs drops from
 3.1MB to 1.2MB.
+
+And the variant a host hands `warmScreenEngine` now WINS. It used to be
+last-warm-wins, which meant `@vendoai/ui`'s own no-variant re-warm on the first
+screen mount silently took the engine back — so the documented hatch existed and
+never held, and a venue with no network and no asset URL (an offline
+single-bundle page, workerd) could not run screens at all. An explicitly passed
+variant is now kept: every later default warm is a no-op, and a default already
+in flight lands nowhere.

--- a/.gitignore
+++ b/.gitignore
@@ -107,6 +107,10 @@ design-canvas/
 packages/apps/box/claude-turn.mjs
 packages/apps/box/turn-routes.mjs
 
+# The screen engine's WebAssembly, copied out of the wasmfile dependency by
+# @vendoai/apps' build (and shipped by its "files") — generated, never authored.
+packages/apps/quickjs.wasm
+
 # Agent working notes and factory process exhaust — useful locally, not shipped.
 # Lane contracts, raw proof logs, and eval run dumps stay on their branches.
 # Skills are the exception: they are shared project tooling, so they are tracked.

--- a/genbench/package.json
+++ b/genbench/package.json
@@ -14,6 +14,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
+    "@jitl/quickjs-singlefile-browser-release-sync": "^0.32.0",
     "@vendoai/apps": "workspace:*",
     "@vendoai/core": "workspace:*",
     "@vendoai/guard": "workspace:*",

--- a/genbench/src/mount.tsx
+++ b/genbench/src/mount.tsx
@@ -28,6 +28,23 @@ import { PayloadView } from "@vendoai/ui/tree";
 import { useEffect, type JSX } from "react";
 import { createRoot } from "react-dom/client";
 
+/**
+ * The engine build THIS page runs on, pinned rather than defaulted.
+ *
+ * The harness contract's first rule is SELF-CONTAINED — the page is opened with
+ * no network at all — and `render.ts` bundles it as ONE esbuild IIFE, where
+ * `import.meta` is empty. The stock build fetches its WebAssembly as an emitted
+ * asset, and neither half of that exists here. The SINGLE-FILE build carries the
+ * bytes inside the JavaScript, which is the one thing this page can hold; the
+ * string it embeds is unparseable after SWC re-quotes it (#1496) and perfectly
+ * fine after esbuild, and esbuild is the only bundler this page ever sees.
+ *
+ * Pinned at module scope so it is ONE stable key: `warmScreenEngine` memoizes on
+ * the variant, and an explicitly passed one wins over every later default warm —
+ * including `PayloadView`'s own, which asks for no variant.
+ */
+const PAGE_ENGINE = import("@jitl/quickjs-singlefile-browser-release-sync");
+
 declare global {
   interface Window {
     /** The one seam every contender's page answers through, injected by
@@ -93,7 +110,7 @@ async function opened(): Promise<UIPayload> {
   // live screen, and `PayloadView` boots its own VM off this same warmed module
   // (`ui/src/tree/screen-engine.ts`) — so awaiting it here is what lets the
   // settle signal below be two frames rather than a guess at how long a VM takes.
-  await warmScreenEngine();
+  await warmScreenEngine(PAGE_ENGINE);
   const plan = interactive.queryPlan ?? [];
   if (plan.length === 0) return served;
   const answer = (asks: readonly ScreenQuery[]): Record<string, unknown> => Object.fromEntries(asks.map((query) => {

--- a/packages/apps/package.json
+++ b/packages/apps/package.json
@@ -50,17 +50,18 @@
   },
   "files": [
     "dist",
+    "quickjs.wasm",
     "README.md",
     "box"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build": "tsc -p tsconfig.json && node -e \"require('node:fs').copyFileSync(require.resolve('@jitl/quickjs-wasmfile-release-sync/wasm'), 'quickjs.wasm')\"",
     "test": "vitest run",
     "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json --noEmit",
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@jitl/quickjs-singlefile-browser-release-sync": "^0.32.0",
+    "@jitl/quickjs-wasmfile-release-sync": "^0.32.0",
     "@vendoai/core": "workspace:*",
     "acorn": "^8.15.0",
     "croner": "^9.0.0",
@@ -75,7 +76,6 @@
   },
   "peerDependencies": {
     "@anthropic-ai/claude-agent-sdk": ">=0.3.0 <1",
-    "@jitl/quickjs-wasmfile-release-sync": "^0.32.0",
     "ai": ">=6.0.0 <7",
     "e2b": "^2.32.0",
     "sucrase": "^3.35.0",
@@ -85,9 +85,6 @@
   },
   "peerDependenciesMeta": {
     "@anthropic-ai/claude-agent-sdk": {
-      "optional": true
-    },
-    "@jitl/quickjs-wasmfile-release-sync": {
       "optional": true
     },
     "ai": {
@@ -108,7 +105,7 @@
   },
   "devDependencies": {
     "@ai-sdk/anthropic": "3.0.12",
-    "@jitl/quickjs-wasmfile-release-sync": "^0.32.0",
+    "@jitl/quickjs-singlefile-browser-release-sync": "^0.32.0",
     "@types/node": "^22.0.0",
     "ai": "6.0.28",
     "e2b": "^2.32.0",
@@ -117,5 +114,11 @@
     "typescript": "^5.6.0",
     "typescript-6": "npm:typescript@6.0.3",
     "vitest": "^3.2.6"
+  },
+  "imports": {
+    "#engine/wasm": {
+      "node": "./dist/contract/genui/wasm-node.js",
+      "default": "./dist/contract/genui/wasm-browser.js"
+    }
   }
 }

--- a/packages/apps/src/contract/genui/component/boot.ts
+++ b/packages/apps/src/contract/genui/component/boot.ts
@@ -71,12 +71,18 @@ export type ScreenEngineVariant = Parameters<typeof newQuickJSWASMModuleFromVari
 const engines = new Map<ScreenEngineVariant, Promise<QuickJSWASMModule>>();
 let stock: ScreenEngineVariant | null = null;
 
-/** The module every screen boots on — ONE shared slot. Every completed warm
- *  reassigns it, including a warm that only hit the memo above, and
- *  {@link bootScreen} reads it with no variant selector. So warming two variants
- *  is NOT a supported per-screen choice: the warm that resolved LAST is the
- *  module every subsequent boot gets. The per-variant map dedupes LOADING only —
- *  it does not decide which module runs a screen. */
+/** The variant a host handed over BY NAME, once it has. AN EXPLICITLY PASSED
+ *  VARIANT WINS — the same law every adapter slot in this codebase keeps, and
+ *  the only thing that makes the hatch below real: `@vendoai/ui` re-warms with
+ *  no variant of its own when a screen mounts (`ui/src/tree/screen-engine.ts`),
+ *  so a default that could overwrite a pinned one would discard the host's
+ *  choice on the first paint. */
+let pinned: ScreenEngineVariant | null = null;
+
+/** The module every screen boots on — ONE shared slot, which {@link bootScreen}
+ *  reads with no variant selector. So warming two variants is NOT a per-screen
+ *  choice: a pinned variant is the module every boot gets, and absent one it is
+ *  whichever warm resolved last. The per-variant map dedupes LOADING only. */
 let wasm: QuickJSWASMModule | null = null;
 
 /**
@@ -87,20 +93,30 @@ let wasm: QuickJSWASMModule | null = null;
  * bytes — ../variant.ts holds it and says why the bytes may not ride inside the
  * JavaScript.
  *
- * A venue that cannot run that build passes its own variant, and the memo is
- * keyed on the variant itself, so warming one twice loads it once. `stock` is
- * held for the same reason — the default needs one stable key, not a fresh
- * variant per call. Warming TWO variants in one process is another matter: see
- * the `wasm` slot above for what a host gets then.
+ * A venue that cannot run that build passes its own, and it STICKS: every later
+ * default warm is a no-op, and a default already in flight lands nowhere. That
+ * is what a venue with no network and no asset URL needs — genbench's offline
+ * single-bundle page, workerd's deploy-time module — because the host warms
+ * once and every library-side warm after it must honour that, not race it.
+ *
+ * The memo is keyed on the variant itself, so warming one twice loads it once.
+ * `stock` is held for the same reason: the default needs one stable key, not a
+ * fresh variant per call.
  */
 export async function warmScreenEngine(variant?: ScreenEngineVariant): Promise<void> {
+  if (variant === undefined && pinned !== null) return;
   const key = variant ?? (stock ??= stockVariant());
+  if (variant !== undefined) pinned = key;
   let booting = engines.get(key);
   if (booting === undefined) {
     booting = newQuickJSWASMModuleFromVariant(key);
     engines.set(key, booting);
   }
-  wasm = await booting;
+  const module = await booting;
+  // A default warm that was already in flight when the host pinned its own must
+  // not land on top of it — the early return above only catches the ones that
+  // start after.
+  if (pinned === null || pinned === key) wasm = module;
 }
 
 /** What a VM threw, read out before its handle goes away. */

--- a/packages/apps/src/contract/genui/component/boot.ts
+++ b/packages/apps/src/contract/genui/component/boot.ts
@@ -36,6 +36,7 @@ import {
   type QuickJSHandle,
   type QuickJSWASMModule,
 } from "quickjs-emscripten-core";
+import { stockVariant } from "../variant.js";
 import { wallClockBudget, type ScreenTurn, type TurnLimit } from "./budget.js";
 import { SCREEN_RUNTIME, installSource, sealSource } from "./vm-program.js";
 import {
@@ -82,19 +83,18 @@ let wasm: QuickJSWASMModule | null = null;
  * Load the WebAssembly. Running a screen is synchronous — this one-time load is
  * not, so a caller awaits it once before the first {@link bootScreen}.
  *
- * The default variant is the SINGLE-FILE BROWSER build, for `$expr`'s reason:
- * the WebAssembly rides inside the JavaScript, so no host bundler has to be
- * taught to emit a `.wasm`, and it reaches for no Node builtin. The import stays
- * a literal specifier because `@vendoai/ui` depends on a bundler inlining it.
+ * The default variant is the WASMFILE build with the WebAssembly handed in as
+ * bytes — ../variant.ts holds it and says why the bytes may not ride inside the
+ * JavaScript.
  *
  * A venue that cannot run that build passes its own variant, and the memo is
  * keyed on the variant itself, so warming one twice loads it once. `stock` is
  * held for the same reason — the default needs one stable key, not a fresh
- * import promise per call. Warming TWO variants in one process is another
- * matter: see the `wasm` slot above for what a host gets then.
+ * variant per call. Warming TWO variants in one process is another matter: see
+ * the `wasm` slot above for what a host gets then.
  */
 export async function warmScreenEngine(variant?: ScreenEngineVariant): Promise<void> {
-  const key = variant ?? (stock ??= import("@jitl/quickjs-singlefile-browser-release-sync"));
+  const key = variant ?? (stock ??= stockVariant());
   let booting = engines.get(key);
   if (booting === undefined) {
     booting = newQuickJSWASMModuleFromVariant(key);

--- a/packages/apps/src/contract/genui/expr.ts
+++ b/packages/apps/src/contract/genui/expr.ts
@@ -50,6 +50,7 @@ import type { Expression, Node } from "acorn";
 import type { QuickJSContext, QuickJSRuntime, QuickJSWASMModule } from "quickjs-emscripten-core";
 import { isFail, newQuickJSWASMModuleFromVariant } from "quickjs-emscripten-core";
 import type { Json } from "@vendoai/core";
+import { stockVariant } from "./variant.js";
 
 /** A computed binding value; the string is the expression source. */
 export interface ExprBinding {
@@ -252,15 +253,11 @@ let held: { data: object; context: QuickJSContext } | null = null;
  * `undefined`, which is exactly how it reads while its query data is still in
  * flight, and the boot races a network round-trip it reliably wins.
  *
- * The variant is the SINGLE-FILE BROWSER build: the WebAssembly rides inside
- * the JavaScript, so no host bundler has to be taught to emit a `.wasm`
- * asset, and it reaches for no Node builtin — which is what makes it the ONE
- * variant for both venues (the `-mjs-` build imports `node:module` and dies in
- * a browser bundle; this one runs in Node too).
+ * The variant is the engine's own — ./variant.ts, one build and one set of
+ * WebAssembly bytes for the screen engine and for this.
  */
 export async function warmExprRuntime(): Promise<void> {
-  booting ??= import("@jitl/quickjs-singlefile-browser-release-sync")
-    .then((module) => newQuickJSWASMModuleFromVariant(module.default));
+  booting ??= newQuickJSWASMModuleFromVariant(stockVariant());
   const quickjs = await booting;
   runtime ??= quickjs.newRuntime();
   runtime.setMemoryLimit(EXPR_MEMORY_LIMIT_BYTES);

--- a/packages/apps/src/contract/genui/variant.ts
+++ b/packages/apps/src/contract/genui/variant.ts
@@ -1,0 +1,43 @@
+/**
+ * The QuickJS build every venue boots on, and the WebAssembly it boots from.
+ *
+ * The engine used to ride the SINGLE-FILE build, where the WebAssembly is a raw
+ * binary string inside the JavaScript. That build cannot survive a modern
+ * minifier: the WASM bytes contain a backtick, SWC re-quotes the string with
+ * backticks, and the chunk it emits opens a template literal whose `\0` bytes
+ * are illegal octal escapes — `SyntaxError: Octal escape sequences are not
+ * allowed in template strings`, in Turbopack's server, SSR and browser chunks
+ * alike, which is every screen refused in a production build (#1496). esbuild
+ * quotes it safely, which is why the Vite harness and the workerd gate never
+ * caught it.
+ *
+ * So the bytes travel as a FILE. The wasmfile build's loader is ten kilobytes
+ * of ordinary JavaScript that any bundler prints correctly, and `wasmBinary`
+ * hands it the module's bytes directly (`#engine/wasm`: read off disk on Node,
+ * fetched as a bundler-emitted asset everywhere else) — so nothing has to
+ * locate a `.wasm` relative to a chunk that moved.
+ *
+ * A venue that must supply its own module still can, and workerd must: see
+ * ../../server/edge/paint.ts, which wraps the same build around a
+ * `WebAssembly.Module` its deployment imported.
+ */
+import { newVariant } from "quickjs-emscripten-core";
+import loadWasm from "#engine/wasm";
+import type { ScreenEngineVariant } from "./component/boot.js";
+
+/** What `newVariant` takes and returns here, picked out of the engine's own
+ *  parameter type — ../../server/edge/paint.ts names it the same way, and for
+ *  the same reason: no dependency on `@jitl/quickjs-ffi-types` to spell it. */
+type SyncVariant = Extract<Awaited<ScreenEngineVariant>, { type: "sync" }>;
+
+/** The stock variant, built once per call — `warmScreenEngine` memoizes on the
+ *  promise it gets back, so callers hold one, not one each.
+ *
+ *  The cast is the NodeNext interop wart paint.ts documents: this dependency's
+ *  `.d.ts` is modelled as CommonJS, so the namespace types as
+ *  `{ default: <the namespace> }` where its ESM entry default-exports the
+ *  variant. */
+export const stockVariant = async (): Promise<SyncVariant> => {
+  const base = await import("@jitl/quickjs-wasmfile-release-sync");
+  return newVariant(base.default as unknown as SyncVariant, { wasmBinary: loadWasm });
+};

--- a/packages/apps/src/contract/genui/wasm-browser.ts
+++ b/packages/apps/src/contract/genui/wasm-browser.ts
@@ -1,0 +1,10 @@
+/** The engine's WebAssembly, fetched as an asset — the default arm of
+ *  `#engine/wasm` (../../../package.json). `new URL(…, import.meta.url)` is the
+ *  ONE asset form Turbopack, webpack, Vite and esbuild all emit and rewrite, so
+ *  the bundler that builds the host's page also ships the `.wasm` beside it.
+ *  See ./variant.ts for why the bytes travel as a file at all. */
+export default async function loadWasm(): Promise<ArrayBuffer> {
+  const response = await fetch(new URL("../../../quickjs.wasm", import.meta.url));
+  if (!response.ok) throw new Error(`the screen engine's WebAssembly answered ${response.status} — @vendoai/apps ships quickjs.wasm beside its dist, and this host's bundler did not emit it`);
+  return response.arrayBuffer();
+}

--- a/packages/apps/src/contract/genui/wasm-node.ts
+++ b/packages/apps/src/contract/genui/wasm-node.ts
@@ -2,9 +2,16 @@
  *  (../../../package.json). See ./variant.ts for why the bytes travel as a file
  *  and not inside the JavaScript. */
 import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 export default async function loadWasm(): Promise<ArrayBuffer> {
-  const bytes = await readFile(new URL("../../../quickjs.wasm", import.meta.url));
+  // NOT `new URL("…", import.meta.url)`: Vite REWRITES that exact expression
+  // into an emitted-asset URL, so under vitest (and any Vite host) this arm
+  // would be handed an `http:` URL that `readFile` refuses. Resolving from the
+  // module's own directory is the same path — `../../../` lands on the package
+  // root from `src/` and from `dist/` alike — and nothing rewrites it.
+  const bytes = await readFile(join(dirname(fileURLToPath(import.meta.url)), "../../../quickjs.wasm"));
   // A Node read lands in a POOLED buffer, so the ArrayBuffer behind it holds
   // other reads too — the slice is what makes these bytes the whole module.
   return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;

--- a/packages/apps/src/contract/genui/wasm-node.ts
+++ b/packages/apps/src/contract/genui/wasm-node.ts
@@ -1,0 +1,11 @@
+/** The engine's WebAssembly, read off disk — the `node` arm of `#engine/wasm`
+ *  (../../../package.json). See ./variant.ts for why the bytes travel as a file
+ *  and not inside the JavaScript. */
+import { readFile } from "node:fs/promises";
+
+export default async function loadWasm(): Promise<ArrayBuffer> {
+  const bytes = await readFile(new URL("../../../quickjs.wasm", import.meta.url));
+  // A Node read lands in a POOLED buffer, so the ArrayBuffer behind it holds
+  // other reads too — the slice is what makes these bytes the whole module.
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+}

--- a/packages/apps/tests/contract/genui/component/warm-pin.test.ts
+++ b/packages/apps/tests/contract/genui/component/warm-pin.test.ts
@@ -1,0 +1,59 @@
+/**
+ * An explicitly passed variant WINS.
+ *
+ * `@vendoai/ui` re-warms the engine with no variant of its own the moment a
+ * screen mounts (`ui/src/tree/screen-engine.ts`), so a default warm that could
+ * take the slot back would discard the host's choice on the first paint — the
+ * documented hatch would exist and never hold. That is not hypothetical: it is
+ * why genbench's offline single-bundle page could not run screens at all
+ * (#1496), and it is the same law every adapter slot in this codebase keeps.
+ *
+ * The default is made UNLOADABLE here, which is exactly the venue that needs
+ * this: a page with no network and no asset URL cannot produce the stock
+ * variant's bytes at all. So a screen painting at the end can only mean the
+ * pinned variant is the one that ran — with the guard reverted, the default warm
+ * runs, throws, and this file goes red.
+ *
+ * The two tests are ORDERED, because the pin is module state: the unpinned
+ * behaviour can only be asked before anything has pinned.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { bootScreen, warmScreenEngine } from "../../../../src/contract/genui/component/index.js";
+import { CATALOG, compileScreen, textsOf } from "./screen-fixture.test-util.js";
+
+const NO_BYTES = "this venue cannot produce the stock variant's WebAssembly";
+
+vi.mock("#engine/wasm", () => ({
+  default: () => { throw new Error(NO_BYTES); },
+}));
+
+const PAINTS = `
+import { Text } from "@vendo/screen";
+export default function S() { return <Text text="pinned" />; }`;
+
+describe("the variant a host pinned", () => {
+  it("is not what an unpinned warm reaches for — that one takes the default, and its failure surfaces", async () => {
+    await expect(warmScreenEngine()).rejects.toThrow(NO_BYTES);
+  });
+
+  it("survives the library's own default re-warm, and is what boots the screen", async () => {
+    const base = (await import("@jitl/quickjs-singlefile-browser-release-sync")).default;
+    let builds = 0;
+    const pinned = { ...base, importFFI: () => { builds += 1; return base.importFFI(); } };
+
+    await warmScreenEngine(pinned);
+    expect(builds).toBe(1);
+
+    // What `@vendoai/ui` calls on every screen mount. It must not reach for the
+    // default at all — reaching for it here is the throw above, not a silent swap.
+    await expect(warmScreenEngine()).resolves.toBeUndefined();
+    expect(builds).toBe(1);
+
+    const screen = bootScreen({ compiledSource: compileScreen(PAINTS), queries: {}, catalog: CATALOG });
+    try {
+      expect(textsOf(screen.tree())).toEqual(["pinned"]);
+    } finally {
+      screen.dispose();
+    }
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -772,6 +772,9 @@ importers:
 
   genbench:
     dependencies:
+      '@jitl/quickjs-singlefile-browser-release-sync':
+        specifier: ^0.32.0
+        version: 0.32.0
       '@vendoai/apps':
         specifier: workspace:*
         version: link:../packages/apps

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -940,7 +940,7 @@ importers:
       '@anthropic-ai/claude-agent-sdk':
         specifier: '>=0.3.0 <1'
         version: 0.3.214(@anthropic-ai/sdk@0.112.3(zod@3.25.76))(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(zod@3.25.76)
-      '@jitl/quickjs-singlefile-browser-release-sync':
+      '@jitl/quickjs-wasmfile-release-sync':
         specifier: ^0.32.0
         version: 0.32.0
       '@vendoai/core':
@@ -980,7 +980,7 @@ importers:
       '@ai-sdk/anthropic':
         specifier: 3.0.12
         version: 3.0.12(zod@3.25.76)
-      '@jitl/quickjs-wasmfile-release-sync':
+      '@jitl/quickjs-singlefile-browser-release-sync':
         specifier: ^0.32.0
         version: 0.32.0
       '@types/node':
@@ -13736,14 +13736,6 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.7(vite@6.4.3(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))':
-    dependencies:
-      '@vitest/spy': 3.2.7
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 6.4.3(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
-
   '@vitest/mocker@3.2.7(vite@6.4.3(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 3.2.7
@@ -19215,7 +19207,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.7
-      '@vitest/mocker': 3.2.7(vite@6.4.3(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+      '@vitest/mocker': 3.2.7(vite@6.4.3(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
       '@vitest/pretty-format': 3.2.7
       '@vitest/runner': 3.2.7
       '@vitest/snapshot': 3.2.7

--- a/turbo.json
+++ b/turbo.json
@@ -2,6 +2,11 @@
   "$schema": "https://turbo.build/schema.json",
   "tasks": {
     "build": { "dependsOn": ["^build"], "outputs": ["dist/**", ".next/**", "!.next/cache/**"] },
+    // The screen engine's WebAssembly is copied out of the wasmfile dependency at
+    // build time and sits at the package root, so it is the same relative path from
+    // src/ (vitest) and from dist/ (a published install). It has to be a declared
+    // OUTPUT or a cache hit restores dist/ and leaves the engine with no bytes.
+    "@vendoai/apps#build": { "dependsOn": ["^build"], "outputs": ["dist/**", "quickjs.wasm"] },
     "test": { "dependsOn": ["^build", "build"], "env": ["CI", "POSTGRES_URL", "VITEST_MIN_FORKS", "VITEST_MAX_FORKS", "VITEST_MIN_THREADS", "VITEST_MAX_THREADS"] },
     "test:ui": { "dependsOn": ["^build", "build"], "env": ["CI", "VITEST_MIN_FORKS", "VITEST_MAX_FORKS", "VITEST_MIN_THREADS", "VITEST_MAX_THREADS"] },
     "test:coverage": { "dependsOn": ["^build", "build"], "outputs": ["coverage/**"], "env": ["CI", "POSTGRES_URL", "VITEST_MIN_FORKS", "VITEST_MAX_FORKS", "VITEST_MIN_THREADS", "VITEST_MAX_THREADS"] },


### PR DESCRIPTION
Fixes #1496.

## What was broken

No AI-generated screen rendered in **any** Next production build.

The screen engine and `$expr` booted the **single-file** QuickJS build, which
carries its WebAssembly as a raw binary string inside the JavaScript. That
string cannot survive a modern minifier: the WASM bytes contain a backtick, SWC
(used by **both** Turbopack and Next's webpack) re-quotes the string with
backticks, and the chunk that comes out opens a template literal whose `\0`
bytes are illegal octal escapes.

```
SyntaxError: Octal escape sequences are not allowed in template strings.
```

The emitted chunk is not parseable JavaScript, so the VM never started and the
checks floor correctly refused every screen. It broke all three layers —
`.next/server/chunks/`, `.next/server/chunks/ssr/` and `.next/static/chunks/` —
so the in-browser engine was dead too. esbuild quotes it safely, which is
exactly why `packages/ui`'s vite harness and the workerd portability gate were
green and nobody caught it.

**This is PRE-EXISTING on `main`, and it is not the remix work.** It reproduces
at `3d85eb548` with an ordinary generated screen ("Where did my money go?") and
no remix involved. Establishing that cost a full build cycle — please don't
re-derive it.

## The fix

Stop shipping the WASM as a JS string. `@vendoai/apps` now rides the **wasmfile**
build (≈9KB of ordinary loader JS plus a real `.wasm`), ships its own
`quickjs.wasm` beside `dist`, and hands the bytes to `newVariant` as
`wasmBinary` through a `#engine/wasm` condition map:

- **Node** — read off disk (`wasm-node.ts`), resolved from the module's own
  directory. Deliberately *not* `new URL(…, import.meta.url)`: that is the exact
  expression Vite rewrites into an emitted-asset URL, so under vitest this arm
  was handed an `http:` URL and `readFile` refused it — six `@vendoai/ui` suites
  died with `TypeError: The URL must be of scheme file`. Same shape as the bug
  being fixed: a bundler transforming something that looked inert.
- **everywhere else** — `fetch(new URL("../../../quickjs.wasm", import.meta.url))`
  (`wasm-browser.ts`), the one asset form Turbopack, webpack, Vite and esbuild
  all emit and rewrite — and here the rewrite is exactly what is wanted.

That is the same mechanism `server/edge/paint.ts` already uses to hand workerd a
`WebAssembly.Module`, so there is one variant module for every venue
(`contract/genui/variant.ts`).

## Proof

| # | Proof | Result |
|---|---|---|
| 1 | `node --check` on every emitted chunk in all three locations | **PARSE_OK** — 267/267 chunks (114 server + 103 ssr + 50 static) |
| 2 | Fresh `next build` + `next start`, scripted Playwright turn on an ordinary generated screen ("Where did my money go?") | **PASS** — screen rendered, bar `data-state="ready"`, 160 DOM nodes, 3 SVG marks, live `$9,180.81` breakdown, zero contained notices, and the browser fetched `/_next/static/media/quickjs.<hash>.wasm` → 200 |
| 3 | Revert the two call sites → rebuild → the failure returns; restore → green | **reverted: PARSE_FAIL** 4 chunks, one in each of the three locations, `SyntaxError: Octal escape sequences are not allowed in template strings`; **restored: PARSE_OK** |
| 4 | Sandbox isolation unchanged, asserted against the built `dist/` | `fetch`, `XMLHttpRequest`, `WebSocket`, `process`, `window`, `localStorage`, the tool bridge and `preact` are all `undefined` inside the VM; `setTimeout`, `setInterval` and `Math.random` still refuse when called; `document` is still Preact's in-VM recorder with no host DOM behind it; the 32MB cap still raises `out of memory` and the engine survives it |
| 5 | Shipped bytes | **−1,953,721 B / −63%** — the QuickJS `@vendoai/apps` installs drops from 3,106,403 B (singlefile-browser) to 1,152,682 B (wasmfile 649,548 B + the 503,134 B `quickjs.wasm` it ships) |

`packages/ui`'s vite harness (`test:ui`, 12 specs, production-built) and the
workerd portability gate stay green — now for the right reason.

## Behaviour change — an explicitly passed engine variant now WINS

**Read this bit.** `warmScreenEngine(variant)` has always been the documented
hatch for a venue that cannot run the default build. It did not actually hold.

| | before | after |
|---|---|---|
| `warmScreenEngine(v)` then `warmScreenEngine()` | the default takes the engine back — **last warm wins** | the default is a **no-op**; `v` still runs every screen |
| a default warm still in flight when a host pins | it lands on top of the pin | it lands nowhere |
| no host ever pins | unchanged — last warm wins | unchanged |

Why it mattered: `@vendoai/ui` re-warms with **no** variant the moment a screen
mounts (`ui/src/tree/screen-engine.ts`), so every host that pinned one had its
choice discarded on the first paint. That is the same law every adapter slot in
this repo already keeps — *an explicitly passed adapter always wins, defaults
fill only the slots a host left unset* — restored to the one place that had
inverted it. The doc comments on `boot.ts`'s `wasm` slot and `warmScreenEngine`
stated the old semantics and were rewritten with the code.

This is what unblocks **`genbench`**, whose page is opened with **no network at
all** and bundled as one esbuild IIFE (`genbench/src/render.ts:69`) — `import.meta`
is empty and there is no asset to fetch, so the bytes have to be *inside* the
bundle. It now pins the single-file build through the hatch, which esbuild
inlines correctly (esbuild is the only bundler that page ever sees).

Both halves are load-bearing, and both were proven able to fail:

- `packages/apps/tests/contract/genui/component/warm-pin.test.ts` makes the
  default **unloadable** and asserts a pinned variant still boots the screen.
  Revert the guard → it goes red with
  `Error: this venue cannot produce the stock variant's WebAssembly` at
  `boot.ts:114`. Restore → green.
- genbench: the pin alone fixes 4 of the 5; the guard fixes the 5th — the live
  interactive screen, the only case where `PayloadView` boots its own VM and the
  default re-warm could clobber. Revert the guard with the pin in place → that
  one test alone returns red. Restore → **31/31 green** (`liveness`, `mount`,
  `render`).

## Notes

- `quickjs.wasm` is copied out of the dependency by `@vendoai/apps`' build, so it
  is gitignored, listed in `files`, and declared as a turbo `output` — a cache
  hit that restored `dist/` alone would leave the engine with no bytes.
- A dead end, for the record: `@jitl/quickjs-singlefile-cjs-release-sync` behind
  a condition map fails identically — the CJS build embeds the same binary
  string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
