### PR TITLE
feat(agents,ui,vendo): a standalone agent is one mount, and the page it answers is stock useChat

### DIFF
--- a/fixtures/integration-browser/e2e/agent-chat.spec.ts
+++ b/fixtures/integration-browser/e2e/agent-chat.spec.ts
@@ -1,0 +1,84 @@
+/**
+ * THE SEAM: the shipped `useVendoChat` in a real browser against a real
+ * `agentHandler()` over real HTTP, with no stub on either side.
+ *
+ * One script, one run, the whole flow — a turn that parks on a real guard
+ * approval, a person answering it in the page, and the parked call actually
+ * running. What makes it a seam test rather than a demo is the last assertion:
+ * the refund is read back from the SERVER's own record, so a page that merely
+ * rendered a convincing sentence cannot pass.
+ */
+import { expect, test } from "@playwright/test";
+
+test("a parked approval is answered in the page, and the parked call then runs", async ({ page, request }) => {
+  await page.goto("/agent.html");
+  await expect(page.getByTestId("composer")).toBeVisible();
+
+  // Nothing has run yet: the mount's own record is the baseline.
+  expect((await (await request.get("/__agent/refunds")).json() as { refunded: string[] }).refunded).toEqual([]);
+
+  await page.getByTestId("composer").fill("refund invoice 7");
+  await page.getByTestId("send").click();
+
+  // 1. The turn reached the agent and came back with the conversation's id on
+  //    the response header — the round trip, not a rendered guess.
+  await expect(page.getByTestId("thread-id")).toHaveText(/^thr_/);
+
+  // 2. It PARKED. The guard's ask crossed the stream as a real
+  //    `approval-requested` part and the hook surfaced it as an interruption,
+  //    naming the tool the agent is waiting to run.
+  await expect(page.getByTestId("interruption")).toHaveCount(1);
+  await expect(page.getByTestId("interruption-tool")).toHaveText("host_refund");
+  await page.screenshot({ path: "e2e/artifacts/agent-chat-parked.png", fullPage: true });
+  // Still nothing has run — the park is real, not cosmetic.
+  expect((await (await request.get("/__agent/refunds")).json() as { refunded: string[] }).refunded).toEqual([]);
+
+  // 3. The person answers, in the page, through the hook's own `resume`.
+  await page.getByTestId("approve").click();
+
+  // 4. The parked call RAN — server-side evidence, not screen text.
+  await expect(async () => {
+    const { refunded } = await (await request.get("/__agent/refunds")).json() as { refunded: string[] };
+    expect(refunded).toEqual(["inv_7"]);
+  }).toPass({ timeout: 20_000 });
+
+  // 5. And the turn CARRIED ON to its answer, read back through this mount's
+  //    own thread route.
+  //
+  //    WHERE THE LIVE LEG STOPS, precisely: the ai-SDK ends its read of the
+  //    response at `tool-approval-request` — by its model a park ends the
+  //    request and the client resumes with a new one — so the browser is no
+  //    longer listening when the unblocked turn finishes. The turn still runs
+  //    to completion and still persists (the refund above is the proof), and
+  //    the umbrella covers the live gap with a stream-rejoin route
+  //    (`GET /threads/:id/stream`) that this mount does not have. Watching a
+  //    parked turn finish without a reload is durable resume, which is
+  //    `POST /turns/:id/resume` — wired here, and still a 501 seam.
+  const threadId = await page.getByTestId("thread-id").textContent();
+  await page.goto(`/agent.html?thread=${threadId ?? ""}`);
+  await expect(page.getByTestId("message-assistant").last()).toHaveText(/Refund sent\./);
+  await expect(page.getByTestId("interruption")).toHaveCount(0);
+  await page.screenshot({ path: "e2e/artifacts/agent-chat-resumed.png", fullPage: true });
+});
+
+test("the conversation is read back from the server after a reload, approvals included", async ({ page }) => {
+  await page.goto("/agent.html");
+  await page.getByTestId("composer").fill("refund invoice 7");
+  await page.getByTestId("send").click();
+  await expect(page.getByTestId("interruption")).toHaveCount(1);
+  const threadId = await page.getByTestId("thread-id").textContent();
+
+  // A FULL reload, with the browser's own stores emptied first: whatever comes
+  // back can only have come from the server.
+  await page.evaluate(() => {
+    globalThis.localStorage.clear();
+    globalThis.sessionStorage.clear();
+  });
+  await page.goto(`/agent.html?thread=${threadId ?? ""}`);
+
+  // Reopened purely from the server's transcript: the user's message is back,
+  // and so is the approval it is still waiting on.
+  await expect(page.getByTestId("message-user")).toHaveText("refund invoice 7");
+  await expect(page.getByTestId("interruption")).toHaveCount(1);
+  await page.screenshot({ path: "e2e/artifacts/agent-chat-reloaded.png", fullPage: true });
+});

--- a/fixtures/integration-browser/e2e/harness/agent-backend.ts
+++ b/fixtures/integration-browser/e2e/harness/agent-backend.ts
@@ -1,0 +1,134 @@
+/**
+ * The STANDALONE agent leg: a real `agent()` behind a real `agentHandler()`, on
+ * its own loopback listener, with nothing stubbed between it and the page.
+ *
+ * The browser half is `useVendoChat` (@vendoai/ui); this is the half it talks
+ * to. Both are real, which is the whole point — this repo has shipped a dead
+ * feature more than once because the producer and the consumer each mocked the
+ * other and could therefore never disagree (CLAUDE.md).
+ *
+ * Only the THINKER is scripted, exactly as the node suites script it: a harness
+ * is `{ name, run }` and nothing more, so a fixture brain needs no model, no
+ * provider key and no network. It calls one write-risk tool, which the policy
+ * says to ASK about — so the turn parks on a real guard approval, the runtime
+ * streams a real `approval-requested` part, and the only thing that can move it
+ * forward is the browser answering.
+ */
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+import { agent, agentHandler, tool } from "@vendoai/agents";
+import type { Harness } from "@vendoai/core";
+import { createStore } from "@vendoai/store";
+
+const BASE_PATH = "/api/agent";
+const CONTROL = "/__agent";
+
+export interface AgentBackend {
+  /** The origin the Vite proxy targets for `/api/agent` and `/__agent`. */
+  url: string;
+  close(): Promise<void>;
+}
+
+export async function startAgentBackend(): Promise<AgentBackend> {
+  /** SERVER-SIDE evidence that the approved call really ran. A spec that only
+   *  reads the page cannot tell an executed refund from a rendered sentence. */
+  const refunded: string[] = [];
+
+  const refund = tool({
+    name: "host_refund",
+    description: "Refund an invoice",
+    inputSchema: { type: "object", properties: { invoiceId: { type: "string" } }, required: ["invoiceId"] },
+    risk: "write",
+    execute(input) {
+      refunded.push(String((input as { invoiceId?: unknown }).invoiceId));
+      return { refunded: true };
+    },
+  });
+
+  /** One write, then a word about it. The call BLOCKS until a person answers,
+   *  which is what makes the page's approval the thing that unblocks the turn. */
+  const scripted: Harness<unknown> = {
+    name: "refunder",
+    async *run(turn) {
+      const outcome = await turn.tools.call("host_refund", { invoiceId: "inv_7" });
+      yield { type: "text", delta: outcome.status === "ok" ? "Refund sent." : "Refund not sent." };
+    },
+  };
+
+  const support = agent({
+    name: "support",
+    harness: scripted,
+    store: createStore({ dataDir: "memory://integration-browser-agent" }),
+    tools: [refund],
+    guard: { policy: { rules: [{ match: { risk: "write" }, action: "ask" }] } },
+  });
+
+  const handle = support.handler({
+    basePath: BASE_PATH,
+    // The fixture's whole host session: identity resolution has its own unit
+    // tests, and a fixed subject keeps this spec about the seam.
+    resolveUser: async () => ({ subject: "user_ada" }),
+  });
+
+  const server = createServer((incoming, outgoing) => {
+    void serve(incoming, outgoing).catch((error: unknown) => {
+      outgoing.statusCode = 500;
+      outgoing.end(error instanceof Error ? error.message : "agent bridge failed");
+    });
+  });
+
+  async function serve(incoming: IncomingMessage, outgoing: ServerResponse): Promise<void> {
+    const url = new URL(incoming.url ?? "/", "http://127.0.0.1");
+    if (url.pathname === `${CONTROL}/refunds`) {
+      outgoing.writeHead(200, { "content-type": "application/json" });
+      outgoing.end(JSON.stringify({ refunded }));
+      return;
+    }
+    const chunks: Buffer[] = [];
+    for await (const chunk of incoming) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    const headers = new Headers();
+    for (const [name, value] of Object.entries(incoming.headers)) {
+      if (value !== undefined) headers.set(name, Array.isArray(value) ? value.join(", ") : value);
+    }
+    const response = await handle(new Request(`http://127.0.0.1${incoming.url ?? "/"}`, {
+      method: incoming.method,
+      headers,
+      ...(chunks.length === 0 ? {} : { body: new Uint8Array(Buffer.concat(chunks)) }),
+    }));
+    outgoing.statusCode = response.status;
+    response.headers.forEach((value, name) => outgoing.setHeader(name, value));
+    if (response.body === null) {
+      outgoing.end();
+      return;
+    }
+    // STREAMED, never buffered — for the reason the umbrella's bridge states:
+    // `arrayBuffer()` waits for the turn to END, and a parked turn never does.
+    // The approval card would never reach the browser, so the tap that resumes
+    // the turn could never happen and the turn could only time out.
+    outgoing.flushHeaders();
+    const reader = response.body.getReader();
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      outgoing.write(Buffer.from(value));
+    }
+    outgoing.end();
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+
+  return {
+    url: `http://127.0.0.1:${(server.address() as AddressInfo).port}`,
+    close: () =>
+      new Promise<void>((resolve) => {
+        server.closeAllConnections();
+        server.close(() => resolve());
+      }),
+  };
+}

--- a/fixtures/integration-browser/e2e/harness/agent-main.tsx
+++ b/fixtures/integration-browser/e2e/harness/agent-main.tsx
@@ -1,0 +1,70 @@
+/**
+ * The browser half of the standalone seam: the SHIPPED `useVendoChat`, against
+ * the real `agentHandler()` mount next door. Deliberately unstyled and
+ * unadorned — every element here exists to be asserted on, and nothing between
+ * the hook and the wire is this file's own invention.
+ */
+import { useVendoChat } from "@vendoai/ui";
+import { useState } from "react";
+import { createRoot } from "react-dom/client";
+
+const textOf = (parts: { type: string }[]): string =>
+  parts.filter((part): part is { type: "text"; text: string } => part.type === "text")
+    .map((part) => part.text)
+    .join("");
+
+function AgentChat(): React.JSX.Element {
+  // The hook stores nothing, so the conversation's id is the HOST's to carry.
+  // This one carries it in the URL — the same way a real app's route would.
+  const opened = new URLSearchParams(globalThis.location.search).get("thread") ?? undefined;
+  const chat = useVendoChat({
+    api: "/api/agent",
+    ...(opened === undefined ? {} : { threadId: opened }),
+    onThreadId: (id) => {
+      const next = new URL(globalThis.location.href);
+      next.searchParams.set("thread", id);
+      globalThis.history.replaceState(null, "", next);
+    },
+  });
+  const [draft, setDraft] = useState("");
+
+  return (
+    <main>
+      <p data-testid="thread-id">{chat.threadId ?? ""}</p>
+      <p data-testid="status">{chat.status}</p>
+      <ul data-testid="messages">
+        {chat.messages.map((message) => (
+          <li key={message.id} data-testid={`message-${message.role}`}>{textOf(message.parts)}</li>
+        ))}
+      </ul>
+      <ul data-testid="interruptions">
+        {chat.interruptions.map((interruption) => (
+          <li key={interruption.id} data-testid="interruption">
+            <span data-testid="interruption-tool">
+              {interruption.type === "approval" ? interruption.toolCall.tool : "input"}
+            </span>
+            <button data-testid="approve" onClick={() => void chat.resume({ [interruption.id]: "approve" })}>
+              Approve
+            </button>
+          </li>
+        ))}
+      </ul>
+      <input
+        data-testid="composer"
+        value={draft}
+        onChange={(event) => setDraft(event.target.value)}
+      />
+      <button
+        data-testid="send"
+        onClick={() => {
+          chat.sendMessage({ text: draft });
+          setDraft("");
+        }}
+      >
+        Send
+      </button>
+    </main>
+  );
+}
+
+createRoot(document.getElementById("root") as HTMLElement).render(<AgentChat />);

