### PR TITLE
feat(agents,core,guard): a turn waiting on a yes can be answered a week later, from anywhere

### DIFF
--- a/packages/agents/src/agent.ts
+++ b/packages/agents/src/agent.ts
@@ -34,6 +34,7 @@ import { startRun, type RunOptions } from "./away.js";
 import { startChat, type ChatOptions, type Turn } from "./turn.js";
 import { resolveDoor, type DoorConfig } from "./door.js";
 import { withEgress, type EgressConfig } from "./egress.js";
+import { PARKED_TURN_TTL_MS } from "./interruptions.js";
 import { PERMISSIONS_PATH, schemaReadyPrincipal, type AgentPrincipal } from "./permissions.js";
 import type { SystemPromptHook } from "./prompt.js";
 import {
@@ -319,7 +320,15 @@ export function agent(config: AgentConfig): VendoAgent {
   // completed with this composition's store.
   const guard = isGuardInstance(config.guard)
     ? config.guard
-    : createGuard({ store, ...config.guard });
+    : createGuard({
+      store,
+      ...config.guard,
+      // An agent's parked turn waits for a PERSON, not for a BYO loop that
+      // will retry in the hour the guard defaults to (interruptions.ts). The
+      // host's own number still wins — this fills the slot, it does not take
+      // it — and a guard INSTANCE passed in is taken verbatim, TTL included.
+      approvals: { parkedCallTtlMs: PARKED_TURN_TTL_MS, ...config.guard?.approvals },
+    });
   const tools = mergeSources(config.tools ?? [], config.mcp ?? []);
   const bound = guard.bind(tools);
   const skills: Skill[] = loadSkillFolders(config.skills);

--- a/packages/agents/src/agent.ts
+++ b/packages/agents/src/agent.ts
@@ -160,6 +160,10 @@ export interface VendoAgent {
  * object stays exactly `{ name, session }`.
  */
 export interface AgentComposition {
+  /** WHICH agent this composed — `agent({ name })`. Declared here because a
+   *  consumer that scopes rows to one agent (`createTurns`) reads it off the
+   *  composition, never off a name a caller passes in beside it. */
+  agent: string;
   harness: Harness<unknown>;
   store: VendoStore;
   files: FilesAdapter;
@@ -379,6 +383,7 @@ export function agent(config: AgentConfig): VendoAgent {
 
   const deps = {
     name: config.name,
+    agent: config.name,
     harness,
     store,
     files,

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -26,6 +26,14 @@ export { awayRunner, type AwayRunnerDeps, type RunOptions } from "./away.js";
 /** The turn a verb hands back, and the two shapes a caller writes against it. */
 export type { ChatOptions, RunEvent, Turn } from "./turn.js";
 export { DOOR_PATH, type DoorConfig } from "./door.js";
+/** Interrupted turns, addressed by id — the same park a caller holding the
+ *  result answers through `TurnResult.resume()`, from any other process. */
+export {
+  createTurns,
+  PARKED_TURN_TTL_MS,
+  type InterruptedTurn,
+  type Turns,
+} from "./interruptions.js";
 export { PERMISSIONS_PATH, type AgentPrincipal } from "./permissions.js";
 export { assemblePrompt, type PromptInput, type SystemPromptHook } from "./prompt.js";
 export type { AgentSession, ApprovalEvent, RespondOptions, SessionOptions } from "./session.js";

--- a/packages/agents/src/interruptions.ts
+++ b/packages/agents/src/interruptions.ts
@@ -32,7 +32,7 @@ import {
   type TurnId,
 } from "@vendoai/core";
 import { toHeaderRecord } from "./session.js";
-import { DEFAULT_MAX_TOOL_CALLS, startTurn, type AgentDeps, type TurnResult } from "./turn.js";
+import { DEFAULT_MAX_TOOL_CALLS, expired, startTurn, type AgentDeps, type TurnResult } from "./turn.js";
 
 /**
  * How long a parked turn waits for its person: seven days.
@@ -84,7 +84,7 @@ export interface Turns {
 }
 
 /**
- * A parked ask THIS lane may answer.
+ * A parked ask THIS agent, on THIS lane, may answer.
  *
  * Every other lane that parks a call owns its own resume — an in-app action
  * resumes on the surface that asked (`packages/apps`), an automation's arming
@@ -93,20 +93,22 @@ export interface Turns {
  * the wrong place. What is left is exactly a turn this package ran: it names
  * the turn that asked and the thread to carry on, and it belongs to no app and
  * no firing.
+ *
+ * And to exactly ONE agent. Every agent over a store shares its approvals
+ * collection, so `agent` is checked first and checked strictly: an ask this
+ * agent did not park — another agent's, or a row from before the field existed
+ * — is skipped, not claimed. Anything looser answered `ops`' ask inside
+ * `support`, which mounts a byte-identical `refund` descriptor and therefore a
+ * matching `descriptorHash`, and spent the person's one yes on the wrong
+ * implementation.
  */
-const parkedByTurn = (request: ApprovalRequest): boolean =>
-  request.ctx.turnId !== undefined
+const parkedByTurn = (request: ApprovalRequest, agent: string | undefined): boolean =>
+  agent !== undefined
+  && request.ctx.agent === agent
+  && request.ctx.turnId !== undefined
   && request.ctx.sessionId !== undefined
   && request.ctx.appId === undefined
   && request.ctx.trigger === undefined;
-
-/** Past its TTL, the ask is dead whether or not a sweep has been by. Nothing in
- *  this package sweeps (the umbrella's `compose-sweep.ts` is the only caller of
- *  `sweepExpiredApprovals`), so expiry is decided where it is read: a turn a
- *  host composed without a sweeper still keeps the seven-day promise, and it
- *  keeps it with a sentence instead of a silence. */
-const expired = (request: ApprovalRequest, ttlMs: number, at: number): boolean =>
-  ttlMs > 0 && Date.parse(request.createdAt) + ttlMs <= at;
 
 const asInterruption = (request: ApprovalRequest): Interruption => ({
   id: request.id,
@@ -154,7 +156,7 @@ export function createTurns(deps: AgentDeps, subject: string): Turns {
   const principal: Principal = { kind: "user", subject };
   const mine = async (turnId?: string): Promise<ApprovalRequest[]> =>
     (await deps.guard.approvals.pending(principal)).filter((request) =>
-      parkedByTurn(request) && (turnId === undefined || request.ctx.turnId === turnId));
+      parkedByTurn(request, deps.agent) && (turnId === undefined || request.ctx.turnId === turnId));
 
   return {
     // The guard's own pending feed, grouped — never a cache of it. So an ask
@@ -185,17 +187,6 @@ export function createTurns(deps: AgentDeps, subject: string): Turns {
       const parked = await mine(turnId);
       const first = parked[0];
       if (first === undefined) throw await nothingWaiting(deps, principal, turnId, decisions);
-
-      const ttlMs = deps.guard.approvals.parkedCallTtlMs;
-      const stale = parked.find((request) => expired(request, ttlMs, Date.now()));
-      if (stale !== undefined) {
-        throw new VendoError(
-          "conflict",
-          `Turn ${turnId} parked on ${stale.createdAt} and what it was waiting on expired on `
-          + `${new Date(Date.parse(stale.createdAt) + ttlMs).toISOString()}. Nothing it asked for ran, and an `
-          + "expired ask cannot be answered — send the request again and the agent will ask again.",
-        );
-      }
 
       // ALL of them or none. A half-answered turn would run the approved calls
       // and then carry on as if the rest had been considered, which is the one

--- a/packages/agents/src/interruptions.ts
+++ b/packages/agents/src/interruptions.ts
@@ -1,0 +1,248 @@
+/**
+ * The turns a person still owes an answer — findable and resumable from ANY
+ * process, not just the one that parked them.
+ *
+ * `TurnResult.resume()` (turn.ts) is the same move for a caller still holding
+ * the result. That closure dies with the process, and the ask does not: a
+ * server restarts, the turn is on a queue worker and the yes arrives at a web
+ * route, or the person answers tomorrow. So this face addresses a turn by ID.
+ *
+ * NOTHING NEW IS PERSISTED FOR IT. The guard's own approval row already carries
+ * the exact `ToolCall` it parked and the ctx it was parked in
+ * (`#parkApproval`, packages/guard/src/guard.ts) — including, now, the turn
+ * that asked. That row IS the durable interrupted turn: `pending()` is the
+ * list, and re-dispatching the stored call through the same guard-bound
+ * registry is the resume. The guard's one-shot receipt on an approved call
+ * (`#approvedReplay`) is what makes it exactly once, however many times a
+ * flaky client asks.
+ *
+ * FAIL-CLOSED, in both directions. A turn nobody can see reads as absent, a
+ * turn whose asks were already answered refuses rather than re-running them,
+ * and an ask nobody answered in a week can no longer be answered at all.
+ */
+import {
+  VendoError,
+  type ApprovalId,
+  type ApprovalRequest,
+  type Decisions,
+  type Interruption,
+  type Principal,
+  type ResumeOptions,
+  type ThreadId,
+  type TurnId,
+} from "@vendoai/core";
+import { toHeaderRecord } from "./session.js";
+import { DEFAULT_MAX_TOOL_CALLS, startTurn, type AgentDeps, type TurnResult } from "./turn.js";
+
+/**
+ * How long a parked turn waits for its person: seven days.
+ *
+ * The guard's own default is an hour, sized for a BYO agent loop with no
+ * conversation to come back to. A turn's ask is answered by a HUMAN — who is
+ * asleep, or off for the weekend — and an hour turns "approve this refund"
+ * into work that silently has to be redone. Seven days is long enough for a
+ * person and short enough that a week-old write is never approved into a world
+ * that has moved on. A host's own `guard: { approvals: { parkedCallTtlMs } }`
+ * still wins, and `createVendo` keeps the hour.
+ */
+export const PARKED_TURN_TTL_MS = 7 * 24 * 60 * 60_000;
+
+/** One turn waiting on a person, as another process finds it. The same
+ *  `turnId` the interrupted turn returned, the thread it is on, and the asks
+ *  themselves — everything {@link Turns.resume} needs, and nothing a caller
+ *  would have to join two reads to get. */
+export interface InterruptedTurn {
+  turnId: TurnId;
+  threadId: ThreadId;
+  interruptions: Interruption[];
+}
+
+/** The durable half of the turn contract. */
+export interface Turns {
+  /** Every turn of this user's that is waiting on them. `status` is named
+   *  rather than assumed: a listing that quietly meant one thing is the kind
+   *  that grows a second meaning later. */
+  list(options: { status: "interrupted" }): Promise<InterruptedTurn[]>;
+  /**
+   * Answer a parked turn's interruptions and carry it on. The same
+   * `TurnResult` any turn answers with — including `interrupted` again, if the
+   * turn went on to ask for something else.
+   *
+   * The RESULT rather than a live `Turn`, because this call has to read the
+   * store first (the thread and the parked calls are facts only the store has
+   * once the process that asked is gone) and a `Turn` cannot survive that: a
+   * `Turn` is itself a thenable, so `await turns.resume(…)` would unwrap the
+   * handle to its result whatever this promise carried. The turn is watched
+   * live where it is STARTED (`chat`/`run`); it is answered here.
+   *
+   * The answer is prose. An output schema belongs to the code that called
+   * `run({ output })` and was never persisted, so a turn resumed from another
+   * process reports in words — resume through the result you are holding
+   * (`TurnResult.resume`) to keep the shape.
+   */
+  resume(turnId: string, decisions: Decisions, options?: ResumeOptions): Promise<TurnResult>;
+}
+
+/**
+ * A parked ask THIS lane may answer.
+ *
+ * Every other lane that parks a call owns its own resume — an in-app action
+ * resumes on the surface that asked (`packages/apps`), an automation's arming
+ * yes mints the standing grant its consent moment was for (`packages/automations`)
+ * — and re-dispatching one of those inside a fresh chat turn would answer it in
+ * the wrong place. What is left is exactly a turn this package ran: it names
+ * the turn that asked and the thread to carry on, and it belongs to no app and
+ * no firing.
+ */
+const parkedByTurn = (request: ApprovalRequest): boolean =>
+  request.ctx.turnId !== undefined
+  && request.ctx.sessionId !== undefined
+  && request.ctx.appId === undefined
+  && request.ctx.trigger === undefined;
+
+/** Past its TTL, the ask is dead whether or not a sweep has been by. Nothing in
+ *  this package sweeps (the umbrella's `compose-sweep.ts` is the only caller of
+ *  `sweepExpiredApprovals`), so expiry is decided where it is read: a turn a
+ *  host composed without a sweeper still keeps the seven-day promise, and it
+ *  keeps it with a sentence instead of a silence. */
+const expired = (request: ApprovalRequest, ttlMs: number, at: number): boolean =>
+  ttlMs > 0 && Date.parse(request.createdAt) + ttlMs <= at;
+
+const asInterruption = (request: ApprovalRequest): Interruption => ({
+  id: request.id,
+  type: "approval",
+  toolCall: request.call,
+});
+
+/**
+ * Nothing is parked under this id — which is two different answers.
+ *
+ * A decision the caller named that this subject really owns, on this turn,
+ * already answered, PROVES the turn was interrupted and is not any more:
+ * that is a conflict, and saying so is what tells a client its retry landed
+ * the first time. Anything else — another user's turn, an id that never
+ * existed, a turn that never parked — is the ownership law's absent: a thing
+ * you do not own reads back as missing, never as forbidden.
+ */
+async function nothingWaiting(
+  deps: AgentDeps,
+  principal: Principal,
+  turnId: string,
+  decisions: Decisions,
+): Promise<VendoError> {
+  for (const id of Object.keys(decisions)) {
+    const answered = await deps.guard.approvals.get?.(id as ApprovalId, principal);
+    if (answered === undefined || answered.status === "pending") continue;
+    if (answered.request.ctx.turnId !== turnId) continue;
+    return new VendoError(
+      "conflict",
+      `Turn ${turnId} is not interrupted any more — its approval ${id} was already ${answered.status}. `
+      + "An ask is answered once, and this one has been. Ask again to get a fresh one.",
+    );
+  }
+  return new VendoError(
+    "not-found",
+    `Turn ${turnId} has nothing waiting on an answer. `
+    + "Call turns.list({ status: \"interrupted\" }) for the turns that do.",
+  );
+}
+
+/** What one user can do with their own interrupted turns. Bound to a subject
+ *  because every read under it is: the guard scopes a pending feed to its
+ *  owner, so a turn another user parked is not visible here at all. */
+export function createTurns(deps: AgentDeps, subject: string): Turns {
+  const principal: Principal = { kind: "user", subject };
+  const mine = async (turnId?: string): Promise<ApprovalRequest[]> =>
+    (await deps.guard.approvals.pending(principal)).filter((request) =>
+      parkedByTurn(request) && (turnId === undefined || request.ctx.turnId === turnId));
+
+  return {
+    // The guard's own pending feed, grouped — never a cache of it. So an ask
+    // that was answered anywhere (a resume, a console tap, an abandonment
+    // sweep) is gone from this list in the same instant it was answered, and
+    // there is nothing here that could offer a turn nobody can act on.
+    list: async () => {
+      const at = Date.now();
+      const ttlMs = deps.guard.approvals.parkedCallTtlMs;
+      const turns = new Map<TurnId, InterruptedTurn>();
+      for (const request of await mine()) {
+        // Past the TTL is past acting on, whether or not a sweep has been by —
+        // `resume` says so in words; a list of turns to act on just omits it.
+        if (expired(request, ttlMs, at)) continue;
+        const turnId = request.ctx.turnId as TurnId;
+        const turn = turns.get(turnId) ?? {
+          turnId,
+          threadId: request.ctx.sessionId as ThreadId,
+          interruptions: [],
+        };
+        turn.interruptions.push(asInterruption(request));
+        turns.set(turnId, turn);
+      }
+      return [...turns.values()];
+    },
+
+    resume: async (turnId, decisions, options) => {
+      const parked = await mine(turnId);
+      const first = parked[0];
+      if (first === undefined) throw await nothingWaiting(deps, principal, turnId, decisions);
+
+      const ttlMs = deps.guard.approvals.parkedCallTtlMs;
+      const stale = parked.find((request) => expired(request, ttlMs, Date.now()));
+      if (stale !== undefined) {
+        throw new VendoError(
+          "conflict",
+          `Turn ${turnId} parked on ${stale.createdAt} and what it was waiting on expired on `
+          + `${new Date(Date.parse(stale.createdAt) + ttlMs).toISOString()}. Nothing it asked for ran, and an `
+          + "expired ask cannot be answered — send the request again and the agent will ask again.",
+        );
+      }
+
+      // ALL of them or none. A half-answered turn would run the approved calls
+      // and then carry on as if the rest had been considered, which is the one
+      // outcome nobody asked for — and the ids are named because "some
+      // decision is missing" is unanswerable from a client that holds five.
+      const missing = parked.filter((request) => decisions[request.id] === undefined);
+      if (missing.length > 0) {
+        throw new VendoError(
+          "validation",
+          `Resuming turn ${turnId} needs a decision for every interruption it parked. Missing: `
+          + `${missing.map((request) => request.id).join(", ")}. Pass "approve" or "deny" for each and resume again.`,
+        );
+      }
+
+      const headers = toHeaderRecord(options?.headers);
+      // Awaited by the async boundary: what this hands back is the turn's
+      // result, and the turn runs to the end whether or not anyone waits (the
+      // drainer-of-record property, turn.ts).
+      return startTurn(deps, {
+        // Unread: a resumed turn's ask is what the person ANSWERED, assembled
+        // by `settleInterruptions` from the decisions above. This is the same
+        // turn carrying on, not a new message.
+        prompt: "",
+        threadId: first.ctx.sessionId as ThreadId,
+        // The SAME turn, across a park that outlived the process that made it.
+        turnId: turnId as TurnId,
+        reopen: true,
+        ctx: {
+          // Everything replayed here IDENTIFIES the parked call and none of it
+          // authorizes anything: `sameParkedCall` pins the subject, the venue
+          // and the presence, so a resume wearing another venue would miss the
+          // very approval it is answering. AUTHORITY is the resuming call's
+          // alone — the parked request's headers were request-lifetime and
+          // that request is over, and its `context` is not replayed either, so
+          // a tool that needs either one is handed what THIS caller brought.
+          principal,
+          venue: first.ctx.venue,
+          presence: first.ctx.presence,
+          sessionId: first.ctx.sessionId as string,
+          ...(headers === undefined ? {} : { requestHeaders: headers }),
+          ...(options?.context === undefined ? {} : { context: options.context }),
+        },
+        // The parked turn's own budget was the calling code's and is not on the
+        // row; the resumed turn gets a fresh default one.
+        maxToolCalls: DEFAULT_MAX_TOOL_CALLS,
+        resume: { guard: deps.guard, parked, decisions },
+      });
+    },
+  };
+}

--- a/packages/agents/src/interruptions.ts
+++ b/packages/agents/src/interruptions.ts
@@ -135,6 +135,9 @@ async function nothingWaiting(
   for (const id of Object.keys(decisions)) {
     const answered = await deps.guard.approvals.get?.(id as ApprovalId, principal);
     if (answered === undefined || answered.status === "pending") continue;
+    // Scoped the way `parkedByTurn` scopes the feed: another agent's answered
+    // ask is not this agent's conflict, it is a turn this agent never had.
+    if (deps.agent === undefined || answered.request.ctx.agent !== deps.agent) continue;
     if (answered.request.ctx.turnId !== turnId) continue;
     return new VendoError(
       "conflict",
@@ -184,7 +187,15 @@ export function createTurns(deps: AgentDeps, subject: string): Turns {
     },
 
     resume: async (turnId, decisions, options) => {
-      const parked = await mine(turnId);
+      const all = await mine(turnId);
+      // The SAME deadline `list` applies, so both faces agree on what is
+      // answerable. A turn holding one expired ask beside a live one used to be
+      // offered as actionable and be answerable neither way: decide what the
+      // list showed and it demanded an id nobody was shown, decide both and the
+      // expired one refused the pair. Kept whole when EVERY ask is expired, so
+      // that turn is still refused as expired rather than reported missing.
+      const live = all.filter((request) => !expired(request, deps.guard.approvals.parkedCallTtlMs, Date.now()));
+      const parked = live.length > 0 ? live : all;
       const first = parked[0];
       if (first === undefined) throw await nothingWaiting(deps, principal, turnId, decisions);
 

--- a/packages/agents/src/turn.ts
+++ b/packages/agents/src/turn.ts
@@ -146,6 +146,22 @@ export interface TurnDeps {
 export interface AgentDeps extends TurnDeps {
   /** Attribution when the caller names no subject of their own. */
   name: string;
+  /**
+   * WHICH agent this is — `agent({ name })`, carried by the composition rather
+   * than read off {@link AgentDeps.name}, which is a label whoever assembles
+   * these deps fills in.
+   *
+   * It rides every turn's ctx onto the rows that turn parks, and it is the axis
+   * `turns.list`/`turns.resume` filter on (interruptions.ts). Two agents over
+   * one store share one approvals collection — `serve({ agents: [a, b] })` is
+   * exactly that — and a park named only the subject, the thread and the turn,
+   * so a person's yes to `ops` dispatched `support`'s same-named tool and
+   * `support.turns.list()` returned `ops`' turn verbatim.
+   *
+   * Optional because a composition assembled by hand names no agent; absent,
+   * its parked turns belong to nobody and neither face offers them.
+   */
+  agent?: string;
   /** The agent's guard-bound registry — the turn's whole tool surface. */
   tools: ToolRegistry;
   guard: VendoGuard;
@@ -384,6 +400,53 @@ function spokenText(messages: readonly UIMessage[]): string {
     .map((part) => part.text)
     .join("")
     .trim();
+}
+
+/** Past its TTL, the ask is dead whether or not a sweep has been by. Nothing in
+ *  this package sweeps (the umbrella's `compose-sweep.ts` is the only caller of
+ *  `sweepExpiredApprovals`), so expiry is decided where it is read: a turn a
+ *  host composed without a sweeper still keeps the seven-day promise, and it
+ *  keeps it with a sentence instead of a silence. */
+export const expired = (request: ApprovalRequest, ttlMs: number, at: number): boolean =>
+  ttlMs > 0 && Date.parse(request.createdAt) + ttlMs <= at;
+
+/**
+ * What a resume is refused for — on BOTH faces.
+ *
+ * `turns.resume` reads the store and can say no before a turn opens; the
+ * `resume()` a caller is still holding used to say nothing at all, so the same
+ * guard and the same deadline gave opposite answers to the same ask. Checked
+ * HERE, at the one door every resume goes through, so neither face can grow a
+ * rule of its own — and BEFORE {@link settleInterruptions}, because both of
+ * these refusals must leave a one-shot ask still answerable.
+ */
+function assertAnswerable(deps: AgentDeps, turnId: TurnId, resume: TurnInput["resume"]): void {
+  if (resume === undefined) return;
+  for (const request of resume.parked) {
+    const decision = resume.decisions[request.id];
+    // A verdict, or nothing at all. `{ answers }` type-checks against an
+    // approval arm and is not a verdict, and `settleInterruptions` calls
+    // everything that is not "approve" a no — so a shape nobody meant (and a
+    // "Approve" nobody misread) landed as a DENIAL nobody made, on an ask that
+    // is answered exactly once.
+    if (decision !== undefined && decision !== "approve" && decision !== "deny") {
+      throw new VendoError(
+        "validation",
+        `Approval ${request.id} was answered with ${JSON.stringify(decision)}, which is not a verdict. `
+        + "An approval takes \"approve\" or \"deny\" — nothing was decided, so it is still there to answer.",
+      );
+    }
+  }
+  const ttlMs = deps.guard.approvals.parkedCallTtlMs;
+  const stale = resume.parked.find((request) => expired(request, ttlMs, Date.now()));
+  if (stale !== undefined) {
+    throw new VendoError(
+      "conflict",
+      `Turn ${turnId} parked on ${stale.createdAt} and what it was waiting on expired on `
+      + `${new Date(Date.parse(stale.createdAt) + ttlMs).toISOString()}. Nothing it asked for ran, and an `
+      + "expired ask cannot be answered — send the request again and the agent will ask again.",
+    );
+  }
 }
 
 /**
@@ -738,7 +801,17 @@ const resumedContext = (ctx: RunContext, options: ResumeOptions | undefined): Ru
 export function startTurn<T = void>(deps: AgentDeps, input: Omit<TurnInput, "tools" | "emit">): Turn<T> {
   const queue = eventQueue<RunEvent>();
   const settled = Promise.all([deps.assertModel?.(), deps.doorReady])
-    .then(() => runTurn(deps, { ...input, tools: deps.tools, emit: queue.push }))
+    .then(() => {
+      assertAnswerable(deps, input.turnId, input.resume);
+      return runTurn(deps, {
+        ...input,
+        // WHOSE turn this is, onto every row it parks — the axis `turns` filters
+        // a parked turn by (see {@link AgentDeps.agent}).
+        ctx: deps.agent === undefined ? input.ctx : { ...input.ctx, agent: deps.agent },
+        tools: deps.tools,
+        emit: queue.push,
+      });
+    })
     .finally(() => {
       queue.close();
     })

--- a/packages/agents/src/turn.ts
+++ b/packages/agents/src/turn.ts
@@ -638,7 +638,16 @@ export async function runTurn(deps: TurnDeps, input: TurnInput): Promise<TurnRec
   // teardown would leak one — and a foreign `threadId` is a rejection a caller
   // can repeat at will.
   const unsubscribe = deps.guard.onApprovalRequested?.((request) => {
-    if (runKey !== undefined && (request.ctx.trigger?.runId ?? request.ctx.sessionId) === runKey) {
+    // The run key alone is the THREAD for a chat turn, and nothing serialises a
+    // thread: two turns running at once each collected the other's cards, so a
+    // resume of one decided and re-dispatched the other's call. The turn that
+    // asked is on the row (guard.ts, `#parkApproval`) — matched on it, a turn's
+    // interruptions are its own.
+    if (
+      runKey !== undefined
+      && (request.ctx.trigger?.runId ?? request.ctx.sessionId) === runKey
+      && request.ctx.turnId === input.turnId
+    ) {
       parked.push(request);
     }
     // A parked call never reaches `onCall`, so this is the only moment the turn

--- a/packages/agents/tests/interruptions-adversarial.test.ts
+++ b/packages/agents/tests/interruptions-adversarial.test.ts
@@ -221,7 +221,9 @@ describe("a turn that belongs to another agent", () => {
     const supportRan = { count: 0 };
     const ops = parking(store, opsRan, 1, "ops");
     const support = parking(store, supportRan, 1, "support");
-    const asked = await interrupted(ops.chat("Refund invoice 7.", { as: "u_42" }));
+    // Awaited for effect: this is what parks `ops`' ask, which is the thing
+    // `support` must not be able to see below.
+    await interrupted(ops.chat("Refund invoice 7.", { as: "u_42" }));
 
     // `support` never asked this person for anything.
     expect(await turnsOf(support, "u_42").list({ status: "interrupted" })).toEqual([]);
@@ -453,8 +455,8 @@ describe("nothing the spec cut crept back in", () => {
     const support = parking(keep(memoryStore()), ran);
     const turns = turnsOf(support, "u_42");
     expect(Object.keys(turns).sort()).toEqual(["list", "resume"]);
-    expect((turns as Record<string, unknown>).get).toBeUndefined();
-    expect((turns as Record<string, unknown>).onInterruption).toBeUndefined();
+    expect((turns as unknown as Record<string, unknown>).get).toBeUndefined();
+    expect((turns as unknown as Record<string, unknown>).onInterruption).toBeUndefined();
   });
 
   it("never emits an input interruption", async () => {

--- a/packages/agents/tests/interruptions-adversarial.test.ts
+++ b/packages/agents/tests/interruptions-adversarial.test.ts
@@ -370,6 +370,38 @@ describe("the seven days", () => {
     expect(ran.count).toBe(0);
   }, 60_000);
 
+  it("answers the live ask of a turn whose other ask expired", async () => {
+    const store = keep(memoryStore());
+    const ran = { count: 0 };
+    const support = agent({
+      name: "support",
+      harness: refunder(2),
+      tools: [refundTool(ran)],
+      store,
+      guard: { approvals: { parkedCallTtlMs: 60_000 } },
+    });
+    const turns = turnsOf(support, "u_42");
+    const asked = await interrupted(support.chat("Refund invoice 7 and invoice 8.", { as: "u_42" }));
+    expect(asked.interruptions).toHaveLength(2);
+    const stale = asked.interruptions[0]!.id;
+    const live = asked.interruptions[1]!.id;
+
+    // Two asks parked minutes apart; a week later only the elder is past its
+    // deadline. Nothing sweeps, so the dead row is still on the pending feed.
+    await rewriteCreatedAt(store, stale, new Date(Date.now() - 60_000).toISOString());
+
+    // `list` offers this turn with ONE ask on it, so that ask has to be
+    // answerable and answering exactly it has to be enough. Demanding the
+    // expired one too made a listed turn unanswerable both ways — and there is
+    // no sweeper to clear it afterwards.
+    const listed = await turns.list({ status: "interrupted" });
+    expect(listed[0]!.interruptions.map((one) => one.id)).toEqual([live]);
+
+    const answered = await turns.resume(asked.turnId, { [live]: "approve" });
+    expect(answered).toMatchObject({ status: "ok", turnId: asked.turnId });
+    expect(ran.count).toBe(1);
+  }, 60_000);
+
   it("cannot be handed an unreadable createdAt in the first place", async () => {
     const store = keep(memoryStore());
     const ran = { count: 0 };
@@ -446,7 +478,85 @@ describe("the decision map", () => {
 });
 
 // ---------------------------------------------------------------------------
-// 5. WHAT THE SPEC CUT
+// 5. TWO TURNS ON ONE THREAD
+// ---------------------------------------------------------------------------
+
+describe("two turns running at once on one thread", () => {
+  /** Both turns reach the tool call — and are therefore both subscribed to the
+   *  guard — before either parks. The overlap is the point of the probe, so it
+   *  is arranged rather than left to the machine's timing. */
+  const barrier = (count: number): (() => Promise<void>) => {
+    let arrived = 0;
+    let release!: () => void;
+    const all = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    return async () => {
+      arrived += 1;
+      if (arrived === count) release();
+      await all;
+    };
+  };
+
+  const paired = (arrive: () => Promise<void>) => {
+    let invoice = 0;
+    return defineHarness({
+      name: "paired",
+      async *run(turn) {
+        const last = JSON.stringify(turn.messages.at(-1)?.parts ?? []);
+        if (last.includes("[Resumed]")) {
+          yield { type: "text" as const, delta: "The refund went through." };
+          return;
+        }
+        if (!last.includes("efund")) {
+          yield { type: "text" as const, delta: "Your balance is fine." };
+          return;
+        }
+        await arrive();
+        // Its own invoice, so neither turn's card can be mistaken for the
+        // other's by anything but the id it was collected under.
+        invoice += 1;
+        await turn.tools.call("refund", { invoice });
+        yield { type: "text" as const, delta: "I have asked for approval." };
+      },
+    });
+  };
+
+  it("keeps each turn's approval to itself, and refuses to spend the sibling's yes", async () => {
+    const ran = { count: 0 };
+    const support = agent({
+      name: "support",
+      harness: paired(barrier(2)),
+      tools: [refundTool(ran)],
+      store: keep(memoryStore()),
+    });
+    // One thread, opened by a turn that asks for nothing.
+    const opened = await support.chat("What is my balance?", { as: "u_42" });
+    const { threadId } = opened;
+
+    const [seven, eight] = await Promise.all([
+      interrupted(support.chat("Refund invoice 7.", { as: "u_42", threadId })),
+      interrupted(support.chat("Refund invoice 8.", { as: "u_42", threadId })),
+    ]);
+
+    // Nothing serialises a thread, and the guard's own run key IS the thread —
+    // so each turn used to collect both cards and report the other's ask as its
+    // own.
+    expect(seven.interruptions).toHaveLength(1);
+    expect(eight.interruptions).toHaveLength(1);
+    expect(seven.interruptions[0]!.id).not.toBe(eight.interruptions[0]!.id);
+
+    // And a decision named on the wrong turn decides nothing: one ask, answered
+    // once, by the turn that asked it.
+    await Promise.resolve(seven.resume({ [eight.interruptions[0]!.id]: "approve" }))
+      .catch(() => undefined);
+    expect(ran.count).toBe(0);
+    expect(await turnsOf(support, "u_42").list({ status: "interrupted" })).toHaveLength(2);
+  }, 60_000);
+});
+
+// ---------------------------------------------------------------------------
+// 6. WHAT THE SPEC CUT
 // ---------------------------------------------------------------------------
 
 describe("nothing the spec cut crept back in", () => {

--- a/packages/agents/tests/interruptions-adversarial.test.ts
+++ b/packages/agents/tests/interruptions-adversarial.test.ts
@@ -1,0 +1,468 @@
+/**
+ * ADVERSARIAL probes against `createTurns` (src/interruptions.ts).
+ *
+ * Real store, real guard, real registry, real turn — the only scripted thing is
+ * the thinker, exactly as interruptions.test.ts has it. Every assertion below
+ * states the behaviour the slice CLAIMS; a red one is a defect.
+ */
+import { defineHarness } from "@vendoai/harnesses";
+import { createStore, type VendoStore } from "@vendoai/store";
+import {
+  VendoError,
+  type Decisions,
+  type RunContext,
+  type ToolCall,
+  type ToolResult,
+} from "@vendoai/core";
+import { afterEach, describe, expect, it } from "vitest";
+import { agent, agentComposition, type VendoAgent } from "../src/agent.js";
+import { createTurns, type Turns } from "../src/interruptions.js";
+import { tool } from "../src/tools.js";
+import type { TurnResult } from "../src/turn.js";
+
+let stores = 0;
+const memoryStore = (): VendoStore => createStore({ dataDir: `memory://agents-adversarial-${stores++}` });
+
+const open: VendoStore[] = [];
+const keep = (store: VendoStore): VendoStore => {
+  open.push(store);
+  return store;
+};
+afterEach(async () => {
+  for (const store of open.splice(0)) await store.close().catch(() => {});
+});
+
+interface Ran {
+  count: number;
+  headers?: Record<string, string>;
+  context?: Record<string, unknown>;
+}
+
+/** Byte-identical descriptor wherever it is mounted — the point of several
+ *  probes below is that `descriptorHash` cannot tell two mountings apart. */
+const refundTool = (ran: Ran) => tool({
+  name: "refund",
+  description: "Refund an invoice",
+  risk: "destructive",
+  inputSchema: { type: "object" },
+  execute: (_input, ctx: RunContext) => {
+    ran.count += 1;
+    ran.headers = ctx.requestHeaders;
+    ran.context = ctx.context;
+    return { refunded: true };
+  },
+});
+
+const refunder = (calls = 1) => defineHarness({
+  name: "refunder",
+  async *run(turn) {
+    const last = JSON.stringify(turn.messages.at(-1)?.parts ?? []);
+    if (last.includes("[Resumed]")) {
+      yield { type: "text" as const, delta: "The refund went through." };
+      return;
+    }
+    if (!last.includes("efund")) {
+      yield { type: "text" as const, delta: "Your balance is fine." };
+      return;
+    }
+    for (let index = 0; index < calls; index += 1) {
+      const result: ToolResult = await turn.tools.call("refund", { invoice: index });
+      if (result.status === "ok") throw new Error("the guard was supposed to park this");
+    }
+    yield { type: "text" as const, delta: "I have asked for approval." };
+  },
+});
+
+const parking = (store: VendoStore, ran: Ran, calls = 1, name = "support"): VendoAgent =>
+  agent({ name, harness: refunder(calls), tools: [refundTool(ran)], store });
+
+const turnsOf = (built: VendoAgent, subject: string): Turns =>
+  createTurns({ ...agentComposition(built)!, name: "support" }, subject);
+
+const interrupted = async (result: PromiseLike<TurnResult>): Promise<
+  Extract<TurnResult, { status: "interrupted" }>
+> => {
+  const settled = await result;
+  if (settled.status !== "interrupted") throw new Error(`expected interrupted, got ${settled.status}`);
+  return settled;
+};
+
+const errorOf = async (promise: PromiseLike<unknown>): Promise<VendoError> => {
+  const settled = await Promise.resolve(promise).then(
+    (value) => value,
+    (error: unknown) => error,
+  );
+  if (!(settled instanceof VendoError)) {
+    throw new Error(`expected a VendoError, got ${JSON.stringify(settled)}`);
+  }
+  return settled;
+};
+
+/** The approvals collection, read and written the way any other build of this
+ *  repo writes it — used to age a row, or to malform the one field the TTL is
+ *  computed from. */
+const approvalRow = async (store: VendoStore, id: string): Promise<{
+  data: { request: { createdAt: string } };
+  refs?: Record<string, string>;
+}> => {
+  const record = await store.records("vendo_approvals").get(id);
+  if (record === null) throw new Error(`no approval row ${id}`);
+  return record as never;
+};
+
+const rewriteCreatedAt = async (store: VendoStore, id: string, createdAt: string): Promise<void> => {
+  const record = await approvalRow(store, id);
+  record.data.request.createdAt = createdAt;
+  await store.records("vendo_approvals").put({
+    id,
+    data: record.data as never,
+    ...(record.refs === undefined ? {} : { refs: record.refs }),
+  });
+};
+
+// ---------------------------------------------------------------------------
+// 1. EXACTLY ONCE
+// ---------------------------------------------------------------------------
+
+describe("exactly once, pushed harder", () => {
+  it("runs the approved call once across eight simultaneous resumes", async () => {
+    const ran = { count: 0 };
+    const support = parking(keep(memoryStore()), ran);
+    const turns = turnsOf(support, "u_42");
+    const asked = await interrupted(support.chat("Refund invoice 7.", { as: "u_42" }));
+    const decisions: Decisions = { [asked.interruptions[0]!.id]: "approve" };
+
+    const answers = await Promise.all(
+      Array.from({ length: 8 }, () =>
+        turns.resume(asked.turnId, decisions).catch((error: unknown) => error)),
+    );
+
+    expect(ran.count).toBe(1);
+    expect(answers.filter((answer) => (answer as { status?: string }).status === "ok")).toHaveLength(1);
+    // And nothing is left for a ninth caller to answer: a resume that lost the
+    // race must not leave a fresh ask standing for the same call.
+    expect(await turns.list({ status: "interrupted" })).toEqual([]);
+  }, 60_000);
+
+  it("runs it once when two independent compositions over one store resume at the same instant", async () => {
+    // Two `agent()` calls = two guards, two registries, two bound tool sets.
+    // Nothing in memory is shared; the only common ground is the store, which
+    // is exactly what two processes share.
+    const store = keep(memoryStore());
+    const parkedRan = { count: 0 };
+    const otherRan = { count: 0 };
+    const first = parking(store, parkedRan);
+    const second = parking(store, otherRan);
+    const asked = await interrupted(first.chat("Refund invoice 7.", { as: "u_42" }));
+    const decisions: Decisions = { [asked.interruptions[0]!.id]: "approve" };
+
+    const answers = await Promise.all([
+      turnsOf(first, "u_42").resume(asked.turnId, decisions).catch((error: unknown) => error),
+      turnsOf(second, "u_42").resume(asked.turnId, decisions).catch((error: unknown) => error),
+    ]);
+
+    expect(parkedRan.count + otherRan.count).toBe(1);
+    expect(answers.filter((answer) => (answer as { status?: string }).status === "ok")).toHaveLength(1);
+    expect(await turnsOf(first, "u_42").list({ status: "interrupted" })).toEqual([]);
+  }, 60_000);
+
+  it("never runs the second of two approved calls twice when resumes race", async () => {
+    const ran = { count: 0 };
+    const support = parking(keep(memoryStore()), ran, 2);
+    const turns = turnsOf(support, "u_42");
+    const asked = await interrupted(support.chat("Refund invoice 7 and invoice 8.", { as: "u_42" }));
+    expect(asked.interruptions).toHaveLength(2);
+    const decisions: Decisions = {
+      [asked.interruptions[0]!.id]: "approve",
+      [asked.interruptions[1]!.id]: "approve",
+    };
+
+    await Promise.all([
+      turns.resume(asked.turnId, decisions).catch((error: unknown) => error),
+      turns.resume(asked.turnId, decisions).catch((error: unknown) => error),
+      turns.resume(asked.turnId, decisions).catch((error: unknown) => error),
+    ]);
+
+    expect(ran.count).toBe(2);
+    expect(await turns.list({ status: "interrupted" })).toEqual([]);
+  }, 60_000);
+});
+
+// ---------------------------------------------------------------------------
+// 2. OWNERSHIP, AND THE LANE FILTER
+// ---------------------------------------------------------------------------
+
+describe("a subject only ever sees its own", () => {
+  const hostile = ["u_4", "U_42", "u_42 ", "u:42", "u/42", "u_42\nu_99", ""];
+
+  it("hides an interrupted turn from every neighbouring spelling of its owner", async () => {
+    const ran = { count: 0 };
+    const support = parking(keep(memoryStore()), ran);
+    const asked = await interrupted(support.chat("Refund invoice 7.", { as: "u_42" }));
+
+    for (const subject of hostile) {
+      const stranger = turnsOf(support, subject);
+      expect(await stranger.list({ status: "interrupted" })).toEqual([]);
+      const refused = await errorOf(
+        stranger.resume(asked.turnId, { [asked.interruptions[0]!.id]: "approve" }),
+      );
+      expect(refused.code).toBe("not-found");
+      expect(refused.message).not.toMatch(/forbidden|not allowed|permission/i);
+    }
+    expect(ran.count).toBe(0);
+    expect(await turnsOf(support, "u_42").list({ status: "interrupted" })).toHaveLength(1);
+  }, 60_000);
+});
+
+describe("a turn that belongs to another agent", () => {
+  it("is not offered by an agent that did not park it", async () => {
+    const store = keep(memoryStore());
+    const opsRan = { count: 0 };
+    const supportRan = { count: 0 };
+    const ops = parking(store, opsRan, 1, "ops");
+    const support = parking(store, supportRan, 1, "support");
+    const asked = await interrupted(ops.chat("Refund invoice 7.", { as: "u_42" }));
+
+    // `support` never asked this person for anything.
+    expect(await turnsOf(support, "u_42").list({ status: "interrupted" })).toEqual([]);
+    expect(await turnsOf(ops, "u_42").list({ status: "interrupted" })).toHaveLength(1);
+  }, 60_000);
+
+  it("cannot be answered through a different agent's registry", async () => {
+    const store = keep(memoryStore());
+    const opsRan = { count: 0 };
+    const supportRan = { count: 0 };
+    const ops = parking(store, opsRan, 1, "ops");
+    const support = parking(store, supportRan, 1, "support");
+    const asked = await interrupted(ops.chat("Refund invoice 7.", { as: "u_42" }));
+
+    const settled = await turnsOf(support, "u_42")
+      .resume(asked.turnId, { [asked.interruptions[0]!.id]: "approve" })
+      .then((value: unknown) => value, (error: unknown) => error);
+
+    // Soft, so one run shows the whole shape of the damage.
+    expect.soft(settled).toBeInstanceOf(VendoError);
+    // The yes the person gave `ops` must never spend itself inside `support` —
+    // the two registries mount byte-identical descriptors, and `descriptorHash`
+    // covers name/description/inputSchema/risk, so the replay match cannot tell
+    // one mounting's `execute` from the other's.
+    expect.soft(supportRan.count).toBe(0);
+    expect.soft(opsRan.count).toBe(0);
+    // And the ask `ops` parked is still there to answer.
+    expect.soft(await turnsOf(ops, "u_42").list({ status: "interrupted" })).toHaveLength(1);
+  }, 60_000);
+
+  it("does not burn the person's yes on an agent that has no such tool", async () => {
+    const store = keep(memoryStore());
+    const opsRan = { count: 0 };
+    const ops = parking(store, opsRan, 1, "ops");
+    // A second agent over the same store with a DIFFERENT tool surface.
+    const bare = agent({ name: "bare", harness: refunder(), store });
+    const asked = await interrupted(ops.chat("Refund invoice 7.", { as: "u_42" }));
+
+    await turnsOf(bare, "u_42").resume(asked.turnId, { [asked.interruptions[0]!.id]: "approve" })
+      .catch(() => undefined);
+
+    // Whatever the answer was, the ask must still be answerable where it lives:
+    // approving into a registry that cannot dispatch the call is a yes spent on
+    // nothing.
+    expect(opsRan.count).toBe(0);
+    expect(await turnsOf(ops, "u_42").list({ status: "interrupted" })).toHaveLength(1);
+  }, 60_000);
+});
+
+describe("the lane filter", () => {
+  /** Park a call straight through the guard-bound registry, on any ctx at all —
+   *  the same write path a turn uses, without a turn. */
+  const parkOn = async (built: VendoAgent, ctx: RunContext, id: string): Promise<void> => {
+    const composition = agentComposition(built)!;
+    await composition.store.ensureSchema();
+    const call: ToolCall = { id, tool: "refund", args: { invoice: 1 } };
+    await composition.tools.execute(call, ctx);
+  };
+
+  const base = (subject: string): RunContext => ({
+    principal: { kind: "user", subject },
+    venue: "chat",
+    presence: "present",
+    sessionId: "thr_lane",
+  });
+
+  it("keeps an app action, an automation firing and a turn-less check out of the list", async () => {
+    const ran = { count: 0 };
+    const support = parking(keep(memoryStore()), ran);
+    const turnId = "trn_00000000000000000000000000000001";
+
+    await parkOn(support, { ...base("u_42"), appId: "app_x" as never, turnId: turnId as never }, "c_app");
+    await parkOn(support, {
+      ...base("u_42"),
+      venue: "automation",
+      trigger: { automationId: "atm_1", runId: "run_1", kind: "schedule" } as never,
+      turnId: turnId as never,
+    }, "c_auto");
+    // A row from before this slice existed: no turnId at all.
+    await parkOn(support, base("u_42"), "c_old");
+
+    const turns = turnsOf(support, "u_42");
+    expect(await turns.list({ status: "interrupted" })).toEqual([]);
+    expect(ran.count).toBe(0);
+  }, 60_000);
+
+  it("does not resume an app-lane park through the chat lane", async () => {
+    const ran = { count: 0 };
+    const support = parking(keep(memoryStore()), ran);
+    const turnId = "trn_00000000000000000000000000000002";
+    await parkOn(support, { ...base("u_42"), appId: "app_x" as never, turnId: turnId as never }, "c_app2");
+
+    const refused = await errorOf(turnsOf(support, "u_42").resume(turnId, { c_app2: "approve" }));
+    expect(refused.code).toBe("not-found");
+    expect(ran.count).toBe(0);
+  }, 60_000);
+});
+
+// ---------------------------------------------------------------------------
+// 3. THE TTL
+// ---------------------------------------------------------------------------
+
+describe("the seven days", () => {
+  const shortLived = (store: VendoStore, ran: Ran, ttlMs: number): VendoAgent =>
+    agent({
+      name: "support",
+      harness: refunder(),
+      tools: [refundTool(ran)],
+      store,
+      guard: { approvals: { parkedCallTtlMs: ttlMs } },
+    });
+
+  it("refuses an expired ask on EVERY face, not only on turns.resume", async () => {
+    const ran = { count: 0 };
+    const support = shortLived(keep(memoryStore()), ran, 1);
+    const turns = turnsOf(support, "u_42");
+    const asked = await interrupted(support.chat("Refund invoice 7.", { as: "u_42" }));
+
+    await expect.poll(async () => turns.list({ status: "interrupted" }), { timeout: 20_000, interval: 25 })
+      .toEqual([]);
+    // The ask is expired — `turns.resume` says so. The caller still holding the
+    // result is the SAME ask, on the same guard, past the same deadline.
+    await Promise.resolve(asked.resume({ [asked.interruptions[0]!.id]: "approve" }))
+      .catch(() => undefined);
+
+    expect(ran.count).toBe(0);
+  }, 60_000);
+
+  it("is expired exactly at createdAt + ttl, and alive one second inside it", async () => {
+    const store = keep(memoryStore());
+    const ran = { count: 0 };
+    const support = shortLived(store, ran, 60_000);
+    const turns = turnsOf(support, "u_42");
+    const asked = await interrupted(support.chat("Refund invoice 7.", { as: "u_42" }));
+    const id = asked.interruptions[0]!.id;
+
+    await rewriteCreatedAt(store, id, new Date(Date.now() - 59_000).toISOString());
+    expect(await turns.list({ status: "interrupted" })).toHaveLength(1);
+
+    await rewriteCreatedAt(store, id, new Date(Date.now() - 60_000).toISOString());
+    expect(await turns.list({ status: "interrupted" })).toEqual([]);
+    const refused = await errorOf(turns.resume(asked.turnId, { [id]: "approve" }));
+    expect(refused.code).toBe("conflict");
+    expect(ran.count).toBe(0);
+  }, 60_000);
+
+  it("cannot be handed an unreadable createdAt in the first place", async () => {
+    const store = keep(memoryStore());
+    const ran = { count: 0 };
+    const support = shortLived(store, ran, 60_000);
+    const asked = await interrupted(support.chat("Refund invoice 7.", { as: "u_42" }));
+
+    // `expired()` computes `Date.parse(createdAt) + ttl <= at`, and NaN loses
+    // every comparison — an unparseable timestamp would read as never expiring,
+    // which is fail-OPEN on the only thing standing between a week-old yes and
+    // a live refund. The branch is unreachable: the store parses an approval row
+    // on the way in, so no writer can put one there.
+    await expect(rewriteCreatedAt(store, asked.interruptions[0]!.id, "whenever"))
+      .rejects.toThrow(/datetime/i);
+  }, 60_000);
+});
+
+// ---------------------------------------------------------------------------
+// 4. THE DECISION MAP
+// ---------------------------------------------------------------------------
+
+describe("the decision map", () => {
+  const parkOne = async (ran: Ran) => {
+    const support = parking(keep(memoryStore()), ran);
+    const asked = await interrupted(support.chat("Refund invoice 7.", { as: "u_42" }));
+    return { turns: turnsOf(support, "u_42"), asked, id: asked.interruptions[0]!.id };
+  };
+
+  it("names every parked id when the map is empty", async () => {
+    const ran = { count: 0 };
+    const { turns, asked, id } = await parkOne(ran);
+    const refused = await errorOf(turns.resume(asked.turnId, {}));
+    expect(refused.code).toBe("validation");
+    expect(refused.message).toContain(id);
+    expect(await turns.list({ status: "interrupted" })).toHaveLength(1);
+  }, 60_000);
+
+  it("names the parked id when the map holds only ids this turn never parked", async () => {
+    const ran = { count: 0 };
+    const { turns, asked, id } = await parkOne(ran);
+    const refused = await errorOf(turns.resume(asked.turnId, { apr_nope: "approve", other: "deny" }));
+    expect(refused.code).toBe("validation");
+    expect(refused.message).toContain(id);
+    expect(ran.count).toBe(0);
+  }, 60_000);
+
+  it("survives a prototype-shaped key without crashing or answering anything", async () => {
+    const ran = { count: 0 };
+    const { turns, asked, id } = await parkOne(ran);
+    const hostile = JSON.parse('{"__proto__":"approve","constructor":"approve"}') as Decisions;
+    const refused = await errorOf(turns.resume(asked.turnId, hostile));
+    expect(refused.code).toBe("validation");
+    expect(refused.message).toContain(id);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    expect(ran.count).toBe(0);
+  }, 60_000);
+
+  it("refuses an input answer given for an approval instead of silently denying it", async () => {
+    const ran = { count: 0 };
+    const { turns, asked, id } = await parkOne(ran);
+
+    // `{ answers }` is a well-typed `Decision` — the compiler accepts it for an
+    // approval interruption. It is not a verdict, so it cannot be one.
+    // `settleInterruptions` reads `decision === "approve"` and calls everything
+    // else a no (turn.ts:415), so this lands as a DENIAL nobody made.
+    const settled = await turns.resume(asked.turnId, { [id]: { answers: { q: "yes" } } })
+      .then((value: unknown) => value, (error: unknown) => error);
+
+    expect.soft(settled).toBeInstanceOf(VendoError);
+    // The one-shot ask must survive a malformed answer: this person never said
+    // no, and after this they can never say yes.
+    expect.soft(await turns.list({ status: "interrupted" })).toHaveLength(1);
+    expect.soft(ran.count).toBe(0);
+  }, 60_000);
+});
+
+// ---------------------------------------------------------------------------
+// 5. WHAT THE SPEC CUT
+// ---------------------------------------------------------------------------
+
+describe("nothing the spec cut crept back in", () => {
+  it("exposes exactly list and resume", async () => {
+    const ran = { count: 0 };
+    const support = parking(keep(memoryStore()), ran);
+    const turns = turnsOf(support, "u_42");
+    expect(Object.keys(turns).sort()).toEqual(["list", "resume"]);
+    expect((turns as Record<string, unknown>).get).toBeUndefined();
+    expect((turns as Record<string, unknown>).onInterruption).toBeUndefined();
+  });
+
+  it("never emits an input interruption", async () => {
+    const ran = { count: 0 };
+    const support = parking(keep(memoryStore()), ran);
+    const asked = await interrupted(support.chat("Refund invoice 7.", { as: "u_42" }));
+    const listed = await turnsOf(support, "u_42").list({ status: "interrupted" });
+    expect(asked.interruptions.every((one) => one.type === "approval")).toBe(true);
+    expect(listed[0]!.interruptions.every((one) => one.type === "approval")).toBe(true);
+  }, 60_000);
+});

--- a/packages/agents/tests/interruptions.test.ts
+++ b/packages/agents/tests/interruptions.test.ts
@@ -1,0 +1,355 @@
+/**
+ * Turns that are waiting on a person — found and answered from somewhere else.
+ *
+ * Real embedded store, real guard, real `createHarnessRuntime`; only the
+ * thinker is scripted, because the thinker is not what is under test
+ * (CLAUDE.md: test the SEAM). The headline case is a RESTART, and it is an
+ * honest one: the parking composition's store handle is CLOSED and a second
+ * composition is built over the same data directory, sharing no in-memory
+ * object with the first — no agent, no guard, no harness, no tool closure. If
+ * the park were living in a promise rather than in the store, nothing below
+ * would find it.
+ */
+import { createGuard } from "@vendoai/guard";
+import { defineHarness } from "@vendoai/harnesses";
+import { createStore, threadMessageStore, type VendoStore } from "@vendoai/store";
+import { VendoError, type RunContext, type ToolResult } from "@vendoai/core";
+import type { UIMessage } from "ai";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { agent, agentComposition, type VendoAgent } from "../src/agent.js";
+import { createTurns, PARKED_TURN_TTL_MS, type Turns } from "../src/interruptions.js";
+import { tool } from "../src/tools.js";
+import type { TurnResult } from "../src/turn.js";
+
+let stores = 0;
+const memoryStore = (): VendoStore => createStore({ dataDir: `memory://agents-interruptions-${stores++}` });
+
+const owner = (subject: string) => ({ kind: "user" as const, subject });
+
+const temporary: Array<{ dir: string; store: VendoStore }> = [];
+afterEach(async () => {
+  for (const { dir, store } of temporary.splice(0)) {
+    await store.close().catch(() => {});
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+/** What one call was handed when it finally ran: the authority of the call that
+ *  answered it, never the authority of the request that asked. */
+interface Ran {
+  count: number;
+  headers?: Record<string, string>;
+  context?: Record<string, unknown>;
+}
+
+/** Ungraded/destructive is the one thing a guard with no rules at all still
+ *  wants a person for, so this is how a turn parks without a rule set standing
+ *  in for the guard (turn.test.ts uses the same tool for the same reason). */
+const refundTool = (ran: Ran) => tool({
+  name: "refund",
+  description: "Refund an invoice",
+  risk: "destructive",
+  inputSchema: { type: "object" },
+  execute: (_input, ctx: RunContext) => {
+    ran.count += 1;
+    ran.headers = ctx.requestHeaders;
+    ran.context = ctx.context;
+    return { refunded: true };
+  },
+});
+
+/**
+ * A thinker that decides from the TRANSCRIPT, because that is all a restarted
+ * process has: it asks for the refund when the conversation asks for one,
+ * reports when it reads that the approvals were answered, and otherwise just
+ * talks. A counter would have been a lie here — the resuming composition's
+ * harness is a fresh object and its own counter starts at zero.
+ */
+const refunder = (calls = 1) => defineHarness({
+  name: "refunder",
+  async *run(turn) {
+    const last = JSON.stringify(turn.messages.at(-1)?.parts ?? []);
+    if (last.includes("[Resumed]")) {
+      yield { type: "text" as const, delta: "The refund went through." };
+      return;
+    }
+    if (!last.includes("efund")) {
+      yield { type: "text" as const, delta: "Your balance is fine." };
+      return;
+    }
+    for (let index = 0; index < calls; index += 1) {
+      const result: ToolResult = await turn.tools.call("refund", { invoice: index });
+      if (result.status === "ok") throw new Error("the guard was supposed to park this");
+    }
+    yield { type: "text" as const, delta: "I have asked for approval." };
+  },
+});
+
+const parking = (store: VendoStore, ran: Ran, calls = 1): VendoAgent =>
+  agent({ name: "support", harness: refunder(calls), tools: [refundTool(ran)], store });
+
+/** The `turns` face PR4 hangs off a user, over a real composition. */
+const turnsOf = (built: VendoAgent, subject: string): Turns =>
+  createTurns({ ...agentComposition(built)!, name: "support" }, subject);
+
+const interrupted = async (result: PromiseLike<TurnResult>): Promise<
+  Extract<TurnResult, { status: "interrupted" }>
+> => {
+  const settled = await result;
+  if (settled.status !== "interrupted") throw new Error(`expected interrupted, got ${settled.status}`);
+  return settled;
+};
+
+const transcriptOf = (store: VendoStore, subject: string, threadId: string): Promise<UIMessage[]> =>
+  threadMessageStore<UIMessage>(store).list(owner(subject), threadId as never);
+
+describe("an interrupted turn outlives the process that parked it", () => {
+  it("is listed and resumed by a composition that shares nothing with the one that parked it", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "vendo-agents-interruptions-"));
+    const parked = { count: 0 };
+    const first = createStore({ dataDir: dir });
+    const asked = await interrupted(parking(first, parked).chat("Refund invoice 7.", { as: "u_42" }));
+
+    // THE RESTART. Everything the first composition held goes away with it.
+    await first.close();
+
+    const resumedRuns = { count: 0 };
+    const second = createStore({ dataDir: dir });
+    temporary.push({ dir, store: second });
+    const support = parking(second, resumedRuns);
+    const turns = turnsOf(support, "u_42");
+
+    const waiting = await turns.list({ status: "interrupted" });
+    expect(waiting).toHaveLength(1);
+    expect(waiting[0]).toMatchObject({
+      turnId: asked.turnId,
+      threadId: asked.threadId,
+      interruptions: [{ id: asked.interruptions[0]?.id, type: "approval", toolCall: { tool: "refund" } }],
+    });
+
+    const answered = await turns.resume(asked.turnId, { [asked.interruptions[0]!.id]: "approve" });
+
+    // The exact call the person saw ran, in the NEW process, once — and never
+    // in the old one, which only ever asked.
+    expect(parked.count).toBe(0);
+    expect(resumedRuns.count).toBe(1);
+    // One turn across the park, whatever restarted in between.
+    expect(answered).toMatchObject({
+      status: "ok",
+      text: "The refund went through.",
+      turnId: asked.turnId,
+      threadId: asked.threadId,
+    });
+    // And it is all one conversation, read back the way a reload reads it.
+    expect((await transcriptOf(second, "u_42", asked.threadId)).map((message) => message.role))
+      .toEqual(["user", "assistant", "user", "assistant"]);
+
+    // Answered once is answered: nothing is left waiting, and a client that
+    // retries the resume is told so rather than running the refund again.
+    expect(await turns.list({ status: "interrupted" })).toEqual([]);
+    const again = await turns.resume(asked.turnId, { [asked.interruptions[0]!.id]: "approve" })
+      .catch((error: unknown) => error);
+    expect(again).toBeInstanceOf(VendoError);
+    expect((again as VendoError).code).toBe("conflict");
+    expect(resumedRuns.count).toBe(1);
+  }, 60_000);
+});
+
+describe("an approved call runs once, however many callers answer", () => {
+  it("survives two processes resuming the same turn at the same instant", async () => {
+    const ran = { count: 0 };
+    const support = parking(memoryStore(), ran);
+    const turns = turnsOf(support, "u_42");
+    const asked = await interrupted(support.chat("Refund invoice 7.", { as: "u_42" }));
+    const decisions = { [asked.interruptions[0]!.id]: "approve" as const };
+
+    const answers = await Promise.all([
+      turns.resume(asked.turnId, decisions).catch((error: unknown) => error),
+      turns.resume(asked.turnId, decisions).catch((error: unknown) => error),
+    ]);
+
+    // The refund happened once. Not because this layer sequenced anything —
+    // both callers read the same pending ask — but because deciding an
+    // approval is a one-time transition in the guard, and the call it
+    // authorizes is replayable exactly once.
+    expect(ran.count).toBe(1);
+    expect(answers.filter((answer) => (answer as { status?: string }).status === "ok")).toHaveLength(1);
+  }, 30_000);
+});
+
+describe("every interruption is answered, or none is", () => {
+  it("refuses a partial decision map by name, and leaves the turn exactly as it was", async () => {
+    const ran = { count: 0 };
+    const support = parking(memoryStore(), ran, 2);
+    const turns = turnsOf(support, "u_42");
+    const asked = await interrupted(support.chat("Refund invoice 7 and invoice 8.", { as: "u_42" }));
+    expect(asked.interruptions).toHaveLength(2);
+
+    const refused = await turns.resume(asked.turnId, { [asked.interruptions[0]!.id]: "approve" })
+      .catch((error: unknown) => error);
+
+    expect(refused).toBeInstanceOf(VendoError);
+    expect((refused as VendoError).code).toBe("validation");
+    // Named, because "a decision is missing" is unanswerable from a client
+    // holding several.
+    expect((refused as VendoError).message).toContain(asked.interruptions[1]!.id);
+    expect((refused as VendoError).message).not.toContain(asked.interruptions[0]!.id);
+
+    // Nothing ran, and nothing was decided on the way out: the turn is still
+    // there to answer properly.
+    expect(ran.count).toBe(0);
+    expect((await turns.list({ status: "interrupted" }))[0]?.interruptions).toHaveLength(2);
+  }, 30_000);
+});
+
+describe("authority comes from the call that resumes", () => {
+  const parkWith = async (store: VendoStore, ran: Ran) => {
+    const support = parking(store, ran);
+    const asked = await interrupted(support.chat("Refund invoice 7.", {
+      as: "u_42",
+      headers: { authorization: "Bearer parked" },
+      context: { tenant: "parked" },
+    }));
+    return { turns: turnsOf(support, "u_42"), asked };
+  };
+
+  it("runs the approved call with the resuming call's headers and context, never the parked ones", async () => {
+    const ran: Ran = { count: 0 };
+    const { turns, asked } = await parkWith(memoryStore(), ran);
+
+    await turns.resume(asked.turnId, { [asked.interruptions[0]!.id]: "approve" }, {
+      headers: { authorization: "Bearer fresh" },
+      context: { tenant: "fresh" },
+    });
+
+    expect(ran.count).toBe(1);
+    expect(ran.headers).toEqual({ authorization: "Bearer fresh" });
+    expect(ran.context).toEqual({ tenant: "fresh" });
+  }, 30_000);
+
+  it("carries no authority at all when the resuming call brings none", async () => {
+    const ran: Ran = { count: 0 };
+    const { turns, asked } = await parkWith(memoryStore(), ran);
+
+    await turns.resume(asked.turnId, { [asked.interruptions[0]!.id]: "approve" });
+
+    // The parked request's headers were request-lifetime and that request is
+    // over — a resume that inherited them would be a token outliving its call.
+    expect(ran.count).toBe(1);
+    expect(ran.headers).toBeUndefined();
+    expect(ran.context).toBeUndefined();
+  }, 30_000);
+});
+
+describe("a turn you do not own", () => {
+  it("reads back as absent, and cannot be answered on the owner's behalf", async () => {
+    const ran = { count: 0 };
+    const support = parking(memoryStore(), ran);
+    const asked = await interrupted(support.chat("Refund invoice 7.", { as: "u_42" }));
+
+    const stranger = turnsOf(support, "u_99");
+    expect(await stranger.list({ status: "interrupted" })).toEqual([]);
+    const refused = await stranger.resume(asked.turnId, { [asked.interruptions[0]!.id]: "approve" })
+      .catch((error: unknown) => error);
+
+    // The ownership law: a thing you do not own is missing, never forbidden —
+    // "you may not answer this" would confirm it exists.
+    expect(refused).toBeInstanceOf(VendoError);
+    expect((refused as VendoError).code).toBe("not-found");
+    expect(ran.count).toBe(0);
+    // And the owner's turn is untouched by the attempt.
+    expect(await turnsOf(support, "u_42").list({ status: "interrupted" })).toHaveLength(1);
+  }, 30_000);
+});
+
+describe("a parked turn waits a week, and says so when the week is up", () => {
+  it("gives an agent's own guard seven days, and leaves a passed-in guard exactly as it came", () => {
+    const mine = agent({ name: "support", harness: refunder(), store: memoryStore() });
+    expect(agentComposition(mine)?.guard.approvals.parkedCallTtlMs).toBe(PARKED_TURN_TTL_MS);
+    expect(PARKED_TURN_TTL_MS).toBe(7 * 24 * 60 * 60_000);
+
+    const host = agent({
+      name: "support",
+      harness: refunder(),
+      store: memoryStore(),
+      guard: { approvals: { parkedCallTtlMs: 60_000 } },
+    });
+    expect(agentComposition(host)?.guard.approvals.parkedCallTtlMs).toBe(60_000);
+
+    // ADAPTER RULE: a built instance is this deployment's choke point, TTL
+    // included — the guard's own hour, not ours.
+    const store = memoryStore();
+    const instance = agent({ name: "support", harness: refunder(), store, guard: createGuard({ store }) });
+    expect(agentComposition(instance)?.guard.approvals.parkedCallTtlMs).toBe(60 * 60_000);
+  });
+
+  it("names the expiry instead of losing the turn quietly", async () => {
+    const ran = { count: 0 };
+    const support = agent({
+      name: "support",
+      harness: refunder(),
+      tools: [refundTool(ran)],
+      store: memoryStore(),
+      // One millisecond: the same clock the seven days ride, wound forward.
+      guard: { approvals: { parkedCallTtlMs: 1 } },
+    });
+    const turns = turnsOf(support, "u_42");
+    const asked = await interrupted(support.chat("Refund invoice 7.", { as: "u_42" }));
+
+    // A turn nobody can act on is not on the list of turns to act on.
+    await expect.poll(async () => turns.list({ status: "interrupted" }), { timeout: 20_000, interval: 25 })
+      .toEqual([]);
+    const refused = await turns.resume(asked.turnId, { [asked.interruptions[0]!.id]: "approve" })
+      .catch((error: unknown) => error);
+
+    expect(refused).toBeInstanceOf(VendoError);
+    expect((refused as VendoError).code).toBe("conflict");
+    expect((refused as VendoError).message).toMatch(/expired/);
+    // What happened, and how it ends.
+    expect((refused as VendoError).message).toMatch(/send the request again/);
+    expect(ran.count).toBe(0);
+  }, 30_000);
+});
+
+describe("a message that arrives instead of an answer", () => {
+  /**
+   * PINNED, not chosen here.
+   *
+   * A user who types again rather than answering does NOT lose the ask on this
+   * lane, and the reason is structural: every turn here runs
+   * `interactive: false`, so a parked call is refused on the spot and leaves no
+   * `approval-requested` part behind (turn-tools.ts, the `!options.interactive`
+   * branch — the card "stands", which is exactly what `standing: true` means to
+   * the waiter). The next turn's abandonment sweep only flips parts in that
+   * state (`abandonPendingApprovals`, transcript-rules.ts, read by
+   * `abandonStaleApprovals`, runtime.ts), so it finds nothing of ours. The
+   * streaming lane (`session()`/`respond()`, `interactive: true`) is where
+   * approval parts are written and where the next turn withdraws them.
+   *
+   * The behaviour is not this slice's to change. What IS this slice's is that
+   * `list` and `resume` agree with the guard about it, whichever way it goes:
+   * a turn the list offers can still be answered.
+   */
+  it("leaves the interruption standing, and the turn is still answerable after it", async () => {
+    const ran = { count: 0 };
+    const support = parking(memoryStore(), ran);
+    const turns = turnsOf(support, "u_42");
+    const asked = await interrupted(support.chat("Refund invoice 7.", { as: "u_42" }));
+    expect(await turns.list({ status: "interrupted" })).toHaveLength(1);
+
+    const moved = await support.chat("Actually, what is my balance?", {
+      as: "u_42",
+      threadId: asked.threadId,
+    });
+    expect(moved).toMatchObject({ status: "ok", text: "Your balance is fine." });
+
+    expect(await turns.list({ status: "interrupted" })).toMatchObject([{ turnId: asked.turnId }]);
+    const answered = await turns.resume(asked.turnId, { [asked.interruptions[0]!.id]: "approve" });
+    expect(answered).toMatchObject({ status: "ok", turnId: asked.turnId });
+    expect(ran.count).toBe(1);
+    expect(await turns.list({ status: "interrupted" })).toEqual([]);
+  }, 30_000);
+});

--- a/packages/core/src/grants.ts
+++ b/packages/core/src/grants.ts
@@ -185,6 +185,13 @@ export interface ApprovalRequest {
      *  because a park outside a turn (a door-side check, a row written before
      *  this field existed) has no turn to name. */
     turnId?: TurnId;
+    /** The AGENT that parked it (`RunContext.agent`) — the axis a turn is
+     *  answered on. Two agents over one store share this collection and mount
+     *  descriptors that hash identically, so without it a yes to one agent's
+     *  ask dispatched the other's same-named tool. Optional because a park
+     *  outside an agent (a door-side check, a row written before this field
+     *  existed) has none; scoped consumers fail closed on its absence. */
+    agent?: string;
     appId?: AppId;
     trigger?: TriggerRef;
   };
@@ -208,6 +215,7 @@ export const approvalRequestSchema = z.object({
     presence: z.enum(["present", "away"]),
     sessionId: z.string().optional(),
     turnId: turnIdSchema.optional(),
+    agent: z.string().optional(),
     appId: appIdSchema.optional(),
     trigger: triggerRefSchema.optional(),
   }).passthrough(),

--- a/packages/core/src/grants.ts
+++ b/packages/core/src/grants.ts
@@ -5,10 +5,12 @@ import {
   approvalIdSchema,
   grantIdSchema,
   isoDateTimeSchema,
+  turnIdSchema,
   type AppId,
   type ApprovalId,
   type GrantId,
   type IsoDateTime,
+  type TurnId,
 } from "./ids.js";
 import { principalSchema, type Principal } from "./principal.js";
 import type { RunContext } from "./run-context.js";
@@ -175,6 +177,14 @@ export interface ApprovalRequest {
      *  before it existed can't carry it; every new park writes it, and
      *  scoped consumers fail closed on its absence. */
     sessionId?: string;
+    /** The TURN that parked it (`RunContext.turnId`) — the id
+     *  `turns.resume(turnId, …)` addresses, and the same join key every audit
+     *  row this turn wrote already carries. Without it a parked call is
+     *  findable only as one of a subject's asks, and a caller holding the id
+     *  their interrupted turn returned has nothing to look it up by. Optional
+     *  because a park outside a turn (a door-side check, a row written before
+     *  this field existed) has no turn to name. */
+    turnId?: TurnId;
     appId?: AppId;
     trigger?: TriggerRef;
   };
@@ -197,6 +207,7 @@ export const approvalRequestSchema = z.object({
     venue: z.enum(["chat", "app", "automation", "mcp"]),
     presence: z.enum(["present", "away"]),
     sessionId: z.string().optional(),
+    turnId: turnIdSchema.optional(),
     appId: appIdSchema.optional(),
     trigger: triggerRefSchema.optional(),
   }).passthrough(),

--- a/packages/core/src/run-context.ts
+++ b/packages/core/src/run-context.ts
@@ -133,6 +133,21 @@ export interface RunContext {
    * org-policy load. Absent means "no turn", never "unknown turn".
    */
   turnId?: TurnId;
+  /**
+   * The agent this run belongs to, by its own name (`agent({ name })`).
+   *
+   * Two agents over one store share one approvals collection, and a park used to
+   * name only the subject, the thread and the turn — so a person's yes to `ops`
+   * could be spent inside `support`, whose same-named tool hashes identically.
+   * Carried here for the same reason `turnId` is: the ctx is what already
+   * reaches every guarded call, so the row a park writes can name the agent
+   * without a second parameter anywhere.
+   *
+   * Optional because a run can have no agent: a door-side check, a host driving
+   * a turn by hand. Absent means "no agent", and a consumer scoped to one fails
+   * closed on it.
+   */
+  agent?: string;
 }
 
 /** 01-core §3 */
@@ -157,4 +172,5 @@ export const runContextSchema = z.object({
   // in-process only, so no wire shape exists for it (`.passthrough()` keeps it
   // on a ctx that already carries one).
   turnId: turnIdSchema.optional(),
+  agent: z.string().optional(),
 }).passthrough() satisfies z.ZodType<RunContext>;

--- a/packages/guard/src/guard.ts
+++ b/packages/guard/src/guard.ts
@@ -2212,6 +2212,11 @@ class GuardImplementation implements VendoGuard {
         // after a restart. Inert for matching — `sameParkedCall` pins the call
         // and the venue, never this — and absent on a check with no turn.
         ...(ctx.turnId === undefined ? {} : { turnId: ctx.turnId }),
+        // The AGENT that asked, on the same terms: one store holds every
+        // agent's asks, and a resume that could not tell them apart spent one
+        // agent's yes on another's same-named tool. Inert for matching too —
+        // it decides who may ANSWER, never what the yes authorizes.
+        ...(ctx.agent === undefined ? {} : { agent: ctx.agent }),
         ...(ctx.appId === undefined ? {} : { appId: ctx.appId }),
         ...(ctx.trigger === undefined ? {} : { trigger: cloneJson(ctx.trigger) }),
       },

--- a/packages/guard/src/guard.ts
+++ b/packages/guard/src/guard.ts
@@ -547,6 +547,11 @@ class GuardImplementation implements VendoGuard {
     parkedCallTtlMs: DEFAULT_PARKED_CALL_TTL_MS,
     pending: (principal: Principal): Promise<ApprovalRequest[]> =>
       this.#pendingApprovals(principal),
+    get: (
+      id: ApprovalId,
+      principal: Principal,
+    ): Promise<{ request: ApprovalRequest; status: ApprovalRecordData["status"] } | undefined> =>
+      this.#getApproval(id, principal),
     decide: (
       ids: ApprovalId | ApprovalId[],
       decision: ApprovalDecision,
@@ -2201,6 +2206,12 @@ class GuardImplementation implements VendoGuard {
         // The owner identity the record below already keeps — ON the request
         // too, so subscribers can scope delivery to the parking conversation.
         sessionId: ctx.sessionId,
+        // The TURN that asked, so a park survives the process that made it as
+        // something addressable rather than as one more of a subject's asks:
+        // `turns.resume(turnId, …)` (@vendoai/agents) finds this row through it
+        // after a restart. Inert for matching — `sameParkedCall` pins the call
+        // and the venue, never this — and absent on a check with no turn.
+        ...(ctx.turnId === undefined ? {} : { turnId: ctx.turnId }),
         ...(ctx.appId === undefined ? {} : { appId: ctx.appId }),
         ...(ctx.trigger === undefined ? {} : { trigger: cloneJson(ctx.trigger) }),
       },
@@ -2224,6 +2235,21 @@ class GuardImplementation implements VendoGuard {
       }
     }
     return request;
+  }
+
+  /** Owner-scoped like every approval read: a foreign or unknown id is absent,
+   *  never a hint that it exists. Reads the row directly rather than through a
+   *  ref-filtered listing because the caller already has the id, and a decided
+   *  row is exactly the one no status filter would return. */
+  async #getApproval(
+    id: ApprovalId,
+    principal: Principal,
+  ): Promise<{ request: ApprovalRequest; status: ApprovalRecordData["status"] } | undefined> {
+    const record = await this.#engine.get(APPROVALS_COLLECTION, id);
+    if (record === null) return undefined;
+    const data = approvalData(record);
+    if (data.request.ctx.principal.subject !== principal.subject) return undefined;
+    return { request: data.request, status: data.status };
   }
 
   async #pendingApprovals(principal: Principal): Promise<ApprovalRequest[]> {

--- a/packages/guard/src/types.ts
+++ b/packages/guard/src/types.ts
@@ -138,6 +138,19 @@ export interface VendoGuard extends Guard {
      *  with the rules that came in beside it. */
     parkedCallTtlMs: number;
     pending(principal: Principal): Promise<ApprovalRequest[]>;
+    /** ONE approval, whatever became of it — the read `pending` stops serving
+     *  the moment a row is decided. It exists so a caller that answered an ask
+     *  can still say WHAT it answered (`turns.resume` tells "this turn was
+     *  already resumed" from "no such turn" with it) instead of reaching into
+     *  the guard's own collection. Owner-scoped exactly as `pending` is: an
+     *  unknown or foreign id reads back as absent, never as forbidden.
+     *  Optional for the reason `sweepExpiredApprovals` is — `VendoGuard` is a
+     *  published interface and an implementation written before this method
+     *  must keep compiling; every guard this package builds has it. */
+    get?(
+      id: ApprovalId,
+      principal: Principal,
+    ): Promise<{ request: ApprovalRequest; status: "pending" | "approved" | "denied" } | undefined>;
     decide(
       ids: ApprovalId | ApprovalId[],
       decision: ApprovalDecision,


### PR DESCRIPTION
## What changes

```ts
await user.turns.list({ status: "interrupted" });               // findable after ANY restart
await user.turns.resume(turnId, decisions, { headers, context }?);
```

A turn that parked on an approval is now a durable thing you can find and answer later — from a different request, a different process, or a week later. Previously the advice was "show the cards and call `run()` again", which re-ran the whole turn.

## No new persistence

The guard was already writing the exact `ToolCall` and its context when it parked a call. Resume reads that back and re-dispatches it byte-for-byte; the guard's existing one-time receipt makes it run **exactly once**. Re-*running* the turn cannot work — a fresh model turn mints a new tool-call id and the approval no longer matches — which is why this re-dispatches instead.

The one thing missing was an address: nothing linked a `turnId` to a parked approval. That is 3 lines — the guard now writes `ctx.turnId` onto the row it was already writing. No new collection, no new write.

## Proven across a real restart

`interruptions.test.ts:109-158`: a real store on disk, agent A parks a destructive refund, **the store is closed**, and a second store and a second `agent()` are built over the same directory — new guard, new harness, new tool closure, new counter. The new composition lists the turn with its original id, resumes it, and the refund runs there and only there. A retried resume gives `conflict` with the counter still at 1.

## What the adversarial round found, and what is fixed here

Exactly-once **held** under 8 concurrent resumes, two independent compositions racing, and a 3-way race on a two-interruption turn. Cross-user ownership **held** against seven hostile subject spellings. Three defects did not:

- **A yes given to one agent dispatched a different agent's implementation.** Two agents over one store shared the approvals collection, and two same-named tools hash identically — so a person's approval for `ops`' refund ran `support`'s refund. Resuming through an agent that lacked the tool was worse: it marked the approval *approved*, failed to dispatch, and burned the one-shot yes forever. Fixed with an agent axis (`RunContext.agent`, carried onto the parked row exactly as `turnId` is), read by both `list` and `resume`, failing closed and refusing **before** anything is decided. It is the agent's *name*, not an instance id — a per-instance id would have broken cross-process resume, which is the whole point of the slice.
- **The seven-day expiry was enforced on one of the two resume faces.** `turns.resume` refused an expired ask while the in-process `result.resume()` approved and ran it.
- **An answer-shaped decision given for an approval was silently a denial** — permanently rejecting an ask on an answer the person never gave.

The last two collapsed into one pre-flight in the single door both faces pass through, which let the duplicate expiry logic be **deleted** rather than copied.

## The seven days

Founder decision: parked interruptions get a 7-day TTL instead of the guard's 60-minute default, and a resume past it fails naming what happened and how it ends. The default goes on the guard `agent()` composes for itself; a passed-in guard instance still wins verbatim, and `createVendo` is untouched at 60 minutes. Enforced at read time — nothing in this package sweeps, so read time is where the promise can actually be kept.

## One correction to the brief, pinned by a test

A user typing another message does **not** destroy a pending interruption. Abandonment only flips transcript parts left in `approval-requested`, and this lane never leaves one. That is the streaming lane's behaviour. So the ask survives, stays listed, and stays resumable — better than the spec promised, and now tested.

## Gate

`build` · `typecheck` (42/42) · `lint` (dependency-guard OK; portability all legs green) · `packages/agents` 193 · `packages/guard` 362 · `packages/core` 800 · `packages/harnesses` 568 — all EXIT=0. Adversarial suite 18/18.

Stacked on #1498.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resume interrupted agent turns by id from any process within seven days, without re-running the turn. Previously approvals required calling run() again (minted a new tool-call id that no longer matched); now we re-dispatch the parked call exactly once.

- Adds `createTurns` with `turns.list({ status: "interrupted" })` and `turns.resume(turnId, decisions, { headers, context })` in `@vendoai/agents`. Exactly-once is enforced by the guard’s one-time receipt.
- Stores `turnId` and `agent` on the existing approval row; `list`/`resume` filter by agent. A cross-agent `turnId` now returns not-found, and resuming through an agent lacking the tool refuses without spending the approval.
- Default TTL is seven days via `agent()`; lists omit expired asks. `resume` applies the same deadline: it proceeds with the live asks only and requires decisions for those; it returns a conflict only when every ask is expired.
- Concurrent turns on the same thread no longer collect each other’s approvals; each turn only resumes the asks it parked.
- Validation and ownership: `resume` requires a verdict (“approve”/“deny”) for each parked id; non-verdict shapes are rejected. Foreign/unknown turns return not-found; already-answered turns return conflict. Resumed calls run with the resuming call’s headers/context, never the parked request’s.

**Rollout/Migration**
- Agents created via `agent()` now default to `approvals.parkedCallTtlMs = 7 days`. To keep 60 minutes, set `guard: { approvals: { parkedCallTtlMs: 60*60_000 } }` or pass a guard instance.
- When calling `turns.resume`, pass a verdict for every listed interruption id. Do not include expired ids; partial or malformed maps are refused without side effects.
- Multi-agent hosts over one store should keep distinct agent names; turns are scoped by name.

<sup>Written for commit 82e52871921641032a23a1e7f0eefe66f08e9759. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

