### PR TITLE
perf(vendo): a texted reply stops waiting for three things it does not need

### DIFF
--- a/.changeset/channel-send-final-flag.md
+++ b/.changeset/channel-send-final-flag.md
@@ -1,0 +1,33 @@
+---
+"@vendoai/vendo": patch
+---
+
+Every text this channel sends now says whether it is the last one. A reply the
+model splits at a divider goes out in pieces, and until now each piece looked
+exactly like a whole answer on the wire — so the far side could only guess
+whether to keep the typing indicator up or take it down, and it guessed wrong in
+both directions: dropped between "On it." and the answer, or left spinning after
+the last word.
+
+`ChannelsService.send` takes an optional `final`, and the Cloud adapter passes it
+straight through to `/api/v1/channels/text/send`. Optional on purpose — a host
+carrying its own texts keeps the implementation it already wrote, and a carrier
+with nothing to do with the flag ignores it.
+
+The flag scopes to one MESSAGE, never to the turn. It says "no more of this text
+is coming", not "nothing else will arrive" — nothing could say the second one,
+because `vendo_text_me` and an automation firing reach the same conversation at
+any moment, and a turn's own grant-set question is decided from the live approval
+feed only after the reply has gone out. A receiver reads it to stop showing a
+reply as still-being-written, never as "stop listening".
+
+The value is decided by what each send truthfully is, never by position. Only
+`streamTexts` has a mid-reply cut to declare, and it reads finality off the
+stream rather than off the divider: the segment goes out the moment its divider
+passes, and what comes next may be a tool call that takes three seconds or
+nothing at all, so the end of the stream is what settles it. That is also what
+marks the last text of a reply signed off with a divider — that cut is only
+recognized once the stream has ended. Everything else is one whole message with
+nothing behind it: an approval card and a grant-set ask are questions the
+conversation then waits on, the set receipts and the "you're linked" ack end
+their exchange, and a `vendo_text_me` push has no stream behind it at all.

