### PR TITLE
fix(apps): a display brick takes the `key` the format skill asks for

### DIFF
--- a/.changeset/intrinsic-key.md
+++ b/.changeset/intrinsic-key.md
@@ -1,0 +1,16 @@
+---
+"@vendoai/apps": patch
+---
+
+A screen may write `key` on a display brick again. The screen typings declared
+`key` once, on `JSX.IntrinsicAttributes` — but TypeScript intersects that into a
+value-based element only, never into an intrinsic tag, which takes
+`JSX.IntrinsicElements[tag]` verbatim. So `<Card key={id}>` compiled and
+`<li key={id}>` was a hard TS2322, while the format skill was telling the model
+to write `key={…}` on every row it maps: the product demanded exactly what its
+own checker refused. The refusal was unreadable on top of being wrong — a
+whole-attribute error attributed to the first attribute printed `prop "key" on
+<li> takes string | number, but this value is string`, so a model repairing the
+screen flipped `key={i}` and `key={String(i)}` until it ran out of rounds. The
+display bricks now carry `key` in their own props type, beside `children` and
+`style`.

--- a/packages/apps/src/server/checking/screen-typings.ts
+++ b/packages/apps/src/server/checking/screen-typings.ts
@@ -539,8 +539,13 @@ ${SAFE_STYLE_PROPERTIES.map((property) => `  ${property}?: string | number;`).jo
  *  display bricks and NOTHING else — that is what keeps `<img>` and `<script>`
  *  errors while `<div>` compiles — and each one takes only children and an
  *  inline style, so `className`, `onClick` and `dangerouslySetInnerHTML` are
- *  type errors on the tag itself. `IntrinsicAttributes` carries `key`, because a
- *  list rendered with `.map()` writes one and it is React's, not the tag's.
+ *  type errors on the tag itself — plus `key`, because a list rendered with
+ *  `.map()` writes one on whatever it maps to. `IntrinsicAttributes` says the
+ *  same thing for a COMPONENT, and only for a component: TypeScript intersects
+ *  it into a value-based element's props and never into an intrinsic tag's,
+ *  which take `IntrinsicElements[tag]` verbatim. Declaring `key` in one place
+ *  only made `key={i}` on `<div>` a hard error while the format skill was
+ *  telling the model to write exactly that.
  *
  *  `Element` is BRANDED rather than empty. `{}` is the type every value is
  *  assignable to — a closure included — so an empty `Element` made
@@ -554,7 +559,7 @@ const JSX_FRAME = `declare namespace JSX {
   interface ElementChildrenAttribute { children: {} }
   interface IntrinsicAttributes { key?: string | number }
   interface IntrinsicElements {
-${DISPLAY_TAG_NAMES.map((tag) => `    ${tag}: { children?: any; style?: ${SAFE_STYLE_TYPE} };`).join("\n")}
+${DISPLAY_TAG_NAMES.map((tag) => `    ${tag}: { children?: any; style?: ${SAFE_STYLE_TYPE}; key?: string | number };`).join("\n")}
   }
 }`;
 

--- a/packages/apps/tests/checking/component-screen.test.ts
+++ b/packages/apps/tests/checking/component-screen.test.ts
@@ -806,6 +806,39 @@ export default function S() {
     }
   });
 
