### PR TITLE
feat(vendo): a texted reply says which piece is the last one

### DIFF
--- a/.changeset/channel-send-final-flag.md
+++ b/.changeset/channel-send-final-flag.md
@@ -1,0 +1,33 @@
+---
+"@vendoai/vendo": patch
+---
+
+Every text this channel sends now says whether it is the last one. A reply the
+model splits at a divider goes out in pieces, and until now each piece looked
+exactly like a whole answer on the wire — so the far side could only guess
+whether to keep the typing indicator up or take it down, and it guessed wrong in
+both directions: dropped between "On it." and the answer, or left spinning after
+the last word.
+
+`ChannelsService.send` takes an optional `final`, and the Cloud adapter passes it
+straight through to `/api/v1/channels/text/send`. Optional on purpose — a host
+carrying its own texts keeps the implementation it already wrote, and a carrier
+with nothing to do with the flag ignores it.
+
+The flag scopes to one MESSAGE, never to the turn. It says "no more of this text
+is coming", not "nothing else will arrive" — nothing could say the second one,
+because `vendo_text_me` and an automation firing reach the same conversation at
+any moment, and a turn's own grant-set question is decided from the live approval
+feed only after the reply has gone out. A receiver reads it to stop showing a
+reply as still-being-written, never as "stop listening".
+
+The value is decided by what each send truthfully is, never by position. Only
+`streamTexts` has a mid-reply cut to declare, and it reads finality off the
+stream rather than off the divider: the segment goes out the moment its divider
+passes, and what comes next may be a tool call that takes three seconds or
+nothing at all, so the end of the stream is what settles it. That is also what
+marks the last text of a reply signed off with a divider — that cut is only
+recognized once the stream has ended. Everything else is one whole message with
+nothing behind it: an approval card and a grant-set ask are questions the
+conversation then waits on, the set receipts and the "you're linked" ack end
+their exchange, and a `vendo_text_me` push has no stream behind it at all.

