### PR TITLE
feat(core,apps,ui,vendo): the remix follows the page it was forked from

### DIFF
--- a/.changeset/remix-live-props-courier.md
+++ b/.changeset/remix-live-props-courier.md
@@ -1,0 +1,37 @@
+---
+"@vendoai/agents": patch
+"@vendoai/core": minor
+"@vendoai/apps": minor
+"@vendoai/ui": minor
+"@vendoai/vendo": minor
+---
+
+A remix follows the page it was forked from. The `<Remixable>` wrapper now
+couriers its wrapped instance's live serializable props to the server — on mount
+and again on every change — and the ported screen is painted on them.
+
+Until now it was painted on the baseline's `sampleProps`, captured the day
+`vendo sync` ran. Maple's remixed net-worth card read `$54,907.15` — the
+hardcoded declared example in the host's own registry — while the host's card two
+inches away read `$142,929.30`, with a visibly different chart series. A port
+renders FROM its props and a query resolves before the render, so nothing in the
+screen's source could ever have carried them; the capture was the only value the
+floor had.
+
+`AppSeed.props` records them, `POST /apps/:id/props` (`apps.seed.props`,
+`client.apps.courierProps`) is the door, and the checks floor's props resolver
+prefers them over the capture — which remains the fallback for a remix whose
+wrapper has not couriered yet. Writing props is provenance about the call site,
+not a content edit: it mints no version and replays no wish, so it is safe on
+every render the props really change on.
+
+The boundary is the captured baseline's own declared prop names, applied at the
+door, so a prop the host component never declared is dropped before it is stored.
+JSON-serializable values only, as before.
+
+Also removes the client-side splice this replaces. It searched the payload for a
+node named `seedComponentName(slot)` with `source: "generated"`; a remix is a
+ported SCREEN whose tree is whatever rendering produced — nodes marked
+`source: "ported"` — and that name only ever names a seat in
+`document.components`. The find never matched and the merge never ran, which is
+why the numbers were stale in the first place.

--- a/packages/agents/src/http/router.ts
+++ b/packages/agents/src/http/router.ts
@@ -142,7 +142,7 @@ export function internalError(): Response {
   return errorResponse(new VendoError("not-implemented", "Internal Vendo error"));
 }
 
-function object(value: unknown, label: string): Record<string, unknown> {
+export function object(value: unknown, label: string): Record<string, unknown> {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
     throw new VendoError("validation", `${label} must be an object`);
   }

--- a/packages/apps/src/server/doors/build-surface.ts
+++ b/packages/apps/src/server/doors/build-surface.ts
@@ -631,15 +631,28 @@ export const createBuildSurface = (
         // remixes ever renders, least of all on the read half (`saves: false`).
         ported: async (appId) => (config.seedBaselines ?? []).length > 0
           && (await deps.runtime().get(appId, ctx))?.seed !== undefined,
-        // The props a port paints with, off the SAME row: the seed names the
-        // component, and the component's baseline carries the host's own
-        // captured sampleProps. Consulted by the floor only after `ported`
-        // answered yes, so an authored screen costs no extra read.
+        // The props a port paints with, off the SAME row. Consulted by the floor
+        // only after `ported` answered yes, so an authored screen costs no extra
+        // read.
+        //
+        // THE COURIER WINS. `seed.props` is what the `<Remixable>` wrapper last
+        // shipped from the live host instance this remix stands in for; the
+        // baseline's `sampleProps` is what `vendo sync` captured, frozen the day
+        // it ran. Preferring the capture is how a remixed balance card painted
+        // its sync-time number forever while the host's own component, two
+        // inches away, painted today's — the port renders FROM its props and no
+        // prop is in any source it could read, so the courier is the page's only
+        // route in.
+        //
+        // The capture remains the fallback, and a real one: a remix whose wrapper
+        // has not couriered yet — the seconds between the row landing and the
+        // first render, or a host that mounts it somewhere no wrapper wraps —
+        // paints on the captured values rather than on nothing.
         props: async (appId) => {
-          const component = (await deps.runtime().get(appId, ctx))?.seed?.component;
-          return component === undefined
-            ? undefined
-            : (config.seedBaselines ?? []).find((candidate) => candidate.slot === component)?.sampleProps;
+          const seed = (await deps.runtime().get(appId, ctx))?.seed;
+          if (seed === undefined) return undefined;
+          if (seed.props !== undefined) return seed.props;
+          return (config.seedBaselines ?? []).find((candidate) => candidate.slot === seed.component)?.sampleProps;
         },
         ...rowHalf,
       });

