### PR TITLE
feat(agents): one call binds the person, and every surface below it is theirs

### DIFF
--- a/packages/agents/src/agent.ts
+++ b/packages/agents/src/agent.ts
@@ -34,6 +34,7 @@ import { startRun, type RunOptions } from "./away.js";
 import { startChat, type ChatOptions, type Turn } from "./turn.js";
 import { resolveDoor, type DoorConfig } from "./door.js";
 import { withEgress, type EgressConfig } from "./egress.js";
+import { createUser, type AgentUser, type UserOptions } from "./facade.js";
 import { PARKED_TURN_TTL_MS } from "./interruptions.js";
 import { rememberTool, storeMemory, type MemoryAdapter } from "./memory.js";
 import { PERMISSIONS_PATH, schemaReadyPrincipal, type AgentPrincipal } from "./permissions.js";
@@ -117,6 +118,21 @@ export interface VendoAgent {
    */
   chat(message: string, options?: ChatOptions): Turn;
   /**
+   * Everything this agent does FOR ONE PERSON, with who they are bound once —
+   * their turns, their conversations, and what it remembers about them.
+   *
+   *     const user = support.forUser("u_42", {
+   *       profile: { name: "Dana", plan: "pro" },
+   *       context: { tenantId },
+   *     });
+   *     await user.chat("where is my refund?", { headers: request.headers });
+   *
+   * `profile` and `context` are FACTS about the person and are bound here.
+   * `headers` are the authority of ONE request, so they ride per call and are
+   * never kept — see facade.ts.
+   */
+  forUser(subject: string, options?: UserOptions): AgentUser;
+  /**
    * `respond` answers a person over HTTP: one turn, an AI-SDK UI-message-stream
    * `Response` to return from your route, with the conversation's id on
    * `x-vendo-thread-id`.
@@ -147,6 +163,10 @@ export interface VendoAgent {
    * `disable()` by a person outlives every redeploy.
    */
   on(when: When, task: string, options?: OnOptions): void;
+  /** @deprecated A session is request-lifetime and the THREAD is what outlives
+   *  it, so the durable noun is the one to hold: `agent.forUser(subject)` for
+   *  the turns, `user.threads` for the conversations. `respond()` is unchanged.
+   *  Still supported — nothing about this call has changed. */
   session(subject: string, options?: SessionOptions): Promise<AgentSession>;
   /**
    * This agent's MCP door, present exactly when its harness thinks outside this
@@ -429,6 +449,7 @@ export function agent(config: AgentConfig): VendoAgent {
   const built: VendoAgent = {
     name: config.name,
     chat: (message, options) => startChat(deps, message, options),
+    forUser: (subject, options) => createUser(deps, subject, options),
     async respond(subject, message, options = {}) {
       await requireModel();
       const session = await createSession(deps, subject, options);

--- a/packages/agents/src/away.ts
+++ b/packages/agents/src/away.ts
@@ -41,7 +41,10 @@ export type AwayRunnerDeps = TurnDeps;
 
 export interface RunOptions<T = void> {
   /** Whose run this is — the subject every grant, workspace and audit row is
-   *  scoped to. Unset, the agent runs as itself. */
+   *  scoped to. Unset, the agent runs as itself.
+   *  @deprecated Name the person ONCE — `agent.forUser(subject)` — rather than
+   *  on every call, and their turns, conversations and memories come with them.
+   *  Still honored: a run that passes it behaves exactly as it always has. */
   as?: string;
   /** Server-trust identity facts, model-visible (`[User]`). */
   user?: Record<string, Json>;

--- a/packages/agents/src/facade.ts
+++ b/packages/agents/src/facade.ts
@@ -147,17 +147,28 @@ export function createUser(deps: AgentDeps, subject: string, options: UserOption
     chat: (message, callOptions) => startChat(deps, message, { ...callOptions, ...durable }),
 
     // `createTurns` verbatim — ONE implementation of list and resume, with this
-    // subject bound. A resume's authority is the RESUMING call's alone
-    // (interruptions.ts), which is why `headers` and `context` stay its own
-    // options and the facade binds neither into it.
+    // subject bound.
     turns: {
       list: async (listOptions) => {
         await migrated();
         return turns.list(listOptions);
       },
+      // The bound context rides a resume too. A resume's authority is the
+      // RESUMING call's alone (interruptions.ts), and this IS the resuming
+      // call's: the facade's standing context is alive right now, where the
+      // parked request's — which that rule is about, and which is still never
+      // replayed — is over. Without it a guard rule keyed on `tenantId` would
+      // decide the resumed turn differently from the chat turn that parked it,
+      // with nothing in the API to hint why. A per-call context wins over the
+      // bound one; HEADERS are absent here and always will be, because the
+      // facade holds none to carry.
       resume: async (turnId, decisions, resumeOptions) => {
         await migrated();
-        return turns.resume(turnId, decisions, resumeOptions);
+        const context = { ...durable.context, ...resumeOptions?.context };
+        return turns.resume(turnId, decisions, {
+          ...resumeOptions,
+          ...(Object.keys(context).length === 0 ? {} : { context }),
+        });
       },
     },
 

--- a/packages/agents/src/facade.ts
+++ b/packages/agents/src/facade.ts
@@ -1,0 +1,197 @@
+/**
+ * ONE user, bound once — and everything this agent does for them.
+ *
+ * A host serving a person re-stated the same three things on every call: whose
+ * turn it is, what the model may say about them, and what the tools need to act
+ * on their behalf. `forUser` names them once and hands back the four faces that
+ * follow from it — this user's turns, their conversations, and what the agent
+ * remembers about them.
+ *
+ * WHAT IS BOUND AND WHAT IS NOT is the whole design. `profile` and `context`
+ * are FACTS about a person: true between requests, so they are bound here and
+ * ride every call. `headers` are the authority of ONE request — they expire
+ * with it — so they ride PER CALL and are never kept. A facade that remembered
+ * the first request's cookie would spend one caller's authority on the next
+ * caller's turn, and nothing downstream could tell the difference.
+ *
+ * IT IMPLEMENTS NOTHING. `chat` is `startChat` with the subject filled in,
+ * `turns` is `createTurns`, `threads` is the store's own thread helpers and
+ * `memories` is the composition's memory adapter — each scoped to this subject,
+ * which is the one thing this file adds.
+ */
+import { VendoError, type Json, type Principal, type ThreadId } from "@vendoai/core";
+import { threadMessageStore, threadStore } from "@vendoai/store";
+import type { UIMessage } from "ai";
+import { createTurns, type Turns } from "./interruptions.js";
+import type { Memory, MemoryAdapter } from "./memory.js";
+import { startChat, type AgentDeps, type ChatOptions, type Turn } from "./turn.js";
+
+/** Who this user is, for as long as the facade lives. */
+export interface UserOptions {
+  /** Server-trust identity facts, model-visible (the `[User]` block) — the same
+   *  channel `chat({ user })` fills, under the name a host thinks of it by.
+   *  Nothing the user typed belongs here: the model reads it as established. */
+  profile?: Record<string, Json>;
+  /** What the guard and the host's own tools need to act for this person —
+   *  a tenant, a locale, an account id. JSON-only because it is BOUND: it
+   *  outlives the request that named it, and a closure bound into a long-lived
+   *  facade would run in turns its author never saw. */
+  context?: Record<string, unknown>;
+}
+
+/** What one call brings that a facade cannot hold: the request's own authority,
+ *  the conversation to continue, and the way to stop it. `as`, `user` and
+ *  `context` are gone by construction — they were bound at {@link createUser}
+ *  and passing them per call is what this face exists to end. */
+export type UserChatOptions = Omit<ChatOptions, "as" | "user" | "context">;
+
+/** One conversation of this user's. */
+export interface UserThread {
+  readonly id: ThreadId;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+  /** The transcript, oldest first — read when it is asked for, never with the
+   *  listing: a settings screen shows twenty conversations and opens one. */
+  messages(): Promise<UIMessage[]>;
+}
+
+/** This user's conversations. There is no `create` and no `chat` here: a thread
+ *  is what a turn leaves behind, so one begins at `user.chat(message)` and is
+ *  continued with `user.chat(message, { threadId })`. */
+export interface Threads {
+  /** Most recently touched first. */
+  list(): Promise<UserThread[]>;
+  /** A thread this user does not own is `not-found` — never an empty transcript
+   *  that reads like a conversation nobody said anything in. */
+  get(id: string): Promise<UserThread>;
+  delete(id: string): Promise<void>;
+}
+
+/** What the agent remembers about this user — the person's own view of it, so
+ *  there is no `add`: a memory is made by the model calling `remember` in front
+ *  of them, and forgetting is theirs alone. */
+export interface Memories {
+  /** Everything, newest first. */
+  list(): Promise<readonly Memory[]>;
+  delete(id: string): Promise<void>;
+  clear(): Promise<void>;
+}
+
+export interface AgentUser {
+  /** ONE turn of this user's conversation. The bound profile and context ride
+   *  along; `headers` are this request's and are not kept. */
+  chat(message: string, options?: UserChatOptions): Turn;
+  /** The turns of theirs that are waiting on them. */
+  readonly turns: Turns;
+  readonly threads: Threads;
+  readonly memories: Memories;
+}
+
+/** Everything one agent does for one person. `agent.forUser` is the door;
+ *  this takes the composition, so a host that assembled its own can hang the
+ *  same face off it. */
+export function createUser(deps: AgentDeps, subject: string, options: UserOptions = {}): AgentUser {
+  const principal: Principal = { kind: "user", subject };
+  /** Bound ONCE and spread into every turn. Spread LAST, so no cast can talk a
+   *  call into acting as somebody else. */
+  const durable: Pick<ChatOptions, "as" | "user" | "context"> = {
+    as: subject,
+    ...(options.profile === undefined ? {} : { user: options.profile }),
+    ...(options.context === undefined ? {} : { context: options.context }),
+  };
+
+  /** Every read below can be the FIRST thing a host calls — a memories screen
+   *  or an approvals inbox renders before this deployment's first turn — so the
+   *  schema is ensured exactly as `createSession`, the away runner and the
+   *  permissions mount do, or a virgin store answers with `relation
+   *  "vendo_threads" does not exist`. Latched: a polled surface must not run a
+   *  migration check per call. A turn ensures it itself (turn.ts). */
+  let ready: Promise<void> | undefined;
+  const migrated = async (): Promise<void> => {
+    ready ??= deps.store.ensureSchema();
+    await ready;
+  };
+
+  const threads = threadStore(deps.store);
+  const transcript = threadMessageStore<UIMessage>(deps.store);
+  const asThread = (row: { id: string; createdAt: string; updatedAt: string }): UserThread => ({
+    id: row.id as ThreadId,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+    messages: () => transcript.list(principal, row.id as ThreadId),
+  });
+
+  /**
+   * The adapter, or the sentence saying it was never turned on.
+   *
+   * An empty list is the wrong answer for a feature nobody configured: a
+   * settings screen would show "nothing remembered" where the truth is "nothing
+   * is ever remembered", and `delete` would report success having removed
+   * nothing. So all three verbs refuse, naming the one line that turns it on.
+   */
+  const memory = async (): Promise<MemoryAdapter> => {
+    if (deps.memory === undefined) {
+      throw new VendoError(
+        "validation",
+        "This agent has no memory, so there is nothing to list or forget. Pass `memory: true` to agent() "
+        + "for the store-backed default, or your own MemoryAdapter.",
+      );
+    }
+    await migrated();
+    return deps.memory;
+  };
+
+  const turns = createTurns(deps, subject);
+
+  return {
+    chat: (message, callOptions) => startChat(deps, message, { ...callOptions, ...durable }),
+
+    // `createTurns` verbatim — ONE implementation of list and resume, with this
+    // subject bound. A resume's authority is the RESUMING call's alone
+    // (interruptions.ts), which is why `headers` and `context` stay its own
+    // options and the facade binds neither into it.
+    turns: {
+      list: async (listOptions) => {
+        await migrated();
+        return turns.list(listOptions);
+      },
+      resume: async (turnId, decisions, resumeOptions) => {
+        await migrated();
+        return turns.resume(turnId, decisions, resumeOptions);
+      },
+    },
+
+    // Every verb is scoped by the store's own ownership join, so another user's
+    // thread reads back as absent here exactly as it does everywhere else.
+    threads: {
+      list: async () => {
+        await migrated();
+        return (await threads.list(principal)).map(asThread);
+      },
+      get: async (id) => {
+        await migrated();
+        const row = await threads.get(principal, id as ThreadId);
+        if (row === null) {
+          throw new VendoError(
+            "not-found",
+            `No conversation ${id} for this user. A thread belongs to whoever started it — `
+            + "threads.list() has the ones this user owns.",
+          );
+        }
+        return asThread(row);
+      },
+      // Idempotent by the same law: a foreign or already-deleted id sweeps
+      // nothing and says nothing about what exists.
+      delete: async (id) => {
+        await migrated();
+        await threads.delete(principal, id as ThreadId);
+      },
+    },
+
+    memories: {
+      list: async () => (await memory()).list(principal),
+      delete: async (id) => (await memory()).delete(principal, id),
+      clear: async () => (await memory()).clear(principal),
+    },
+  };
+}

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -26,6 +26,16 @@ export { awayRunner, type AwayRunnerDeps, type RunOptions } from "./away.js";
 /** The turn a verb hands back, and the two shapes a caller writes against it. */
 export type { ChatOptions, RunEvent, Turn } from "./turn.js";
 export { DOOR_PATH, type DoorConfig } from "./door.js";
+/** One user, bound once — what `agent.forUser(subject)` hands back. */
+export {
+  createUser,
+  type AgentUser,
+  type Memories,
+  type Threads,
+  type UserChatOptions,
+  type UserOptions,
+  type UserThread,
+} from "./facade.js";
 /** Interrupted turns, addressed by id — the same park a caller holding the
  *  result answers through `TurnResult.resume()`, from any other process. */
 export {

--- a/packages/agents/src/session.ts
+++ b/packages/agents/src/session.ts
@@ -96,6 +96,11 @@ export interface ApprovalEvent {
   deny(): Promise<void>;
 }
 
+/** @deprecated The object a session hands back is request-lifetime, and the
+ *  THREAD is what outlives it — so hold the durable noun instead:
+ *  `agent.forUser(subject)` for the turns, `user.threads` for the
+ *  conversations. Reached only through `agent.session()`, which still works;
+ *  `respond()` is unchanged and is not deprecated. */
 export interface AgentSession {
   /** The conversation this session is on. Hand it back as
    *  `session(subject, { threadId })` to reopen the same conversation later. */

--- a/packages/agents/tests/facade.test.ts
+++ b/packages/agents/tests/facade.test.ts
@@ -62,16 +62,23 @@ const speaker = () => defineHarness({
   },
 });
 
+/** What the approved call was handed when it finally ran. */
+interface Ran {
+  count: number;
+  context: Record<string, unknown> | undefined;
+}
+
 /** Ungraded/destructive is the one thing a guard with no rules at all still
  *  wants a person for — how a turn parks without a rule set standing in for the
  *  guard (interruptions.test.ts uses the same tool for the same reason). */
-const refundTool = (ran: { count: number }) => tool({
+const refundTool = (ran: Ran) => tool({
   name: "refund",
   description: "Refund an invoice",
   risk: "destructive",
   inputSchema: { type: "object" },
-  execute: () => {
+  execute: (_input, ctx: RunContext) => {
     ran.count += 1;
+    ran.context = ctx.context;
     return { refunded: true };
   },
 });
@@ -165,7 +172,7 @@ describe("a user's own conversations", () => {
 
 describe("a user's own parked turns", () => {
   it("are the ones createTurns lists, and only this user can answer them", async () => {
-    const ran = { count: 0 };
+    const ran: Ran = { count: 0, context: undefined };
     const support = agent({
       name: "support",
       harness: refunder(),
@@ -193,6 +200,33 @@ describe("a user's own parked turns", () => {
     // Hers runs the exact call she was asked about, once.
     expect(await dana.turns.resume(asked.turnId, decisions)).toMatchObject({ status: "ok", turnId: asked.turnId });
     expect(ran.count).toBe(1);
+  }, 30_000);
+
+  it("run in the context the facade is bound to, unless the resuming call names its own", async () => {
+    const ran: Ran = { count: 0, context: undefined };
+    const support = agent({
+      name: "support",
+      harness: refunder(),
+      tools: [refundTool(ran)],
+      store: freshStore(),
+    });
+    const user = support.forUser("u_dana", { context: { tenantId: "t_1" } });
+
+    // The bound context is the RESUMING caller's own standing context, alive at
+    // the moment of the resume — so the call the person approved runs in the
+    // tenant that parked it, not in none at all.
+    const first = await interrupted(user.chat("Refund invoice 7."));
+    await user.turns.resume(first.turnId, { [first.interruptions[0]!.id]: "approve" });
+    expect(ran.context).toMatchObject({ tenantId: "t_1" });
+
+    // And the resuming call still gets the last word.
+    const second = await interrupted(user.chat("Refund invoice 8."));
+    await user.turns.resume(
+      second.turnId,
+      { [second.interruptions[0]!.id]: "approve" },
+      { context: { tenantId: "t_2" } },
+    );
+    expect(ran.context).toMatchObject({ tenantId: "t_2" });
   }, 30_000);
 });
 

--- a/packages/agents/tests/facade.test.ts
+++ b/packages/agents/tests/facade.test.ts
@@ -1,0 +1,254 @@
+/**
+ * `forUser`'s contract sentences, held against a real embedded store, a real
+ * guard and real turns — only the thinker is scripted, because the thinker is
+ * not what is under test (CLAUDE.md: test the SEAM).
+ *
+ * The headline is the split between what is BOUND and what is not: a profile
+ * and a context are facts about a person and have to survive every call; a
+ * request's headers are one request's authority and must not survive one. Both
+ * halves are read back off the ctx a TOOL was actually handed and the brief the
+ * HARNESS was actually given — never off the options object the test passed in,
+ * which would only prove the test can spell.
+ */
+import type { Principal, RunContext } from "@vendoai/core";
+import { defineHarness } from "@vendoai/harnesses";
+import { createStore, type VendoStore } from "@vendoai/store";
+import { describe, expect, it } from "vitest";
+import { agent, agentComposition, type VendoAgent } from "../src/agent.js";
+import { createTurns } from "../src/interruptions.js";
+import { tool } from "../src/tools.js";
+import type { TurnResult } from "../src/turn.js";
+
+let stores = 0;
+/** Deliberately UNMIGRATED: `ensureSchema` is the facade's own to pay, and one
+ *  test below is exactly the host that reads before its first turn. */
+const freshStore = (): VendoStore => createStore({ dataDir: `memory://agents-facade-${stores++}` });
+
+const owner = (subject: string): Principal => ({ kind: "user", subject });
+
+/** What ONE tool call was actually handed. */
+interface Seen {
+  subject: string;
+  headers: Record<string, string> | undefined;
+  context: Record<string, unknown> | undefined;
+}
+
+const lookTool = (seen: Seen[]) => tool({
+  name: "look",
+  description: "Look at the account",
+  risk: "read",
+  inputSchema: { type: "object" },
+  execute: (_input, ctx: RunContext) => {
+    seen.push({ subject: ctx.principal.subject, headers: ctx.requestHeaders, context: ctx.context });
+    return { ok: true };
+  },
+});
+
+/** Calls the tool (so the ctx is observed where a host's own code sees it) and
+ *  keeps the brief it was handed (so the model-visible half is observed too). */
+const looker = (briefs: string[]) => defineHarness({
+  name: "looker",
+  async *run(turn) {
+    briefs.push(turn.system ?? "");
+    await turn.tools.call("look", {});
+    yield { type: "text" as const, delta: "Looked." };
+  },
+});
+
+const speaker = () => defineHarness({
+  name: "speaker",
+  async *run() {
+    yield { type: "text" as const, delta: "Done." };
+  },
+});
+
+/** Ungraded/destructive is the one thing a guard with no rules at all still
+ *  wants a person for — how a turn parks without a rule set standing in for the
+ *  guard (interruptions.test.ts uses the same tool for the same reason). */
+const refundTool = (ran: { count: number }) => tool({
+  name: "refund",
+  description: "Refund an invoice",
+  risk: "destructive",
+  inputSchema: { type: "object" },
+  execute: () => {
+    ran.count += 1;
+    return { refunded: true };
+  },
+});
+
+const refunder = () => defineHarness({
+  name: "refunder",
+  async *run(turn) {
+    const last = JSON.stringify(turn.messages.at(-1)?.parts ?? []);
+    if (last.includes("[Resumed]")) {
+      yield { type: "text" as const, delta: "The refund went through." };
+      return;
+    }
+    await turn.tools.call("refund", { invoice: 7 });
+    yield { type: "text" as const, delta: "I have asked for approval." };
+  },
+});
+
+const interrupted = async (result: PromiseLike<TurnResult>): Promise<
+  Extract<TurnResult, { status: "interrupted" }>
+> => {
+  const settled = await result;
+  if (settled.status !== "interrupted") throw new Error(`expected interrupted, got ${settled.status}`);
+  return settled;
+};
+
+describe("forUser binds who a person is — and never what one request may do", () => {
+  it("carries profile and context into every call, and a request's headers into exactly one", async () => {
+    const seen: Seen[] = [];
+    const briefs: string[] = [];
+    const support = agent({
+      name: "support",
+      harness: looker(briefs),
+      tools: [lookTool(seen)],
+      store: freshStore(),
+    });
+    const user = support.forUser("u_42", {
+      profile: { name: "Dana", plan: "pro" },
+      context: { tenantId: "t_1" },
+    });
+
+    await user.chat("one", { headers: { authorization: "Bearer one" } });
+    await user.chat("two", { headers: { authorization: "Bearer two" } });
+    await user.chat("three");
+
+    // DURABLE: bound once, on every call, whatever the call brought.
+    expect(seen.map((call) => call.subject)).toEqual(["u_42", "u_42", "u_42"]);
+    expect(seen.map((call) => call.context)).toEqual([{ tenantId: "t_1" }, { tenantId: "t_1" }, { tenantId: "t_1" }]);
+    expect(briefs).toHaveLength(3);
+    for (const brief of briefs) {
+      expect(brief).toContain("[User]");
+      expect(brief).toContain("Dana");
+      expect(brief).toContain("pro");
+    }
+
+    // REQUEST-LIFETIME: each call sees its own authority and only its own, and
+    // a call that brings none is handed none — the facade kept nothing.
+    expect(seen[0]?.headers).toEqual({ authorization: "Bearer one" });
+    expect(seen[1]?.headers).toEqual({ authorization: "Bearer two" });
+    expect(seen[2]?.headers).toBeUndefined();
+  }, 30_000);
+});
+
+describe("a user's own conversations", () => {
+  it("lists, reads and deletes theirs — and nobody else's", async () => {
+    const support = agent({ name: "support", harness: speaker(), store: freshStore() });
+    const dana = support.forUser("u_dana");
+    const raj = support.forUser("u_raj");
+
+    const hers = dana.chat("What is my balance?");
+    expect(await hers).toMatchObject({ status: "ok" });
+    expect(await raj.chat("And mine?")).toMatchObject({ status: "ok" });
+
+    expect((await dana.threads.list()).map((thread) => thread.id)).toEqual([hers.threadId]);
+    // The transcript, off the lazy accessor rather than the listing.
+    const messages = JSON.stringify(await (await dana.threads.get(hers.threadId)).messages());
+    expect(messages).toContain("What is my balance?");
+    expect(messages).toContain("Done.");
+
+    // Raj cannot see it, cannot read it, and cannot delete it.
+    expect((await raj.threads.list()).map((thread) => thread.id)).not.toContain(hers.threadId);
+    await expect(raj.threads.get(hers.threadId)).rejects.toMatchObject({ code: "not-found" });
+    await raj.threads.delete(hers.threadId);
+    expect((await dana.threads.list()).map((thread) => thread.id)).toEqual([hers.threadId]);
+
+    // Her own delete does remove it, and then it is gone for her too.
+    await dana.threads.delete(hers.threadId);
+    expect(await dana.threads.list()).toEqual([]);
+    await expect(dana.threads.get(hers.threadId)).rejects.toMatchObject({ code: "not-found" });
+  }, 30_000);
+});
+
+describe("a user's own parked turns", () => {
+  it("are the ones createTurns lists, and only this user can answer them", async () => {
+    const ran = { count: 0 };
+    const support = agent({
+      name: "support",
+      harness: refunder(),
+      tools: [refundTool(ran)],
+      store: freshStore(),
+    });
+    const dana = support.forUser("u_dana");
+    const raj = support.forUser("u_raj");
+
+    const asked = await interrupted(dana.chat("Refund invoice 7."));
+    const decisions = { [asked.interruptions[0]!.id]: "approve" as const };
+
+    // The facade's face IS `createTurns(deps, subject)` — same rows, same shape.
+    const direct = createTurns({ ...agentComposition(support)!, name: "support" }, "u_dana");
+    const waiting = await dana.turns.list({ status: "interrupted" });
+    expect(waiting).toEqual(await direct.list({ status: "interrupted" }));
+    expect(waiting).toMatchObject([{ turnId: asked.turnId, threadId: asked.threadId }]);
+
+    // Raj is not offered her turn and cannot answer it — a turn you do not own
+    // reads back as absent, never as forbidden.
+    expect(await raj.turns.list({ status: "interrupted" })).toEqual([]);
+    await expect(raj.turns.resume(asked.turnId, decisions)).rejects.toMatchObject({ code: "not-found" });
+    expect(ran.count).toBe(0);
+
+    // Hers runs the exact call she was asked about, once.
+    expect(await dana.turns.resume(asked.turnId, decisions)).toMatchObject({ status: "ok", turnId: asked.turnId });
+    expect(ran.count).toBe(1);
+  }, 30_000);
+});
+
+describe("what the agent remembers about a user", () => {
+  it("is that user's alone, through every verb the person has", async () => {
+    const store = freshStore();
+    // The writes below are the ADAPTER's, not a turn's, so they pay for the
+    // schema themselves; `memories.*` is the read side under test.
+    await store.ensureSchema();
+    const support = agent({ name: "support", harness: speaker(), store, memory: true });
+    const memory = agentComposition(support)!.memory!;
+    const hers = await memory.remember(owner("u_dana"), "Prefers window seats");
+    await memory.remember(owner("u_raj"), "Prefers the aisle");
+
+    const dana = support.forUser("u_dana");
+    const raj = support.forUser("u_raj");
+    expect((await dana.memories.list()).map((entry) => entry.text)).toEqual(["Prefers window seats"]);
+    expect((await raj.memories.list()).map((entry) => entry.text)).toEqual(["Prefers the aisle"]);
+
+    // Neither forgetting verb reaches across.
+    await raj.memories.delete(hers.id);
+    await raj.memories.clear();
+    expect((await dana.memories.list()).map((entry) => entry.text)).toEqual(["Prefers window seats"]);
+
+    await dana.memories.delete(hers.id);
+    expect(await dana.memories.list()).toEqual([]);
+  });
+
+  it("says memory was never turned on rather than answering an empty list", async () => {
+    const support = agent({ name: "support", harness: speaker(), store: freshStore() });
+    const user = support.forUser("u_dana");
+    await expect(user.memories.list()).rejects.toMatchObject({ code: "validation" });
+    await expect(user.memories.clear()).rejects.toThrow(/memory: true/);
+  });
+});
+
+describe("the first thing a host reads", () => {
+  it("can be the facade itself, on a store no turn has migrated yet", async () => {
+    const user = agent({ name: "support", harness: speaker(), store: freshStore() }).forUser("u_dana");
+    expect(await user.threads.list()).toEqual([]);
+    expect(await user.turns.list({ status: "interrupted" })).toEqual([]);
+  });
+});
+
+describe("the paths forUser replaces", () => {
+  it("still work — a deprecation is a path, not a removal", async () => {
+    const support: VendoAgent = agent({ name: "support", harness: speaker(), store: freshStore() });
+
+    // `run({ as })`: the run is still that subject's, which is provable from the
+    // conversation it left behind — only its owner can see it.
+    const run = support.run("check the account", { as: "u_42" });
+    expect(await run).toMatchObject({ status: "ok" });
+    expect((await support.forUser("u_42").threads.list()).map((thread) => thread.id)).toEqual([run.threadId]);
+
+    // `session()`: still opens a conversation for that subject.
+    const session = await support.session("u_42");
+    expect(session.threadId).toMatch(/^thr_/);
+  }, 30_000);
+});


### PR DESCRIPTION
## What changes

```ts
const user = support.forUser("u_42", {
  profile: { name: "Dana", plan: "pro" },  // model-visible facts — durable
  context: { tenantId },                   // guard/tool context — durable
});

user.chat(msg, { headers: req.headers });  // request authority rides PER CALL, never bound

await user.turns.list({ status: "interrupted" });
await user.threads.list();  (await user.threads.get(id)).messages();
await user.memories.list();
```

One call binds the person; `turns`, `threads` and `memories` are all scoped to them from then on. A facade — it binds a subject and delegates; the behaviour lives in the slices below.

## The distinction that matters, and how it is proven

`profile` and `context` are **durable** — bound once, carried by every call. `headers` are **request-lifetime** — they ride per call and are never bound, because one request's authority must not leak into another's.

The test binds one facade and makes three real turns with different auth headers, then reads everything back off the context a **real tool** was handed and the brief the **real harness** received — never off the options object. Subject and context identical across all three; headers `Bearer one`, `Bearer two`, then absent. Cross-user isolation is a second facade over the same real store: a foreign `threads.get` is `not-found`, a foreign `turns.resume` is `not-found` with the refund counter still at 0, and a foreign `memories.delete`/`clear` removes nothing.

## Two decisions worth a reviewer's eye

**`memories.*` throws when the agent has no memory configured**, rather than answering with an empty list. "Nothing remembered" and "nothing is ever remembered" are different facts, and a settings screen that renders the first while the second is true is lying to the person; a `delete` reporting success having removed nothing is worse. It is host-code error with a one-line fix, so the error says so.

**The facade's durable `context` DOES apply to `turns.resume`.** PR3's rule is that authority comes from the resuming call and is never replayed from the dead request — and the facade's standing context is the live caller's, not the dead request's. Leaving it out would mean a guard rule keyed on `tenantId` evaluates differently for a resumed turn than for the turn that parked it, with nothing in the API explaining why. Bound context underneath, per-call on top, exactly as `chat()` merges them; `headers` still never bind. `interruptions.ts` is untouched.

`turns`/`threads`/`memories` each latch `store.ensureSchema()` in front, for the reason `permissions.ts:18-25` already documents: an approvals inbox or a memories screen can legitimately be the first thing a deployment ever calls.

## Deprecations — path, not removal

`RunOptions.as` → `forUser`. `session()` and `AgentSession` → `forUser`/threads (the thread is the durable noun). JSDoc `@deprecated`, the convention already in this repo. Both still work. **`respond()` is NOT deprecated** — and `SessionOptions` is deliberately untouched, since `RespondOptions extends` it and deprecating the base would have tainted a live verb.

## Gate

`build` · `typecheck` (42/42) · `lint` · `packages/agents` **250 tests** — all EXIT=0.

Stacked on #1500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Binds a person once with `agent.forUser(subject, { profile, context })` and scopes chat, turns, threads, and memories to them. Before, callers re-sent `as/user/context` per call and resumes dropped context; now durable `profile/context` ride every call (including `turns.resume`), while `headers` remain per-call and are never stored. `memories.*` throws when memory is disabled to avoid misreporting “nothing remembered.”

- Adds `packages/agents/src/facade.ts` and exposes `AgentUser` and related types from `index.ts`. The facade delegates to existing implementations (`startChat`, `createTurns`, store thread/message helpers, memory adapter).
- `turns.resume` merges the facade’s bound `context` with any per-call `context`; headers never bind. Threads are user-owned (`get` on foreign is `not-found`; `delete` is idempotent).
- Facade ensures and latches schema on first read so first-call reads (threads/turns) work on a fresh store.
- `RunOptions.as` and `agent.session()` are deprecated but still work; `respond()` is unchanged.

**Migration**
- Use `agent.forUser(subject, { profile, context })` instead of `RunOptions.as` and `agent.session()`; stop passing `as/user/context` per call. Continue passing `headers` per call.
- If exposing memories, enable memory via `agent({ memory: true })` or provide a `MemoryAdapter`; handle the validation error otherwise.

<sup>Written for commit f86c459141da6122a200b912d81b17f2a416e61e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1508?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

