### PR TITLE
fix(vendo): install-DX round-2 mechanical fixes

### DIFF
--- a/.changeset/chilled-pears-shout.md
+++ b/.changeset/chilled-pears-shout.md
@@ -1,0 +1,19 @@
+---
+"@vendoai/vendo": patch
+---
+
+Six mechanical install-DX fixes from a live run of the published CLI. A
+generated `@/lib/vendo` import is a path alias, not the npm package `@/lib`, so
+init no longer writes `"lib": "link:@/lib"` into your package.json and your next
+`npm install` no longer dies on EUNSUPPORTEDPROTOCOL. The predev impact probe
+knocks on the port init wrote to `.env.local` as `VENDO_BASE_URL` instead of
+assuming 3000, so `pnpm dev` on any other port stops reporting "impact unknown".
+`vendo login` keeps its machine-readable JSON receipt off a terminal a human is
+watching, and its one-line pretty ceremony now names the approval URL up front —
+the browser open is best-effort, and a headless box was left with a code and
+nowhere to type it. Every rail row is cleared to end of line, so a select redraw
+can no longer leave a longer line's tail behind. A failed AI brief polish says
+the install is complete and valid with the default brief and names
+`vendo sync --ai`, instead of printing a raw JSON parser error. And the detected
+stack — framework, router, language, package manager, auth — is read back before
+the first question on every run, not only the ones dressed in the rail.