--- a/packages/apps/src/server/remix/seed-surface.ts
+++ b/packages/apps/src/server/remix/seed-surface.ts
@@ -24,6 +24,7 @@ import {
   VendoError,
   safeErrorMessage,
   type AppId,
+  type Json,
   type RunContext,
 } from "@vendoai/core";
 import {
@@ -324,10 +325,56 @@ const reseed = async (
   return landed;
 };
 
+/**
+ * The COURIER: record the live props of the host instance this remix stands in
+ * for.
+ *
+ * A ported screen renders FROM ITS PROPS, and a query resolves before the render,
+ * so nothing in the screen's own source can carry them. With none recorded the
+ * checks floor paints the port on the baseline's captured `sampleProps` — the
+ * values frozen the day `vendo sync` ran — and the remix shows that number
+ * forever while the host's own component beside it shows today's.
+ *
+ * This is PROVENANCE, not content. It writes `seed.props` and touches nothing
+ * else: no version is minted, no wish is recorded and no edit door is entered,
+ * because the person did not change their remix — their page did. That is also
+ * why it is safe to call on every render the props really change on.
+ *
+ * THE BOUNDARY is the captured baseline's own declared prop names. The wrapper
+ * ships whatever the host's call site passed, so a value the component never
+ * declared — anything the page happened to hang on that element — is dropped
+ * HERE, before it is stored, rather than being filtered at each of the places
+ * that later read the seed. A baseline that captured no props declares none and
+ * so admits none: never invented, exactly like the paint it feeds.
+ */
+const courierProps = async (
+  deps: SeedSurfaceDeps,
+  input: { appId: AppId; props: Record<string, Json> },
+  ctx: RunContext,
+): Promise<AppDocument> => {
+  const app = await deps.requireOwned(input.appId, ctx);
+  const seed = app.seed;
+  if (seed === undefined) {
+    throw new VendoError("conflict", `app ${input.appId} was not created from a host component`);
+  }
+  const declared = baselineFor(deps, seed.component).sampleProps ?? {};
+  const props = Object.fromEntries(
+    Object.entries(input.props).filter(([name]) => name in declared),
+  );
+  // An unchanged call site re-couriers the same values on any re-render its host
+  // takes for its own reasons. Writing anyway would put a row through the store
+  // on every one of them, so the no-op is answered from what is already stored.
+  if (JSON.stringify(seed.props ?? {}) === JSON.stringify(props)) return app;
+  const next: AppDocument = { ...app, seed: { ...seed, props } };
+  await deps.engine.put(APPS_COLLECTION, appRecordInput(next, ctx.principal.subject, false, "seed"));
+  return next;
+};
+
 export const createSeedSurface = (deps: SeedSurfaceDeps): AppsRuntime["seed"] => ({
   async drift(appId, ctx): Promise<SeedDrift | null> {
     return seedDrift(await deps.requireOwned(appId, ctx), deps.config.seedBaselines ?? []);
   },
   reseed: (input, ctx) => reseed(deps, input, ctx),
   from: (input, ctx) => seedFrom(deps, input, ctx),
+  props: (input, ctx) => courierProps(deps, input, ctx),
 });

--- a/packages/apps/src/server/runtime/types.ts
+++ b/packages/apps/src/server/runtime/types.ts
@@ -860,6 +860,20 @@ export interface AppsRuntime {
     drift(appId: AppId, ctx: RunContext): Promise<SeedDrift | null>;
     reseed(input: { appId: AppId }, ctx: RunContext): Promise<AppDocument>;
     from(input: SeedFromInput, ctx: RunContext): Promise<AppDocument>;
+    /**
+     * The COURIER: the live props of the host instance this remix stands in for,
+     * shipped by the `<Remixable>` wrapper on mount and on every change.
+     *
+     * A ported screen renders from its props, and no prop is in any source it
+     * could read — so without this the floor paints it on the baseline's frozen
+     * `sampleProps` and the remix shows the sync-time number forever. It writes
+     * `AppSeed.props` and NOTHING else: this is provenance about the call site,
+     * never a content edit, so it mints no version and replays no wish.
+     *
+     * Filtered here to the captured baseline's own declared prop names — a prop
+     * the host component never declared is dropped before it is stored.
+     */
+    props(input: { appId: AppId; props: Record<string, Json> }, ctx: RunContext): Promise<AppDocument>;
   };
   /**
    * execution-v2 — additive machine lifecycle surface (same additive precedent

--- a/packages/core/src/app-document.ts
+++ b/packages/core/src/app-document.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { VENDO_APP_FORMAT } from "./formats.js";
 import type { AutomationId } from "./automation.js";
-import { appIdSchema, isoDateTimeSchema, type AppId, type IsoDateTime } from "./ids.js";
+import { appIdSchema, isoDateTimeSchema, type AppId, type IsoDateTime, type Json } from "./ids.js";
 import { sha256Hex } from "./sha256.js";
 
 /**
@@ -210,6 +210,23 @@ export interface AppSeed {
   /** Wishes the last re-seed could not land on the new baseline. Still in
    *  `wishes` — kept and reported, never dropped. */
   unapplied?: string[];
+  /**
+   * The LIVE props of the host instance this remix stands in for — couriered by
+   * the `<Remixable>` wrapper on mount and on every change, and the values a
+   * ported screen is painted on.
+   *
+   * The alternative is the baseline's captured `sampleProps`, which is what the
+   * floor falls back to and which is frozen the day `vendo sync` ran: a remix of
+   * a balance card painted the sync-time number forever while the host's own
+   * component, two inches away, painted today's. A port renders from its props
+   * and no prop is in any source it could read, so this is the only route the
+   * page's own state has into it.
+   *
+   * Filtered at the door to the captured baseline's own declared prop names, so
+   * a prop the host component never declared is dropped before it is stored.
+   * JSON only, by the same law as every value that crosses into the VM.
+   */
+  props?: Record<string, Json>;
   slot?: string;
   review?: boolean;
 }