--- a/packages/vendo/src/channel-turn.ts
+++ b/packages/vendo/src/channel-turn.ts
@@ -352,18 +352,30 @@ function frameText(frame: string): string {
  * lines anywhere, and a `---` that is still being typed might yet turn into
  * `----`. Answers how many texts went out, so the caller can tell a silent turn
  * from a delivered one.
+ *
+ * `final` is the same fact read the other way: a cut made while the stream is
+ * still open has more of the reply behind it, and one made after the reader is
+ * done does not. It cannot be decided at the divider itself — the segment goes
+ * out the moment its divider passes, and what follows may be a tool call that
+ * takes three seconds or nothing at all — so the end of the stream is what
+ * settles it, which is also why a reply signed off with a divider still marks
+ * its last text: that cut is only recognized once the stream has ended.
  */
-async function streamTexts(response: Response, send: (text: string) => Promise<void>): Promise<number> {
+async function streamTexts(
+  response: Response,
+  send: (text: string, final: boolean) => Promise<void>,
+): Promise<number> {
   if (response.body === null) return 0;
   let segment = "";
   let line = "";
   let sent = 0;
+  let ended = false;
   const flush = async (): Promise<void> => {
     const text = segment.trim();
     segment = "";
     if (text === "") return;
     sent += 1;
-    await send(text);
+    await send(text, ended);
   };
   const feed = async (delta: string): Promise<void> => {
     line += delta;
@@ -380,7 +392,10 @@ async function streamTexts(response: Response, send: (text: string) => Promise<v
   let buffer = "";
   for (;;) {
     const { done, value } = await reader.read();
-    if (done) break;
+    if (done) {
+      ended = true;
+      break;
+    }
     buffer += decoder.decode(value, { stream: true });
     for (let cut = buffer.indexOf("\n\n"); cut !== -1; cut = buffer.indexOf("\n\n")) {
       await feed(frameText(buffer.slice(0, cut)));
@@ -466,8 +481,12 @@ export async function runChannelTurn(
     channelLink: { channel: "text", linkedAt: link.linkedAt ?? new Date().toISOString() },
     ...(memberships === undefined ? {} : { memberships }),
   };
-  const send = (text: string): Promise<void> =>
-    deps.channel.send({ conversationId: event.conversationId, text });
+  // Every text this function sends by hand is the turn's last word: a card and a
+  // grant-set ask are questions the conversation then waits on, and the two set
+  // receipts end the turn. Only `streamTexts` has a mid-reply cut to declare, so
+  // it is the only caller that passes the flag.
+  const send = (text: string, final = true): Promise<void> =>
+    deps.channel.send({ conversationId: event.conversationId, text, final });
 
   const answer = event.text.trim();
   if (YES.test(answer) || NO.test(answer)) {

--- a/packages/vendo/src/channels.ts
+++ b/packages/vendo/src/channels.ts
@@ -22,8 +22,23 @@ export interface ChannelsService {
   register(input: { url: string; secret: string }): Promise<TextChannelRegistration>;
   /** One outbound message on a conversation the user already started. There is
    *  no host-initiated send: `conversationId` always comes from an inbound
-   *  event. */
-  send(input: { conversationId: string; text: string }): Promise<void>;
+   *  event.
+   *
+   *  `final` scopes to THIS MESSAGE and never to the turn: `false` means more of
+   *  the text being written is still coming — a reply the model is cutting at
+   *  dividers, mid-stream — and `true` means this message is whole.
+   *
+   *  It is deliberately NOT a promise that nothing else will arrive on the
+   *  conversation, because nothing can promise that: `vendo_text_me` and an
+   *  automation firing reach the same conversation at any moment, and a turn's
+   *  own grant-set question is decided from the live approval feed only after
+   *  the reply has gone out. A receiver reads it to stop showing a reply as
+   *  still-being-written; it must never read it as "stop listening".
+   *
+   *  Optional, so an implementation written against the older shape (a host's own
+   *  Inkbox account) is still a `ChannelsService`, and so a carrier that has
+   *  nothing to do with it can ignore it. */
+  send(input: { conversationId: string; text: string; final?: boolean }): Promise<void>;
 }
 
 /** What the router side answers: the shared triage number a person texts, the

--- a/packages/vendo/src/compose-channels.ts
+++ b/packages/vendo/src/compose-channels.ts
@@ -189,6 +189,7 @@ export const composeChannels = (composition: VendoComposition): Pick<VendoCompos
           await channels.send({
             conversationId: event.conversationId,
             text: "You're linked. Text me anything you'd do in the app.",
+            final: true,
           });
           return;
         }

--- a/packages/vendo/src/text-me.ts
+++ b/packages/vendo/src/text-me.ts
@@ -104,7 +104,9 @@ export function textMeRegistry(deps: TextMeDeps): ToolRegistry {
         return { status: "error", error: { code: "not-linked", message: noReachablePhone(invite.url) } };
       }
       try {
-        await deps.channel.send({ conversationId: link.conversationId, text });
+        // One whole message with no stream behind it — an automation firing or a
+        // web turn reaching a phone, never a piece of a reply being written.
+        await deps.channel.send({ conversationId: link.conversationId, text, final: true });
       } catch {
         // Loud, and the model's to explain. Rethrowing would surface as "the
         // tool is broken", which the agent retries; a result the person can act

--- a/packages/vendo/tests/channel-approval.e2e.test.ts
+++ b/packages/vendo/tests/channel-approval.e2e.test.ts
@@ -43,7 +43,7 @@ afterEach(async () => {
     "the vendor was down exactly when the card went out". */
 interface FakeConsole {
   baseUrl: string;
-  sent: Array<{ conversationId: string; text: string }>;
+  sent: Array<{ conversationId: string; text: string; final?: boolean }>;
   attempts: number;
   failSends: boolean;
 }
@@ -72,7 +72,7 @@ async function fakeConsole(): Promise<FakeConsole> {
           res.end(JSON.stringify({ error: { code: "unavailable", message: "carrier down" } }));
           return;
         }
-        sent.push(JSON.parse(body) as { conversationId: string; text: string });
+        sent.push(JSON.parse(body) as { conversationId: string; text: string; final?: boolean });
         res.end(JSON.stringify({ ok: true }));
         return;
       }
@@ -213,7 +213,7 @@ describe.sequential("consent over text", () => {
     await waitFor(() => host.paid.length === 1);
     expect(host.paid).toEqual([{ billId: "bill_9", amount: 4200 }]);
     await waitFor(() => cloud.sent.length === 3);
-    expect(cloud.sent[2]).toEqual({ conversationId: "conv_approval", text: "Paid the electric bill." });
+    expect(cloud.sent[2]).toEqual({ conversationId: "conv_approval", text: "Paid the electric bill.", final: true });
   }, 120_000);
 
   it("never decides a card that did not go out over this channel", async () => {

--- a/packages/vendo/tests/channel-arming-consent.e2e.test.ts
+++ b/packages/vendo/tests/channel-arming-consent.e2e.test.ts
@@ -64,7 +64,7 @@ afterEach(async () => {
 
 interface FakeConsole {
   baseUrl: string;
-  sent: Array<{ conversationId: string; text: string }>;
+  sent: Array<{ conversationId: string; text: string; final?: boolean }>;
 }
 
 async function fakeConsole(): Promise<FakeConsole> {
@@ -84,7 +84,7 @@ async function fakeConsole(): Promise<FakeConsole> {
         return;
       }
       if (req.url === "/api/v1/channels/text/send") {
-        state.sent.push(JSON.parse(body) as { conversationId: string; text: string });
+        state.sent.push(JSON.parse(body) as { conversationId: string; text: string; final?: boolean });
         res.end(JSON.stringify({ ok: true }));
         return;
       }
@@ -392,7 +392,7 @@ describe.sequential("job-shaped arming consent, over the channel that armed it",
     });
     expect(host.reads).toBe(before + 1);
     expect(cloud.sent.slice(landed)).toEqual([
-      { conversationId: CONVERSATION, text: "Your checking balance is $412.08." },
+      { conversationId: CONVERSATION, text: "Your checking balance is $412.08.", final: true },
     ]);
   }, 120_000);
 

--- a/packages/vendo/tests/channel-grant-set.e2e.test.ts
+++ b/packages/vendo/tests/channel-grant-set.e2e.test.ts
@@ -69,7 +69,7 @@ afterEach(async () => {
 
 interface FakeConsole {
   baseUrl: string;
-  sent: Array<{ conversationId: string; text: string }>;
+  sent: Array<{ conversationId: string; text: string; final?: boolean }>;
 }
 
 async function fakeConsole(): Promise<FakeConsole> {
@@ -89,7 +89,7 @@ async function fakeConsole(): Promise<FakeConsole> {
         return;
       }
       if (req.url === "/api/v1/channels/text/send") {
-        state.sent.push(JSON.parse(body) as { conversationId: string; text: string });
+        state.sent.push(JSON.parse(body) as { conversationId: string; text: string; final?: boolean });
         res.end(JSON.stringify({ ok: true }));
         return;
       }
@@ -311,7 +311,7 @@ describe.sequential("an automation's grant set, asked over text", () => {
       status: "ok",
     });
     expect(cloud.sent.slice(landed)).toEqual([
-      { conversationId: CONVERSATION, text: "Your checking balance is $412.08." },
+      { conversationId: CONVERSATION, text: "Your checking balance is $412.08.", final: true },
     ]);
   }, 120_000);
 
@@ -344,7 +344,7 @@ describe.sequential("an automation's grant set, asked over text", () => {
     let landed = cloud.sent.length;
     await vendo.emit("balance.checked", {}, owner);
     expect(cloud.sent.slice(landed)).toEqual([
-      { conversationId: CONVERSATION, text: "Your checking balance is $412.08." },
+      { conversationId: CONVERSATION, text: "Your checking balance is $412.08.", final: true },
     ]);
 
     // Then the person takes the Text me permission back. THE OTHER HALF of the
@@ -380,7 +380,7 @@ describe.sequential("an automation's grant set, asked over text", () => {
     landed = cloud.sent.length;
     await vendo.emit("balance.checked", {}, owner);
     expect(cloud.sent.slice(landed)).toEqual([
-      { conversationId: CONVERSATION, text: "Your checking balance is $412.08." },
+      { conversationId: CONVERSATION, text: "Your checking balance is $412.08.", final: true },
     ]);
   }, 120_000);
 

--- a/packages/vendo/tests/channel-imessage.e2e.test.ts
+++ b/packages/vendo/tests/channel-imessage.e2e.test.ts
@@ -38,7 +38,7 @@ afterEach(async () => {
     "the console was down exactly when the reply went out". */
 interface FakeConsole {
   baseUrl: string;
-  sent: Array<{ conversationId: string; text: string }>;
+  sent: Array<{ conversationId: string; text: string; final?: boolean }>;
   attempts: number;
   failSends: boolean;
 }
@@ -66,7 +66,7 @@ async function fakeConsole(): Promise<FakeConsole> {
           res.end(JSON.stringify({ error: { code: "unavailable", message: "carrier down" } }));
           return;
         }
-        state.sent.push(JSON.parse(body) as { conversationId: string; text: string });
+        state.sent.push(JSON.parse(body) as { conversationId: string; text: string; final?: boolean });
         res.end(JSON.stringify({ ok: true }));
         return;
       }
@@ -156,7 +156,7 @@ interface Run {
 }
 
 describe.sequential("how a texted reply arrives", () => {
-  it("sends each text the moment its divider passes, and never sends the divider", async () => {
+  it("sends each text the moment its divider passes, and marks only the last one final", async () => {
     // THE POINT: a reply the model wrote as two texts has to LAND as two texts,
     // the first one while the second is still being written. Buffering the whole
     // turn and sending one message at the end is the behaviour this replaces —
@@ -197,12 +197,19 @@ describe.sequential("how a texted reply arrives", () => {
     // the second — this is the whole latency win, and it cannot be faked by a
     // buffered implementation.
     await waitFor(() => cloud.sent.length === 2);
-    expect(cloud.sent[1]).toEqual({ conversationId: CONVERSATION, text: "On it." });
+    // …and it says so: more of this reply is still being written, which is what
+    // lets the other side keep the typing indicator up instead of guessing.
+    expect(cloud.sent[1]).toEqual({ conversationId: CONVERSATION, text: "On it.", final: false });
 
     release();
 
     await waitFor(() => cloud.sent.length === 3);
-    expect(cloud.sent[2]).toEqual({ conversationId: CONVERSATION, text: "You spent $412 on food." });
+    // The last text carries the opposite claim — including here, where the model
+    // signed off with a divider and no newline after it, so the cut that
+    // delivered this text is only recognized once the stream has ended.
+    expect(cloud.sent[2]).toEqual({ conversationId: CONVERSATION, text: "You spent $412 on food.", final: true });
+    // The link ack is one whole message and nothing follows it.
+    expect(cloud.sent[0]?.final).toBe(true);
     // The divider is a cut point, not content: it is stripped from what goes
     // out, and a trailing one adds no fourth text of its own.
     await waitFor(() => warmed);

--- a/packages/vendo/tests/channel-wire.e2e.test.ts
+++ b/packages/vendo/tests/channel-wire.e2e.test.ts
@@ -35,7 +35,7 @@ afterEach(async () => {
 /** What the console received, in order. */
 interface FakeConsole {
   baseUrl: string;
-  sent: Array<{ conversationId: string; text: string }>;
+  sent: Array<{ conversationId: string; text: string; final?: boolean }>;
   registered: Array<{ url: string; secret: string }>;
 }
 
@@ -59,7 +59,7 @@ async function fakeConsole(): Promise<FakeConsole> {
         return;
       }
       if (req.url === "/api/v1/channels/text/send") {
-        sent.push(payload as unknown as { conversationId: string; text: string });
+        sent.push(payload as unknown as { conversationId: string; text: string; final?: boolean });
         res.end(JSON.stringify({ ok: true }));
         return;
       }
@@ -233,7 +233,7 @@ describe("the inbound door", () => {
     //    conversation.
     expect((await inbound(vendo, { eventId: "evt_turn", text: "what do I owe?" })).status).toBe(202);
     await waitFor(() => cloud.sent.length === 2);
-    expect(cloud.sent[1]).toEqual({ conversationId: "conv_e2e", text: "Two invoices are due." });
+    expect(cloud.sent[1]).toEqual({ conversationId: "conv_e2e", text: "Two invoices are due.", final: true });
 
     // The turn landed in the SAME thread lifecycle the web chat reads.
     const threads = await vendo.harness.threads.list({
@@ -339,7 +339,7 @@ describe("one-text linking — the router's connect tail, relayed ahead", () => 
     // The message that followed it is served as the linked user, not a stranger.
     expect((await inbound(vendo, { eventId: "evt_first", text: "what do I owe?" })).status).toBe(202);
     await waitFor(() => cloud.sent.length === 1);
-    expect(cloud.sent[0]).toEqual({ conversationId: "conv_e2e", text: "Two invoices are due." });
+    expect(cloud.sent[0]).toEqual({ conversationId: "conv_e2e", text: "Two invoices are due.", final: true });
   }, 120_000);
 
   it("answers the text that arrives immediately behind the link", async () => {
@@ -363,7 +363,7 @@ describe("one-text linking — the router's connect tail, relayed ahead", () => 
 
     await inbound(vendo, { eventId: "evt_text_race", text: "what do I owe?" });
     await waitFor(() => cloud.sent.length === 1);
-    expect(cloud.sent[0]).toEqual({ conversationId: "conv_e2e", text: "Two invoices are due." });
+    expect(cloud.sent[0]).toEqual({ conversationId: "conv_e2e", text: "Two invoices are due.", final: true });
   }, 120_000);
 
   it("ignores a link delivery whose code is not live, and stays a stranger", async () => {

--- a/packages/vendo/tests/text-me.e2e.test.ts
+++ b/packages/vendo/tests/text-me.e2e.test.ts
@@ -48,7 +48,7 @@ afterEach(async () => {
  *  really went out rather than that a tool said "ok". */
 interface FakeConsole {
   baseUrl: string;
-  sent: Array<{ conversationId: string; text: string }>;
+  sent: Array<{ conversationId: string; text: string; final?: boolean }>;
   /** On, the router has no live assignment for the conversation: a 404, exactly
    *  as a lapsed iMessage identity answers. */
   failSends: boolean;
@@ -76,7 +76,7 @@ async function fakeConsole(): Promise<FakeConsole> {
           res.end(JSON.stringify({ error: { code: "not-found", message: "no active assignment" } }));
           return;
         }
-        state.sent.push(JSON.parse(body) as { conversationId: string; text: string });
+        state.sent.push(JSON.parse(body) as { conversationId: string; text: string; final?: boolean });
         res.end(JSON.stringify({ ok: true }));
         return;
       }
@@ -219,7 +219,7 @@ describe.sequential("Text me", () => {
     expect(run?.steps).toMatchObject([{ id: "tell", tool: VENDO_TEXT_ME_TOOL, outcome: "ok" }]);
     // And the console really received it, on the conversation the link row
     // learned from the person's own message.
-    expect(cloud.sent[2]).toEqual({ conversationId: CONVERSATION, text: "Your rent cleared." });
+    expect(cloud.sent[2]).toEqual({ conversationId: CONVERSATION, text: "Your rent cleared.", final: true });
   }, 120_000);
 
   it("parks a live turn's text behind the same card any other write earns", async () => {


### PR DESCRIPTION
A reply the model splits at a divider goes out in pieces — that is the whole
point of `streamTexts` — but on the wire every piece looked identical to a whole
answer, so the far side could only guess whether to keep the typing indicator up
or take it down.

## What changed

- `ChannelsService.send` takes an optional `final`. The Cloud adapter posts the
  input object straight through, so `/api/v1/channels/text/send` carries it with
  no adapter change at all. Optional on purpose: a BYO implementation written
  against the older shape is still a `ChannelsService`, and a carrier with
  nothing to do with the flag ignores it.
- `streamTexts` reads finality off the STREAM, not off the divider. A segment
  goes out the moment its divider passes and what follows may be a tool call
  that takes three seconds or nothing at all, so a cut made while the reader is
  open is `final: false` and one made after it is done is `final: true`. That is
  also what marks the last text of a reply signed off with a trailing `---`:
  that cut is only recognized once the stream has ended.
- Every other send is one whole message with nothing behind it, and says so: the
  approval card and the grant-set ask are questions the conversation then waits
  on, the two set receipts and the "you're linked" ack end their exchange, the
  `NOTHING_TO_SAY` fallback is the turn's only word, and a `vendo_text_me` push
  has no stream at all.

## Not in this change

The short-texts teaching S2 asked for is already on `main` — `TEXT_STYLE`
(`channel-turn.ts`) has carried both halves since #1463: `PLAIN_TEXT_RULE`
("write like a text: one short paragraph…") and the divider sentence ("separate
distinct texts with a line containing only `---` … split anything a person would
send as two texts instead of writing one long one"). It rides only on the
channel turn's message parts, so web chat prompts are untouched. Nothing to add.

## Tests

Real path end to end, nothing stubbed on either side of the seam — a real
inbound delivery through the real wire, the real harness stream, the real
channel adapter, and a real HTTP console reading the posted body.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks the last piece of a streamed text reply so clients keep typing indicators accurate. Previously every piece looked like a whole message; now mid-reply pieces send with final: false and the last piece sends with final: true.

- Adds optional final to `ChannelsService.send` and forwards it to `/api/v1/channels/text/send`; BYO implementations remain valid if they ignore it.
- `streamTexts` sets final based on stream completion, not divider position; a trailing divider marks final only once the stream ends.
- All non-stream sends (approval card, grant-set ask, set receipts, link ack, `vendo_text_me`) send with final: true.
- Updates e2e tests to assert the new payload shape and final values.

<sup>Written for commit 9e6c522601a33274863ecd7c1b3ffc7bdedbf133. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