--- a/packages/vendo/src/cli/cloud/device-login.ts
+++ b/packages/vendo/src/cli/cloud/device-login.ts
@@ -50,9 +50,10 @@ export interface DeviceLoginOptions {
   /**
    * The pretty renderer is driving this ceremony, so a human is reading a rail
    * and the machine-readable receipt below is noise sitting under the three
-   * lines of state. Suppressed there and NOWHERE else: `--agent`, `--json`,
-   * piped, non-TTY, CI and standalone `vendo login` all keep it byte for byte,
-   * because something parses each of those.
+   * lines of state. Suppressed there — and, `isTty` above, on any terminal a
+   * human is watching: nothing parses a TTY, and standalone `vendo login`
+   * printed that JSON block at a human who read it as a crash. `--agent`,
+   * piped, non-TTY and CI runs keep it byte for byte.
    *
    * Passed explicitly rather than inferred. `usePrettyOutput()` answers "is
    * this terminal colour-capable", which is a different question — standalone
@@ -203,6 +204,7 @@ export async function runDeviceLogin(
   const fetchImpl = options.fetchImpl ?? fetch;
   const sleep = options.sleep ?? ((ms: number) => new Promise((resolve) => setTimeout(resolve, ms)));
   const now = options.now ?? Date.now;
+  const tty = options.isTty ?? (process.stdout.isTTY === true);
   const base = resolveCloudBaseUrl({
     apiUrl: option(args, "--api-url"),
     env: options.env ?? process.env,
@@ -287,14 +289,13 @@ export async function runDeviceLogin(
       const ceremony = ceremonyFrom(claim.body);
 
       const approvalUrl = ceremony.verification_uri_complete ?? ceremony.verification_uri;
-      const tty = options.isTty ?? (process.stdout.isTTY === true);
       noteStaleCode(pending, now(), output);
       if (options.pretty === true) {
         if (tty) {
-          // One line. The browser is already opening, so the code IS the whole
-          // instruction; the URL is not lost — the stall notice below carries
-          // it as the recovery path if the browser never came up.
-          output.log(`Opening your browser — approve the code ${ceremony.user_code} there…`);
+          // One line, no numbered list — but it NAMES the URL: opening the
+          // browser is best-effort, and on a headless or remote box nothing
+          // comes up, leaving a code with nowhere to type it.
+          output.log(`Opening your browser — approve the code ${ceremony.user_code} at ${approvalUrl}`);
           (options.openBrowser ?? defaultOpenBrowser)(approvalUrl);
         } else {
           output.log(`Vendo Cloud device login — approve the code ${ceremony.user_code} at ${approvalUrl}`);
@@ -417,7 +418,7 @@ export async function runDeviceLogin(
         if (options.rerunHint !== false) {
           output.log("Re-run `vendo init` to finish wiring (it picks the key up from .env.local).");
         }
-        if (options.pretty !== true) {
+        if (options.pretty !== true && !tty) {
           printJson(output, { deviceLogin: true, wroteEnvLocal: true, keyLast4: key.slice(-4) });
         }
         return "approved";
@@ -452,7 +453,7 @@ export async function runDeviceLogin(
     // is not a failure. A re-run resumes this same claim (#479).
     const pendingExit = (): number => {
       output.log(`Still waiting on approval — code ${userCode}. Re-run \`vendo login\` to resume (it continues this same request).`);
-      if (options.pretty !== true) {
+      if (options.pretty !== true && !tty) {
         printJson(output, {
           deviceLogin: true,
           pending: true,

--- a/packages/vendo/src/cli/extract/stages.ts
+++ b/packages/vendo/src/cli/extract/stages.ts
@@ -219,8 +219,8 @@ export async function runBriefStage(input: BriefStageInput): Promise<BriefStageR
     return { brief: artifact.brief, fromStage: true, notes };
   } catch (error) {
     notes.push(
-      `brief stage failed (${message(error)}) — keeping the current brief; `
-      + "the stage's own output is at .vendo/data/extract/brief.json",
+      `the AI polish for your brief did not finish (${message(error)}) — your install is `
+      + "complete and valid with the default brief; run `vendo sync --ai` to try the polish again",
     );
   }
   // The "current brief" is an ARTIFACT, so the fallback reads it from the

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -377,6 +377,31 @@ export async function stackLines(
   ];
 }
 
+/** The read-back, before the first question. Owed to EVERY run a human
+    watches — the rail is only how it is dressed, and gating on the rail is
+    what let a `CI=`/`NO_COLOR` terminal open with a question about an app it
+    never said it had read. Detect first, print second: the banner's arrival
+    plays over the detection, and the reveal then narrates it — a beat per
+    fact, so the wave reads as detection time rather than a burst after it. */
+async function printStack(input: {
+  root: string;
+  options: InitOptions;
+  output: Output;
+  pretty: PrettyOutput | null;
+}): Promise<void> {
+  const { root, options, output, pretty } = input;
+  const stack = await stackLines(root, await resolveFramework(root, options));
+  if (pretty === null) {
+    for (const fact of stack) output.log(fact);
+    return;
+  }
+  const facts = stack.map((text, index) => ({
+    beat: index === 0 ? "Detecting your framework…" : index === 1 ? "Checking auth…" : undefined,
+    text,
+  }));
+  await pretty.revealBlock("Your stack", facts, { beat: "Reading your app…" });
+}
+
 /** Telemetry `router` enum (init_completed): app | pages | none, from the
     same directory evidence appDirectory rides. Express hosts are "none". */
 async function detectRouter(root: string, framework: Exclude<HostFramework, "unknown"> | "custom"): Promise<"app" | "pages" | "none"> {
@@ -2295,22 +2320,7 @@ const explainedPlanFailure = (error: unknown): boolean => {
     }
   }
 
-  // The read-back first: every fact below is already detected for other
-  // reasons, and showing it is the moment the tool proves it looked.
-  if (pretty !== null) {
-    // Detect FIRST, print second: the banner's arrival plays over this work.
-    // The reveal then narrates it — a beat of "Reading your app…" and the
-    // facts landing one by one — so the wave reads as detection time, and the
-    // section arrives as a rhythm instead of a burst after the arrival.
-    const stack = await stackLines(root, await resolveFramework(root, options));
-    // Each fact gets a labeled beat — the scan narrates what it is looking at
-    // while it lands the answer it already has.
-    const facts = stack.map((text, index) => ({
-      beat: index === 0 ? "Detecting your framework…" : index === 1 ? "Checking auth…" : undefined,
-      text,
-    }));
-    await pretty.revealBlock("Your stack", facts, { beat: "Reading your app…" });
-  }
+  await printStack({ root, options, output, pretty });
   const useCase = await resolveUseCase({ root, options, pretty, interactive });
 
   // (No stdin-TTY guard on these defaults: an unshown auth confirm resolving

--- a/packages/vendo/src/cli/pretty.ts
+++ b/packages/vendo/src/cli/pretty.ts
@@ -748,10 +748,13 @@ export function createPrettyOutput(options: PrettyOptions = {}): PrettyOutput {
     return stdout.columns ?? Number.POSITIVE_INFINITY;
   };
   /** One logical line — and the number of terminal ROWS it took, which is what
-      a cursor-up redraw has to rewind. */
+      a cursor-up redraw has to rewind. Each row ends at the erase: a redraw
+      rewinds by the rows this renderer BELIEVES it drew, and wherever that
+      disagrees with the terminal's own wrap, a shorter line lands on a longer
+      one and keeps its tail. Clearing to end of line makes that impossible. */
   const line = (text: string): number => {
     const rows = wrapRail(text, columns());
-    for (const row of rows) write(`${row}\n`);
+    for (const row of rows) write(`${row}${ESC}[K\n`);
     lastWasBar = text === BAR;
     return rows.length;
   };

--- a/packages/vendo/src/cli/provider-deps.ts
+++ b/packages/vendo/src/cli/provider-deps.ts
@@ -357,13 +357,16 @@ export async function ensureVendoPackage(options: { root: string; output: Output
 
 /** Every BARE package a generated module imports, deduped: `@scope/name` or
  *  `name`, subpath dropped. Relative and absolute specifiers are not packages,
- *  and neither are node builtins. */
+ *  and neither are node builtins — nor `@/…`, the tsconfig path alias whose
+ *  empty scope segment makes it no package name at all (installing it wrote
+ *  `"lib": "link:@/lib"` into the host manifest and npm then died on
+ *  EUNSUPPORTEDPROTOCOL). */
 function importedPackages(source: string): string[] {
   const found = new Set<string>();
   const specifiers = /(?:^|[\s;}])(?:import|export)\s[^;]*?from\s*["']([^"']+)["']|\bimport\s*\(\s*["']([^"']+)["']/g;
   for (const match of source.matchAll(specifiers)) {
     const specifier = match[1] ?? match[2] ?? "";
-    if (specifier === "" || specifier.startsWith(".") || specifier.startsWith("/") || specifier.startsWith("node:")) continue;
+    if (specifier === "" || specifier.startsWith(".") || specifier.startsWith("/") || specifier.startsWith("node:") || specifier.startsWith("@/")) continue;
     const parts = specifier.split("/");
     found.add(specifier.startsWith("@") ? parts.slice(0, 2).join("/") : parts[0]!);
   }

--- a/packages/vendo/src/cli/sync-flow.ts
+++ b/packages/vendo/src/cli/sync-flow.ts
@@ -605,11 +605,15 @@ async function runGradingStages(input: {
 async function probeImpact(input: {
   report: SyncReportWithWarnings;
   options: SyncFlowOptions;
+  /** The dotenv-aware environment: init wrote the host's real dev port here as
+      VENDO_BASE_URL, so 3000 is the last resort rather than the assumption. */
+  env: Record<string, string | undefined>;
   output: SyncFlowOptions["output"];
   note: (message: string) => void;
 }): Promise<ToolImpact[] | null> {
-  const { report, options, output, note } = input;
-  const wireUrl = (options.url ?? process.env.VENDO_URL ?? "http://localhost:3000/api/vendo").replace(/\/+$/, "");
+  const { report, options, env, output, note } = input;
+  const base = (env.VENDO_BASE_URL ?? "http://localhost:3000").replace(/\/+$/, "");
+  const wireUrl = (options.url ?? env.VENDO_URL ?? `${base}/api/vendo`).replace(/\/+$/, "");
   const tools = [...new Set([
     ...report.breaking.map((breaking) => breaking.tool),
     ...report.tools.changed,
@@ -753,7 +757,7 @@ export async function runSyncFlow(options: SyncFlowOptions): Promise<SyncFlowRes
   const notes_ = { note, noteError };
   const { themeSummary, themeMs, theme } = await resolveTheme({ root, vendoDir, mode, options, note });
   const { judged, themeDraft } = await runGradingStages({ root, vendoDir, mode, env, options, output, themeSummary, notes: notes_ });
-  const impact = await probeImpact({ report, options, output, note });
+  const impact = await probeImpact({ report, options, env, output, note });
 
   // Pin baselines → Vendo Cloud (decision 4). Part of a NORMAL keyed run, not
   // something `--report` gates: the console's Remix reviews screen cannot show

--- a/packages/vendo/tests/cli/cloud/device-login.test.ts
+++ b/packages/vendo/tests/cli/cloud/device-login.test.ts
@@ -320,6 +320,31 @@ describe("runDeviceLogin", () => {
     expect(opened).toEqual([]);
   });
 
+  // The receipt is for whatever PARSES this run. `pnpm dlx vendoai@latest
+  // login` in a terminal has no parser, and the JSON block under the prose
+  // read as a crash to the human who ran it.
+  it("keeps the machine receipt off a terminal a human is watching", async () => {
+    const { fetchImpl } = scriptedFetch([
+      { status: 200, body: { access_token: KEY, token_type: "Bearer" } },
+    ]);
+    const messages = output();
+    const exit = await runDeviceLogin(["--api-url", "https://console.test"], {
+      output: messages.sink,
+      fetchImpl,
+      root: await tempRoot(),
+      home: await tempRoot(),
+      sleep: async () => {},
+      env: {},
+      isTty: true,
+      openBrowser: () => {},
+    });
+    expect(exit).toBe(0);
+    // The numbered ceremony still reads as prose — the URL and the code are
+    // there. Only the JSON tail is gone.
+    expect(messages.logs.join("\n")).toContain("https://console.test/claim?code=BCDF-GHJK");
+    expect(messages.logs.join("\n")).not.toContain("deviceLogin");
+  });
+
   it("opens the browser at verification_uri_complete when a TTY human is watching", async () => {
     const opened: string[] = [];
     const { fetchImpl } = scriptedFetch([
@@ -339,11 +364,12 @@ describe("runDeviceLogin", () => {
     });
     expect(exit).toBe(0);
     expect(opened).toEqual(["https://console.test/claim?code=BCDF-GHJK"]);
-    // The browser is already opening, so the code IS the whole instruction:
-    // ONE line, no numbered list, no URL competing with it. The URL is not
-    // lost — the stall notice below carries it if the browser never came up.
-    expect(messages.logs[0]).toBe("Opening your browser — approve the code BCDF-GHJK there…");
-    expect(messages.logs.join("\n")).not.toContain("https://console.test/claim");
+    // ONE line, no numbered list — but it NAMES the URL. `defaultOpenBrowser`
+    // is fire-and-forget, so on a headless or remote box nothing opens and the
+    // human had no route to the approval page for the first 20 seconds.
+    expect(messages.logs[0]).toBe(
+      "Opening your browser — approve the code BCDF-GHJK at https://console.test/claim?code=BCDF-GHJK",
+    );
   });
 
   it("holds the expiry sentence back until the pretty ceremony has visibly stalled", async () => {

--- a/packages/vendo/tests/cli/extract/stages.test.ts
+++ b/packages/vendo/tests/cli/extract/stages.test.ts
@@ -83,9 +83,11 @@ describe("runBriefStage", () => {
 
     expect(result.fromStage).toBe(false);
     expect(result.brief).toBe("The humans already described this product.");
+    // The raw parser error alone read as a broken install. It says what broke
+    // (the polish, not the install), that the install stands, and how to retry.
     expect(result.notes).toEqual([
-      "brief stage failed (timed out) — keeping the current brief; "
-      + "the stage's own output is at .vendo/data/extract/brief.json",
+      "the AI polish for your brief did not finish (timed out) — your install is "
+      + "complete and valid with the default brief; run `vendo sync --ai` to try the polish again",
     ]);
   });
 

--- a/packages/vendo/tests/cli/init.test.ts
+++ b/packages/vendo/tests/cli/init.test.ts
@@ -385,6 +385,33 @@ describe("vendo init (zero-question)", () => {
     expect(sink.logs.join("\n")).not.toContain("Auth:");
   });
 
+  /** The landing prompt promises "read what it detects". Gating the read-back
+      on the pretty renderer meant a terminal with CI or NO_COLOR set — still a
+      human, still asked questions — opened on "How will people use your
+      agent?" with nothing above it to read. */
+  it("reads the detected stack back before it asks the first question", async () => {
+    const root = await fixture();
+    await writeFile(join(root, "package.json"), JSON.stringify({
+      name: "host",
+      dependencies: { next: "16.0.0", "@clerk/nextjs": "6.0.0" },
+    }));
+    const sink = output();
+    let readBack = "";
+    expect(await run(root, sink, {
+      interactive: true,
+      selectUseCase: async () => (readBack = sink.logs.join("\n"), "embedded"),
+      confirmAuth: async () => true,
+    })).toBe(0);
+    expect(readBack).toContain("Next.js · App Router · JavaScript · npm");
+    expect(readBack).toContain("Clerk auth (@clerk/nextjs)");
+  });
+
+  it("reads the detected stack back on a --yes run too", async () => {
+    const sink = output();
+    expect(await run(await fixture(), sink, { yes: true })).toBe(0);
+    expect(sink.logs.join("\n")).toContain("Next.js · App Router · JavaScript · npm");
+  });
+
   it("interactive decline + picking none keeps the composition anonymous and names the exact line to add later", async () => {
     const root = await fixture();
     await writeFile(join(root, "package.json"), JSON.stringify({

--- a/packages/vendo/tests/cli/pretty.test.ts
+++ b/packages/vendo/tests/cli/pretty.test.ts
@@ -1080,6 +1080,26 @@ describe("createPrettyOutput (80 columns — the width most people run)", () => 
     expect(settled).not.toContain("○");
   });
 
+  /** A redraw rewinds by the rows the renderer BELIEVES it drew. Where that
+      count and the terminal's own wrap disagree, the erase lands on the wrong
+      row and a shorter line is painted over a longer one — leaving its tail
+      attached ("…any MCP agent (experimental)p/api/chat)"). Ending every row
+      at the erase makes the residue impossible however the rewind landed. */
+  it("select: every row it draws is cleared to end of line", async () => {
+    const chunks: string[] = [];
+    const keys = fakeInput();
+    const pretty = createPrettyOutput({
+      write: (chunk) => chunks.push(chunk), input: keys.input, banner: false, columns: 80,
+    });
+    const choice = pretty.select("How will people use your agent?", [...USE_CASE_OPTIONS]);
+    keys.press("[B"); // redraw: the option list is painted a second time
+    keys.press("1");
+    expect(await choice).toBe("embedded");
+    const rows = chunks.join("").split("\n").filter((row) => row.includes("Embedded in my app"));
+    expect(rows.length).toBeGreaterThan(1);
+    expect(rows.every((row) => row.endsWith(`${ESC}[K`))).toBe(true);
+  });
+
   it("select: the settled long answer stays on the rail and still reads whole", async () => {
     const term = screen(80);
     const keys = fakeInput();

--- a/packages/vendo/tests/cli/provider-deps.test.ts
+++ b/packages/vendo/tests/cli/provider-deps.test.ts
@@ -2,7 +2,7 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { aiBelowPeerFloor, defaultRunner, ensureProviderDeps, ensureVendoPackage, ensureZodFloor, installCommandFor, installStderrTail, providerModuleFor, VENDO_PACKAGE_SPEC, zodBelowAiSdkFloor, ZOD_FLOOR_SPEC } from "../../src/cli/provider-deps.js";
+import { aiBelowPeerFloor, defaultRunner, ensureGeneratedImports, ensureProviderDeps, ensureVendoPackage, ensureZodFloor, installCommandFor, installStderrTail, providerModuleFor, VENDO_PACKAGE_SPEC, zodBelowAiSdkFloor, ZOD_FLOOR_SPEC } from "../../src/cli/provider-deps.js";
 
 // Init installs the provider module the resolved credential loads at
 // runtime (0.4.1 E2E cert finding: nothing declares @ai-sdk/*, so a fresh
@@ -553,6 +553,30 @@ describe("defaultRunner", () => {
     const tail = installStderrTail();
     expect(tail.length).toBeLessThanOrEqual(2000);
     expect(tail).toContain("THE-END");
+  });
+});
+
+// A host whose tsconfig maps `@/*` gets `@/lib/vendo` in its generated files.
+// That specifier's scope segment is empty, so it is no npm package at all —
+// installing it wrote `"lib": "link:@/lib"` into the manifest, and the host's
+// next `npm install` died on EUNSUPPORTEDPROTOCOL.
+
+describe("ensureGeneratedImports", () => {
+  it("installs the packages a generated file imports, never its path aliases", async () => {
+    const root = await tempRoot();
+    await installModule(root, "next");
+    await writeFile(join(root, "package.json"), JSON.stringify({ dependencies: { next: "15.0.0" } }));
+    const calls: Array<{ command: string; args: string[] }> = [];
+    const messages = output();
+    await ensureGeneratedImports({
+      root,
+      sources: [`import { vendo } from "@/lib/vendo";\nimport { anthropic } from "@ai-sdk/anthropic";\n`],
+      output: messages.sink,
+      run: async (command, args) => (calls.push({ command, args }), 0),
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.args.join(" ")).toContain("@ai-sdk/anthropic");
+    expect(calls[0]!.args.join(" ")).not.toContain("@/lib");
   });
 });
 

--- a/packages/vendo/tests/cli/sync-flow.test.ts
+++ b/packages/vendo/tests/cli/sync-flow.test.ts
@@ -177,6 +177,32 @@ describe("runSyncFlow", () => {
  * "Reading your product (…)…" line is the SAME string either way: the label
  * when a renderer is attached, the printed line when there is none.
  */
+/** The impact probe knocks on the dev server the host actually runs, which is
+ *  the port init already wrote to `.env.local` as VENDO_BASE_URL. Hardcoding
+ *  3000 made every `pnpm dev` on any other port report "impact unknown". */
+describe("the impact probe's address", () => {
+  const changed = (async () => ({ ...REPORT, tools: { added: [], removed: [], changed: ["host_a"] } })) as never;
+
+  async function probedUrl(files: Record<string, string>): Promise<string> {
+    const urls: string[] = [];
+    const fetchImpl = (async (url: string | URL) => {
+      urls.push(String(url));
+      throw new Error("offline");
+    }) as unknown as typeof fetch;
+    await flow({ root: await host(files), output: captureOutput().output, sync: changed, ai: false, fetchImpl });
+    return urls[0]!;
+  }
+
+  it("reads the dev port off the env files init wrote", async () => {
+    expect(await probedUrl({ ".env.local": "VENDO_BASE_URL=http://localhost:4321\n" }))
+      .toBe("http://localhost:4321/api/vendo/sync/impact");
+  });
+
+  it("falls back to 3000 when nothing names a base URL", async () => {
+    expect(await probedUrl({})).toBe("http://localhost:3000/api/vendo/sync/impact");
+  });
+});
+
 describe("the slow phases spin when the caller supplies one", () => {
   const scripted = {
     id: "scripted",


### PR DESCRIPTION
Six mechanical CLI fixes from a live install audit of the published 0.29.1. Two checklist items did not land — see the bottom.

Each item: failing test first, smallest fix, green. Every new/changed test was proven red with the fix reverted.

## 1. `@/lib` fake dependency — DONE

**Root cause** `importedPackages()` (`provider-deps.ts:361`) took `parts.slice(0, 2)` of any `@`-prefixed specifier, so the generated `@/lib/vendo` import became the "package" `@/lib`. `ensureGeneratedImports()` then shelled `pnpm add @/lib`, which writes `"lib": "link:@/lib"` into the host's package.json — and the host's next `npm install` hard-fails with EUNSUPPORTEDPROTOCOL.

**Fix** One clause: a specifier starting `@/` has an empty scope segment, so it is no npm package name at all and is skipped alongside relative, absolute and `node:` specifiers. No tsconfig parsing.

**Test** `provider-deps.test.ts` → `ensureGeneratedImports > installs the packages a generated file imports, never its path aliases`. Red before: `install @/lib @ai-sdk/anthropic@^3`. The real package in the same source still installs, so the filter is not over-broad.

## 2. Paste #2 doesn't compile (Mastra branch) — SKIPPED, superseded

Not started when the coordinator's scope update landed: a product decision removes all code/steps from init's printed output in a follow-up slice (init will link docs instead). Left untouched rather than fixing a snippet that is about to be deleted.

For that slice's record, the paste is missing three things against the working `examples/mastra-agent/src/app/api/chat/route.ts`: `import { RequestContext } from "@mastra/core/request-context"`, `const requestContext = new RequestContext()`, and the hand-off `params.requestContext = requestContext`.

## 3. predev probes the wrong port — DONE

**Root cause** `probeImpact()` (`sync-flow.ts:612`) read `options.url ?? process.env.VENDO_URL ?? "http://localhost:3000/api/vendo"` and never looked at the `VENDO_BASE_URL` init itself wrote to `.env.local` from the host's real dev port. Every `pnpm dev` on a non-3000 app logged "impact unknown — dev server not reachable at http://localhost:3000/api/vendo".

**Fix** The probe takes the flow's already-computed dotenv-aware `env` (built at `sync-flow.ts:739`, one statement above the call) and falls back through `VENDO_URL` → `VENDO_BASE_URL` + `/api/vendo` → 3000. Trailing slashes on the base are stripped.

**Test** `sync-flow.test.ts` → `the impact probe's address`, both fallbacks: `VENDO_BASE_URL=http://localhost:4321` in `.env.local` is probed at `http://localhost:4321/api/vendo/sync/impact`; nothing set still probes 3000.

## 4. `--service-key` on local posture leaves `mcp: true` — STOPPED

**Reproduced exactly**, then stopped: the fix as specified violates a locked DX law. Expected-vs-found at the bottom.

## 5. Login output for humans — DONE

**(a) Root cause** `device-login.ts:297` printed only the code on the pretty+TTY path; the URL appeared solely in the 20-second "Still waiting" beat. `defaultOpenBrowser` is fire-and-forget (`execFile(..., () => undefined)`), so on a headless or remote box nothing opened and the human held a code with nowhere to type it.

**Fix** The one line names the URL: `Opening your browser — approve the code BCDF-GHJK at <url>`.

**(b) Root cause** Not pnpm dlx and not pretty detection. `vendo login` **never passes `pretty` at all** — `cli.ts:157` calls `runLoginCommand(args)` with no options, so `options.pretty` is `undefined` on every standalone run and the JSON receipt at `:420` always printed, TTY or not. Only `vendo init`'s embedded step ever sets `pretty: true`.

**Fix** Both receipt sites also require `!tty`. The receipt is for whatever parses the run, and nothing parses a TTY. The numbered prose ceremony is untouched byte for byte — piped, `--agent`, non-TTY and CI runs still get the JSON. Key value is still last-4 only on every path.

**Tests** New: `keeps the machine receipt off a terminal a human is watching` (red before: the JSON block). Changed: `opens the browser at verification_uri_complete when a TTY human is watching` asserted the exact old line *and* that the URL was absent — that assertion pinned the behavior this item reverses, so it was flipped. Called out because it is a spec change, not a test weakened to pass.

## 6. TUI redraw artifact — DONE

**Root cause** `line()` (`pretty.ts:752`) wrote `${row}\n` with no erase, and `select`'s redraw rewinds by the row count the renderer *believes* it drew (`\x1b[NA\x1b[0J`). Where that count and the terminal's own wrap disagree, the erase lands on the wrong row and a shorter line is painted over a longer one, keeping its tail — `…any MCP agent (experimental)p/api/chat)`.

**Fix** Each row ends at the erase: `write(\`${row}${ESC}[K\n\`)`. Residue becomes impossible however the rewind landed.

**Test** `pretty.test.ts` → `select: every row it draws is cleared to end of line`, driving the real select through a redraw and asserting on the emitted bytes.

**Honest scope note** The suite's `screen()` terminal model treats a write at column 0 as "replace the row" (`pretty.test.ts:984`), so it cannot reproduce the artifact by construction — a faithful model would be a test-infrastructure change of its own. The test therefore pins the byte-level contract (every row ends at the erase), which is what makes the artifact impossible; it does not re-render the original broken frame.

## 7. Honest brief-stage failure — DONE

**Root cause** `extract/stages.ts:222` pushed the raw parser error with no guidance: `brief stage failed (Unterminated string in JSON at position 1616…)`.

**Fix** Message only, no retry logic: *"the AI polish for your brief did not finish (…) — your install is complete and valid with the default brief; run `vendo sync --ai` to try the polish again"*. `vendo sync --ai` is a real flag (`cli.ts:101`).

**Test** The existing exact-text assertion in `stages.test.ts` was updated — the message *is* the behavior, so its test moves with it.

## 8. Stack reveal before the first question — DONE

**Root cause** Not ordering. `stackLines` has exactly one call site and it was gated on `pretty !== null`, while the first question is gated on `interactive` — two different predicates. `pretty` additionally requires no `CI` / `NO_COLOR` / `TERM=dumb`, so a real human terminal with `CI` set skipped the read-back entirely and opened on "How will people use your agent?" with nothing above it. There was no plain-text sibling anywhere, unlike the MCP steps block a few hundred lines below.

**Fix** Extracted `printStack()` next to `stackLines`, with the plain branch the pattern was missing: `pretty === null` logs the facts, otherwise the reveal runs unchanged. Detection is already computed one statement before the question, so nothing moved. (Extraction also kept `runInit` under the `sonarjs/cognitive-complexity` ceiling, which the inline version broke.)

**Tests** `init.test.ts` → `reads the detected stack back before it asks the first question` (captures the log through the `selectUseCase` seam, so ordering is asserted, not just presence) and `reads the detected stack back on a --yes run too`. Both red with the plain branch removed.

---

## Item 4 — expected vs found (stopped, not fixed)

**Reproduced.** A `--force` re-run with `--use-case mcp --posture local --service-key` writes `VENDO_SERVICE_KEY` to `.env.local` and leaves `lib/vendo.ts` at `mcp: true`, exactly as reported.

**Found.** Not ordering, not a dropped value, not `--force` (which is never read on this path). `planMcp` computes the correct `compositionSource` every time; `init.ts:1053` only applies it to a change whose `before === null`, and `planNextComposition` only creates such a change when the composition file does not yet exist (`init.ts:1304`). On a re-run there is no entry to patch, so the rewrite is discarded. The env write at `init.ts:1072` has no such guard, which is why the key lands and the door stays shut.

**Why I stopped.** Making the generated composition contain `serviceAuth` on a re-run means writing a source file that already exists, and `init.ts:89` states the constraint as a locked DX law: *"INIT ONLY EVER CREATES FILES IN YOUR SOURCE TREE… A source file that already exists is never written at all, however stale"* — every such case is deliberately a printed `ManualEdit`. Two further facts make a blind rewrite actively destructive: on a re-run `authWired` is `null`, so re-rendering would emit a composition **without the host's `auth: clerk()`**; and `lib/vendo.ts` is the file users are told to hand-edit for auth, models and guard. Overwriting it on `--force` is a user-visible destructive tradeoff, which is a decision to make deliberately, not to improvise inside a mechanical-fix pass.

**Options, for that decision.** (a) Law-compliant: emit a `ManualEdit` naming the two lines, and do not write the key while claiming it is wired. (b) Surgical: patch only the `mcp:` line plus the `serviceKey` const in the existing file — new source-patching machinery, still a write to a user-owned file. (c) Extend `--force` to rewrite the composition — simplest, and it silently destroys hand edits.

## Off-checklist findings (reported, not fixed)

- **The env write and the composition rewrite disagree by design.** `init.ts:1084` already nulls `modelWritten` on a re-run precisely because the composition went untouched, but the `VENDO_SERVICE_KEY` write two lines above has no such guard — so a re-run reports "Generated VENDO_SERVICE_KEY" for a key nothing consumes. Same root as item 4.
- **`vendo cloud device-login` also never sets `pretty`.** It is documented as the alias of `vendo login` but takes the numbered path unconditionally. Item 5(b)'s TTY gate now covers the receipt for both; the collapsed one-line ceremony is still reachable only through `vendo init`.
- **No test can reach init's pretty branch.** Every test in `init.test.ts` injects `options.output`, which forces `pretty` to `null`, and `InitOptions` has no `pretty` seam. The whole rail path in `runInit` is untestable today — item 8's bug lived exactly there.

## Gate

`pnpm build && pnpm test:affected && pnpm typecheck && pnpm lint` — exit 0. `@vendoai/vendo` 2623 passed / 45 skipped; all affected packages green. Log: `/tmp/r2-gate.log`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves CLI install and login DX with six mechanical fixes from a live 0.29.1 audit. Prevents bogus dependency installs, probes the right dev port, clarifies device login, fixes TUI redraw artifacts, makes brief-stage failures actionable, and always reads the detected stack back before prompting.

- Treat `@/…` imports as path aliases, not packages. Stops `pnpm add @/lib` and `package.json` entries like `"lib": "link:@/lib"`. Real packages (e.g., `@ai-sdk/anthropic`) still install.
- Impact probe address: prefer `--url`, then `VENDO_URL`, else `VENDO_BASE_URL` + `/api/vendo`, else `http://localhost:3000/api/vendo` (trailing slashes stripped).
- `vendo login`: on a TTY, suppress the machine JSON receipt and include the approval URL in the first log line; non-TTY/piped/CI runs keep the JSON.
- TUI: clear each rendered row to end-of-line to avoid leftover text after redraws.
- Brief stage: replace raw parser errors with a message that the install is valid and to retry with `vendo sync --ai`.
- `init`: print the detected stack before the first question on all runs, not only with pretty output.
- Not included: re-writing `lib/vendo.ts` on re-run with `--service-key` (left as-is due to the “init only creates files” DX rule). No migration required.

<sup>Written for commit ba64f3dc5327bc0c55ac1df761461e9f7912ee35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1510?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