--- a/.changeset/channel-turn-hotpath.md
+++ b/.changeset/channel-turn-hotpath.md
@@ -1,0 +1,29 @@
+---
+"@vendoai/vendo": patch
+---
+
+Three things a texted reply used to wait for, and now does not.
+
+The host's memberships seam was asked FIRST, before the turn did anything else —
+a round trip in front of somebody holding a phone, taken for a ctx that nothing
+until `harness.stream` reads. It is now started at the top and awaited at the
+ctx, so the guard and store reads a YES/NO costs overlap it instead of queueing
+behind it, and a YES that settles an automation's grant set — which builds no
+ctx at all — never waits for it.
+
+The link write moved BEHIND the answer. It has two readers and only one of them
+can run during the turn: `vendo_text_me` reads the conversation off that row
+(text-me.ts) and nothing else writes it, so a turn that would change what it
+reads — a phone's first ever, a conversation that has moved — still waits. The
+other reader is the next text on this conversation, and the per-conversation
+queue cannot start that turn until this one's promise settles, so awaiting the
+write below the reply is early enough for it.
+
+And `vendo_automate` joins the always-active set beside `vendo_text_me`. The
+belt is cut safest-first at 24 tools, so on a surface with more reads than that
+every WRITE is evicted — which is what buried Text me twice in two days. The
+arming tool is a write too, and it is the ONE thing this channel's hidden
+grounding tells the model to reach for on every inbound text ("to text the user
+later, set up an automation for it"). A texted "text me when the rent clears"
+was therefore a `find_tools` round on the first turn of every fresh thread, for
+a capability the prompt had just promised.

--- a/packages/vendo/src/channel-turn.ts
+++ b/packages/vendo/src/channel-turn.ts
@@ -466,21 +466,15 @@ export async function runChannelTurn(
   // Asserted, never stored — one call, like the wire's own resolver. A link is
   // minted for a host subject, so this principal is never the ephemeral visitor
   // that resolver skips the seam for.
-  const memberships = await deps.memberships?.(principal);
-  const ctx: RunContext = {
-    principal,
-    venue: "chat",
-    presence: "present",
-    sessionId: event.eventId,
-    // What authenticates this turn's HOST calls. `presence: "present"` is true —
-    // a person is holding their phone, which is what lets the guard ask them to
-    // approve a payment — but there is no browser request here, so there are no
-    // credentials to forward. Without this the actions layer takes the present
-    // path, calls the host API with nothing, and the agent ends up apologising
-    // for a sign-in problem the person cannot do anything about.
-    channelLink: { channel: "text", linkedAt: link.linkedAt ?? new Date().toISOString() },
-    ...(memberships === undefined ? {} : { memberships }),
-  };
+  //
+  // STARTED here and awaited at the ctx, never in front of it: this is a host
+  // round trip with somebody holding a phone behind it, and the ctx is the only
+  // thing that wants it. A YES that settles a grant set builds no ctx at all, so
+  // that path overlaps the call and then walks away from it — which is why the
+  // rejection is claimed here, the same bargain `harness-turn.ts`'s `stateRead`
+  // makes: a promise nobody awaits still has to land somewhere.
+  const membershipsRead = deps.memberships?.(principal);
+  void membershipsRead?.catch(() => undefined);
   // Every text this function sends by hand is the turn's last word: a card and a
   // grant-set ask are questions the conversation then waits on, and the two set
   // receipts end the turn. Only `streamTexts` has a mid-reply cut to declare, so
@@ -514,6 +508,22 @@ export async function runChannelTurn(
       return;
     }
   }
+
+  const memberships = await membershipsRead;
+  const ctx: RunContext = {
+    principal,
+    venue: "chat",
+    presence: "present",
+    sessionId: event.eventId,
+    // What authenticates this turn's HOST calls. `presence: "present"` is true —
+    // a person is holding their phone, which is what lets the guard ask them to
+    // approve a payment — but there is no browser request here, so there are no
+    // credentials to forward. Without this the actions layer takes the present
+    // path, calls the host API with nothing, and the agent ends up apologising
+    // for a sign-in problem the person cannot do anything about.
+    channelLink: { channel: "text", linkedAt: link.linkedAt ?? new Date().toISOString() },
+    ...(memberships === undefined ? {} : { memberships }),
+  };
 
   // Subscribed BEFORE the turn: a card can be raised inside the first tool
   // call, and a late subscribe would miss it. Scoped to this conversation, so a
@@ -553,7 +563,25 @@ export async function runChannelTurn(
     // The effective thread, reopened or freshly minted — every door that serves
     // a turn stamps the same header.
     const effective = response.headers.get(THREAD_ID_HEADER);
-    if (effective !== null) await deps.links.rememberTurn(link, effective, event.conversationId);
+    // Behind the answer, not in front of it — on a hosted store this write is a
+    // network call, and it has two readers, only one of which can run during the
+    // turn. `vendo_text_me` reads the CONVERSATION off this row (text-me.ts) and
+    // nothing else writes it, so a turn that would CHANGE what it reads — a
+    // phone's first ever, a conversation that has moved — still waits for it. The
+    // other reader is the next text on this conversation, which reads the THREAD
+    // this names; the per-conversation queue cannot start that turn until this
+    // one's promise settles (compose-channels.ts), so landing the write below the
+    // reply is early enough for it.
+    const remembered = effective === null
+      ? undefined
+      : deps.links.rememberTurn(link, effective, event.conversationId);
+    // Claimed the moment it is started, exactly as `membershipsRead` above is: a
+    // deferred write is unawaited for as long as the reply takes to go out, and
+    // Node's default throw-mode kills the host process over a rejection nobody
+    // has reached yet. This marks it handled without swallowing it — the `await`
+    // below the reply still sees the failure.
+    void remembered?.catch(() => undefined);
+    if (link.conversationId !== event.conversationId) await remembered;
     try {
       if (await streamTexts(response, send) === 0) await send(NOTHING_TO_SAY);
     } catch (error) {
@@ -569,6 +597,9 @@ export async function runChannelTurn(
           + `not replayed: ${error instanceof Error ? error.message : String(error)}`,
       });
     }
+    // The reply is out; the next text on this conversation is what still needs
+    // the write, and it cannot start until this returns.
+    await remembered;
     // The next text in this conversation usually arrives inside the provider's
     // cache TTL, so the prefix is warmed once the person already has their
     // reply — never something they wait behind, and a failure costs nothing but

--- a/packages/vendo/src/channel-turn.ts
+++ b/packages/vendo/src/channel-turn.ts
@@ -352,18 +352,30 @@ function frameText(frame: string): string {
  * lines anywhere, and a `---` that is still being typed might yet turn into
  * `----`. Answers how many texts went out, so the caller can tell a silent turn
  * from a delivered one.
+ *
+ * `final` is the same fact read the other way: a cut made while the stream is
+ * still open has more of the reply behind it, and one made after the reader is
+ * done does not. It cannot be decided at the divider itself — the segment goes
+ * out the moment its divider passes, and what follows may be a tool call that
+ * takes three seconds or nothing at all — so the end of the stream is what
+ * settles it, which is also why a reply signed off with a divider still marks
+ * its last text: that cut is only recognized once the stream has ended.
  */
-async function streamTexts(response: Response, send: (text: string) => Promise<void>): Promise<number> {
+async function streamTexts(
+  response: Response,
+  send: (text: string, final: boolean) => Promise<void>,
+): Promise<number> {
   if (response.body === null) return 0;
   let segment = "";
   let line = "";
   let sent = 0;
+  let ended = false;
   const flush = async (): Promise<void> => {
     const text = segment.trim();
     segment = "";
     if (text === "") return;
     sent += 1;
-    await send(text);
+    await send(text, ended);
   };
   const feed = async (delta: string): Promise<void> => {
     line += delta;
@@ -380,7 +392,10 @@ async function streamTexts(response: Response, send: (text: string) => Promise<v
   let buffer = "";
   for (;;) {
     const { done, value } = await reader.read();
-    if (done) break;
+    if (done) {
+      ended = true;
+      break;
+    }
     buffer += decoder.decode(value, { stream: true });
     for (let cut = buffer.indexOf("\n\n"); cut !== -1; cut = buffer.indexOf("\n\n")) {
       await feed(frameText(buffer.slice(0, cut)));
@@ -466,8 +481,12 @@ export async function runChannelTurn(
     channelLink: { channel: "text", linkedAt: link.linkedAt ?? new Date().toISOString() },
     ...(memberships === undefined ? {} : { memberships }),
   };
-  const send = (text: string): Promise<void> =>
-    deps.channel.send({ conversationId: event.conversationId, text });
+  // Every text this function sends by hand is the turn's last word: a card and a
+  // grant-set ask are questions the conversation then waits on, and the two set
+  // receipts end the turn. Only `streamTexts` has a mid-reply cut to declare, so
+  // it is the only caller that passes the flag.
+  const send = (text: string, final = true): Promise<void> =>
+    deps.channel.send({ conversationId: event.conversationId, text, final });
 
   const answer = event.text.trim();
   if (YES.test(answer) || NO.test(answer)) {

--- a/packages/vendo/src/channels.ts
+++ b/packages/vendo/src/channels.ts
@@ -22,8 +22,23 @@ export interface ChannelsService {
   register(input: { url: string; secret: string }): Promise<TextChannelRegistration>;
   /** One outbound message on a conversation the user already started. There is
    *  no host-initiated send: `conversationId` always comes from an inbound
-   *  event. */
-  send(input: { conversationId: string; text: string }): Promise<void>;
+   *  event.
+   *
+   *  `final` scopes to THIS MESSAGE and never to the turn: `false` means more of
+   *  the text being written is still coming — a reply the model is cutting at
+   *  dividers, mid-stream — and `true` means this message is whole.
+   *
+   *  It is deliberately NOT a promise that nothing else will arrive on the
+   *  conversation, because nothing can promise that: `vendo_text_me` and an
+   *  automation firing reach the same conversation at any moment, and a turn's
+   *  own grant-set question is decided from the live approval feed only after
+   *  the reply has gone out. A receiver reads it to stop showing a reply as
+   *  still-being-written; it must never read it as "stop listening".
+   *
+   *  Optional, so an implementation written against the older shape (a host's own
+   *  Inkbox account) is still a `ChannelsService`, and so a carrier that has
+   *  nothing to do with it can ignore it. */
+  send(input: { conversationId: string; text: string; final?: boolean }): Promise<void>;
 }
 
 /** What the router side answers: the shared triage number a person texts, the

--- a/packages/vendo/src/compose-channels.ts
+++ b/packages/vendo/src/compose-channels.ts
@@ -189,6 +189,7 @@ export const composeChannels = (composition: VendoComposition): Pick<VendoCompos
           await channels.send({
             conversationId: event.conversationId,
             text: "You're linked. Text me anything you'd do in the app.",
+            final: true,
           });
           return;
         }

--- a/packages/vendo/src/compose-harness.ts
+++ b/packages/vendo/src/compose-harness.ts
@@ -5,7 +5,13 @@
  * share, and `vendo_delegate`'s motor.
  */
 import { awayRunner } from "@vendoai/agents";
-import { CONNECTOR_DISCOVERY_TOOLS, VENDO_MAKE_TOOL, type AgentRunner, type Harness } from "@vendoai/core";
+import {
+  CONNECTOR_DISCOVERY_TOOLS,
+  VENDO_AUTOMATE_TOOL,
+  VENDO_MAKE_TOOL,
+  type AgentRunner,
+  type Harness,
+} from "@vendoai/core";
 import { assertHarnessComposable, vendo } from "@vendoai/harnesses";
 import type { VendoComposition } from "./compose-context.js";
 import { storeServesHarnessTurns } from "./compose-store.js";
@@ -30,11 +36,21 @@ import { registerTurnSteer } from "./turn-liveness.js";
  *  Restoring the whole contract belongs to the loadout redesign; the one tool
  *  that broke production does not wait for it.
  *
+ *  `vendo_automate` joins it for the first reason AND the second. The text
+ *  channel's hidden grounding names the automation path on every single inbound
+ *  text — "to text the user later, set up an automation for it" (channel-turn.ts
+ *  TEXT_STYLE) — and arming is a write, so the same safest-first cut that buried
+ *  Text me made the one thing this channel advertises cost a `find_tools` round
+ *  on the first turn of every fresh thread. The exemption rides ON TOP of the
+ *  cap rather than raising it, so the offered set stays inside the 30-50 band
+ *  where selection accuracy is best (tool-search.ts).
+ *
  *  A name with nothing behind it costs nothing: `computeInitialLoadout` filters
  *  the turn's OWN listings through this set (tool-search.ts), so on a deployment
  *  that never opted into texts it simply never matches — no `channels` gate. */
 const PROMPT_TAUGHT_TOOLS: readonly string[] = [
   VENDO_MAKE_TOOL,
+  VENDO_AUTOMATE_TOOL,
   VENDO_TEXT_ME_TOOL,
   ...CONNECTOR_DISCOVERY_TOOLS,
 ];

--- a/packages/vendo/src/text-me.ts
+++ b/packages/vendo/src/text-me.ts
@@ -104,7 +104,9 @@ export function textMeRegistry(deps: TextMeDeps): ToolRegistry {
         return { status: "error", error: { code: "not-linked", message: noReachablePhone(invite.url) } };
       }
       try {
-        await deps.channel.send({ conversationId: link.conversationId, text });
+        // One whole message with no stream behind it — an automation firing or a
+        // web turn reaching a phone, never a piece of a reply being written.
+        await deps.channel.send({ conversationId: link.conversationId, text, final: true });
       } catch {
         // Loud, and the model's to explain. Rethrowing would surface as "the
         // tool is broken", which the agent retries; a result the person can act

--- a/packages/vendo/tests/away-run-tools.seam.test.ts
+++ b/packages/vendo/tests/away-run-tools.seam.test.ts
@@ -18,7 +18,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { automationsInternals } from "@vendoai/automations";
-import type { Harness, Principal, RunContext, ToolDescriptor, ToolRegistry } from "@vendoai/core";
+import { VENDO_AUTOMATE_TOOL, type Harness, type Principal, type RunContext, type ToolDescriptor, type ToolRegistry } from "@vendoai/core";
 import { defineHarness } from "@vendoai/harnesses";
 import { createStore, type VendoStore } from "@vendoai/store";
 import type { LanguageModel } from "ai";
@@ -130,7 +130,7 @@ async function fire(vendo: Vendo): Promise<void> {
 }
 
 describe.sequential("the belt an away firing is handed", () => {
-  it("keeps vendo_text_me on it however many reads crowd the surface", async () => {
+  it("keeps the tools the prompt teaches on it however many reads crowd the surface", async () => {
     // The channel is configured, so the tool is registered and the grant the
     // person gave it is worth something. `VENDO_CLOUD_URL` points nowhere on
     // purpose: this run never reaches the console, and a stray request must fail
@@ -151,7 +151,14 @@ describe.sequential("the belt an away firing is handed", () => {
     // THE POINT: the power the person granted is on the belt the model was
     // handed. Before this, it was the 25th read's turn and every write lost.
     expect(belt).toContain(VENDO_TEXT_ME_TOOL);
-    // …and the cap really did bite, so the line above is a survivor and not an
+    // …and so is the tool that ARMS it. The channel's hidden grounding names the
+    // automation path on every single inbound text ("to text the user later, set
+    // up an automation for it", channel-turn.ts), and arming is a write — so the
+    // same safest-first cut that buried Text me made the one thing this channel
+    // advertises cost a `find_tools` round on the first turn of every fresh
+    // thread.
+    expect(belt).toContain(VENDO_AUTOMATE_TOOL);
+    // …and the cap really did bite, so the lines above are survivors and not an
     // accident of a surface that fit whole.
     expect(belt.filter((name) => name.startsWith("maple_read_")).length).toBeLessThan(READS);
   }, 60_000);

--- a/packages/vendo/tests/channel-approval.e2e.test.ts
+++ b/packages/vendo/tests/channel-approval.e2e.test.ts
@@ -43,7 +43,7 @@ afterEach(async () => {
     "the vendor was down exactly when the card went out". */
 interface FakeConsole {
   baseUrl: string;
-  sent: Array<{ conversationId: string; text: string }>;
+  sent: Array<{ conversationId: string; text: string; final?: boolean }>;
   attempts: number;
   failSends: boolean;
 }
@@ -72,7 +72,7 @@ async function fakeConsole(): Promise<FakeConsole> {
           res.end(JSON.stringify({ error: { code: "unavailable", message: "carrier down" } }));
           return;
         }
-        sent.push(JSON.parse(body) as { conversationId: string; text: string });
+        sent.push(JSON.parse(body) as { conversationId: string; text: string; final?: boolean });
         res.end(JSON.stringify({ ok: true }));
         return;
       }
@@ -213,7 +213,7 @@ describe.sequential("consent over text", () => {
     await waitFor(() => host.paid.length === 1);
     expect(host.paid).toEqual([{ billId: "bill_9", amount: 4200 }]);
     await waitFor(() => cloud.sent.length === 3);
-    expect(cloud.sent[2]).toEqual({ conversationId: "conv_approval", text: "Paid the electric bill." });
+    expect(cloud.sent[2]).toEqual({ conversationId: "conv_approval", text: "Paid the electric bill.", final: true });
   }, 120_000);
 
   it("never decides a card that did not go out over this channel", async () => {

--- a/packages/vendo/tests/channel-arming-consent.e2e.test.ts
+++ b/packages/vendo/tests/channel-arming-consent.e2e.test.ts
@@ -64,7 +64,7 @@ afterEach(async () => {
 
 interface FakeConsole {
   baseUrl: string;
-  sent: Array<{ conversationId: string; text: string }>;
+  sent: Array<{ conversationId: string; text: string; final?: boolean }>;
 }
 
 async function fakeConsole(): Promise<FakeConsole> {
@@ -84,7 +84,7 @@ async function fakeConsole(): Promise<FakeConsole> {
         return;
       }
       if (req.url === "/api/v1/channels/text/send") {
-        state.sent.push(JSON.parse(body) as { conversationId: string; text: string });
+        state.sent.push(JSON.parse(body) as { conversationId: string; text: string; final?: boolean });
         res.end(JSON.stringify({ ok: true }));
         return;
       }
@@ -392,7 +392,7 @@ describe.sequential("job-shaped arming consent, over the channel that armed it",
     });
     expect(host.reads).toBe(before + 1);
     expect(cloud.sent.slice(landed)).toEqual([
-      { conversationId: CONVERSATION, text: "Your checking balance is $412.08." },
+      { conversationId: CONVERSATION, text: "Your checking balance is $412.08.", final: true },
     ]);
   }, 120_000);
 

--- a/packages/vendo/tests/channel-grant-set.e2e.test.ts
+++ b/packages/vendo/tests/channel-grant-set.e2e.test.ts
@@ -69,7 +69,7 @@ afterEach(async () => {
 
 interface FakeConsole {
   baseUrl: string;
-  sent: Array<{ conversationId: string; text: string }>;
+  sent: Array<{ conversationId: string; text: string; final?: boolean }>;
 }
 
 async function fakeConsole(): Promise<FakeConsole> {
@@ -89,7 +89,7 @@ async function fakeConsole(): Promise<FakeConsole> {
         return;
       }
       if (req.url === "/api/v1/channels/text/send") {
-        state.sent.push(JSON.parse(body) as { conversationId: string; text: string });
+        state.sent.push(JSON.parse(body) as { conversationId: string; text: string; final?: boolean });
         res.end(JSON.stringify({ ok: true }));
         return;
       }
@@ -311,7 +311,7 @@ describe.sequential("an automation's grant set, asked over text", () => {
       status: "ok",
     });
     expect(cloud.sent.slice(landed)).toEqual([
-      { conversationId: CONVERSATION, text: "Your checking balance is $412.08." },
+      { conversationId: CONVERSATION, text: "Your checking balance is $412.08.", final: true },
     ]);
   }, 120_000);
 
@@ -344,7 +344,7 @@ describe.sequential("an automation's grant set, asked over text", () => {
     let landed = cloud.sent.length;
     await vendo.emit("balance.checked", {}, owner);
     expect(cloud.sent.slice(landed)).toEqual([
-      { conversationId: CONVERSATION, text: "Your checking balance is $412.08." },
+      { conversationId: CONVERSATION, text: "Your checking balance is $412.08.", final: true },
     ]);
 
     // Then the person takes the Text me permission back. THE OTHER HALF of the
@@ -380,7 +380,7 @@ describe.sequential("an automation's grant set, asked over text", () => {
     landed = cloud.sent.length;
     await vendo.emit("balance.checked", {}, owner);
     expect(cloud.sent.slice(landed)).toEqual([
-      { conversationId: CONVERSATION, text: "Your checking balance is $412.08." },
+      { conversationId: CONVERSATION, text: "Your checking balance is $412.08.", final: true },
     ]);
   }, 120_000);
 

--- a/packages/vendo/tests/channel-imessage.e2e.test.ts
+++ b/packages/vendo/tests/channel-imessage.e2e.test.ts
@@ -38,7 +38,7 @@ afterEach(async () => {
     "the console was down exactly when the reply went out". */
 interface FakeConsole {
   baseUrl: string;
-  sent: Array<{ conversationId: string; text: string }>;
+  sent: Array<{ conversationId: string; text: string; final?: boolean }>;
   attempts: number;
   failSends: boolean;
 }
@@ -66,7 +66,7 @@ async function fakeConsole(): Promise<FakeConsole> {
           res.end(JSON.stringify({ error: { code: "unavailable", message: "carrier down" } }));
           return;
         }
-        state.sent.push(JSON.parse(body) as { conversationId: string; text: string });
+        state.sent.push(JSON.parse(body) as { conversationId: string; text: string; final?: boolean });
         res.end(JSON.stringify({ ok: true }));
         return;
       }
@@ -156,7 +156,7 @@ interface Run {
 }
 
 describe.sequential("how a texted reply arrives", () => {
-  it("sends each text the moment its divider passes, and never sends the divider", async () => {
+  it("sends each text the moment its divider passes, and marks only the last one final", async () => {
     // THE POINT: a reply the model wrote as two texts has to LAND as two texts,
     // the first one while the second is still being written. Buffering the whole
     // turn and sending one message at the end is the behaviour this replaces —
@@ -197,12 +197,19 @@ describe.sequential("how a texted reply arrives", () => {
     // the second — this is the whole latency win, and it cannot be faked by a
     // buffered implementation.
     await waitFor(() => cloud.sent.length === 2);
-    expect(cloud.sent[1]).toEqual({ conversationId: CONVERSATION, text: "On it." });
+    // …and it says so: more of this reply is still being written, which is what
+    // lets the other side keep the typing indicator up instead of guessing.
+    expect(cloud.sent[1]).toEqual({ conversationId: CONVERSATION, text: "On it.", final: false });
 
     release();
 
     await waitFor(() => cloud.sent.length === 3);
-    expect(cloud.sent[2]).toEqual({ conversationId: CONVERSATION, text: "You spent $412 on food." });
+    // The last text carries the opposite claim — including here, where the model
+    // signed off with a divider and no newline after it, so the cut that
+    // delivered this text is only recognized once the stream has ended.
+    expect(cloud.sent[2]).toEqual({ conversationId: CONVERSATION, text: "You spent $412 on food.", final: true });
+    // The link ack is one whole message and nothing follows it.
+    expect(cloud.sent[0]?.final).toBe(true);
     // The divider is a cut point, not content: it is stripped from what goes
     // out, and a trailing one adds no fourth text of its own.
     await waitFor(() => warmed);

--- a/packages/vendo/tests/channel-turn-hotpath.test.ts
+++ b/packages/vendo/tests/channel-turn-hotpath.test.ts
@@ -1,0 +1,165 @@
+/**
+ * WHAT A TEXTED REPLY IS ALLOWED TO WAIT FOR.
+ *
+ * Two calls used to stand between an inbound text and the first word on the
+ * person's phone, and neither one is something the answer depends on: the host's
+ * memberships seam, asked before anything else the turn does, and the link write
+ * that remembers which thread this conversation is running in — a network call
+ * on a hosted store.
+ *
+ * They are still guaranteed, just no longer in front of the answer, and the
+ * guarantees are what these cases pin. The link write has two readers and the
+ * order below is theirs: `vendo_text_me` reads the CONVERSATION off the same row
+ * mid-turn (text-me.ts) and nothing else writes it, so a first-ever turn still
+ * waits; the next text on this conversation reads the THREAD it names, and the
+ * per-conversation queue (compose-channels.ts) cannot start that turn until this
+ * one's promise settles — so the write is awaited before the turn returns,
+ * behind the reply instead of in front of it.
+ *
+ * Nothing here asserts on wall-clock time: the write settles a few event-loop
+ * turns late and the cases read the ORDER it settled in, so what they prove is
+ * decided by the code and never by how busy the machine is.
+ */
+import { THREAD_ID_HEADER } from "@vendoai/harnesses";
+import { describe, expect, it } from "vitest";
+import type { ChannelLink } from "../src/channel-links.js";
+import { runChannelTurn } from "../src/channel-turn.js";
+
+const link: ChannelLink = {
+  id: "chl_hot",
+  subject: "user_hot",
+  phone: "+15551230123",
+  linkedAt: "2026-08-19T10:22:10.710Z",
+};
+
+const event = {
+  eventId: "evt_hot",
+  channel: "text" as const,
+  from: "+15551230123",
+  text: "what did I spend on food last month?",
+  conversationId: "conv_hot",
+  receivedAt: "2026-08-19T10:22:11.211Z",
+};
+
+/** A link write that lands a few event-loop turns late — long enough for a reply
+ *  that does not wait for it to get ahead of it, and short enough that one which
+ *  does wait still finishes. */
+const slowWrite = (order: string[]) => async (): Promise<void> => {
+  for (let hop = 0; hop < 5; hop += 1) await new Promise((resolve) => setTimeout(resolve, 0));
+  order.push("wrote");
+};
+
+function turnDeps(order: string[], overrides: Record<string, unknown> = {}) {
+  return {
+    harness: {
+      stream: async () => new Response("data: {\"type\":\"text-delta\",\"delta\":\"ok\"}\n\n", {
+        headers: { "content-type": "text/event-stream", [THREAD_ID_HEADER]: "thr_hot" },
+      }),
+    },
+    guard: {
+      onApprovalRequested: () => () => undefined,
+      approvals: { pending: async () => [], decide: async () => undefined },
+    },
+    channel: { send: async () => { order.push("sent"); } },
+    links: { rememberTurn: slowWrite(order) },
+    asks: {
+      ids: async () => [],
+      add: async () => undefined,
+      consume: async () => undefined,
+      setAsk: async () => null,
+      consumeSet: async () => undefined,
+    },
+    ...overrides,
+  } as unknown as Parameters<typeof runChannelTurn>[0];
+}
+
+describe("what a texted reply waits for", () => {
+  it("answers while the link write is still in flight, and still lands it before the turn ends", async () => {
+    const order: string[] = [];
+    // The write is HELD until the reply is out, so a turn that still waits for it
+    // never sends anything at all and the case's own timeout says so. The row
+    // already names this conversation, which is exactly when overlapping is safe:
+    // the one reader a tool could reach mid-turn already has its answer.
+    let release = (): void => undefined;
+    const held = new Promise<void>((resolve) => { release = resolve; });
+    const deps = turnDeps(order, {
+      channel: { send: async () => { order.push("sent"); release(); } },
+      links: { rememberTurn: async () => { await held; order.push("wrote"); } },
+    });
+
+    await runChannelTurn(deps, { event, link: { ...link, conversationId: event.conversationId } });
+
+    expect(order).toEqual(["sent", "wrote"]);
+  });
+
+  it("claims the deferred write's rejection while it is still deferred, and surfaces it after the reply", async () => {
+    // THE POINT: a promise nobody is awaiting YET is a promise Node considers
+    // unhandled. The reply takes as long as the model does, so a hosted link
+    // store that refuses the write early leaves the rejection unclaimed for that
+    // whole window — and Node's default throw-mode kills the host process there,
+    // before the person holding the phone gets a single word.
+    const order: string[] = [];
+    const unhandled: unknown[] = [];
+    const watch = (reason: unknown): void => { unhandled.push(reason); };
+    process.on("unhandledRejection", watch);
+    try {
+      const deps = turnDeps(order, {
+        // The refusal lands FIRST; the reply is still going out for another
+        // 20ms, which is the window the claim has to cover.
+        links: { rememberTurn: async () => { throw new Error("link store is down"); } },
+        channel: {
+          send: async () => {
+            order.push("sent");
+            await new Promise((resolve) => setTimeout(resolve, 20));
+          },
+        },
+      });
+
+      await expect(runChannelTurn(deps, { event, link: { ...link, conversationId: event.conversationId } }))
+        .rejects.toThrow("link store is down");
+
+      // Claimed, never swallowed: the reply went out first and the failure still
+      // reaches the caller at the await below it.
+      expect(unhandled).toEqual([]);
+      expect(order).toEqual(["sent"]);
+    } finally {
+      process.off("unhandledRejection", watch);
+    }
+  });
+
+  it("waits for the write on the first turn a phone ever sends, so Text me can find the conversation", async () => {
+    const order: string[] = [];
+
+    // No conversation on the row yet. `vendo_text_me` would be told there is no
+    // phone to reach, on the one turn where the person is definitely holding it.
+    await runChannelTurn(turnDeps(order), { event, link });
+
+    expect(order).toEqual(["wrote", "sent"]);
+  });
+
+  it("settles a grant-set answer without waiting on the host's memberships call", async () => {
+    const order: string[] = [];
+    const sent: string[] = [];
+    // A host whose seam never answers. The set decision needs no ctx at all, so
+    // it must not be queued behind a round trip taken for one.
+    const deps = turnDeps(order, {
+      memberships: () => new Promise<never>(() => undefined),
+      channel: { send: async (input: { text: string }) => { sent.push(input.text); } },
+      guard: {
+        onApprovalRequested: () => () => undefined,
+        approvals: { pending: async () => [{ id: "apr_set" }], decide: async () => undefined },
+      },
+      asks: {
+        ids: async () => [],
+        add: async () => undefined,
+        consume: async () => undefined,
+        setAsk: async () => ({ automationId: "atm_hot", approvals: ["apr_set"] }),
+        consumeSet: async () => undefined,
+      },
+    });
+
+    await runChannelTurn(deps, { event: { ...event, text: "YES" }, link });
+
+    expect(sent).toEqual(["Done — it can run on its own now."]);
+  });
+});

--- a/packages/vendo/tests/channel-wire.e2e.test.ts
+++ b/packages/vendo/tests/channel-wire.e2e.test.ts
@@ -35,7 +35,7 @@ afterEach(async () => {
 /** What the console received, in order. */
 interface FakeConsole {
   baseUrl: string;
-  sent: Array<{ conversationId: string; text: string }>;
+  sent: Array<{ conversationId: string; text: string; final?: boolean }>;
   registered: Array<{ url: string; secret: string }>;
 }
 
@@ -59,7 +59,7 @@ async function fakeConsole(): Promise<FakeConsole> {
         return;
       }
       if (req.url === "/api/v1/channels/text/send") {
-        sent.push(payload as unknown as { conversationId: string; text: string });
+        sent.push(payload as unknown as { conversationId: string; text: string; final?: boolean });
         res.end(JSON.stringify({ ok: true }));
         return;
       }
@@ -233,7 +233,7 @@ describe("the inbound door", () => {
     //    conversation.
     expect((await inbound(vendo, { eventId: "evt_turn", text: "what do I owe?" })).status).toBe(202);
     await waitFor(() => cloud.sent.length === 2);
-    expect(cloud.sent[1]).toEqual({ conversationId: "conv_e2e", text: "Two invoices are due." });
+    expect(cloud.sent[1]).toEqual({ conversationId: "conv_e2e", text: "Two invoices are due.", final: true });
 
     // The turn landed in the SAME thread lifecycle the web chat reads.
     const threads = await vendo.harness.threads.list({
@@ -339,7 +339,7 @@ describe("one-text linking — the router's connect tail, relayed ahead", () => 
     // The message that followed it is served as the linked user, not a stranger.
     expect((await inbound(vendo, { eventId: "evt_first", text: "what do I owe?" })).status).toBe(202);
     await waitFor(() => cloud.sent.length === 1);
-    expect(cloud.sent[0]).toEqual({ conversationId: "conv_e2e", text: "Two invoices are due." });
+    expect(cloud.sent[0]).toEqual({ conversationId: "conv_e2e", text: "Two invoices are due.", final: true });
   }, 120_000);
 
   it("answers the text that arrives immediately behind the link", async () => {
@@ -363,7 +363,7 @@ describe("one-text linking — the router's connect tail, relayed ahead", () => 
 
     await inbound(vendo, { eventId: "evt_text_race", text: "what do I owe?" });
     await waitFor(() => cloud.sent.length === 1);
-    expect(cloud.sent[0]).toEqual({ conversationId: "conv_e2e", text: "Two invoices are due." });
+    expect(cloud.sent[0]).toEqual({ conversationId: "conv_e2e", text: "Two invoices are due.", final: true });
   }, 120_000);
 
   it("ignores a link delivery whose code is not live, and stays a stranger", async () => {

--- a/packages/vendo/tests/text-me.e2e.test.ts
+++ b/packages/vendo/tests/text-me.e2e.test.ts
@@ -48,7 +48,7 @@ afterEach(async () => {
  *  really went out rather than that a tool said "ok". */
 interface FakeConsole {
   baseUrl: string;
-  sent: Array<{ conversationId: string; text: string }>;
+  sent: Array<{ conversationId: string; text: string; final?: boolean }>;
   /** On, the router has no live assignment for the conversation: a 404, exactly
    *  as a lapsed iMessage identity answers. */
   failSends: boolean;
@@ -76,7 +76,7 @@ async function fakeConsole(): Promise<FakeConsole> {
           res.end(JSON.stringify({ error: { code: "not-found", message: "no active assignment" } }));
           return;
         }
-        state.sent.push(JSON.parse(body) as { conversationId: string; text: string });
+        state.sent.push(JSON.parse(body) as { conversationId: string; text: string; final?: boolean });
         res.end(JSON.stringify({ ok: true }));
         return;
       }
@@ -219,7 +219,7 @@ describe.sequential("Text me", () => {
     expect(run?.steps).toMatchObject([{ id: "tell", tool: VENDO_TEXT_ME_TOOL, outcome: "ok" }]);
     // And the console really received it, on the conversation the link row
     // learned from the person's own message.
-    expect(cloud.sent[2]).toEqual({ conversationId: CONVERSATION, text: "Your rent cleared." });
+    expect(cloud.sent[2]).toEqual({ conversationId: CONVERSATION, text: "Your rent cleared.", final: true });
   }, 120_000);
 
   it("parks a live turn's text behind the same card any other write earns", async () => {


### PR DESCRIPTION
Stacked on https://github.com/runvendo/vendo/pull/1516 — review that one first.

Three things stood between an inbound text and the first word on the person's
phone. None of them is something the answer depends on.

## 1. The memberships seam moved off the front

`deps.memberships?.(principal)` was the turn's very first `await`, taken for a
ctx that nothing reads until `harness.stream`. It is now started at the top and
awaited at the ctx: the guard and store reads a YES/NO costs run alongside it
instead of behind it, and a YES that settles an automation's grant set — a path
that builds no ctx at all — never waits for it. The dropped promise's rejection
is claimed where it starts, the same bargain `harness-turn.ts`'s `stateRead`
makes.

Honest limit: a plain text still has nothing else to overlap with. Everything
between the seam and `harness.stream` on that path is synchronous, so the
serial round trip only disappears for a texted turn that ALSO has a decision to
settle. Removing it for every text means letting the ctx carry a promise into
`harness.stream`, which the brief ruled out.

## 2. The link write moved behind the answer

`links.rememberTurn` was awaited before `streamTexts` began reading the model
stream. It has two readers and only one can run during the turn:

- `vendo_text_me` reads the CONVERSATION off that row mid-turn (`text-me.ts`)
  and nothing else writes it — so a turn that would CHANGE what it reads (a
  phone's first ever, a conversation that has moved) still waits.
- the next text on this conversation reads the THREAD it names, and the
  per-conversation `inOrder` queue cannot start that turn until this one's
  promise settles — so awaiting the write below the reply is early enough.

## 3. `vendo_automate` joins the always-active set

The belt is cut safest-first at 24, so on a surface with more reads than that
every WRITE is evicted — the mechanism that buried `vendo_text_me` twice in two
days. The arming tool is a write too, and it is the ONE thing this channel's
hidden grounding tells the model to reach for, on every single inbound text
("to text the user later, set up an automation for it"). So "text me when the
rent clears" — the sentence the prompt itself invites — cost a `find_tools`
round on the first turn of every fresh thread.

One name on the list composition already keeps for tools its prompt teaches. It
rides ON TOP of the cap rather than raising it, so the offered set stays inside
the 30-50 band where selection accuracy is best.

## What is NOT here, and why

A fuller/configurable initial loadout for channel turns specifically. `Turn`
deliberately carries no `RunContext`, and `harness-turn.ts` passes
`runtime.run<never>` — so per-venue means a new public per-turn option threaded
through two packages, AND picking a number that trades documented tool-selection
accuracy (tool-search.ts: degrades past 30-50 offered tools) for one round trip,
on the surface where a wrong tool choice is most expensive. The deployment-wide
knob for it already exists and Maple already sets it (`maxInitialTools: 64`).
That trade is a product decision, not a mechanical one — flagging rather than
taking it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up text replies by removing three waits that didn’t affect the answer. Old: replies waited on a memberships fetch, a link write, and tool search that could evict writes. New: memberships fetch runs in parallel, the link write happens after the reply (still awaited when needed), and `vendo_automate` is always available.

- Memberships: start `deps.memberships(principal)` immediately and await it only when building the ctx; the grant-set “YES” path settles without waiting. Rejection is claimed at start to avoid unhandled rejections.
- Link write: move `links.rememberTurn` behind the reply. Await it before sending only when the conversation changes (first text or moved thread); otherwise await after sending but before returning, preserving `vendo_text_me` and next-turn queueing guarantees. Its rejection is also claimed when started; failures still surface after the reply. Tests assert this order and handling.
- Tools: add `VENDO_AUTOMATE_TOOL` to the always-active set with `VENDO_TEXT_ME_TOOL` and `CONNECTOR_DISCOVERY_TOOLS` in `@vendoai/vendo`, preventing write-tool eviction under the safe cap without raising the cap. No migration required.

<sup>Written for commit 26c972d6dd58ad0ac5f7ac6f31aba4e39b86662c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1517?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