+  /** `key` is React's on EVERY element, brick and component alike — the format
+   *  skill asks for one on every row a screen maps. TypeScript only intersects
+   *  `JSX.IntrinsicAttributes` into a value-based element, never into an
+   *  intrinsic tag, so declaring `key` there alone made `<li key={…}>` a TS2322
+   *  that the translator then reported as the self-contradictory `prop "key" on
+   *  <li> takes string | number, but this value is string`. Both spellings are
+   *  asserted here because a fix that only moves the declaration would trade one
+   *  half of the rule for the other. */
+  it("takes `key` on a mapped row, on a display brick and on a Kit component alike", async () => {
+    const result = await check(`import { Stack, Text } from "@vendo/screen";
+
+const NAMES = ["ada", "bob"];
+
+export default function Roster() {
+  return (
+    <Stack gap={8}>
+      <ul>
+        {NAMES.map((name) => <li key={name} style={{ padding: 4 }}>{name}</li>)}
+      </ul>
+      {NAMES.map((name) => <Text key={name} text={name} />)}
+    </Stack>
+  );
+}
+`);
+
+    expect(result).toMatchObject({ ok: true, issues: [] });
+    // …and the key REACHES the paint, so the renderer's React keys are the ones
+    // the screen wrote rather than positions the next repaint reshuffles.
+    const ids = Object.keys(result.initialTree?.nodes ?? {});
+    expect(ids).toContain("root.0.li:ada");
+    expect(ids).toContain("root.Text:bob");
+  });
+
   it("refuses a field the tool's declared response does not carry, and names the real ones", async () => {
     const { text } = await refusal(`import { Text, useQuery } from "@vendo/screen";
 export default function S() {


### PR DESCRIPTION
## What

One line in the screen typings: the display bricks now declare `key?: string | number` in their own props type, beside `children` and `style`. Plus the regression case that reddens without it, and a patch changeset.

## Why

**Every remix or screen that renders a list has failed the checks floor since #1468.**

`key` was declared once, on `JSX.IntrinsicAttributes` (`screen-typings.ts:555`), with a comment saying it was there "because a list rendered with `.map()` writes one". But TypeScript intersects `IntrinsicAttributes` into **value-based** elements only — a component. An intrinsic lowercase tag takes `JSX.IntrinsicElements[tag]` verbatim, which was `{ children?: any; style?: VendoStyle }`. So:

- `<Card key={id}>` — clean.
- `<li key={id}>` — hard `TS2322`.

Meanwhile the format skill (`skills/format-reference.ts:112`) instructs the model: `` `key={…}` on every row you `.map` ``. The product was demanding exactly what its own checker refused.

**And the refusal was unreadable on top of being wrong.** `TS2322` lands on the whole attributes object; `attributeValueFinding` (`screen-program.ts:299`) attributes it to the first attribute, so the sentence handed to the repairing model was self-contradictory:

```
prop "key" on <li> takes string | number, but this value is string — bind a value whose type matches the prop
```

A model reading that flips `key={i}` and `key={String(i)}` forever and burns its repair rounds. The bug therefore cost a whole generation, not one diagnostic.

## Repro

Standalone, against this repo's own tsc (5.9.3), with the frame reduced to the two interfaces:

```
== key on INTRINSIC <div>:
     TS2322 :: Type '{ children: string; key: string; }' is not assignable to type '{ children?: any; style?: VendoStyle | undefined; }'.
                Property 'key' does not exist on type '{ children?: any; style?: VendoStyle | undefined; }'.
== key on VALUE-BASED <Card>: CLEAN
== div with key added to its own type: CLEAN
```

The third line is the fix.

## The fix

`IntrinsicAttributes` is left exactly as it is — it is what makes `key` legal on a Kit or host component, and it works. Declaring `key` a second time in `componentPropsText` would be redundant (verified against tsc, and asserted by the new test, which passes with `componentPropsText` untouched) **and actively harmful**: `elementPropFindings` builds its `Allowed props: …` list from the declared props type, so `key` would start appearing in every Kit component's allowed-props sentence — teaching the model that `key` is a component's prop when it is React's. `screen-program.ts:201` already filters `key` out of written props for exactly that reason.

So: one line, in one place.

## Test

`tests/checking/component-screen.test.ts` — "takes `key` on a mapped row, on a display brick and on a Kit component alike". Whole gauntlet, real compiler, real VM: a screen that maps to `<li key={name}>` **and** to `<Text key={name} />`. It also asserts the key reaches the paint (`root.0.li:ada`, `root.Text:bob`), so a screen's own React keys are what the renderer repaints from rather than positions the next repaint reshuffles.

**Proven it can fail.** With the one line reverted:

```
AssertionError: expected { ok: false, …(3) } to match object { ok: true, issues: [] }
+   "issues": [{ "code": "types",
+     "message": "line 9: prop \"key\" on <li> takes string | number, but this value is string — bind a value whose type matches the prop" }],
+   "ok": false,
```

— i.e. the test reproduces the misattributed sentence verbatim. Restored: green, both halves. No existing test was modified.

## Out of scope

`background` (and gradients generally) is absent from `SAFE_STYLE_PROPERTIES` because that property can fetch via `url()`/`image-set()`. That is a real and debatable gap in what a screen can paint, but it is a separate decision from this bug and the allowlist is untouched here.

Refs #1468

## Verification

- [x] `pnpm build` green (42/42)
- [x] `pnpm typecheck` green (42/42)
- [x] `pnpm lint` green (0 errors)
- [x] Scoped tests green — `packages/apps` `tests/checking/` + `tests/skills/format-reference.test.ts`: **362 passed, 0 failed** (27 files). Covers the changed file's own suites, `component-screen`, `screen-typings`, and `screen-tsc-subsumption`, whose exhaustive `Allowed props: valueCents, series` assertion is the one that would catch a `key` leaking into the props lists.
- [ ] Screenshots — not UI-affecting

The full suite was deliberately not run locally (this laptop was at load ~145 from sibling worktrees, and per `CLAUDE.md` the full suite is CI's job). The green `ci` check is the gate of record.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Display bricks accept key?: string | number in their own props, fixing TS2322 on intrinsic tags (e.g., <li key={...}>) and aligning with the format skill’s guidance for mapped rows. Previously, only `JSX.IntrinsicAttributes` declared `key`, so components accepted it but intrinsic display tags did not.

- Update `screen-typings` to include `key` on JSX `IntrinsicElements` for display bricks; keep `IntrinsicAttributes` unchanged to avoid listing `key` as a component prop.
- Add a regression test that maps to both `<li>` and a Kit component and asserts keys reach the render tree; add a patch changeset for `@vendoai/apps`.
- No UI/runtime impact and no migration required.

<sup>Written for commit 8278cdda372e3d034c2c7d33841d7f42c4f13959. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1512?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