@@ -227,6 +244,7 @@ export const appSeedSchema = z.object({
   instruction: z.string().optional(),
   port: z.string().optional(),
   unapplied: z.array(z.string()).optional(),
+  props: z.record(z.unknown()).optional(),
   slot: z.string().optional(),
   review: z.boolean().optional(),
 }).passthrough().transform(({ instruction, wishes, ...seed }) => ({

--- a/packages/ui/src/chrome/remixable.tsx
+++ b/packages/ui/src/chrome/remixable.tsx
@@ -1,5 +1,5 @@
-import { isValidElement, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
-import { log, seedComponentName, type AppDocument, type AppId, type Json, type TreeNode } from "@vendoai/core";
+import { isValidElement, useCallback, useEffect, useRef, useState, type ReactNode } from "react";
+import { log, type AppDocument, type AppId, type Json } from "@vendoai/core";
 import { useVendoProvider } from "../context.js";
 import { useApp } from "../hooks/use-app.js";
 import { useAppSharing } from "../hooks/use-app-sharing.js";
@@ -148,20 +148,48 @@ function RemixedFork({ appId, slot, review, liveProps, original, onReverted }: {
     }
   }, [error, isLoading, slot]);
 
-  // Live serializable props from the call site flow into the mounted fork on
-  // every render (final-shape data route 1: nothing captured, nothing stale) —
-  // they override the fork-time seed on the pinned node; props an edit set
-  // that the call site does not pass survive underneath. Keyed on content so
-  // an unchanged call site never re-stages the payload.
+  // THE COURIER. The live serializable props from the call site go to the
+  // SERVER, on mount and again whenever they change, and the server repaints the
+  // remix on them (`AppSeed.props`; the checks floor's props resolver in
+  // apps/doors/build-surface.ts). Then re-open, because the paint is what
+  // changed and the surface is what holds it.
+  //
+  // This used to be a client-side splice: clone the payload, find the node named
+  // `seedComponentName(slot)` with `source: "generated"`, and merge the props
+  // onto it. That node does not exist. A remix is a ported SCREEN, whose tree is
+  // whatever rendering it produced — display bricks marked `source: "ported"` —
+  // and `seedComponentName` names a seat in `document.components`, never a node
+  // (apps/doors/write-surface.ts). So the find never matched, the merge never
+  // ran, and the remix painted the values `vendo sync` captured while the host's
+  // own component beside it painted today's. Deleted rather than repaired: the
+  // props have to reach the server anyway, because the screen is painted there.
+  //
+  // Keyed on content, so a host re-rendering for its own reasons couriers
+  // nothing and an unchanged call site costs one comparison.
   const livePropsKey = JSON.stringify(liveProps);
-  const staged = useMemo(() => {
-    if (surface?.kind !== "tree") return surface;
-    const payload = structuredClone(surface.payload);
-    const nodes = payload.nodes as TreeNode[] | undefined;
-    const pinned = nodes?.find(node => node.component === seedComponentName(slot) && node.source === "generated");
-    if (pinned) pinned.props = { ...pinned.props, ...(JSON.parse(livePropsKey) as Record<string, Json>) };
-    return { ...surface, payload };
-  }, [surface, slot, livePropsKey]);
+  // What the server actually KEPT last time. Re-opening is what makes the new
+  // paint visible, and it re-runs the whole checks floor — so it is spent only
+  // when the stored props really moved. The wrapper ships every serializable
+  // prop the call site passes, and the door keeps only the ones the captured
+  // baseline declares; without this, a host prop the component never declared
+  // (a timestamp, a callback's changing identity) would buy a full server
+  // repaint on every tick and change nothing on screen.
+  const stored = useRef<string | undefined>(undefined);
+  useEffect(() => {
+    let live = true;
+    void client.apps.courierProps(appId as AppId, JSON.parse(livePropsKey) as Record<string, Json>)
+      .then((next) => {
+        const kept = JSON.stringify(next.seed?.props ?? {});
+        if (!live || kept === stored.current) return undefined;
+        stored.current = kept;
+        return refresh();
+      })
+      // A courier that does not land leaves the remix on the props it already
+      // had — the last good paint, never a blank one — and the page is not the
+      // place to report it.
+      .catch(() => undefined);
+    return () => { live = false; };
+  }, [client, appId, livePropsKey, refresh]);
 
   // The founder's binding rule (2026-08-02): until a reviewer approves, the
   // ORIGINAL host component stays rendered, untouched. A pending or rejected
@@ -226,11 +254,11 @@ function RemixedFork({ appId, slot, review, liveProps, original, onReverted }: {
         onRefresh={update}
         onRevert={() => client.apps.delete(appId).then(onReverted)}
       >
-        {staged?.kind === "tree" && !underReview ? (
+        {surface?.kind === "tree" && !underReview ? (
           <FluidReveal stateKey={`fork:${appId}`} initialExit={original}>
             <PinMount slot={slot} fallback={Original}>
               <AppFrame
-                surface={staged}
+                surface={surface}
                 components={components}
                 onParked={approval.onParked}
                 onAction={({ action, payload }) => client.apps.call(appId, action, payload ?? {})}

--- a/packages/ui/src/client-impl.ts
+++ b/packages/ui/src/client-impl.ts
@@ -255,6 +255,7 @@ export function createVendoClient(config: VendoClientConfig): VendoClient {
       shipDiff: id => readJson(`/apps/${idPath(id)}/ship-diff`),
       reseed: id => json(`/apps/${idPath(id)}/reseed`, "POST"),
       seedFrom: body => json("/apps/seed", "POST", body),
+      courierProps: (id, props) => json(`/apps/${idPath(id)}/props`, "POST", { props }),
       pingMachine: id => json(`/apps/${idPath(id)}/machine/ping`, "POST"),
       place: (id, slot) => json(`/apps/${idPath(id)}/place`, "POST", { slot }),
       unplace: async (id, slot) => {

--- a/packages/ui/src/client.ts
+++ b/packages/ui/src/client.ts
@@ -153,6 +153,20 @@ export interface VendoClient {
      */
     seedFrom(input: { component: string; slot?: string; instruction: string }): Promise<AppDocument>;
     /**
+     * POST /apps/:id/props — the COURIER. The live serializable props the host's
+     * page is passing the component this remix stands in for, shipped on mount
+     * and again whenever they change.
+     *
+     * A ported screen renders FROM its props, and they exist in no source it
+     * could read, so this call is the only way the page's own state reaches the
+     * remix; without it the server paints the remix on the values `vendo sync`
+     * captured and it shows that number forever. Provenance, not a content edit:
+     * it mints no version, so calling it on every real change is the intent.
+     *
+     * The server keeps only the props the captured baseline declares.
+     */
+    courierProps(id: AppId, props: Record<string, Json>): Promise<AppDocument>;
+    /**
      * POST /apps/:id/machine/ping — the embed surface's keepalive:
      * user activity on an embedded served app rides one host-proxied HEAD
      * through the machine, keeping it from idling out under the user. "woke"

--- a/packages/vendo/src/wire/apps.ts
+++ b/packages/vendo/src/wire/apps.ts
@@ -1,5 +1,5 @@
 import { isVendoError, VendoError, type AccessLevel, type Json, type RunContext, type StoreOps } from "@vendoai/core";
-import { json, requestJson, route, string, type RouteEntry, type WireContext } from "./shared.js";
+import { json, object, requestJson, route, string, type RouteEntry, type WireContext } from "./shared.js";
 
 /** What the ?pending=1 disambiguation learned about a record open() refused
     to serve this caller. */
@@ -347,6 +347,23 @@ export const appRoutes: RouteEntry[] = [
     // acts on its own, because acting means replacing what the person made.
     if (op(wire, "POST", "reseed")) {
       return json(await deps.apps.seed.reseed({ appId }, ctx));
+    }
+    // THE COURIER — the live props of the host instance this remix stands in
+    // for, shipped by the `<Remixable>` wrapper on mount and on every change.
+    // A ported screen renders FROM its props and no prop is in any source it
+    // could read, so without this door the floor paints it on the baseline's
+    // frozen `sampleProps` and the remix shows the sync-time number forever.
+    //
+    // It writes `seed.props` and nothing else — provenance about the call site,
+    // never a content edit — so it mints no version and is safe to call on
+    // every render the props really change on. The runtime owns the level, as
+    // ever, and filters the payload to the captured baseline's declared props.
+    if (op(wire, "POST", "props")) {
+      const body = await requestJson(request);
+      return json(await deps.apps.seed.props({
+        appId,
+        props: object(body["props"], "props") as Record<string, Json>,
+      }, ctx));
     }
     // Placement (2026-08-05) — one app per slot. The level lives in the
     // runtime (viewer: putting an app you can see into your own slot), and

--- a/packages/vendo/src/wire/shared.ts
+++ b/packages/vendo/src/wire/shared.ts
@@ -35,7 +35,7 @@ import type { ConnectionsService } from "../connections.js";
     stays is what only the umbrella has. The per-request RunContext resolution
     lives in wire/context.ts; server.ts assembles the table from the per-area
     modules under src/wire/. */
-export { errorResponse, hex, internalError, json, requestJson, routeSegments, string } from "@vendoai/agents/http";
+export { errorResponse, hex, internalError, json, object, requestJson, routeSegments, string } from "@vendoai/agents/http";
 
 /** Re-exported, not redeclared: the one version literal lives in
     @vendoai/core, beside the deployment-identity headers that stamp it. */

--- a/packages/vendo/tests/remix-live-props.seam.test.ts
+++ b/packages/vendo/tests/remix-live-props.seam.test.ts
@@ -1,0 +1,316 @@
+/**
+ * THE HOST CALL-SITE'S LIVE PROPS BECOME THE PORTED SCREEN'S MOUNT PROPS.
+ *
+ * `<Remixable><NetWorthView valueCents={14292930} /></Remixable>` is the only
+ * place `14292930` exists: it is a prop of the host's own component instance, on
+ * the host's own page, at render time. The port the ✦ fork starts from renders
+ * FROM ITS PROPS — no query, no literal in the source — so the only values it can
+ * paint are the ones the server hands its VM.
+ *
+ * Without a courier, the server hands it `vendo sync`'s CAPTURED `sampleProps`:
+ * the values frozen the day the baseline was written
+ * (`doors/build-surface.ts` — the props resolver the checks floor consults). The
+ * remix then paints yesterday's number forever while the host's own component,
+ * two inches away, paints today's. That is the live defect this seam closes: the
+ * observed remix read $54,907.15 — `valueCents: 5490715`, exactly the capture in
+ * `examples/demo-bank/.vendo/remixable/NetWorthView.json` — while the page read
+ * $142,929.30.
+ *
+ * NOTHING IS STUBBED ON EITHER SIDE, which is the whole point:
+ *
+ *   WRITE  real HTTP `POST /api/vendo/apps/<id>/props` with the live props of the
+ *          instance on the page → the real seed surface → a real PGlite store,
+ *          where they land on `AppSeed.props`.
+ *   READ   real HTTP `GET /api/vendo/apps/<id>/open` → the real checks floor →
+ *          the real component gauntlet, which PAINTS the port on those props.
+ *
+ * The producer cannot fake the consumer's answer and the consumer cannot fake the
+ * producer's value: the assertion is text in the PAINTED TREE that only the
+ * screen could have written, and only if it really received the live number.
+ *
+ * ON CHANGE IS THE POINT, not just on fork. The first open is asserted STALE on
+ * purpose — that is the bug, reproduced through the real wire — and the same app
+ * is then couriered and re-opened. An implementation that only seeded props at
+ * fork time passes the first half and fails the second.
+ *
+ * THE ALLOWLIST is the captured baseline's own declared props. `secretToken`
+ * rides the same wire beside `valueCents` and the screen never sees it — even
+ * though this port DECLARES `secretToken` in its own props type, so the filter is
+ * proved to be the boundary rather than the screen merely being unable to name
+ * it. The paint carries `saw`, the prop names the VM really received, so a
+ * dropped prop and a leaked one are both visible in the tree.
+ *
+ * The one that must be able to fail: drop the `seed.props` preference from the
+ * props resolver in `packages/apps/src/server/doors/build-surface.ts` and the
+ * screen paints the captured 5490715 forever.
+ */
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { SeedBaseline } from "@vendoai/apps";
+import type { AppDocument, Principal } from "@vendoai/core";
+import { createStore } from "@vendoai/store";
+import type { LanguageModel } from "ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { createVendo } from "../src/server.js";
+
+const principal: Principal = { kind: "user", subject: "user_live_props" };
+
+const originalCwd = process.cwd();
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  process.chdir(originalCwd);
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+/** The captured value — what `vendo sync` froze, and what a remix with no
+ *  courier paints forever. The real one, off the demo's own baseline. */
+const CAPTURED_CENTS = 5490715;
+/** What the host's page is really rendering when the person presses ✦. */
+const LIVE_CENTS = 14292930;
+/** …and after a transfer moves the balance. The on-change half. */
+const MOVED_CENTS = 9910430;
+
+/**
+ * The splitter's port, in the shape it really emits for a presentational
+ * component: it renders FROM PROPS and asks no query, which is exactly why the
+ * live number has to arrive as a mount prop or not at all.
+ *
+ * `secretToken` is declared here deliberately. The boundary must be the courier's
+ * allowlist, not the screen's vocabulary — a port that could not name the decoy
+ * would prove nothing about whether the decoy crossed.
+ */
+const PORTED = `import { Stack, Text } from "@vendo/screen";
+
+export default function NetWorthView(props: { valueCents?: number; secretToken?: string }) {
+  const saw = Object.keys(props).sort().join(",");
+  return (
+    <Stack gap={12}>
+      <Text text="Net worth" variant="heading" />
+      <Text text={"value " + String(props.valueCents)} />
+      <Text text={"saw " + saw} />
+    </Stack>
+  );
+}
+`;
+
+const baseline: SeedBaseline = {
+  slot: "NetWorthView",
+  source: "export default function NetWorthView() { return <p>net worth</p>; }\n",
+  hash: "sha256:net-worth-view-1",
+  exportable: false,
+  capturedAt: "2026-08-18T09:00:00.000Z",
+  // The frozen capture: the stale number, and the declared-prop list the
+  // courier's allowlist is drawn from.
+  sampleProps: { valueCents: CAPTURED_CENTS },
+  ported: { source: PORTED, tools: [], holes: [] },
+};
+
+/**
+ * The person's remix — the screen the wish lands, and the thing actually read in
+ * every assertion below. It renders FROM PROPS and asks no query, exactly like
+ * the port it grew from, so the only values it can paint are the ones the server
+ * hands its VM.
+ *
+ * `secretToken` is declared here deliberately. The boundary must be the courier's
+ * allowlist, not the screen's vocabulary — a screen that could not name the decoy
+ * would prove nothing about whether the decoy crossed.
+ */
+const REMIX = `import { Stack, Text } from "@vendo/screen";
+
+export default function NetWorthView(props: { valueCents?: number; secretToken?: string }) {
+  const saw = Object.keys(props).sort().join(",");
+  return (
+    <Stack gap={12}>
+      <Text text="Tracked monthly" variant="heading" />
+      <Text text={"value " + String(props.valueCents)} />
+      <Text text={"saw " + saw} />
+    </Stack>
+  );
+}
+`;
+
+/** The screen agent's own brief — how a prompt is known to be the assembly
+ *  loop's rather than the mandatory reviewer's. */
+const SCREEN_BRIEF_MARKER = "# In this loop";
+
+/**
+ * A model that assembles the remix once, so the ✦ operation completes the way it
+ * does in life: seed the port, then land the person's wish through the ordinary
+ * edit door. Every other prompt gets prose, which is also what ends the loop once
+ * the app is saved, and what the mandatory reviewer reads as "no findings".
+ *
+ * Same shape as this package's other fixture doubles (`mcp-door.test-util.ts`
+ * `screenModel`) — the streamed `finishReason` is a plain string there, and a
+ * double that answers any other shape never lands a screen at all.
+ */
+const scripted = (): LanguageModel => {
+  let saved = false;
+  const assembling = (prompt: unknown): boolean => {
+    if (saved || !JSON.stringify(prompt ?? "").includes(SCREEN_BRIEF_MARKER)) return false;
+    saved = true;
+    return true;
+  };
+  const usage = { inputTokens: 1, outputTokens: 1, totalTokens: 2 };
+  const saveCall = {
+    type: "tool-call" as const,
+    toolCallId: "call_save_app",
+    toolName: "save_app",
+    input: JSON.stringify({ content: REMIX }),
+  };
+  return {
+    specificationVersion: "v2",
+    provider: "vendo-live-props",
+    modelId: "vendo-live-props-v1",
+    supportedUrls: {},
+    async doGenerate({ prompt }: { prompt?: unknown }) {
+      return assembling(prompt)
+        ? { content: [saveCall], finishReason: "tool-calls" as const, usage }
+        : { content: [{ type: "text" as const, text: "done" }], finishReason: "stop" as const, usage };
+    },
+    async doStream({ prompt }: { prompt?: unknown }) {
+      const save = assembling(prompt);
+      return {
+        stream: new ReadableStream({
+          start(controller) {
+            controller.enqueue({ type: "stream-start", warnings: [] });
+            if (save) {
+              controller.enqueue(saveCall);
+              controller.enqueue({ type: "finish", finishReason: "tool-calls", usage });
+            } else {
+              controller.enqueue({ type: "text-start", id: "text_1" });
+              controller.enqueue({ type: "text-delta", id: "text_1", delta: "done" });
+              controller.enqueue({ type: "text-end", id: "text_1" });
+              controller.enqueue({ type: "finish", finishReason: "stop", usage });
+            }
+            controller.close();
+          },
+        }),
+      };
+    },
+  } as unknown as LanguageModel;
+};
+
+const request = (method: string, path: string, body?: unknown): Request =>
+  new Request(`https://host.test/api/vendo${path}`, {
+    method,
+    headers: method === "POST" ? { "content-type": "application/json" } : {},
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  });
+
+/** A deployment whose `.vendo/remixable/` holds the captured baseline — the half
+ *  a real host has on disk. */
+async function deployment() {
+  const root = await mkdtemp(join(tmpdir(), "vendo-live-props-"));
+  cleanups.push(async () => rm(root, { recursive: true, force: true }));
+  await mkdir(join(root, ".vendo", "remixable"), { recursive: true });
+  await writeFile(
+    join(root, ".vendo", "remixable", `${baseline.slot}.json`),
+    JSON.stringify(baseline, null, 2),
+  );
+  const store = createStore({ dataDir: join(root, ".data") });
+  await store.ensureSchema();
+  cleanups.push(async () => store.close());
+  process.chdir(root);
+  return createVendo({
+    models: { default: scripted() },
+    principal: async () => principal,
+    store,
+  });
+}
+
+/** Mint the remix the way the ✦ does, and fail loudly if the port refused. */
+async function seeded(vendo: { handler(request: Request): Promise<Response> }) {
+  const response = await vendo.handler(request("POST", "/apps/seed", {
+    component: "NetWorthView",
+    instruction: "call it tracked monthly",
+  }));
+  expect(response.status).toBe(200);
+  const app = await response.json() as AppDocument;
+  // A refused port or a failed first edit leaves this marker instead of a
+  // screen, and its reason is the only thing that says which.
+  expect(app.buildFailed?.reason).toBeUndefined();
+  return app;
+}
+
+const paintOf = async (vendo: { handler(request: Request): Promise<Response> }, appId: string) => {
+  const opened = await vendo.handler(request("GET", `/apps/${appId}/open`));
+  expect(opened.status).toBe(200);
+  return JSON.stringify(await opened.json());
+};
+
+describe("the host call-site's live props reach the ported screen's paint", () => {
+  it("paints the CAPTURED props until a courier lands, then paints the live ones", async () => {
+    const vendo = await deployment();
+    const app = await seeded(vendo);
+
+    // ── THE DEFECT, reproduced through the real wire. With nothing couriered the
+    //    floor resolves the frozen capture, so the remix opens on the number the
+    //    baseline was written with — the $54,907.15 the browser really showed.
+    expect(await paintOf(vendo, app.id)).toContain(`value ${CAPTURED_CENTS}`);
+
+    // ── THE WRITE PATH: real HTTP, with the live props of the instance the
+    //    person is looking at. `secretToken` rides along as any extra prop would;
+    //    the captured baseline does not declare it.
+    const couriered = await vendo.handler(request("POST", `/apps/${app.id}/props`, {
+      props: { valueCents: LIVE_CENTS, secretToken: "must-not-cross" },
+    }));
+    expect(couriered.status).toBe(200);
+
+    // The props are provenance now — on the seed, beside the component and the
+    // baseline, so every later read of this app resolves against the call site
+    // rather than against whatever the capture froze. The decoy is filtered at
+    // the DOOR, so it is never stored either.
+    const stored = await couriered.json() as AppDocument;
+    expect(stored.seed?.props).toEqual({ valueCents: LIVE_CENTS });
+
+    // ── THE READ PATH: real HTTP open, which re-runs the screen through the real
+    //    floor and paints it on the props the courier landed.
+    const painted = await paintOf(vendo, app.id);
+
+    // ── THE LOAD-BEARING ASSERTION. This number exists nowhere in the port, the
+    //    baseline, the instruction or the capture: the screen painted it from the
+    //    prop it was handed. It can only be here if the browser's live prop
+    //    crossed the wire, landed on the seed, and reached the VM.
+    expect(painted).toContain(`value ${LIVE_CENTS}`);
+    expect(painted).not.toContain(`value ${CAPTURED_CENTS}`);
+
+    // ── THE BOUNDARY. The baseline declares `valueCents` and nothing else, so
+    //    `valueCents` is ALL the screen was handed — even though this port's own
+    //    props type names `secretToken`.
+    expect(painted).toContain('"text":"saw valueCents"');
+    expect(painted).not.toContain("must-not-cross");
+
+    // …and the edit really landed on the port, so this is the person's remix
+    // being read and not the pristine capture.
+    expect(painted).toContain("Tracked monthly");
+  }, 120_000);
+
+  it("follows the host page ON CHANGE, not only on the first courier", async () => {
+    const vendo = await deployment();
+    const app = await seeded(vendo);
+
+    const courier = async (valueCents: number) => {
+      const response = await vendo.handler(request("POST", `/apps/${app.id}/props`, {
+        props: { valueCents, secretToken: "must-not-cross" },
+      }));
+      expect(response.status).toBe(200);
+    };
+
+    // The page as the person first sees it.
+    await courier(LIVE_CENTS);
+    expect(await paintOf(vendo, app.id)).toContain(`value ${LIVE_CENTS}`);
+
+    // ── THE CHANGE. A transfer moves the balance, the host re-renders the
+    //    wrapped component with a new prop, and the wrapper couriers it. This is
+    //    the half a fork-time-only implementation cannot pass.
+    await courier(MOVED_CENTS);
+    const moved = await paintOf(vendo, app.id);
+    expect(moved).toContain(`value ${MOVED_CENTS}`);
+    expect(moved).not.toContain(`value ${LIVE_CENTS}`);
+
+    // The boundary holds on every courier, not just the first.
+    expect(moved).toContain('"text":"saw valueCents"');
+    expect(moved).not.toContain("must-not-cross");
+  }, 120_000);
+});


### PR DESCRIPTION
A remixed component now follows the host page's live state. The `<Remixable>`
wrapper couriers its wrapped instance's live serializable props to the server —
on mount and again on every change — and the ported screen is painted on them.

## The defect

The remix was painted on the baseline's `sampleProps`, captured the day
`vendo sync` ran. Maple's remixed net-worth card read **$54,907.15** while the
host's own card two inches away read **$142,929.30**, with a visibly different
chart series.

That number is not a coincidence — it is the hardcoded declared example at
`examples/demo-bank/src/vendo/registry.tsx:90`, and the whole chain is:

```
registry.tsx:90  (declared example, valueCents: 5490715)
  → actions/sync/index.ts  samplePropsFor
  → .vendo/remixable/NetWorthView.json  sampleProps
  → apps/server/doors/build-surface.ts  the props resolver
  → apps/server/checking/floor.ts
      ├→ checking/component-screen.ts   the SERVER paint
      └→ interactive.props → ui/tree/use-screen.ts   the client's VM boot
```

A port renders FROM its props, and a query resolves before the render, so
nothing in the screen's own source could ever have carried them. The capture was
the only value the floor had.

## The courier

| hop | where |
| --- | --- |
| produce | `ui/src/chrome/remixable.tsx` — couriers `serializableProps`, keyed on content |
| client | `ui/src/client.ts` · `client-impl.ts` — `apps.courierProps` |
| door | `vendo/src/wire/apps.ts` — `POST /apps/:appId/props` |
| surface | `apps/src/server/runtime/types.ts` — `seed.props(...)` |
| write | `apps/src/server/remix/seed-surface.ts` — allowlist + store |
| record | `core/src/app-document.ts` — `AppSeed.props` |
| **read** | `apps/src/server/doors/build-surface.ts` — **prefers `seed.props` over the capture** |

The capture stays the fallback, and a real one: a remix whose wrapper has not
couriered yet paints on the captured values rather than on nothing.

Writing props is **provenance about the call site, not a content edit** — it
mints no version and replays no wish — so it is safe on every render the props
really change on. The wrapper re-opens the app only when the *stored* props
moved, so a host prop the component never declared cannot buy a server repaint.

## Security

Unchanged posture. JSON-serializable values only; the allowlist is the captured
baseline's own **declared prop names**, applied at the door, so a prop the host
component never declared is dropped before it is stored. Everything rides the
existing guard/audit path — no new capability, no bypass.

The seam test rides a decoy `secretToken` on the same wire and proves it never
reaches the screen **even though the port declares it in its own props type** —
so the filter is demonstrably the boundary, not the screen's vocabulary.

## Deletes the dead client splice

`remixable.tsx` used to search the payload for a node named
`seedComponentName(slot)` with `source: "generated"`. A remix is a ported
**screen**, whose tree is whatever rendering produced — nodes marked
`source: "ported"` — and that name only ever names a *seat* in
`document.components` (`apps/doors/write-surface.ts`). The find never matched
and the merge never ran. The code looked live and was not, which is why the
numbers were stale. Removed rather than repaired: the screen is painted on the
server, so the props have to reach the server anyway.

## Deliberately not carried

The query-args arm from the parked re-derive (`993a42cda`). `screenQueryRunner`
merges nothing today, and merging props into args on the refetch side alone
would break the approved-replay pinning that hashes `(app.id, tool, args)`. The
Maple defect is a **mount-props** problem, not a query-args one.

## Proof

Real browser, fresh production build, fresh `next start`, scripted in one pass.

- The remix mounts on **$142,929.30** — the host's live value, not the capture.
- A real `POST /api/transfers` moves the balance.
- The remix **follows to $140,429.30**; `seed.props.valueCents` goes
  `14292930 → 14042930`.

Proven it can fail: reverting the one read-side line freezes the remix at
**$54,907.15** through the identical walk, *while the couriered props are still
provably in the store* — which isolates that line as the load-bearing one.

Local gate green: build, `test:affected` (46/46 tasks), typecheck (44/44), lint
(0 errors), `ui` 1495 tests, and the new seam test both ways.
