### PR TITLE
feat(ui): the generated remix wiring carries its holes to the renderer, so a hole paints

### DIFF
--- a/examples/demo-bank/src/components/vendo/VendoRoot.tsx
+++ b/examples/demo-bank/src/components/vendo/VendoRoot.tsx
@@ -4,6 +4,9 @@ import { type ReactNode } from "react";
 import { useRouter } from "next/navigation";
 import { VendoProvider, type ToolMetaMap } from "@vendoai/vendo/react";
 import { withBasePath } from "@/lib/base-path";
+// Written by `vendo sync` (the `prebuild`/`predev` step) and gitignored, so it
+// exists before anything imports it.
+import { remixWiring } from "../../../.vendo/generated/remix-wiring";
 import { mapleRegistry } from "@/vendo/registry";
 import { mapleRoutes } from "@/vendo/routes";
 import { mapleTheme } from "@/vendo/theme";
@@ -34,6 +37,10 @@ export function VendoRoot({
       // bare `/api/vendo`, which 404s once the app is served at a subpath.
       baseUrl={withBasePath("/api/vendo")}
       components={mapleRegistry}
+      // The other half of the sentence `vendo sync` prints: the server catalog
+      // knows the hole NAMES, the provider carries their implementations.
+      // Without it the renderer paints `Unknown component "AreaChart"`.
+      remixWiring={remixWiring}
       theme={mapleTheme}
       // "Pin to dashboard" lands here — placement is a first-class Vendo
       // write, so naming the slot is the whole wiring.

--- a/packages/ui/e2e/harness/main.tsx
+++ b/packages/ui/e2e/harness/main.tsx
@@ -46,6 +46,7 @@ import {
   type ReactNode,
 } from "react";
 import { createRoot } from "react-dom/client";
+import { Area, AreaChart, CartesianGrid, XAxis } from "recharts";
 import "./styles.css";
 
 const NOW = "2026-07-11T12:00:00.000Z";
@@ -899,6 +900,63 @@ function TreeScenario() {
     <TreeThemeBoundary>
       <TreeView tree={tree} components={components} onAction={onAction} />
     </TreeThemeBoundary>
+  );
+}
+
+/** A host sub-component hole — the host's own child component, which the port
+ *  kept calling by the name the host wrote. */
+function PriceBadge({ amount }: { amount?: number }) {
+  return <b className="host-card">{`$${(amount ?? 0).toLocaleString("en-US")}`}</b>;
+}
+
+/** `.vendo/generated/remix-wiring.ts` as the host imports it: the SAME const
+ *  `createVendo({ remixWiring })` takes, handed to the provider too. Every name
+ *  below is a hole the splitter found as a JSX tag in the host's own source —
+ *  four from npm, one of the host's own — and NONE of them is in the harness
+ *  `components` map, so the wiring's leg is the only way any of them paints. */
+const holeWiring = {
+  SpendCard: { tools: {}, holes: { AreaChart, Area, CartesianGrid, XAxis } },
+  AccountRow: { tools: {}, holes: { PriceBadge } },
+} as const;
+
+/** The paint a ported SpendCard produces: the chart and every part of it are
+ *  separate holes, so they arrive as separate nodes and recharts has to compose
+ *  them back through the renderer's own node wrappers. */
+const holePayload = {
+  formatVersion: "vendo-genui/v2",
+  root: "root",
+  nodes: [
+    { id: "root", component: "Stack", children: ["title", "badge", "chart"] },
+    { id: "title", component: "Text", props: { text: "Spending this year", variant: "heading" } },
+    { id: "badge", component: "PriceBadge", props: { amount: 4_820 } },
+    {
+      id: "chart",
+      component: "AreaChart",
+      props: {
+        width: 560,
+        height: 220,
+        data: [
+          { month: "Jan", value: 310 }, { month: "Feb", value: 480 }, { month: "Mar", value: 395 },
+          { month: "Apr", value: 620 }, { month: "May", value: 540 }, { month: "Jun", value: 760 },
+        ],
+      },
+      children: ["grid", "axis", "curve"],
+    },
+    { id: "grid", component: "CartesianGrid", props: { strokeDasharray: "3 3" } },
+    { id: "axis", component: "XAxis", props: { dataKey: "month" } },
+    {
+      id: "curve",
+      component: "Area",
+      props: { dataKey: "value", stroke: "#3b82f6", fill: "#bfdbfe", isAnimationActive: false },
+    },
+  ],
+} as UIPayload;
+
+function RemixHolesScenario() {
+  return (
+    <VendoProvider client={baseClient} remixWiring={holeWiring}>
+      <VendoSlot id="spend-card" pin={{ payload: holePayload }} />
+    </VendoProvider>
   );
 }
 
@@ -2046,6 +2104,7 @@ function scenario(pathname: string): { title: string; theme?: Partial<VendoTheme
     case "/notice": return { title: "Unconfigured policy", ownProvider: true, content: (<VendoProvider client={unconfiguredClient} components={components}><NoPolicyNotice /></VendoProvider>) };
     case "/tree": return { title: "Tree containment", content: <TreeScenario /> };
     case "/tree-injected": return { title: "Injected payload (captured host component)", content: <InjectedTreeScenario /> };
+    case "/tree-holes": return { title: "Remix holes — npm + host sub-component, from the generated wiring", content: <RemixHolesScenario />, ownProvider: true };
     case "/tree-inclient": return { title: "In-client venue (hash-pinned approval)", content: <InClientScenario /> };
     case "/tree-review": return { title: "Review-kind standing (pending / rejected)", content: <ReviewStandingScenario /> };
     case "/tree-drift": return { title: "Seed drift (host component updated)", content: <SeedDriftScenario /> };

--- a/packages/ui/e2e/remix-holes.spec.ts
+++ b/packages/ui/e2e/remix-holes.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "@playwright/test";
+import { openScenario } from "./helpers.js";
+
+const SHOTS = "/tmp/s5-holes";
+
+/**
+ * The holes a `<Remixable>` split leaves behind, painted for real. Nothing on
+ * this page is in the harness `components` map: the generated wiring const —
+ * the same one `createVendo({ remixWiring })` takes — is the only thing that
+ * carries these five components to the renderer.
+ */
+test("remix holes paint real components, from the generated wiring alone", async ({ page }) => {
+  await openScenario(page, "tree-holes");
+
+  // The npm hole: real recharts, composed back out of four separate tree nodes
+  // through the renderer's own per-node wrappers. Geometry, not just presence —
+  // a curve that resolved but drew nothing would pass a DOM-only assertion.
+  const curve = page.locator("path.recharts-area-area");
+  await expect(curve).toBeVisible();
+  const box = await curve.boundingBox();
+  expect(box?.width ?? 0).toBeGreaterThan(200);
+  expect(box?.height ?? 0).toBeGreaterThan(40);
+
+  // Its sibling holes drew too, off the host's own data keys.
+  await expect(page.locator(".recharts-cartesian-grid")).toBeVisible();
+  await expect(page.getByText("Jun", { exact: true })).toBeVisible();
+
+  // The host sub-component hole, resolved by the name the host wrote.
+  await expect(page.getByText("$4,820", { exact: true })).toBeVisible();
+
+  await page.screenshot({ path: `${SHOTS}/holes.png`, fullPage: true, animations: "disabled" });
+});

--- a/packages/ui/src/context.tsx
+++ b/packages/ui/src/context.tsx
@@ -114,6 +114,21 @@ export function hostComponentMap(components: HostComponentsInput | undefined): R
   return map;
 }
 
+/** The client half of the generated remix wiring (`vendo sync` writes
+ * `.vendo/generated/remix-wiring.ts`; `holes` binds a name the ported screen
+ * renders to the component itself). Read STRUCTURALLY, so the host hands the
+ * whole generated const over — `tools` and all — exactly as it hands it to
+ * `createVendo({ remixWiring })`. */
+export type RemixWiringInput = Record<string, { holes?: Record<string, ComponentType<never>> }>;
+
+/** Every slot's holes, folded name-keyed — a component name is global here, so
+ * two slots rendering the same hole are one entry rather than a collision. */
+function remixHoles(wiring: RemixWiringInput | undefined): Record<string, ComponentType> {
+  return Object.fromEntries(
+    Object.values(wiring ?? {}).flatMap((slot) => Object.entries(slot.holes ?? {})),
+  ) as Record<string, ComponentType>;
+}
+
 export function VendoProvider(props: {
   client?: VendoClient;
   /** The wire mount, path prefix included ("/maple/api/vendo"). Default
@@ -121,6 +136,13 @@ export function VendoProvider(props: {
       carries its own base. */
   baseUrl?: string;
   components?: HostComponentsInput;
+  /** The same generated const `createVendo({ remixWiring })` takes. Its holes
+      join the components map as its WEAKEST leg — mirroring the server, where a
+      hole is the weakest leg of the catalog (`vendo` compose-surfaces.ts) — so a
+      `components` entry for the same name still wins. Both ends need it: the
+      client screen VM's vocabulary is built from this map too (tree/renderer.tsx),
+      so a hole missing here is a name the port cannot even paint. */
+  remixWiring?: RemixWiringInput;
   theme?: Partial<VendoTheme>;
   /** The host's `.vendo/fonts.css` text — see VendoContextValue.fonts. */
   fonts?: string;
@@ -144,7 +166,7 @@ export function VendoProvider(props: {
   onNavigate?(nav: VendoNavigation): void;
   children: ReactNode;
 }): ReactNode {
-  const { client, baseUrl, components, theme, fonts, transport, onPin, pinSlot, tools, connectors, discoverability, greeting, intl, captureScreen, routes, onNavigate, children } = props;
+  const { client, baseUrl, components, remixWiring, theme, fonts, transport, onPin, pinSlot, tools, connectors, discoverability, greeting, intl, captureScreen, routes, onNavigate, children } = props;
   const currency = intl?.currency;
   const locale = intl?.locale;
   // Installed during RENDER, not in an effect: the formatters are called while
@@ -157,7 +179,7 @@ export function VendoProvider(props: {
   const value = useMemo<VendoContextValue>(
     () => ({
       client: client ?? createVendoClient(baseUrl === undefined ? {} : { baseUrl }),
-      components: hostComponentMap(components),
+      components: { ...remixHoles(remixWiring), ...hostComponentMap(components) },
       theme: resolveTheme(defaultVendoTheme, theme),
       fonts,
       transport,
@@ -172,7 +194,7 @@ export function VendoProvider(props: {
       routes,
       onNavigate,
     }),
-    [client, baseUrl, components, theme, fonts, transport, onPin, pinSlot, tools, connectors, discoverability, greeting, resolvedIntl, captureScreen, routes, onNavigate],
+    [client, baseUrl, components, remixWiring, theme, fonts, transport, onPin, pinSlot, tools, connectors, discoverability, greeting, resolvedIntl, captureScreen, routes, onNavigate],
   );
   return <VendoContext.Provider value={value}>{children}</VendoContext.Provider>;
 }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -13,7 +13,7 @@ export {
   type VendoClient,
   type VendoClientConfig,
 } from "./client.js";
-export { VendoProvider, hostComponentMap, useVendoProvider, useVendoDiscoverability, useVendoGreeting, useVendoTheme, useVendoThemeOrDefault, useVendoTools, type ConnectorOption, type HostComponentsInput } from "./context.js";
+export { VendoProvider, hostComponentMap, useVendoProvider, useVendoDiscoverability, useVendoGreeting, useVendoTheme, useVendoThemeOrDefault, useVendoTools, type ConnectorOption, type HostComponentsInput, type RemixWiringInput } from "./context.js";
 export { useVendoNavigate, useVendoRoutes } from "./routes.js";
 /** The standalone agent's conversation — one `agentHandler()` mount, no embed. */
 export { useVendoChat, type UseVendoChatOptions } from "./use-vendo-chat.js";

--- a/packages/ui/test/tree/remix-holes.test.tsx
+++ b/packages/ui/test/tree/remix-holes.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+import type { ComponentType } from "react";
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { Area, AreaChart } from "recharts";
+import { VENDO_TREE_FORMAT, type ToolOutcome, type UIPayload } from "@vendoai/core";
+import { TreeView, type WalkTree } from "../../src/tree/index.js";
+import { VendoProvider } from "../../src/index.js";
+import { VendoSlot } from "../../src/chrome/index.js";
+
+afterEach(cleanup);
+
+const ok = async (): Promise<ToolOutcome> => ({ status: "ok", output: null });
+
+const tree = (nodes: WalkTree["nodes"]): WalkTree & { formatVersion: typeof VENDO_TREE_FORMAT } =>
+  ({ formatVersion: VENDO_TREE_FORMAT, root: "root", nodes });
+
+/** A host's own sub-component — one of the two kinds of hole the splitter emits
+ *  (`actions` sync/split/port.ts: an imported binding used as a JSX tag). */
+function PriceBadge({ amount }: { amount?: number }) {
+  return <b data-testid="badge">{`$${amount ?? 0}`}</b>;
+}
+
+/** The npm kind, nested exactly as a host writes it: the chart and its curve are
+ *  two separate holes, so they arrive as two separate nodes. */
+const CHART_NODES: WalkTree["nodes"] = [
+  { id: "root", component: "Stack", children: ["chart"] },
+  {
+    id: "chart",
+    component: "AreaChart",
+    props: { width: 320, height: 180, data: [{ month: "Jan", value: 3 }, { month: "Feb", value: 8 }] },
+    children: ["curve"],
+  },
+  { id: "curve", component: "Area", props: { dataKey: "value", isAnimationActive: false } },
+];
+
+/** The generated `.vendo/generated/remix-wiring.ts` const, as the host imports it
+ *  and hands to BOTH `createVendo` and the provider — `tools` included, because
+ *  the host passes the whole thing rather than picking it apart. */
+const WIRING = {
+  SpendCard: { tools: {}, holes: { AreaChart, Area } },
+  AccountRow: { tools: {}, holes: { PriceBadge } },
+} as const;
+
+const slotPayload = (nodes: WalkTree["nodes"]): UIPayload =>
+  ({ formatVersion: VENDO_TREE_FORMAT, root: "root", nodes } as UIPayload);
+
+describe("a hole resolves by name in the renderer", () => {
+  it("paints a host sub-component hole", () => {
+    render(
+      <TreeView
+        tree={tree([
+          { id: "root", component: "Stack", children: ["badge"] },
+          { id: "badge", component: "PriceBadge", props: { amount: 42 } },
+        ])}
+        components={{ PriceBadge: PriceBadge as ComponentType }}
+        onAction={ok}
+      />,
+    );
+    expect(screen.getByTestId("badge").textContent).toBe("$42");
+  });
+
+  it("paints a composite npm hole — recharts draws the curve its child node declared", () => {
+    render(
+      <TreeView
+        tree={tree(CHART_NODES)}
+        components={{ AreaChart: AreaChart as ComponentType, Area: Area as ComponentType }}
+        onAction={ok}
+      />,
+    );
+    expect(document.querySelector("path.recharts-area-area")).not.toBeNull();
+  });
+
+  it("says so rather than painting nothing when the hole was never registered", () => {
+    render(<TreeView tree={tree(CHART_NODES)} components={{}} onAction={ok} />);
+    expect(screen.getByRole("note", { name: "Unknown component" }).textContent).toContain("AreaChart");
+  });
+});
+
+describe("the generated wiring carries its holes to the renderer", () => {
+  it("paints an npm hole the host only ever registered as wiring", () => {
+    render(
+      <VendoProvider remixWiring={WIRING}>
+        <VendoSlot id="hero" pin={{ payload: slotPayload(CHART_NODES) }} />
+      </VendoProvider>,
+    );
+    expect(document.querySelector("path.recharts-area-area")).not.toBeNull();
+  });
+
+  it("paints a host sub-component hole the host only ever registered as wiring", () => {
+    render(
+      <VendoProvider remixWiring={WIRING}>
+        <VendoSlot id="hero" pin={{ payload: slotPayload([{ id: "root", component: "PriceBadge", props: { amount: 7 } }]) }} />
+      </VendoProvider>,
+    );
+    expect(screen.getByTestId("badge").textContent).toBe("$7");
+  });
+
+  it("lets an explicit components entry win, exactly as it wins over a hole in the server's catalog", () => {
+    render(
+      <VendoProvider
+        remixWiring={WIRING}
+        components={{ PriceBadge: (() => <b data-testid="badge">the host's own</b>) as ComponentType<never> }}
+      >
+        <VendoSlot id="hero" pin={{ payload: slotPayload([{ id: "root", component: "PriceBadge", props: { amount: 7 } }]) }} />
+      </VendoProvider>,
+    );
+    expect(screen.getByTestId("badge").textContent).toBe("the host's own");
+  });
+});

--- a/packages/vendo/src/screen-agent.ts
+++ b/packages/vendo/src/screen-agent.ts
@@ -175,10 +175,17 @@ export const EDIT_APP_TOOL = "edit_app";
  * A fresh build's app is the file the run is about to write, so opening it or
  * listing its saved records can only answer `not-found`: two entries on a
  * ten-step menu whose one possible use is a step spent learning that. An edit
- * starts the other way round — the document already on the person's screen is the
- * thing being changed, so reading it is the first move. Withheld from the brief's
- * button half too on a fresh build (`withheld` below): a screen cannot offer to
- * open an app nobody has made yet.
+ * starts the other way round — the app already on the person's screen is the
+ * thing being changed, so what it is showing is worth a step. Withheld from the
+ * brief's button half too on a fresh build (`withheld` below): a screen cannot
+ * offer to open an app nobody has made yet.
+ *
+ * NEITHER OF THESE READS THE SOURCE, and believing otherwise cost a whole
+ * investigation: `vendo_apps_open` is the client's render door
+ * (`apps` persistence/open.ts `paintedScreenSurface`) — it RE-RUNS the screen and
+ * answers with the flattened tree plus the compiled module, deliberately, because
+ * that is what a caller mounts. The `app.tsx` a run starts from reaches the model
+ * as {@link ScreenInput.source} instead, and only for a remix.
  */
 const EDIT_TOOLS: readonly string[] = ["vendo_apps_open", "vendo_apps_data_list"];
 
@@ -294,6 +301,11 @@ export interface ScreenInput {
    *  in the same bytes the box rung is handed. Knowledge, not instruction, so it
    *  sits with the job description rather than with the deployment's voice. */
   briefing?: string;
+  /** The `app.tsx` this run starts from — a REMIX's ported source, and nothing
+   *  else's ({@link ScreenAssemblerDeps.storedScreen} answers only for a seeded
+   *  row, `replayFrom` only for a re-seed). Absent on every other edit, whose
+   *  first message stays the ask alone. See {@link startingSource}. */
+  source?: string;
 }
 
 /** What one assembly run answers. `ScreenOutcome` plus the title an assembled
@@ -615,6 +627,39 @@ const judgeScreen = async (
   if (output.ok && findings.length === 0) return undefined;
   return refusal(path, findings);
 };
+
+/**
+ * The screen this run starts from, IN FRONT OF THE MODEL — the remix's whole
+ * reason to exist, and the one thing it never had.
+ *
+ * A remix's first act is an edit of the host component's own ported code
+ * (`remix/seed-surface.ts` `seedFrom`), and the loop checks that code out into
+ * the workspace. But the workspace is not somewhere this loop can READ: the
+ * loadout carries no file hand, `edit_app` can only replace passages the model
+ * quotes back character for character, and `vendo_apps_open` answers with the
+ * render rather than the source ({@link EDIT_TOOLS}). So the port sat staged and
+ * invisible, and every remix wrote a replacement out of the catalog instead —
+ * guessing a host component's props, which the checks floor then refused. The
+ * ask alone could never have produced anything else.
+ *
+ * A message rather than a section of the brief: the brief heads a cached prefix
+ * shared by every assembly, and this is one app's file.
+ *
+ * REMIXES ONLY. `source` is filled from the source this run starts on, which
+ * exists for a seeded row and nothing else — an ordinary edit's first message is
+ * still the ask, byte for byte.
+ */
+const startingSource = (source: string | undefined): string =>
+  source === undefined ? "" : `This app already has a screen: the host's own component, ported into this dialect.
+It is below, and it is what the ask under it changes — edit THIS code, keep every
+part the ask does not name, and never replace it with something built from the
+catalog.
+
+\`\`\`tsx
+${source}
+\`\`\`
+
+`;
 
 /** How much room the screen has, when the host said. Said ONLY then: a screen
  *  cannot measure its own surface, so a width this file guessed would read to the
@@ -1131,7 +1176,11 @@ export async function assembleScreen(
   loadout.push(acting(saveApp), acting(editApp));
 
   const turn: Turn<VendoHarnessOptions> = {
-    messages: [{ id: `screen_${input.appId}`, role: "user", parts: [{ type: "text", text: input.request }] }],
+    messages: [{
+      id: `screen_${input.appId}`,
+      role: "user",
+      parts: [{ type: "text", text: `${startingSource(input.source)}${input.request}` }],
+    }],
     // The listings are read ONCE and handed back verbatim: a closed loadout has
     // nothing to discover, so re-reading them mid-run would be a second projection
     // of the same static menu.
@@ -1477,7 +1526,8 @@ export function screenAssembler(deps: ScreenAssemblerDeps): ScreenAssembler {
       // the loss happens a turn later. Proven: re-add the commit and
       // `remix-port-seed.e2e.test.ts`'s re-seed guarantee goes red on the
       // workspace half.
-      if (start !== undefined && start.trim() !== "") await base.writeFile(checkout, start);
+      const staged = start !== undefined && start.trim() !== "" ? start : undefined;
+      if (staged !== undefined) await base.writeFile(checkout, staged);
       /** The last SETTLED paint of this app, kept as it goes past on its way to the
        *  person's screen. It is the only place the resolved query answers exist —
        *  the seam spreads them beside the description on the final paint — so the
@@ -1530,6 +1580,7 @@ export function screenAssembler(deps: ScreenAssemblerDeps): ScreenAssembler {
           request: request.request,
           ...(request.viewport === undefined ? {} : { viewport: request.viewport }),
           ...(pack === undefined ? {} : { briefing: renderBriefingPack(pack) }),
+          ...(staged === undefined ? {} : { source: staged }),
         },
       );
       if (result.kind !== "assembled") return result;


### PR DESCRIPTION
> **Not a merge candidate today.** This sits above S4 (#1479), which does **not** pass its done-means yet — S4's yield is currently **0 of 2** real components, pending the holes-and-button rework Yousef just ruled. This PR is open so review can run in parallel with that rework, not because it is ready to land. Base will move under it as S4 gains commits.

**Slice 5.** Base `yousefh409/remix-s4-splitter`. 5 files, +227/−4.

## What this proves on its own

**Holes actually render.** Four separate recharts nodes compose into a real chart — grid and axis included — and a host sub-component paints by name. Both proven on a **fresh production build**, with the fix reverted first to show the test can fail.

## The change

One missing hop, **19 lines in `packages/ui/src/context.tsx`** (25 insertions, 3 deletions in that file).

`<VendoProvider remixWiring>` folds each slot's holes into the components map **as the weakest leg**, mirroring the server's own precedence rather than inventing a second rule. A host-supplied component of the same name still wins.

**No change was needed to `compose-*.ts`.** The server-side registration was already correct — the gap was entirely on the client, which is why the fix is this small. Worth stating because the original plan assumed composition work that turned out to be unnecessary.

## Scope

Everything else here is proof, not mechanism: the e2e harness fixture, the production browser spec, and the renderer tests.

## Standing on a moving base

S4's tip moved from `0de602ea2` to `aee9a37e8` while this was being prepared, and more is landing (icon-holes and button-rewrite transforms in `packages/actions/src/sync/split/*`, plus a ✦ inversion fix on `yousefh409/remix-sparkle-gate`). This branch is rebased onto `0de602ea2`; GitHub computes the diff from the merge-base, so the 5 files above are this slice's own work regardless. It will be rebased again before merge, with a byte-for-byte losslessness check each time.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renders holes from generated remix wiring on the client and lets remix runs edit the ported source. Previously ported screens showed “Unknown component”; now VendoProvider merges wiring holes with lowest precedence. Previously a remix started from the ask alone; now the first message includes the ported `app.tsx`.

- Adds `remixWiring?: RemixWiringInput` to `VendoProvider` and merges `{ ...remixHoles(remixWiring), ...hostComponentMap(components) }`, mirroring server precedence; no server compose changes. Re-exports `RemixWiringInput` from `packages/ui/src/index.ts`.
- Updates `examples/demo-bank` to import `.vendo/generated/remix-wiring` and pass it to `VendoProvider`, so ported screens paint real `recharts` components and host sub-components.
- Verifies behavior with unit tests and a Playwright spec (`/tree-holes`) that draws real `recharts` geometry and a host sub-component using wiring only.
- Remix-only: `packages/vendo/src/screen-agent.ts` includes the ported source in the first message (`ScreenInput.source`), so the model edits the component’s own code; also clarifies the `EDIT_TOOLS` comment.
- Known gap: a hole name colliding with a Kit component still resolves to the Kit due to builtin precedence.
- Adoption: Pass the generated `.vendo/generated/remix-wiring.ts` const to `<VendoProvider remixWiring={...}>`; use `components` to override. Keep `components={mapleRegistry}` as a bare identifier to preserve the static catalog scan.

<sup>Written for commit d9712607a885af60804a5e87ff6aac0a8cd5ee08. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1505?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