--- a/fixtures/integration-browser/e2e/harness/agent.html
+++ b/fixtures/integration-browser/e2e/harness/agent.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vendo standalone agent — browser seam</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/agent-main.tsx"></script>
+  </body>
+</html>

--- a/fixtures/integration-browser/e2e/harness/vite.config.ts
+++ b/fixtures/integration-browser/e2e/harness/vite.config.ts
@@ -1,5 +1,6 @@
 import { fileURLToPath } from "node:url";
 import { defineConfig, type ViteDevServer } from "vite";
+import { startAgentBackend } from "./agent-backend.ts";
 import { startBackends } from "./backends.ts";
 
 const harnessRoot = fileURLToPath(new URL(".", import.meta.url));
@@ -8,6 +9,10 @@ const harnessRoot = fileURLToPath(new URL(".", import.meta.url));
  *  wire and the booted fixture host app (both started in-process here). */
 export default defineConfig(async () => {
   const backends = await startBackends();
+  // The standalone agent leg is its OWN mount on its own listener: it composes
+  // `agent()` directly, with no umbrella and no host app in the picture, which
+  // is exactly the deployment `agentHandler()` exists for.
+  const standalone = await startAgentBackend();
 
   return {
     root: harnessRoot,
@@ -23,12 +28,16 @@ export default defineConfig(async () => {
         // path, so the mount prefix must survive to the wire.
         "/api/vendo": { target: backends.wireUrl, changeOrigin: false },
         "/__test": { target: backends.wireUrl, changeOrigin: false },
+        // Same rule: `agentHandler` self-routes on the FULL path, so the mount
+        // prefix must survive to it.
+        "/api/agent": { target: standalone.url, changeOrigin: false },
+        "/__agent": { target: standalone.url, changeOrigin: false },
       },
     },
     plugins: [{
       name: "vendo-backends-lifecycle",
       configureServer(server: ViteDevServer) {
-        server.httpServer?.once("close", () => void backends.close());
+        server.httpServer?.once("close", () => void Promise.all([backends.close(), standalone.close()]));
       },
     }],
   };

--- a/fixtures/integration-browser/package.json
+++ b/fixtures/integration-browser/package.json
@@ -15,6 +15,7 @@
     "@modelcontextprotocol/ext-apps": "^1.7.4",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@vendoai/actions": "workspace:*",
+    "@vendoai/agents": "workspace:*",
     "@vendoai/core": "workspace:*",
     "@vendoai/store": "workspace:*",
     "@vendoai/ui": "workspace:*",

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -36,6 +36,10 @@
     "./claude-code": {
       "types": "./dist/claude-code.d.ts",
       "default": "./dist/claude-code.js"
+    },
+    "./http": {
+      "types": "./dist/http/router.d.ts",
+      "default": "./dist/http/router.js"
     }
   },
   "files": [

--- a/packages/agents/src/agent.ts
+++ b/packages/agents/src/agent.ts
@@ -33,6 +33,7 @@ import { declareAutomation, type OnOptions } from "./automations.js";
 import { startRun, type RunOptions } from "./away.js";
 import { startChat, type ChatOptions, type Turn } from "./turn.js";
 import { resolveDoor, type DoorConfig } from "./door.js";
+import { agentHandler, type HandlerOptions } from "./handler.js";
 import { withEgress, type EgressConfig } from "./egress.js";
 import { PERMISSIONS_PATH, schemaReadyPrincipal, type AgentPrincipal } from "./permissions.js";
 import type { SystemPromptHook } from "./prompt.js";
@@ -134,6 +135,13 @@ export interface VendoAgent {
    */
   on(when: When, task: string, options?: OnOptions): void;
   session(subject: string, options?: SessionOptions): Promise<AgentSession>;
+  /**
+   * This whole agent over HTTP, as ONE fetch handler for the host to mount —
+   * the chat turn, the thread lifecycle, and the door and permission planes
+   * below. See {@link agentHandler}, which is the same thing for a caller
+   * holding the options rather than the agent.
+   */
+  handler(options: HandlerOptions): (request: Request) => Promise<Response>;
   /**
    * This agent's MCP door, present exactly when its harness thinks outside this
    * process (`requires.toolDoor`). A library cannot add a route to the host's
@@ -398,6 +406,7 @@ export function agent(config: AgentConfig): VendoAgent {
       return session.stream(message, options.signal === undefined ? {} : { signal: options.signal });
     },
     run: (task, options) => startRun(deps, task, options),
+    handler: (options) => agentHandler(built, options),
     on: (when, task, options) => declareAutomation(built, when, task, options),
     async session(subject, options) {
       await requireModel();

--- a/packages/agents/src/handler.ts
+++ b/packages/agents/src/handler.ts
@@ -11,20 +11,29 @@
  * Three planes come off the one catch-all, in the order a request meets them:
  * the engine's dial-back door (always-on internal plumbing on its own fixed
  * path, answering a live turn's own credential and nothing else), the
- * approvals/grants wire the agent already builds, and then this mount's own
- * table — the chat turn, the thread lifecycle, the durable resume.
+ * approvals/grants wire under THIS mount, and then its own table — the chat
+ * turn, the thread lifecycle, the durable resume.
+ *
+ * The permission wire is mounted HERE, on this basePath and behind this mount's
+ * `resolveUser`, rather than forwarded to `agent.permissions` on its fixed
+ * `/api/vendo`. Two reasons, and the browser found both: deciding an approval
+ * is what UNBLOCKS a parked turn (the guard's decision resolves the waiter the
+ * turn is sitting on — packages/harnesses/src/turn-tools.ts:122,382), so a
+ * client that cannot reach this wire has a park it can never answer; and a
+ * standalone host configures identity once, in `resolveUser`, so the asks a
+ * person sees must be scoped to the same person the turns are.
  *
  * The table runs on `./http/router.js`, the SAME route runtime the umbrella's
  * wire runs on, so a standalone mount and the embed cannot drift into two
  * routers with two ideas of what `/threads/:id` means.
  *
- * MOUNTING NOTE: the door and the permission wire keep their own absolute paths
- * (`DOOR_PATH`, `PERMISSIONS_PATH`) because the box dials the first and
- * `@vendoai/ui`'s consent surfaces post to the second. A deployment whose engine
- * thinks outside this process therefore routes those paths here too — mounting
- * this handler at `/api/vendo` puts all three under one catch-all.
+ * MOUNTING NOTE: the door keeps its own absolute path (`DOOR_PATH`) because that
+ * is the address the box dials. A deployment whose engine thinks outside this
+ * process therefore routes that path here too — mounting this handler at
+ * `/api/vendo` puts it and everything else under one catch-all.
  */
 import { isVendoError, VendoError, type Json, type Principal, type ThreadId } from "@vendoai/core";
+import { handlePermissionRequest } from "@vendoai/guard";
 import { threadMessageStore, threadStore } from "@vendoai/store";
 import type { UIMessage } from "ai";
 import { agentComposition, type VendoAgent } from "./agent.js";
@@ -53,6 +62,17 @@ export interface HandlerUser {
   context?: Record<string, unknown>;
 }
 
+/**
+ * Two options the v1 spec names are deliberately ABSENT rather than forgotten.
+ *
+ * `publicOrigin` could not take effect: the door's origin is fixed when
+ * `agent()` composes, and `resolveDoor` already throws the boot error naming
+ * both ways out for a sandboxed engine with no origin (door.ts:96-107) — long
+ * before a mount exists. `mcp` governs a PUBLIC MCP/auth plane, which this
+ * package does not serve; the spec defaults it OFF, so omitting it and
+ * defaulting it off are the same behaviour. Both are additive the day either
+ * has something to do.
+ */
 export interface HandlerOptions {
   /** Where the host mounted this handler. */
   basePath: string;
@@ -146,10 +166,6 @@ export function agentHandler(
       // authenticates every request with the live turn's own credential, so it
       // owes this mount's `resolveUser` nothing and must not be challenged by it.
       if (agent.door !== undefined && url.pathname === DOOR_PATH) return await agent.door(request);
-      // The five permission routes, which answer `undefined` for every path they
-      // do not own — which is what lets them sit in front of this table.
-      const permissions = await agent.permissions(request);
-      if (permissions !== undefined) return permissions;
       const path = relativePath(mount, url);
       if (path === null) throw new VendoError("not-found", "unknown route");
       const user = await options.resolveUser(request);
@@ -164,6 +180,18 @@ export function agentHandler(
       // fresh entry door, and a virgin store must not answer the first request
       // with a missing relation.
       await composition.store.ensureSchema();
+      const principal: Principal = { kind: "user", subject: user.subject };
+      // The five permission routes, ahead of the table and sharing the identity
+      // already resolved above. The area check is what keeps the body unread for
+      // everything else — `POST /threads` needs its own.
+      if (["approvals", "grants"].includes(path.split("/").filter(Boolean)[0] ?? "")) {
+        const answered = await handlePermissionRequest(composition.guard, principal, {
+          method: request.method as "GET" | "POST" | "DELETE",
+          path,
+          ...(request.method === "POST" ? { body: await request.json().catch(() => undefined) } : {}),
+        });
+        if (answered !== undefined) return json(answered.body);
+      }
       const forwarded = options.headers === false ? undefined : options.headers ?? request.headers;
       const routed = await dispatchRoutes(ROUTES, {
         request,
@@ -173,7 +201,7 @@ export function agentHandler(
         agent,
         threads,
         transcript,
-        principal: { kind: "user", subject: user.subject },
+        principal,
         subject: user.subject,
         turn: {
           ...(user.profile === undefined ? {} : { user: user.profile }),

--- a/packages/agents/src/handler.ts
+++ b/packages/agents/src/handler.ts
@@ -1,0 +1,194 @@
+/**
+ * ONE mount: the whole agent over HTTP.
+ *
+ * A library cannot add a route to the host's server, so — like `door` and
+ * `permissions` — this comes back as a fetch handler for the host to mount:
+ *
+ *     const handle = agentHandler(support, { basePath: "/api/agent", resolveUser });
+ *     // Next: export { handle as GET, handle as POST, handle as DELETE }
+ *     // Hono: app.all("/api/agent/*", (c) => handle(c.req.raw))
+ *
+ * Three planes come off the one catch-all, in the order a request meets them:
+ * the engine's dial-back door (always-on internal plumbing on its own fixed
+ * path, answering a live turn's own credential and nothing else), the
+ * approvals/grants wire the agent already builds, and then this mount's own
+ * table — the chat turn, the thread lifecycle, the durable resume.
+ *
+ * The table runs on `./http/router.js`, the SAME route runtime the umbrella's
+ * wire runs on, so a standalone mount and the embed cannot drift into two
+ * routers with two ideas of what `/threads/:id` means.
+ *
+ * MOUNTING NOTE: the door and the permission wire keep their own absolute paths
+ * (`DOOR_PATH`, `PERMISSIONS_PATH`) because the box dials the first and
+ * `@vendoai/ui`'s consent surfaces post to the second. A deployment whose engine
+ * thinks outside this process therefore routes those paths here too — mounting
+ * this handler at `/api/vendo` puts all three under one catch-all.
+ */
+import { isVendoError, VendoError, type Json, type Principal, type ThreadId } from "@vendoai/core";
+import { threadMessageStore, threadStore } from "@vendoai/store";
+import type { UIMessage } from "ai";
+import { agentComposition, type VendoAgent } from "./agent.js";
+import { DOOR_PATH } from "./door.js";
+import {
+  dispatchRoutes,
+  errorResponse,
+  json,
+  relativePath,
+  requestJson,
+  route,
+  routeSegments,
+  string,
+  type RouteContext,
+  type RouteEntry,
+} from "./http/router.js";
+import type { RespondOptions } from "./session.js";
+
+/** Who the host says is asking. */
+export interface HandlerUser {
+  /** The subject every thread, grant and audit row on this request is scoped to. */
+  subject: string;
+  /** Server-trust identity facts, model-visible (`[User]`). */
+  profile?: Record<string, Json>;
+  /** Guard/tools context: functions run at check-time, data survives parking. */
+  context?: Record<string, unknown>;
+}
+
+export interface HandlerOptions {
+  /** Where the host mounted this handler. */
+  basePath: string;
+  /** The host's own session, read per request. `null` is UNAUTHENTICATED and
+   *  answers 401 — a mount with nobody asking serves nobody's conversation. */
+  resolveUser: (request: Request) => Promise<HandlerUser | null>;
+  /** What the turn's own tools forward as the caller's authority. Unset → this
+   *  request's own headers, which is what a same-origin host wants; `false` →
+   *  nothing. Per request either way: request-lifetime authority does not
+   *  outlive the request. */
+  headers?: Record<string, string> | false;
+}
+
+/** The per-request view this mount's handlers read, on top of what the shared
+ *  matcher needs. */
+interface AgentWire extends RouteContext {
+  agent: VendoAgent;
+  threads: ReturnType<typeof threadStore>;
+  transcript: ReturnType<typeof threadMessageStore<UIMessage>>;
+  principal: Principal;
+  subject: string;
+  /** The identity every turn on THIS request runs with. */
+  turn: RespondOptions;
+}
+
+const ROUTES: readonly RouteEntry<AgentWire>[] = [
+  // One turn, as an AI-SDK UI-message stream — the same Response `respond()`
+  // hands back, with the conversation's id on `x-vendo-thread-id`. The request's
+  // own signal rides along, so a client that leaves cancels the turn instead of
+  // paying a provider to answer nobody.
+  route("POST", "/threads", async ({ request, agent, subject, turn }) => {
+    const body = await requestJson(request);
+    return agent.respond(subject, body["message"] as UIMessage, {
+      ...turn,
+      ...(body["threadId"] === undefined ? {} : { threadId: string(body["threadId"], "threadId") }),
+      signal: request.signal,
+    });
+  }),
+  route("GET", "/threads", async ({ threads, principal }) => json(await threads.list(principal))),
+  // Grouped like the umbrella's arm: an unhandled method falls through to the
+  // table's not-found rather than being answered here.
+  route("*", "/threads/:id", async ({ request, threads, transcript, principal, params }) => {
+    const id = string(params["id"], "thread id") as ThreadId;
+    if (request.method === "GET") {
+      // The thread row is the ownership record and every read joins it under
+      // this subject, so a foreign id reads back as absent — the same answer as
+      // one that never existed.
+      if (await threads.get(principal, id) === null) {
+        throw new VendoError("not-found", `thread not found: ${id}`);
+      }
+      return json({ id, messages: await transcript.list(principal, id) });
+    }
+    if (request.method === "DELETE") {
+      await threads.delete(principal, id);
+      return json({});
+    }
+    return undefined;
+  }),
+  // SEAM — durable resume is `turns.resume`, and its rules (partial decision
+  // maps, `conflict` on a turn that is not interrupted, the turnId that stays
+  // stable across park and resume) are frozen in the slice that owns it. The
+  // route is wired so this mount's shape is final; a second set of those rules
+  // invented here is exactly how one rule becomes two. Until that verb lands,
+  // an approval is answered in the stream it was asked in.
+  route("POST", "/turns/:turnId/resume", async () => {
+    throw new VendoError(
+      "not-implemented",
+      "Durable resume is not wired in this build. Answer the approval on the turn's own stream.",
+    );
+  }),
+];
+
+export function agentHandler(
+  agent: VendoAgent,
+  options: HandlerOptions,
+): (request: Request) => Promise<Response> {
+  const composition = agentComposition(agent);
+  if (composition === undefined) {
+    throw new VendoError("validation", "agentHandler(agent) needs an agent built by agent().");
+  }
+  // A host may spell the mount with a trailing slash; strip it once here rather
+  // than doubling it into every boundary below.
+  const mount = options.basePath.replace(/\/$/, "");
+  const threads = threadStore(composition.store);
+  const transcript = threadMessageStore<UIMessage>(composition.store);
+
+  return async (request) => {
+    try {
+      const url = new URL(request.url);
+      // The door FIRST, on its own absolute path: it is internal plumbing that
+      // authenticates every request with the live turn's own credential, so it
+      // owes this mount's `resolveUser` nothing and must not be challenged by it.
+      if (agent.door !== undefined && url.pathname === DOOR_PATH) return await agent.door(request);
+      // The five permission routes, which answer `undefined` for every path they
+      // do not own — which is what lets them sit in front of this table.
+      const permissions = await agent.permissions(request);
+      if (permissions !== undefined) return permissions;
+      const path = relativePath(mount, url);
+      if (path === null) throw new VendoError("not-found", "unknown route");
+      const user = await options.resolveUser(request);
+      // 401, not 403: `resolveUser` answering null means nobody is asking. The
+      // umbrella's wire answers 403 to an unresolved principal
+      // (packages/vendo/src/wire/context.ts) because there it is the HOST's
+      // session that already ran and declined; here this is the first identity
+      // check the request meets, and an unauthenticated caller is told to
+      // authenticate.
+      if (user === null) return new Response(null, { status: 401 });
+      // The same gate `createSession` and the permission mount pay: this is a
+      // fresh entry door, and a virgin store must not answer the first request
+      // with a missing relation.
+      await composition.store.ensureSchema();
+      const forwarded = options.headers === false ? undefined : options.headers ?? request.headers;
+      const routed = await dispatchRoutes(ROUTES, {
+        request,
+        path,
+        segments: routeSegments(path),
+        params: {},
+        agent,
+        threads,
+        transcript,
+        principal: { kind: "user", subject: user.subject },
+        subject: user.subject,
+        turn: {
+          ...(user.profile === undefined ? {} : { user: user.profile }),
+          ...(user.context === undefined ? {} : { context: user.context }),
+          ...(forwarded === undefined ? {} : { headers: forwarded }),
+        },
+      });
+      if (routed !== undefined) return routed;
+      throw new VendoError("not-found", "unknown route");
+    } catch (error) {
+      // A refusal this mount can name answers in the wire's envelope; anything
+      // else is the host's own failure and PROPAGATES, so their logging sees it
+      // rather than a swallowed 500 that says nothing.
+      if (isVendoError(error)) return errorResponse(error);
+      throw error;
+    }
+  };
+}

--- a/packages/agents/src/http/router.ts
+++ b/packages/agents/src/http/router.ts
@@ -1,0 +1,181 @@
+/**
+ * The shared HTTP route runtime: the mount-relative path, the route-table types
+ * and matcher, the envelope helpers, and the param validators.
+ *
+ * Generic in the per-request context, because the matcher only ever READS
+ * `request`/`path`/`segments` and WRITES `params` — whatever else a caller hangs
+ * off its own context (composed deps, a RunContext resolver) is invisible here.
+ * `@vendoai/vendo`'s wire binds this to its own WireContext (wire/shared.ts).
+ */
+import { isVendoError, VendoError, type VendoErrorCode } from "@vendoai/core";
+
+export function isJsonRequest(request: Request): boolean {
+  return request.headers.get("content-type")?.split(";", 1)[0]?.trim().toLowerCase()
+    === "application/json";
+}
+
+/** The mount-relative raw path a route table matches on, or null when the URL
+    falls outside the mount entirely (the caller answers not-found). */
+export function relativePath(mount: string, url: URL): string | null {
+  if (url.pathname === mount) return "/";
+  if (!url.pathname.startsWith(`${mount}/`)) return null;
+  return url.pathname.slice(mount.length);
+}
+
+/** What the matcher needs from a per-request context: the raw request, the
+    mount-relative raw path, the decoded segments, and the slot the matched
+    entry's `:param` captures land in. */
+export interface RouteContext {
+  request: Request;
+  path: string;
+  readonly segments: string[];
+  params: Record<string, string>;
+}
+
+/** A handler answers with a Response, or returns undefined to FALL THROUGH to
+    the next entry — mirroring the old if-chain, where a matched-path block
+    whose method/operation checks all missed simply fell out the bottom (any
+    side effects it ran, e.g. context resolution, stand). */
+export type RouteHandler<W extends RouteContext> = (wire: W) => Promise<Response | undefined>;
+
+type RoutePattern =
+  /** Raw-path equality — no decoding, matching the old `path === "/x"` arms. */
+  | { kind: "exact"; path: string }
+  /** Raw-path prefix — matching the old `path.startsWith("/x/")` arms. */
+  | { kind: "prefix"; prefix: string }
+  /** Decoded-segment match: literals compare against decoded values, `:name`
+      captures, a trailing rest wildcard allows ZERO or more extra segments —
+      matching the old `head === "x" && segments.length >= n` arms. */
+  | { kind: "segments"; parts: string[]; rest: boolean };
+
+export interface RouteEntry<W extends RouteContext> {
+  /** Exact method, or "*" for grouped handlers that dispatch methods inside. */
+  method: string;
+  pattern: RoutePattern;
+  handler: RouteHandler<W>;
+}
+
+/** Table entry from a pattern string: no `:param` and no trailing `/*` means
+    raw-path equality; otherwise decoded-segment matching (trailing `/*` = rest
+    wildcard, zero or more segments). */
+export function route<W extends RouteContext>(method: string, pattern: string, handler: RouteHandler<W>): RouteEntry<W> {
+  if (!pattern.includes(":") && !pattern.endsWith("/*")) {
+    return { method, pattern: { kind: "exact", path: pattern }, handler };
+  }
+  const rest = pattern.endsWith("/*");
+  const parts = (rest ? pattern.slice(0, -2) : pattern).split("/").filter(Boolean);
+  return { method, pattern: { kind: "segments", parts, rest }, handler };
+}
+
+/** Table entry matching on a raw path prefix (webhooks, proxy, the doctor
+    production gate) — never decodes, exactly like the old startsWith arms.
+    Raw string match, no segment boundary — include the trailing slash. */
+export function prefixRoute<W extends RouteContext>(method: string, prefix: string, handler: RouteHandler<W>): RouteEntry<W> {
+  return { method, pattern: { kind: "prefix", prefix }, handler };
+}
+
+function matchRoute<W extends RouteContext>(entry: RouteEntry<W>, wire: W): Record<string, string> | null {
+  if (entry.method !== "*" && entry.method !== wire.request.method) return null;
+  const pattern = entry.pattern;
+  if (pattern.kind === "exact") return pattern.path === wire.path ? {} : null;
+  if (pattern.kind === "prefix") return wire.path.startsWith(pattern.prefix) ? {} : null;
+  // Segment access may throw the invalid-encoding validation error — only ever
+  // reached after every raw pre-route entry has had its chance, preserving the
+  // old chain's ordering (prefix routes served /proxy/%zz; /threads/%zz threw).
+  const segments = wire.segments;
+  if (pattern.rest ? segments.length < pattern.parts.length : segments.length !== pattern.parts.length) {
+    return null;
+  }
+  const params: Record<string, string> = {};
+  for (let i = 0; i < pattern.parts.length; i++) {
+    const part = pattern.parts[i]!;
+    if (part.startsWith(":")) params[part.slice(1)] = segments[i]!;
+    else if (part !== segments[i]) return null;
+  }
+  return params;
+}
+
+/** Scan the table in order; a handler returning undefined keeps scanning
+    (fall-through). No match → undefined; the caller answers not-found. */
+export async function dispatchRoutes<W extends RouteContext>(
+  routes: readonly RouteEntry<W>[],
+  wire: W,
+): Promise<Response | undefined> {
+  for (const entry of routes) {
+    const params = matchRoute(entry, wire);
+    if (params === null) continue;
+    wire.params = params;
+    const response = await entry.handler(wire);
+    if (response !== undefined) return response;
+  }
+  return undefined;
+}
+
+const STATUS_BY_CODE: Record<VendoErrorCode, number> = {
+  validation: 400,
+  "not-found": 404,
+  blocked: 403,
+  // Build contract §9.4 — the caller sees the thing but may not do this to it.
+  forbidden: 403,
+  conflict: 409,
+  "cloud-required": 402,
+  "sandbox-unavailable": 501,
+  "not-implemented": 501,
+  // Table entry only, for the same reason knowledge-wire.ts's copy carries
+  // one: this wire builds its OWN VendoError responses and never parses a
+  // status code back into one, so there is no STATUS_TO_CODE here to extend.
+  unavailable: 503,
+  // Same: a schema proposal is a typed store's answer to its own client, and
+  // this wire has no table to propose.
+  "schema-proposal": 409,
+};
+
+export function json(body: unknown, status = 200): Response {
+  return Response.json(body, { status });
+}
+
+export function errorResponse(error: VendoError): Response {
+  return json({ error: { code: error.code, message: error.message } }, STATUS_BY_CODE[error.code]);
+}
+
+export function internalError(): Response {
+  return errorResponse(new VendoError("not-implemented", "Internal Vendo error"));
+}
+
+function object(value: unknown, label: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new VendoError("validation", `${label} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+export function string(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new VendoError("validation", `${label} must be a non-empty string`);
+  }
+  return value;
+}
+
+export async function requestJson(request: Request): Promise<Record<string, unknown>> {
+  try {
+    return object(await request.json(), "request body");
+  } catch (error) {
+    if (isVendoError(error)) throw error;
+    throw new VendoError("validation", "request body must be valid JSON");
+  }
+}
+
+export function routeSegments(path: string): string[] {
+  try {
+    return path.split("/").filter(Boolean).map(decodeURIComponent);
+  } catch {
+    throw new VendoError("validation", "route contains invalid URL encoding");
+  }
+}
+
+/** Bytes → lowercase hex. Used by wire/misc.ts's timing-safe digest compare. */
+export function hex(bytes: ArrayBuffer | Uint8Array): string {
+  let out = "";
+  for (const b of bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes)) out += b.toString(16).padStart(2, "0");
+  return out;
+}

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -26,6 +26,9 @@ export { awayRunner, type AwayRunnerDeps, type RunOptions } from "./away.js";
 /** The turn a verb hands back, and the two shapes a caller writes against it. */
 export type { ChatOptions, RunEvent, Turn } from "./turn.js";
 export { DOOR_PATH, type DoorConfig } from "./door.js";
+/** One mount for the whole agent — the chat wire, the thread lifecycle, and the
+ *  door and permission planes it already serves. */
+export { agentHandler, type HandlerOptions, type HandlerUser } from "./handler.js";
 export { PERMISSIONS_PATH, type AgentPrincipal } from "./permissions.js";
 export { assemblePrompt, type PromptInput, type SystemPromptHook } from "./prompt.js";
 export type { AgentSession, ApprovalEvent, RespondOptions, SessionOptions } from "./session.js";

--- a/packages/agents/tests/handler.test.ts
+++ b/packages/agents/tests/handler.test.ts
@@ -199,15 +199,17 @@ describe("the conversation", () => {
 });
 
 describe("the other two planes", () => {
-  it("serves the permission wire on its own mount", async () => {
+  it("serves the permission wire on its OWN mount, scoped to the resolved user", async () => {
     const handle = mount();
 
-    const response = await handle(request("GET", "/api/vendo/approvals"));
+    const response = await handle(request("GET", `${BASE}/approvals`));
 
-    // No `principal` was composed on this agent, so the wire's own answer for
-    // "a person's asks need a person" is what comes back — proof it ran, and
-    // that this handler did not answer not-found over it.
-    expect(response.status).toBe(401);
+    // Under this basePath and behind this mount's `resolveUser` — no second
+    // identity to configure, and reachable by a client that only knows `api`.
+    // Deciding an approval is what unblocks a parked turn, so a client that
+    // cannot reach this wire has a park it can never answer.
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual([]);
   });
 
   it("hands the door its own path without ever asking who is calling", async () => {

--- a/packages/agents/tests/handler.test.ts
+++ b/packages/agents/tests/handler.test.ts
@@ -1,0 +1,228 @@
+/**
+ * The one mount, over the REAL composed agent — real embedded store, real
+ * guard, real runtime; only the thinker is scripted (CLAUDE.md: test the SEAM).
+ *
+ * What matters here is that ONE catch-all really does serve three planes: the
+ * engine's door answers without ever meeting `resolveUser`, the approvals wire
+ * answers on its own mount, and this table serves the conversation — with the
+ * thread that came out of a turn readable back through the routes a browser
+ * reloads against.
+ */
+import type { RunContext } from "@vendoai/core";
+import { defineHarness } from "@vendoai/harnesses";
+import { createStore } from "@vendoai/store";
+import { describe, expect, it } from "vitest";
+import { agent } from "../src/agent.js";
+import { DOOR_PATH } from "../src/door.js";
+import { agentHandler, type HandlerOptions } from "../src/handler.js";
+import { tool } from "../src/tools.js";
+import { THREAD_ID_HEADER } from "../src/index.js";
+
+let stores = 0;
+const memoryStore = () => createStore({ dataDir: `memory://agents-handler-${stores++}` });
+
+const BASE = "/api/agent";
+
+const speaks = (text: string) =>
+  defineHarness({
+    name: "speaks",
+    async *run() {
+      yield { type: "text" as const, delta: text };
+    },
+  });
+
+/** A `Turn` deliberately carries no RunContext (packages/core/src/harness.ts:72),
+ *  so the ctx a request composed is observed where it really lands: in a tool. */
+let seen: RunContext | undefined;
+/** Read through a call: assigning `undefined` before each test narrows the
+ *  binding, and the write happens in a callback the compiler cannot follow. */
+const lastCtx = (): RunContext | undefined => seen;
+const peek = tool({
+  name: "host_peek",
+  description: "Report who is asking",
+  inputSchema: { type: "object", properties: {} },
+  risk: "read",
+  execute(_input, ctx) {
+    seen = ctx;
+    return {};
+  },
+});
+
+const peeking = () =>
+  defineHarness({
+    name: "peeking",
+    async *run(turn) {
+      await turn.tools.call("host_peek", {});
+      yield { type: "text" as const, delta: "ok" };
+    },
+  });
+
+const boxy = () =>
+  defineHarness({
+    name: "boxy",
+    requires: { toolDoor: true },
+    async *run() {},
+  });
+
+const dana = async (): Promise<{ subject: string }> => ({ subject: "user_dana" });
+
+function mount(
+  options: Partial<HandlerOptions> & { harness?: ReturnType<typeof speaks> } = {},
+): (request: Request) => Promise<Response> {
+  const { harness, ...handlerOptions } = options;
+  const support = agent({
+    name: "support",
+    harness: harness ?? speaks("hello"),
+    store: memoryStore(),
+    tools: [peek],
+    door: { baseUrl: "https://app.example.com" },
+  });
+  return agentHandler(support, { basePath: BASE, resolveUser: dana, ...handlerOptions });
+}
+
+const request = (method: string, path: string, body?: unknown): Request =>
+  new Request(`https://app.example.com${path}`, {
+    method,
+    ...(body === undefined ? {} : { body: JSON.stringify(body), headers: { "content-type": "application/json" } }),
+  });
+
+const say = (text: string, threadId?: string): Request =>
+  request("POST", `${BASE}/threads`, {
+    ...(threadId === undefined ? {} : { threadId }),
+    message: { id: `msg_${text}`, role: "user", parts: [{ type: "text", text }] },
+  });
+
+/** One turn, DRAINED — the stream's finish is what persists the transcript. */
+async function turn(handle: (request: Request) => Promise<Response>, text: string, threadId?: string) {
+  const response = await handle(say(text, threadId));
+  await response.text();
+  return response;
+}
+
+describe("identity", () => {
+  it("401s when the host's session says nobody is asking", async () => {
+    const handle = mount({ resolveUser: async () => null });
+
+    expect((await handle(say("hi"))).status).toBe(401);
+  });
+
+  it("carries the resolved user's profile and context onto the turn", async () => {
+    seen = undefined;
+    const handle = mount({
+      harness: peeking(),
+      resolveUser: async () => ({ subject: "user_dana", profile: { plan: "pro" }, context: { tenantId: "t_1" } }),
+    });
+
+    await turn(handle, "hello");
+
+    expect(lastCtx()?.principal.subject).toBe("user_dana");
+    expect(lastCtx()?.user).toEqual({ plan: "pro" });
+    expect(lastCtx()?.context).toEqual({ tenantId: "t_1" });
+  });
+
+  it("forwards the request's own headers by default, and none with headers: false", async () => {
+    const authorized = (): Request =>
+      new Request(`https://app.example.com${BASE}/threads`, {
+        method: "POST",
+        headers: { "content-type": "application/json", authorization: "Bearer host-session" },
+        body: JSON.stringify({ message: { id: "m1", role: "user", parts: [{ type: "text", text: "hi" }] } }),
+      });
+
+    seen = undefined;
+    await (await mount({ harness: peeking() })(authorized())).text();
+    const forwarded = lastCtx();
+
+    seen = undefined;
+    await (await mount({ harness: peeking(), headers: false })(authorized())).text();
+
+    expect(forwarded?.requestHeaders?.["authorization"]).toBe("Bearer host-session");
+    expect(lastCtx()?.requestHeaders).toBeUndefined();
+  });
+});
+
+describe("the conversation", () => {
+  it("answers a turn with the thread id, and reads that thread back", async () => {
+    const handle = mount();
+
+    const response = await turn(handle, "hello");
+    const threadId = response.headers.get(THREAD_ID_HEADER);
+
+    expect(threadId).toMatch(/^thr_/);
+    const listed = await (await handle(request("GET", `${BASE}/threads`))).json() as Array<{ id: string }>;
+    expect(listed.map((thread) => thread.id)).toEqual([threadId]);
+
+    const thread = await (await handle(request("GET", `${BASE}/threads/${threadId}`)))
+      .json() as { id: string; messages: Array<{ role: string }> };
+    expect(thread.id).toBe(threadId);
+    expect(thread.messages.map((message) => message.role)).toEqual(["user", "assistant"]);
+  });
+
+  it("continues the thread it is handed", async () => {
+    const handle = mount();
+    const first = await turn(handle, "hello");
+    const threadId = first.headers.get(THREAD_ID_HEADER)!;
+
+    const second = await turn(handle, "again", threadId);
+
+    expect(second.headers.get(THREAD_ID_HEADER)).toBe(threadId);
+    const thread = await (await handle(request("GET", `${BASE}/threads/${threadId}`)))
+      .json() as { messages: unknown[] };
+    expect(thread.messages).toHaveLength(4);
+  });
+
+  it("deletes a thread, and answers not-found for one this subject does not own", async () => {
+    const handle = mount();
+    const threadId = (await turn(handle, "hello")).headers.get(THREAD_ID_HEADER)!;
+
+    expect((await handle(request("DELETE", `${BASE}/threads/${threadId}`))).status).toBe(200);
+    expect((await handle(request("GET", `${BASE}/threads/${threadId}`))).status).toBe(404);
+    expect((await handle(request("GET", `${BASE}/threads/thr_someone_else`))).status).toBe(404);
+  });
+
+  it("answers not-found outside its own mount", async () => {
+    const handle = mount();
+
+    const response = await handle(request("GET", "/api/other/threads"));
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: { code: "not-found", message: "unknown route" } });
+  });
+
+  it("names the slice that owns durable resume rather than inventing its rules", async () => {
+    const handle = mount();
+
+    const response = await handle(request("POST", `${BASE}/turns/trn_1/resume`, { decisions: {} }));
+
+    expect(response.status).toBe(501);
+    expect(await response.json()).toMatchObject({ error: { code: "not-implemented" } });
+  });
+});
+
+describe("the other two planes", () => {
+  it("serves the permission wire on its own mount", async () => {
+    const handle = mount();
+
+    const response = await handle(request("GET", "/api/vendo/approvals"));
+
+    // No `principal` was composed on this agent, so the wire's own answer for
+    // "a person's asks need a person" is what comes back — proof it ran, and
+    // that this handler did not answer not-found over it.
+    expect(response.status).toBe(401);
+  });
+
+  it("hands the door its own path without ever asking who is calling", async () => {
+    let asked = 0;
+    const handle = mount({
+      harness: boxy(),
+      resolveUser: async () => {
+        asked += 1;
+        return { subject: "user_dana" };
+      },
+    });
+
+    const response = await handle(request("POST", DOOR_PATH, {}));
+
+    expect(response.status).not.toBe(404);
+    expect(asked).toBe(0);
+  });
+});

--- a/packages/agents/tests/http-router.test.ts
+++ b/packages/agents/tests/http-router.test.ts
@@ -1,0 +1,177 @@
+import { VendoError, vendoErrorCodeSchema } from "@vendoai/core";
+import { describe, expect, it } from "vitest";
+import {
+  dispatchRoutes,
+  errorResponse,
+  isJsonRequest,
+  prefixRoute,
+  relativePath,
+  requestJson,
+  route,
+  routeSegments,
+  type RouteContext,
+} from "../src/http/router.js";
+
+const wire = (method: string, path: string): RouteContext => ({
+  request: new Request(`https://app.example.com${path}`, { method }),
+  path,
+  get segments() {
+    return routeSegments(path);
+  },
+  params: {},
+});
+
+/** What every handler in these tests answers, so a 200 means "this entry ran". */
+const ok = async () => new Response("ok");
+
+describe("route", () => {
+  it("matches an exact path and its method", async () => {
+    const table = [route("GET", "/threads", ok)];
+
+    expect(await dispatchRoutes(table, wire("GET", "/threads"))).toBeInstanceOf(Response);
+    expect(await dispatchRoutes(table, wire("POST", "/threads"))).toBeUndefined();
+    expect(await dispatchRoutes(table, wire("GET", "/threads/a"))).toBeUndefined();
+  });
+
+  it("captures :param segments, decoded", async () => {
+    const context = wire("GET", "/apps/my%20app/fn/run");
+    const seen: Record<string, string>[] = [];
+    const table = [route("GET", "/apps/:appId/fn/:name", async ({ params }) => {
+      seen.push(params);
+      return new Response("ok");
+    })];
+
+    await dispatchRoutes(table, context);
+
+    expect(seen).toEqual([{ appId: "my app", name: "run" }]);
+  });
+
+  it("lets a trailing /* match zero or more extra segments, but not fewer", async () => {
+    const table = [route("GET", "/runs/:runId/*", ok)];
+
+    expect(await dispatchRoutes(table, wire("GET", "/runs/r1"))).toBeInstanceOf(Response);
+    expect(await dispatchRoutes(table, wire("GET", "/runs/r1/events/2"))).toBeInstanceOf(Response);
+    expect(await dispatchRoutes(table, wire("GET", "/runs"))).toBeUndefined();
+  });
+
+  it("serves any method on \"*\", so a grouped handler dispatches methods itself", async () => {
+    const table = [route("*", "/connections/:id", ok)];
+
+    expect(await dispatchRoutes(table, wire("DELETE", "/connections/c1"))).toBeInstanceOf(Response);
+    expect(await dispatchRoutes(table, wire("PATCH", "/connections/c1"))).toBeInstanceOf(Response);
+  });
+});
+
+describe("prefixRoute", () => {
+  it("matches the RAW path and never decodes it", async () => {
+    const table = [prefixRoute("GET", "/proxy/", ok)];
+
+    // The reason prefix entries exist: a percent-encoding a decoder would
+    // reject still reaches the proxy verbatim.
+    expect(await dispatchRoutes(table, wire("GET", "/proxy/%zz"))).toBeInstanceOf(Response);
+    expect(await dispatchRoutes(table, wire("GET", "/proxied/x"))).toBeUndefined();
+  });
+});
+
+describe("dispatchRoutes", () => {
+  it("scans in order, falls through a handler that answers undefined, and answers undefined on no match", async () => {
+    const ran: string[] = [];
+    const table = [
+      route("GET", "/x", async () => {
+        ran.push("first");
+        return undefined;
+      }),
+      route("GET", "/x", async () => {
+        ran.push("second");
+        return new Response("second");
+      }),
+      route("GET", "/x", async () => {
+        ran.push("third");
+        return new Response("third");
+      }),
+    ];
+
+    const response = await dispatchRoutes(table, wire("GET", "/x"));
+
+    expect(await response?.text()).toBe("second");
+    expect(ran).toEqual(["first", "second"]);
+    expect(await dispatchRoutes(table, wire("GET", "/y"))).toBeUndefined();
+  });
+});
+
+describe("errorResponse", () => {
+  // Every code core defines, so a new one added there without a status here
+  // fails HERE rather than at a caller's first refusal (an unmapped code makes
+  // Response.json throw on an undefined status).
+  const STATUSES: Record<(typeof vendoErrorCodeSchema.options)[number], number> = {
+    validation: 400,
+    "cloud-required": 402,
+    blocked: 403,
+    forbidden: 403,
+    "not-found": 404,
+    conflict: 409,
+    "schema-proposal": 409,
+    "not-implemented": 501,
+    "sandbox-unavailable": 501,
+    unavailable: 503,
+  };
+
+  it.each(vendoErrorCodeSchema.options)("maps %s to its status", (code) => {
+    expect(errorResponse(new VendoError(code, "nope")).status).toBe(STATUSES[code]);
+  });
+
+  it("carries the code and message in the envelope", async () => {
+    const response = errorResponse(new VendoError("not-found", "unknown Vendo route"));
+
+    expect(await response.json()).toEqual({ error: { code: "not-found", message: "unknown Vendo route" } });
+  });
+});
+
+describe("requestJson", () => {
+  const body = (raw: string) => new Request("https://app.example.com/x", { method: "POST", body: raw });
+
+  it("returns an object body", async () => {
+    expect(await requestJson(body(`{"a":1}`))).toEqual({ a: 1 });
+  });
+
+  it.each([["an array", "[1]"], ["a scalar", `"hi"`], ["null", "null"], ["unparseable", "{"]])(
+    "refuses %s as validation",
+    async (_label, raw) => {
+      await expect(requestJson(body(raw))).rejects.toMatchObject({ code: "validation" });
+    },
+  );
+});
+
+describe("routeSegments", () => {
+  it("throws validation on a bad percent-encoding", () => {
+    expect(() => routeSegments("/threads/%zz")).toThrow(/invalid URL encoding/);
+  });
+});
+
+describe("relativePath", () => {
+  const at = (pathname: string) => relativePath("/api/vendo", new URL(`https://app.example.com${pathname}`));
+
+  it("strips the mount, and answers / for the mount itself", () => {
+    expect(at("/api/vendo")).toBe("/");
+    expect(at("/api/vendo/threads")).toBe("/threads");
+  });
+
+  it("answers null outside the mount, including a prefix that only looks like it", () => {
+    expect(at("/other")).toBeNull();
+    expect(at("/api/vendoxyz")).toBeNull();
+  });
+});
+
+describe("isJsonRequest", () => {
+  const withType = (value: string) =>
+    isJsonRequest(new Request("https://app.example.com/x", { method: "POST", headers: { "content-type": value } }));
+
+  it("ignores parameters and casing", () => {
+    expect(withType("Application/JSON; charset=utf-8")).toBe(true);
+    expect(withType("text/plain")).toBe(false);
+  });
+
+  it("is false with no content-type at all", () => {
+    expect(isJsonRequest(new Request("https://app.example.com/x", { method: "POST" }))).toBe(false);
+  });
+});

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -15,6 +15,8 @@ export {
 } from "./client.js";
 export { VendoProvider, hostComponentMap, useVendoProvider, useVendoDiscoverability, useVendoGreeting, useVendoTheme, useVendoThemeOrDefault, useVendoTools, type ConnectorOption, type HostComponentsInput } from "./context.js";
 export { useVendoNavigate, useVendoRoutes } from "./routes.js";
+/** The standalone agent's conversation — one `agentHandler()` mount, no embed. */
+export { useVendoChat, type UseVendoChatOptions } from "./use-vendo-chat.js";
 export { defaultVendoGreeting, type VendoDiscoverability, type VendoGreeting } from "./chrome/discoverability.js";
 export type { ToolMeta, ToolMetaMap } from "./chrome/humanize.js";
 export type { VendoAppEmbedProps, VendoApprovalEmbedProps, VendoApprovalEmbedState, VendoToolResultProps } from "./embeds.js";

--- a/packages/ui/src/use-vendo-chat.ts
+++ b/packages/ui/src/use-vendo-chat.ts
@@ -84,6 +84,10 @@ export function useVendoChat({ api, threadId, onThreadId }: UseVendoChatOptions)
   // state to have lost.
   useEffect(() => {
     if (threadId === undefined) return undefined;
+    // Switching conversations moves the live id too — after the early return, so
+    // a server-minted id is never clobbered by the prop that never carried one.
+    activeThreadId.current = threadId;
+    setEffectiveThreadId(threadId);
     let active = true;
     void globalThis
       .fetch(`${base}/threads/${encodeURIComponent(threadId)}`)
@@ -139,11 +143,16 @@ export function useVendoChat({ api, threadId, onThreadId }: UseVendoChatOptions)
         // no interruption here to answer.
         const ids = Object.entries(decisions).filter(([, decision]) => decision === verdict).map(([id]) => id);
         if (ids.length === 0) continue;
-        await globalThis.fetch(`${base}/approvals/decide`, {
+        const response = await globalThis.fetch(`${base}/approvals/decide`, {
           method: "POST",
           headers: { "content-type": "application/json" },
           body: JSON.stringify({ ids, decision: { approve } }),
         });
+        // A refusal — 409 for an approval already answered or long expired — has
+        // to reach the caller: swallowed, the page draws the decision as landed
+        // while the turn stays parked until it expires, which is the very thing
+        // going to the guard at all was meant to prevent.
+        if (!response.ok) throw new Error(`Vendo could not record the ${verdict} decision (${response.status}).`);
       }
     },
     [base],

--- a/packages/ui/src/use-vendo-chat.ts
+++ b/packages/ui/src/use-vendo-chat.ts
@@ -18,7 +18,6 @@ import {
   DefaultChatTransport,
   getToolName,
   isToolUIPart,
-  lastAssistantMessageIsCompleteWithApprovalResponses,
   type UIMessage,
 } from "ai";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -76,10 +75,6 @@ export function useVendoChat({ api, threadId, onThreadId }: UseVendoChatOptions)
     ...(threadId === undefined ? {} : { id: threadId }),
     messages: [],
     transport,
-    // The parked turn resumes SERVER-side once every requested approval has an
-    // answer: the SDK sends the decided messages back, and the agent re-dispatches
-    // the approved call. That is why `resume` below only has to record answers.
-    sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses,
   });
 
   const { setMessages } = chat;
@@ -119,19 +114,39 @@ export function useVendoChat({ api, threadId, onThreadId }: UseVendoChatOptions)
     return pending;
   }, [chat.messages]);
 
-  const { addToolApprovalResponse } = chat;
-  /** Answer what the turn is waiting on, keyed by {@link Interruption.id}. */
+  /**
+   * Answer what the turn is waiting on, keyed by {@link Interruption.id}.
+   *
+   * The decision goes to the mount's PERMISSION wire, not to the SDK's local
+   * approval channel, because the guard's decision is the thing that unblocks
+   * the turn: a parked call is sitting on a waiter that only
+   * `guard.approvals.decide` resolves. Flipping the part in the browser instead
+   * changes what the page draws and nothing about what the agent is doing, and
+   * the turn goes on to expire unanswered — which is exactly what the browser
+   * seam test caught. Once the guard is told, the turn carries on and its own
+   * stream reports the call's outcome, so nothing here has to patch the
+   * transcript.
+   *
+   * Two requests at most: the wire decides a BATCH, so the ids are grouped by
+   * verdict rather than answered one at a time.
+   */
   const resume = useCallback(
     async (decisions: Decisions): Promise<void> => {
-      for (const [id, decision] of Object.entries(decisions)) {
+      for (const approve of [true, false]) {
+        const verdict = approve ? "approve" : "deny";
         // v1 mints the approval arm only — `input` is wire-defined and unemitted
         // (packages/core/src/turn-result.ts) — so an `{ answers }` decision has
         // no interruption here to answer.
-        if (decision !== "approve" && decision !== "deny") continue;
-        await addToolApprovalResponse({ id, approved: decision === "approve" });
+        const ids = Object.entries(decisions).filter(([, decision]) => decision === verdict).map(([id]) => id);
+        if (ids.length === 0) continue;
+        await globalThis.fetch(`${base}/approvals/decide`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ ids, decision: { approve } }),
+        });
       }
     },
-    [addToolApprovalResponse],
+    [base],
   );
 
   return {

--- a/packages/ui/src/use-vendo-chat.ts
+++ b/packages/ui/src/use-vendo-chat.ts
@@ -1,0 +1,148 @@
+/**
+ * The standalone agent's conversation, in a page — one `agentHandler()` mount,
+ * stock `useChat`, nothing of its own kept in the browser.
+ *
+ * It is `useVendoThread`'s thinner sibling: no provider, no client, no embed
+ * chrome, no situation channel — just the transport, the thread id round-trip,
+ * and the two things a host has to render for an agent that asks permission.
+ *
+ * NOTHING IS STORED HERE. The conversation's id round-trips on the response
+ * header and is handed back through `onThreadId` for the host to keep wherever
+ * it already keeps route state; the transcript — pending approvals included —
+ * is read back from the server, which is what makes `interruptions` survive a
+ * reload without this hook owning a byte of browser storage.
+ */
+import type { Decisions, Interruption, Json } from "@vendoai/core";
+import { useChat } from "@ai-sdk/react";
+import {
+  DefaultChatTransport,
+  getToolName,
+  isToolUIPart,
+  lastAssistantMessageIsCompleteWithApprovalResponses,
+  type UIMessage,
+} from "ai";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+/** Written out rather than imported, for the reason `use-vendo-thread.ts` (its
+    own copy) states: the literal is defined in @vendoai/harnesses beside the
+    wire that stamps it, and @vendoai/ui may depend on core and apps alone
+    (scripts/dependency-guard.mjs). */
+const THREAD_ID_HEADER = "x-vendo-thread-id";
+
+export interface UseVendoChatOptions {
+  /** Where `agentHandler()` is mounted — `"/api/agent"`. */
+  api: string;
+  /** Reopen this conversation; omit for a new one. */
+  threadId?: string;
+  /** The id the server minted, the moment it lands. Keep it where your app
+   *  already keeps route state — this hook keeps nothing. */
+  onThreadId?: (threadId: string) => void;
+}
+
+export function useVendoChat({ api, threadId, onThreadId }: UseVendoChatOptions) {
+  const base = api.replace(/\/$/, "");
+  // The live id: a ref because the transport closure reads it per request, and
+  // state because the caller renders it.
+  const activeThreadId = useRef(threadId);
+  const [effectiveThreadId, setEffectiveThreadId] = useState(threadId);
+  const announce = useRef(onThreadId);
+  announce.current = onThreadId;
+
+  const transport = useMemo(
+    () =>
+      new DefaultChatTransport<UIMessage>({
+        api: `${base}/threads`,
+        fetch: async (input, init) => {
+          const response = await globalThis.fetch(input, init);
+          const returned = response.headers.get(THREAD_ID_HEADER);
+          if (returned !== null && returned !== activeThreadId.current) {
+            activeThreadId.current = returned;
+            setEffectiveThreadId(returned);
+            announce.current?.(returned);
+          }
+          return response;
+        },
+        prepareSendMessagesRequest: ({ messages }) => {
+          const message = messages.at(-1);
+          if (message === undefined) throw new Error("Cannot send an empty Vendo turn.");
+          const id = activeThreadId.current;
+          return { body: { ...(id === undefined ? {} : { threadId: id }), message } };
+        },
+      }),
+    [base],
+  );
+
+  const chat = useChat<UIMessage>({
+    ...(threadId === undefined ? {} : { id: threadId }),
+    messages: [],
+    transport,
+    // The parked turn resumes SERVER-side once every requested approval has an
+    // answer: the SDK sends the decided messages back, and the agent re-dispatches
+    // the approved call. That is why `resume` below only has to record answers.
+    sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses,
+  });
+
+  const { setMessages } = chat;
+  // Reopening reads the transcript back through the mount's own route, which is
+  // the whole durability story: an approval parked before a reload comes back in
+  // the messages, so `interruptions` below is populated again with no client
+  // state to have lost.
+  useEffect(() => {
+    if (threadId === undefined) return undefined;
+    let active = true;
+    void globalThis
+      .fetch(`${base}/threads/${encodeURIComponent(threadId)}`)
+      .then(response => (response.ok ? response.json() as Promise<{ messages: UIMessage[] }> : undefined))
+      .then(thread => {
+        if (active && thread !== undefined) setMessages(thread.messages);
+      })
+      .catch(() => undefined);
+    return () => {
+      active = false;
+    };
+  }, [base, threadId, setMessages]);
+
+  /** What this conversation is waiting on a person for, in the vocabulary the
+   *  server speaks (`Interruption`) rather than the SDK's part shape. */
+  const interruptions = useMemo<Interruption[]>(() => {
+    const pending: Interruption[] = [];
+    for (const message of chat.messages) {
+      for (const part of message.parts) {
+        if (!isToolUIPart(part) || part.state !== "approval-requested") continue;
+        pending.push({
+          id: part.approval.id,
+          type: "approval",
+          toolCall: { id: part.toolCallId, tool: getToolName(part), args: part.input as Json },
+        });
+      }
+    }
+    return pending;
+  }, [chat.messages]);
+
+  const { addToolApprovalResponse } = chat;
+  /** Answer what the turn is waiting on, keyed by {@link Interruption.id}. */
+  const resume = useCallback(
+    async (decisions: Decisions): Promise<void> => {
+      for (const [id, decision] of Object.entries(decisions)) {
+        // v1 mints the approval arm only — `input` is wire-defined and unemitted
+        // (packages/core/src/turn-result.ts) — so an `{ answers }` decision has
+        // no interruption here to answer.
+        if (decision !== "approve" && decision !== "deny") continue;
+        await addToolApprovalResponse({ id, approved: decision === "approve" });
+      }
+    },
+    [addToolApprovalResponse],
+  );
+
+  return {
+    threadId: effectiveThreadId,
+    messages: chat.messages,
+    sendMessage: chat.sendMessage,
+    status: chat.status,
+    error: chat.error,
+    /** Pending, and durable across a reload — read back from the server. */
+    interruptions,
+    resume,
+    stop: chat.stop,
+  };
+}

--- a/packages/ui/test/use-vendo-chat.test.tsx
+++ b/packages/ui/test/use-vendo-chat.test.tsx
@@ -1,0 +1,164 @@
+// @vitest-environment jsdom
+/**
+ * The standalone chat hook against a REAL HTTP listener speaking the mount's
+ * own shapes — the fetch, the round trip, the stream and the thread-id header
+ * are all real; only the agent behind them is scripted.
+ *
+ * The two properties worth pinning are the ones a host cannot see until it is
+ * too late: the conversation's id is handed OUT rather than kept, and a pending
+ * approval comes back from the server on reload rather than from anything this
+ * hook stored.
+ */
+import { renderHook, waitFor } from "@testing-library/react";
+import { createUIMessageStream, createUIMessageStreamResponse, type UIMessage } from "ai";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useVendoChat } from "../src/use-vendo-chat.js";
+
+const THREAD_ID = "thr_seeded";
+
+/** One parked approval, exactly as a reloaded transcript carries it. */
+const parked: UIMessage[] = [
+  { id: "m_1", role: "user", parts: [{ type: "text", text: "refund invoice #7" }] },
+  {
+    id: "m_2",
+    role: "assistant",
+    parts: [
+      {
+        type: "tool-host_refund",
+        toolCallId: "call_1",
+        state: "approval-requested",
+        input: { invoiceId: "7" },
+        approval: { id: "apr_1" },
+      } as UIMessage["parts"][number],
+    ],
+  },
+];
+
+interface Mount {
+  url: string;
+  /** Every POST body the browser sent, in order. */
+  sent: Array<Record<string, unknown>>;
+  thread: UIMessage[];
+  close(): Promise<void>;
+}
+
+/** The mount's two routes, and nothing else: a turn that answers, and the
+ *  transcript read-back a reload does. */
+async function serveMount(): Promise<Mount> {
+  const sent: Array<Record<string, unknown>> = [];
+  const thread: UIMessage[] = [];
+  const server: Server = createServer((incoming, outgoing) => {
+    void (async () => {
+      const url = new URL(incoming.url ?? "/", "http://127.0.0.1");
+      if (incoming.method === "GET" && url.pathname === `/threads/${THREAD_ID}`) {
+        outgoing.writeHead(200, { "content-type": "application/json" });
+        outgoing.end(JSON.stringify({ id: THREAD_ID, messages: thread }));
+        return;
+      }
+      const chunks: Buffer[] = [];
+      for await (const chunk of incoming) chunks.push(chunk as Buffer);
+      const body = JSON.parse(Buffer.concat(chunks).toString() || "{}") as Record<string, unknown>;
+      sent.push(body);
+      // A real mount answers a decided approval by RUNNING the call it parked,
+      // so the turn's reply carries that call's output. Without it the approval
+      // stays pending forever and the SDK, correctly, keeps re-sending.
+      const decided = (body["message"] as UIMessage | undefined)?.parts.find(
+        (part) => "state" in part && part.state === "approval-responded",
+      ) as { toolCallId?: string } | undefined;
+      const response = createUIMessageStreamResponse({
+        stream: createUIMessageStream({
+          execute: ({ writer }) => {
+            if (decided?.toolCallId !== undefined) {
+              writer.write({ type: "tool-output-available", toolCallId: decided.toolCallId, output: { ok: true } });
+            }
+            writer.write({ type: "text-start", id: "t1" });
+            writer.write({ type: "text-delta", id: "t1", delta: "done" });
+            writer.write({ type: "text-end", id: "t1" });
+          },
+        }),
+      });
+      outgoing.writeHead(200, {
+        ...Object.fromEntries(response.headers),
+        "x-vendo-thread-id": THREAD_ID,
+      });
+      outgoing.end(await response.text());
+    })();
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  return {
+    url: `http://127.0.0.1:${(server.address() as AddressInfo).port}`,
+    sent,
+    thread,
+    close: () =>
+      new Promise<void>((resolve) => {
+        server.closeAllConnections();
+        server.close(() => resolve());
+      }),
+  };
+}
+
+let mount: Mount;
+
+beforeEach(async () => {
+  mount = await serveMount();
+});
+
+afterEach(async () => {
+  await mount.close();
+});
+
+describe("useVendoChat", () => {
+  it("hands the server's thread id out instead of keeping one", async () => {
+    const announced: string[] = [];
+    const { result } = renderHook(() =>
+      useVendoChat({ api: mount.url, onThreadId: (id) => announced.push(id) }));
+
+    result.current.sendMessage({ text: "hello" });
+
+    await waitFor(() => expect(result.current.threadId).toBe(THREAD_ID));
+    expect(announced).toEqual([THREAD_ID]);
+    // The whole no-hidden-storage claim, checked rather than asserted in prose.
+    expect(globalThis.localStorage.length).toBe(0);
+    expect(globalThis.sessionStorage.length).toBe(0);
+  });
+
+  it("sends the live thread id back on the next turn", async () => {
+    const { result } = renderHook(() => useVendoChat({ api: mount.url }));
+
+    result.current.sendMessage({ text: "hello" });
+    await waitFor(() => expect(result.current.threadId).toBe(THREAD_ID));
+    result.current.sendMessage({ text: "again" });
+
+    await waitFor(() => expect(mount.sent).toHaveLength(2));
+    expect(mount.sent[0]?.["threadId"]).toBeUndefined();
+    expect(mount.sent[1]?.["threadId"]).toBe(THREAD_ID);
+  });
+
+  it("reads a parked approval back from the server on reload", async () => {
+    mount.thread.push(...parked);
+
+    const { result } = renderHook(() => useVendoChat({ api: mount.url, threadId: THREAD_ID }));
+
+    await waitFor(() => expect(result.current.interruptions).toHaveLength(1));
+    expect(result.current.interruptions[0]).toEqual({
+      id: "apr_1",
+      type: "approval",
+      toolCall: { id: "call_1", tool: "host_refund", args: { invoiceId: "7" } },
+    });
+  });
+
+  it("resume answers the approval and the decided turn goes back to the server", async () => {
+    mount.thread.push(...parked);
+    const { result } = renderHook(() => useVendoChat({ api: mount.url, threadId: THREAD_ID }));
+    await waitFor(() => expect(result.current.interruptions).toHaveLength(1));
+
+    await result.current.resume({ apr_1: "approve" });
+
+    // The SDK sends the decided messages back on its own once every requested
+    // approval has an answer — that send IS the resume.
+    await waitFor(() => expect(mount.sent).toHaveLength(1));
+    await waitFor(() => expect(result.current.interruptions).toHaveLength(0));
+  });
+});

--- a/packages/ui/test/use-vendo-chat.test.tsx
+++ b/packages/ui/test/use-vendo-chat.test.tsx
@@ -38,8 +38,10 @@ const parked: UIMessage[] = [
 
 interface Mount {
   url: string;
-  /** Every POST body the browser sent, in order. */
+  /** Every turn body the browser sent, in order. */
   sent: Array<Record<string, unknown>>;
+  /** Every approval decision the browser posted to the permission wire. */
+  decided: Array<Record<string, unknown>>;
   thread: UIMessage[];
   close(): Promise<void>;
 }
@@ -48,6 +50,7 @@ interface Mount {
  *  transcript read-back a reload does. */
 async function serveMount(): Promise<Mount> {
   const sent: Array<Record<string, unknown>> = [];
+  const decided: Array<Record<string, unknown>> = [];
   const thread: UIMessage[] = [];
   const server: Server = createServer((incoming, outgoing) => {
     void (async () => {
@@ -60,19 +63,16 @@ async function serveMount(): Promise<Mount> {
       const chunks: Buffer[] = [];
       for await (const chunk of incoming) chunks.push(chunk as Buffer);
       const body = JSON.parse(Buffer.concat(chunks).toString() || "{}") as Record<string, unknown>;
+      if (url.pathname === "/approvals/decide") {
+        decided.push(body);
+        outgoing.writeHead(200, { "content-type": "application/json" });
+        outgoing.end("{}");
+        return;
+      }
       sent.push(body);
-      // A real mount answers a decided approval by RUNNING the call it parked,
-      // so the turn's reply carries that call's output. Without it the approval
-      // stays pending forever and the SDK, correctly, keeps re-sending.
-      const decided = (body["message"] as UIMessage | undefined)?.parts.find(
-        (part) => "state" in part && part.state === "approval-responded",
-      ) as { toolCallId?: string } | undefined;
       const response = createUIMessageStreamResponse({
         stream: createUIMessageStream({
           execute: ({ writer }) => {
-            if (decided?.toolCallId !== undefined) {
-              writer.write({ type: "tool-output-available", toolCallId: decided.toolCallId, output: { ok: true } });
-            }
             writer.write({ type: "text-start", id: "t1" });
             writer.write({ type: "text-delta", id: "t1", delta: "done" });
             writer.write({ type: "text-end", id: "t1" });
@@ -90,6 +90,7 @@ async function serveMount(): Promise<Mount> {
   return {
     url: `http://127.0.0.1:${(server.address() as AddressInfo).port}`,
     sent,
+    decided,
     thread,
     close: () =>
       new Promise<void>((resolve) => {
@@ -149,16 +150,32 @@ describe("useVendoChat", () => {
     });
   });
 
-  it("resume answers the approval and the decided turn goes back to the server", async () => {
+  it("resume tells the GUARD, on the mount's own permission wire", async () => {
     mount.thread.push(...parked);
     const { result } = renderHook(() => useVendoChat({ api: mount.url, threadId: THREAD_ID }));
     await waitFor(() => expect(result.current.interruptions).toHaveLength(1));
 
     await result.current.resume({ apr_1: "approve" });
 
-    // The SDK sends the decided messages back on its own once every requested
-    // approval has an answer — that send IS the resume.
-    await waitFor(() => expect(mount.sent).toHaveLength(1));
-    await waitFor(() => expect(result.current.interruptions).toHaveLength(0));
+    // The guard's decision is what unblocks the parked turn; flipping the part
+    // in the browser instead moves nothing on the server, and the browser seam
+    // test caught exactly that. It is the APPROVAL id that is sent, not the
+    // tool call's.
+    expect(mount.decided).toEqual([{ ids: ["apr_1"], decision: { approve: true } }]);
+    // And no turn was started to carry it — the parked one is still running.
+    expect(mount.sent).toEqual([]);
+  });
+
+  it("groups a mixed decision map into one call per verdict", async () => {
+    mount.thread.push(...parked);
+    const { result } = renderHook(() => useVendoChat({ api: mount.url, threadId: THREAD_ID }));
+    await waitFor(() => expect(result.current.interruptions).toHaveLength(1));
+
+    await result.current.resume({ apr_1: "approve", apr_2: "deny", apr_3: "deny" });
+
+    expect(mount.decided).toEqual([
+      { ids: ["apr_1"], decision: { approve: true } },
+      { ids: ["apr_2", "apr_3"], decision: { approve: false } },
+    ]);
   });
 });

--- a/packages/ui/test/use-vendo-chat.test.tsx
+++ b/packages/ui/test/use-vendo-chat.test.tsx
@@ -42,6 +42,9 @@ interface Mount {
   sent: Array<Record<string, unknown>>;
   /** Every approval decision the browser posted to the permission wire. */
   decided: Array<Record<string, unknown>>;
+  /** Make the permission wire refuse from here on — a 409, which is what the
+   *  wire answers for an approval already decided or long expired. */
+  refuse(): void;
   thread: UIMessage[];
   close(): Promise<void>;
 }
@@ -52,10 +55,11 @@ async function serveMount(): Promise<Mount> {
   const sent: Array<Record<string, unknown>> = [];
   const decided: Array<Record<string, unknown>> = [];
   const thread: UIMessage[] = [];
+  let refusing = false;
   const server: Server = createServer((incoming, outgoing) => {
     void (async () => {
       const url = new URL(incoming.url ?? "/", "http://127.0.0.1");
-      if (incoming.method === "GET" && url.pathname === `/threads/${THREAD_ID}`) {
+      if (incoming.method === "GET" && url.pathname.startsWith("/threads/")) {
         outgoing.writeHead(200, { "content-type": "application/json" });
         outgoing.end(JSON.stringify({ id: THREAD_ID, messages: thread }));
         return;
@@ -65,7 +69,7 @@ async function serveMount(): Promise<Mount> {
       const body = JSON.parse(Buffer.concat(chunks).toString() || "{}") as Record<string, unknown>;
       if (url.pathname === "/approvals/decide") {
         decided.push(body);
-        outgoing.writeHead(200, { "content-type": "application/json" });
+        outgoing.writeHead(refusing ? 409 : 200, { "content-type": "application/json" });
         outgoing.end("{}");
         return;
       }
@@ -91,6 +95,9 @@ async function serveMount(): Promise<Mount> {
     url: `http://127.0.0.1:${(server.address() as AddressInfo).port}`,
     sent,
     decided,
+    refuse: () => {
+      refusing = true;
+    },
     thread,
     close: () =>
       new Promise<void>((resolve) => {
@@ -177,5 +184,34 @@ describe("useVendoChat", () => {
       { ids: ["apr_1"], decision: { approve: true } },
       { ids: ["apr_2", "apr_3"], decision: { approve: false } },
     ]);
+  });
+
+  it("raises a refused decision instead of reporting it as landed", async () => {
+    mount.thread.push(...parked);
+    mount.refuse();
+    const { result } = renderHook(() => useVendoChat({ api: mount.url, threadId: THREAD_ID }));
+    await waitFor(() => expect(result.current.interruptions).toHaveLength(1));
+
+    // A 409 is the wire saying this approval was already answered or has
+    // expired. Resolved as success it reads as "the approval landed" while the
+    // turn is still parked, waiting for a decision that never arrives.
+    await expect(result.current.resume({ apr_1: "approve" })).rejects.toThrow(/409/);
+  });
+
+  it("points the next turn at the thread it was switched to", async () => {
+    const { result, rerender } = renderHook(
+      ({ id }: { id: string }) => useVendoChat({ api: mount.url, threadId: id }),
+      { initialProps: { id: THREAD_ID } },
+    );
+
+    rerender({ id: "thr_switched" });
+    await waitFor(() => expect(result.current.threadId).toBe("thr_switched"));
+    result.current.sendMessage({ text: "hello" });
+
+    // The transcript already reloads for the new thread; the outbound turn has
+    // to follow it, or the conversation on screen and the one being written to
+    // are two different threads.
+    await waitFor(() => expect(mount.sent).toHaveLength(1));
+    expect(mount.sent[0]?.["threadId"]).toBe("thr_switched");
   });
 });

--- a/packages/vendo/src/react.tsx
+++ b/packages/vendo/src/react.tsx
@@ -27,6 +27,9 @@ export {
   // routes.ts
   useVendoNavigate,
   useVendoRoutes,
+  // use-vendo-chat.ts
+  useVendoChat,
+  type UseVendoChatOptions,
   // chrome/discoverability.ts
   defaultVendoGreeting,
   type VendoDiscoverability,

--- a/packages/vendo/src/server.ts
+++ b/packages/vendo/src/server.ts
@@ -8,6 +8,7 @@
  * is where a host names it.
  */
 import { provideCloudAdapters } from "@vendoai/agents";
+import { isJsonRequest, relativePath } from "@vendoai/agents/http";
 import { isVendoError, log, VendoError } from "@vendoai/core";
 import { announceBootSummary, bootSummaryFor } from "./boot-summary.js";
 import { createComposition } from "./compose-context.js";
@@ -216,17 +217,6 @@ export { guard, createGuard, type GuardRules, type VendoGuard } from "@vendoai/g
 // assignment, no I/O — safe at module scope under workerd (portability gate).
 provideCloudAdapters({ sandbox: cloudSandbox });
 
-function isJsonRequest(request: Request): boolean {
-  return request.headers.get("content-type")?.split(";", 1)[0]?.trim().toLowerCase()
-    === "application/json";
-}
-
-function relativePath(url: URL): string | null {
-  if (url.pathname === BASE_PATH) return "/";
-  if (!url.pathname.startsWith(`${BASE_PATH}/`)) return null;
-  return url.pathname.slice(BASE_PATH.length);
-}
-
 /** The door path set of each composition, keyed by its own instance: the wire
     matches it (`isDoorPath`) and `wellKnownVendoHandler` must match the SAME
     one, and the base-path prefix it is built from is a composition fact rather
@@ -381,7 +371,7 @@ function createWireHandler(deps: WireDeps): (request: Request) => Promise<Respon
         await deps.ready();
         return await deps.door.handler(request);
       }
-      const path = relativePath(url);
+      const path = relativePath(BASE_PATH, url);
       if (path === null) throw new VendoError("not-found", "unknown Vendo route");
       // Learn the same-origin default only from a request that addresses a real
       // Vendo route (defense in depth beyond the untrusted-forwarding rule).

--- a/packages/vendo/src/wire/shared.ts
+++ b/packages/vendo/src/wire/shared.ts
@@ -1,8 +1,14 @@
+import {
+  dispatchRoutes as dispatchHttpRoutes,
+  prefixRoute as httpPrefixRoute,
+  route as httpRoute,
+  type RouteEntry as HttpRouteEntry,
+  type RouteHandler as HttpRouteHandler,
+} from "@vendoai/agents/http";
 import type { AppsRuntime, AppTokens } from "@vendoai/apps";
 import type { SandboxVenue } from "@vendoai/apps";
 import type { AutomationsEngine } from "@vendoai/automations";
 import {
-  isVendoError,
   VendoError,
   type Json,
   type Membership,
@@ -11,7 +17,6 @@ import {
   type StoreOps,
   type ToolOutcome,
   type ToolRegistry,
-  type VendoErrorCode,
 } from "@vendoai/core";
 import type { VendoGuard } from "@vendoai/guard";
 import type { McpDoor } from "@vendoai/mcp";
@@ -22,10 +27,14 @@ import type { HarnessTurns } from "../harness-turn.js";
 import type { ChannelDoor } from "../channels.js";
 import type { ConnectionsService } from "../connections.js";
 
-/** The shared wire toolkit (kill-list B4): the route-table types and matcher,
-    the JSON/error envelope helpers, and the param validators every wire area
-    shares. The per-request RunContext resolution lives in wire/context.ts;
-    server.ts assembles the table from the per-area modules under src/wire/. */
+/** The shared wire toolkit (kill-list B4). The generic half — the route-table
+    types and matcher, the envelope helpers, the param validators — lives in
+    `@vendoai/agents/http` now, so there is exactly ONE route runtime; it is
+    re-exported here, so every wire area keeps its `./shared.js` import. What
+    stays is what only the umbrella has. The per-request RunContext resolution
+    lives in wire/context.ts; server.ts assembles the table from the per-area
+    modules under src/wire/. */
+export { errorResponse, hex, internalError, json, requestJson, routeSegments, string } from "@vendoai/agents/http";
 
 /** Re-exported, not redeclared: the one version literal lives in
     @vendoai/core, beside the deployment-identity headers that stamp it. */
@@ -41,26 +50,6 @@ export type { SandboxVenue };
     Cloud model gateway, then the honest keyless failure; the ladder resolves
     lazily, so /status cannot name the rung without forcing a resolution). */
 export type ModelVenue = "custom" | "ladder";
-
-const STATUS_BY_CODE: Record<VendoErrorCode, number> = {
-  validation: 400,
-  "not-found": 404,
-  blocked: 403,
-  // Build contract §9.4 — the caller sees the thing but may not do this to it.
-  forbidden: 403,
-  conflict: 409,
-  "cloud-required": 402,
-  "sandbox-unavailable": 501,
-  "not-implemented": 501,
-  // Table entry only, for the same reason knowledge-wire.ts's copy carries
-  // one: this umbrella wire builds its OWN VendoError responses and never
-  // parses a status code back into one, so there is no STATUS_TO_CODE here
-  // to extend.
-  unavailable: 503,
-  // Same: a schema proposal is a typed store's answer to its own client, and
-  // this wire has no table to propose.
-  "schema-proposal": 409,
-};
 
 export interface WireDeps {
   principal: (req: Request) => Promise<Principal | null>;
@@ -189,96 +178,16 @@ export interface WireContext {
   deps: WireDeps;
 }
 
-/** A handler answers with a Response, or returns undefined to FALL THROUGH to
-    the next entry — mirroring the old if-chain, where a matched-path block
-    whose method/operation checks all missed simply fell out the bottom (any
-    side effects it ran, e.g. context resolution, stand). */
-export type RouteHandler = (wire: WireContext) => Promise<Response | undefined>;
-
-type RoutePattern =
-  /** Raw-path equality — no decoding, matching the old `path === "/x"` arms. */
-  | { kind: "exact"; path: string }
-  /** Raw-path prefix — matching the old `path.startsWith("/x/")` arms. */
-  | { kind: "prefix"; prefix: string }
-  /** Decoded-segment match: literals compare against decoded values, `:name`
-      captures, a trailing rest wildcard allows ZERO or more extra segments —
-      matching the old `head === "x" && segments.length >= n` arms. */
-  | { kind: "segments"; parts: string[]; rest: boolean };
-
-export interface RouteEntry {
-  /** Exact method, or "*" for grouped handlers that dispatch methods inside. */
-  method: string;
-  pattern: RoutePattern;
-  handler: RouteHandler;
-}
-
-/** Table entry from a pattern string: no `:param` and no trailing `/*` means
-    raw-path equality; otherwise decoded-segment matching (trailing `/*` = rest
-    wildcard, zero or more segments). */
-export function route(method: string, pattern: string, handler: RouteHandler): RouteEntry {
-  if (!pattern.includes(":") && !pattern.endsWith("/*")) {
-    return { method, pattern: { kind: "exact", path: pattern }, handler };
-  }
-  const rest = pattern.endsWith("/*");
-  const parts = (rest ? pattern.slice(0, -2) : pattern).split("/").filter(Boolean);
-  return { method, pattern: { kind: "segments", parts, rest }, handler };
-}
-
-/** Table entry matching on a raw path prefix (webhooks, proxy, the doctor
-    production gate) — never decodes, exactly like the old startsWith arms.
-    Raw string match, no segment boundary — include the trailing slash. */
-export function prefixRoute(method: string, prefix: string, handler: RouteHandler): RouteEntry {
-  return { method, pattern: { kind: "prefix", prefix }, handler };
-}
-
-function matchRoute(entry: RouteEntry, wire: WireContext): Record<string, string> | null {
-  if (entry.method !== "*" && entry.method !== wire.request.method) return null;
-  const pattern = entry.pattern;
-  if (pattern.kind === "exact") return pattern.path === wire.path ? {} : null;
-  if (pattern.kind === "prefix") return wire.path.startsWith(pattern.prefix) ? {} : null;
-  // Segment access may throw the invalid-encoding validation error — only ever
-  // reached after every raw pre-route entry has had its chance, preserving the
-  // old chain's ordering (prefix routes served /proxy/%zz; /threads/%zz threw).
-  const segments = wire.segments;
-  if (pattern.rest ? segments.length < pattern.parts.length : segments.length !== pattern.parts.length) {
-    return null;
-  }
-  const params: Record<string, string> = {};
-  for (let i = 0; i < pattern.parts.length; i++) {
-    const part = pattern.parts[i]!;
-    if (part.startsWith(":")) params[part.slice(1)] = segments[i]!;
-    else if (part !== segments[i]) return null;
-  }
-  return params;
-}
-
-/** Scan the table in order; a handler returning undefined keeps scanning
-    (fall-through). No match → undefined; the caller answers not-found. */
-export async function dispatchRoutes(
-  routes: readonly RouteEntry[],
-  wire: WireContext,
-): Promise<Response | undefined> {
-  for (const entry of routes) {
-    const params = matchRoute(entry, wire);
-    if (params === null) continue;
-    wire.params = params;
-    const response = await entry.handler(wire);
-    if (response !== undefined) return response;
-  }
-  return undefined;
-}
-
-export function json(body: unknown, status = 200): Response {
-  return Response.json(body, { status });
-}
-
-export function errorResponse(error: VendoError): Response {
-  return json({ error: { code: error.code, message: error.message } }, STATUS_BY_CODE[error.code]);
-}
-
-export function internalError(): Response {
-  return errorResponse(new VendoError("not-implemented", "Internal Vendo error"));
-}
+/** The umbrella's binding of the shared route runtime to its own WireContext.
+    Bound as VALUES rather than re-exported generics: a handler written with an
+    implicit parameter (`route("GET", "/x", async ({ deps }) => …)`) has no
+    inference site, so the annotation here is what contextually types it. */
+export type RouteHandler = HttpRouteHandler<WireContext>;
+export type RouteEntry = HttpRouteEntry<WireContext>;
+export const route: (method: string, pattern: string, handler: RouteHandler) => RouteEntry = httpRoute;
+export const prefixRoute: (method: string, prefix: string, handler: RouteHandler) => RouteEntry = httpPrefixRoute;
+export const dispatchRoutes: (routes: readonly RouteEntry[], wire: WireContext) => Promise<Response | undefined> =
+  dispatchHttpRoutes;
 
 /** Orgs are a Vendo Cloud capability, not an OSS one (kill-list A5): every
     /orgs route and every org-scoped param on /approvals and /grants answers
@@ -289,46 +198,13 @@ export function orgsCloudRequired(): never {
   throw new VendoError("cloud-required", "orgs are a Vendo Cloud capability");
 }
 
-function object(value: unknown, label: string): Record<string, unknown> {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    throw new VendoError("validation", `${label} must be an object`);
-  }
-  return value as Record<string, unknown>;
-}
-
-export function string(value: unknown, label: string): string {
-  if (typeof value !== "string" || value.length === 0) {
-    throw new VendoError("validation", `${label} must be a non-empty string`);
-  }
-  return value;
-}
-
-export async function requestJson(request: Request): Promise<Record<string, unknown>> {
-  try {
-    return object(await request.json(), "request body");
-  } catch (error) {
-    if (isVendoError(error)) throw error;
-    throw new VendoError("validation", "request body must be valid JSON");
-  }
-}
-
+/** Stays here, and deliberately NOT trimmed: `vendo doctor` reads operator
+    variables with this exact predicate so doctor and runtime agree on what
+    counts as set (doctor-config-checks.ts, doctor-wiring-checks.ts), and
+    boot-summary.ts's `keySet` documents itself as the stricter one. The trimmed
+    reader in @vendoai/agents' door.ts is a different question — an ORIGIN. */
 export function environment(name: string): string | undefined {
   if (typeof process === "undefined") return undefined;
   const value = process.env[name];
   return typeof value === "string" && value.length > 0 ? value : undefined;
-}
-
-export function routeSegments(path: string): string[] {
-  try {
-    return path.split("/").filter(Boolean).map(decodeURIComponent);
-  } catch {
-    throw new VendoError("validation", "route contains invalid URL encoding");
-  }
-}
-
-/** Bytes → lowercase hex. Used by wire/misc.ts's timing-safe digest compare. */
-export function hex(bytes: ArrayBuffer | Uint8Array): string {
-  let out = "";
-  for (const b of bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes)) out += b.toString(16).padStart(2, "0");
-  return out;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -609,6 +609,9 @@ importers:
       '@vendoai/actions':
         specifier: workspace:*
         version: link:../../packages/actions
+      '@vendoai/agents':
+        specifier: workspace:*
+        version: link:../../packages/agents
       '@vendoai/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -13736,14 +13739,6 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.7(vite@6.4.3(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))':
-    dependencies:
-      '@vitest/spy': 3.2.7
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 6.4.3(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
-
   '@vitest/mocker@3.2.7(vite@6.4.3(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 3.2.7
@@ -19215,7 +19210,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.7
-      '@vitest/mocker': 3.2.7(vite@6.4.3(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+      '@vitest/mocker': 3.2.7(vite@6.4.3(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
       '@vitest/pretty-format': 3.2.7
       '@vitest/runner': 3.2.7
       '@vitest/snapshot': 3.2.7


### PR DESCRIPTION
## What changes

```ts
const handle = support.handler({ basePath: "/api/agent", resolveUser });
// Next:  export { handle as GET, handle as POST, handle as DELETE }
// Hono:  app.all("/api/agent/*", (c) => handle(c.req.raw))
```
```tsx
const chat = useVendoChat({ api: "/api/agent", threadId, onThreadId });
chat.interruptions;                 // pending, durable across reload
await chat.resume({ [id]: "approve" });
```

One mount and one hook. Before this, a host wiring `agent()` hand-wrote three routes and the chat wire from the docs.

## One router, not two

`@vendoai/vendo` had a real HTTP route runtime; `@vendoai/agents` had none — so the moment agents grew a chat route it would have copied ~80 lines of `server.ts`. The generic half moves down into `@vendoai/agents/http` (matching, dispatch, error→status, body parsing, mount stripping) and `wire/shared.ts` becomes a re-export shim, so **all ~40 existing importers keep their specifier**.

That is the proof this was behaviour-preserving: **2,582 `packages/vendo` tests pass with zero test files edited**, and the whole extraction is **+51 net source lines**.

## The seam test found a dead feature

`CLAUDE.md` asks for a test where neither side mocks the other, because this repo has shipped a dead feature four times that way. It happened again here, and the test caught it:

**The page rendered a correct consent card, the Approve click looked like it landed, and the refund never ran.** The turn sat on its waiter for 90 seconds and gave up with "the approval request expired unanswered". Both unit suites were green throughout — each side was right about its own half.

Root cause: a parked call waits on a **guard** decision, and only `guard.approvals.decide` resolves that waiter. The hook was answering through the ai-SDK's *local* approval channel, which repaints the page and tells the server nothing. Fixed: `resume()` posts to the permission wire, and the mount serves that wire under its own `basePath` behind its own `resolveUser` — a client that only knows `api` cannot reach a plane pinned elsewhere, and a standalone host configures identity once.

Two tests written earlier in this PR were then corrected, stated out loud, because the browser proved them wrong. A real browser outranks a unit test that agreed with the bug.

## What the browser test actually exercises

Real Chromium → the shipped `useVendoChat` → real HTTP → the real `handler()` → a real `agent()` with a real guard policy and a real store. Only the *thinker* is scripted. It asserts the refund ran **from the server's own record**, not from text on screen. A second test clears `localStorage`/`sessionStorage` and reloads: transcript and pending approval both come back from the server, which is the no-hidden-storage claim.

It lives in `fixtures/integration-browser` because `packages/ui` may only depend on core — so a test inside `packages/ui` physically cannot import the real counterparty, which is exactly how this class of bug survives.

## Two spec options deliberately absent

`publicOrigin` would be dead on arrival — the door's origin is fixed at `agent()` time and already throws the exact boot error the spec describes. `mcp` governs a public MCP plane that does not exist in this package, so absent and default-off are the same behaviour. Both are named in a comment on `HandlerOptions` so they read as considered, not forgotten; both are additive later without breaking anyone.

`POST /turns/:id/resume` answers 501 naming the seam — #1503 owns those rules, and inventing a second set is how one rule becomes two.

## Gate

`build` · `typecheck` · `lint` (dependency-guard OK; portability all legs green) · `packages/agents` 203 · `packages/ui` 1384 · **browser seam 2/2** — all EXIT=0.

Stacked on #1498.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes a standalone agent one HTTP mount and ships a thin chat hook that speaks to it, so hosts stop hand-wiring routes and approvals actually unblock parked turns.

- Adds `agent.handler({ basePath, resolveUser, headers? })` and `agentHandler(agent, options)`. Routes: POST `/threads` streams a turn and returns `x-vendo-thread-id`; GET `/threads` lists; GET/DELETE `/threads/:id` read/delete; `POST /turns/:turnId/resume` is wired but returns 501 to name the durable-resume seam.
- Serves approvals/grants under this mount and behind its `resolveUser`; unauthenticated requests return 401. The MCP door stays on its absolute path and never challenges identity.
- Extracts the shared HTTP route runtime to `@vendoai/agents/http` and re-exports it in the umbrella so both mounts share paths and envelopes; existing `@vendoai/vendo` importers keep their `./wire/shared` specifier.
- Introduces `useVendoChat` in `@vendoai/ui`: stock `useChat` transport with no client storage. It round-trips the thread id, reloads the transcript (including pending approvals) from the server, and `resume()` posts decisions to this mount’s permission wire. Refused decisions now bubble (e.g. 409), thread switches update the live id, and the hook is re-exported from `@vendoai/vendo`.

- Minimal adoption
  - Mount once: create `const handle = support.handler({ basePath: "/api/agent", resolveUser })` and export it as GET/POST/DELETE (or `app.all("/api/agent/*", c => handle(c.req.raw))`). Ensure your server also routes the door’s absolute path if the engine thinks outside the process.
  - In the client, replace hand wiring with `useVendoChat({ api: "/api/agent", threadId?, onThreadId? })` and render `interruptions` with a call to `resume({ [id]: "approve" | "deny" })`.
  - If a standalone client previously pointed approvals at `/api/vendo`, use this mount’s `/approvals/*` instead. Existing umbrella consumers do not change.

<sup>Written for commit cdb7e12bcb3daccb04554f1c56dd907f0dd509f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

