### PR TITLE
test: the install seam has a permanent stranger — pack → init → live answer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ concurrency:
 #                     per-package coverage floors (they cannot be enforced on a
 #                     single shard — see the comment on that job)
 #   ci                aggregate; KEEPS the required-check name `ci`
-#   integration-legs  the e2e fleet in 4 duration-balanced legs
+#   integration-legs  the e2e fleet in 5 duration-balanced legs
 #   integration       aggregate; KEEPS the required-check name `integration`
 #   conformance       the three-package conformance suite
 #   audit             supply-chain gate
@@ -519,7 +519,7 @@ jobs:
           fi
           echo "all lanes green"
 
-  # The integration suites, split four ways.
+  # The integration suites, split five ways.
   #
   # This job WAS the whole run's critical path: 493s of a 507s full-suite wall
   # on main run 31930304532, nine suites end to end on one runner while eleven
@@ -599,6 +599,25 @@ jobs:
             guarded: ""
             build: "--filter=@vendoai-corpus/express-host^... --filter=@vendoai-examples/ai-sdk-agent^... --filter=@vendoai-examples/mastra-agent^..."
             suites: "@vendoai-corpus/express-host @vendoai-examples/ai-sdk-agent @vendoai-examples/mastra-agent @vendoai-fixtures/existing-agents-e2e"
+          # The install seam: pack the publish set, `pnpm add` the tarballs into
+          # a stranger app in a temp dir, run the real CLI, boot it, and drive
+          # one deterministic turn. Its own leg rather than a passenger on
+          # `orphans` because it is the slowest of the always-on suites and a
+          # leg of its own costs wall time only when it is the longest.
+          #
+          # UNGUARDED, for a sharper version of the orphans leg's reason: this
+          # suite declares NO workspace dependency at all — it discovers the
+          # publishable packages on disk and packs them — so `--affected` can
+          # never mark it, and a probe would skip every PR including the one
+          # that breaks the install.
+          #
+          # `vendoai...` is the whole publish set in one filter: the alias
+          # depends on the umbrella, which depends on every other block. All
+          # fourteen must carry a real dist/ before they are packed.
+          - name: install-seam
+            guarded: ""
+            build: "--filter=vendoai..."
+            suites: "@vendoai-fixtures/install-seam"
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -127,4 +127,5 @@ packages/vendo/.wire-parity.*
 # Harness/test run outputs — write-only sinks, never committed
 corpus/reports/
 fixtures/existing-agents-e2e/.artifacts/
+fixtures/install-seam/.artifacts/
 genbench/runs/

--- a/fixtures/install-seam/app/.gitignore
+++ b/fixtures/install-seam/app/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+.next/
+vendor/
+.vendo/
+.env*
+pnpm-lock.yaml

--- a/fixtures/install-seam/app/app/api/chat/route.ts
+++ b/fixtures/install-seam/app/app/api/chat/route.ts
@@ -1,0 +1,36 @@
+import { vendoTools } from "@vendoai/vendo/ai-sdk";
+import { convertToModelMessages, stepCountIs, streamText, type UIMessage } from "ai";
+import { scriptedModel, type TurnSpec } from "../../../lib/scripted-model";
+// `vendo` is what `vendo init` writes into lib/vendo.ts. The import exists
+// before init runs — this app is the existing-agent quickstart's starting
+// point, where the loop is already there and Vendo's composition is the piece
+// init supplies.
+import { vendo } from "@/lib/vendo";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+/** The demo principal init's anonymous composition resolves. Both sides must
+ *  name the same subject, or what chat creates is invisible to the embeds. */
+const demoUser = { kind: "user", subject: "demo-user" } as const;
+
+/**
+ * This app's own agent loop — the AI SDK quickstart shape, plus the one touch
+ * the existing-agent quickstart asks for: spread `vendoTools` into the loop's
+ * tools so every host call routes through policy → execution → audit.
+ *
+ * The model's moves arrive in the request body (see lib/scripted-model.ts);
+ * everything downstream of them is the real thing.
+ */
+export async function POST(req: Request): Promise<Response> {
+  const { messages, script } = (await req.json()) as { messages: UIMessage[]; script: TurnSpec[] };
+
+  const result = streamText({
+    model: scriptedModel(script),
+    messages: await convertToModelMessages(messages),
+    stopWhen: stepCountIs(5),
+    tools: await vendoTools(vendo, { principal: demoUser }),
+  });
+
+  return result.toUIMessageStreamResponse();
+}

--- a/fixtures/install-seam/app/app/api/todos/route.ts
+++ b/fixtures/install-seam/app/app/api/todos/route.ts
@@ -1,0 +1,29 @@
+import { createTodo, listTodos } from "../../../lib/todos";
+
+export const dynamic = "force-dynamic";
+
+/** List the signed-in person's todos. */
+export function GET(req: Request): Response {
+  const url = new URL(req.url);
+  const done = url.searchParams.get("done");
+  return Response.json({
+    todos: listTodos(done === null ? undefined : done === "true"),
+  });
+}
+
+/** Add a todo to the list. */
+export async function POST(req: Request): Promise<Response> {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return Response.json({ error: "title is required" }, { status: 400 });
+  }
+
+  const input = typeof body === "object" && body !== null ? (body as { title?: unknown }) : {};
+  if (typeof input.title !== "string" || input.title.length === 0) {
+    return Response.json({ error: "title is required" }, { status: 400 });
+  }
+
+  return Response.json({ todo: createTodo(input.title) });
+}

--- a/fixtures/install-seam/app/app/layout.tsx
+++ b/fixtures/install-seam/app/app/layout.tsx
@@ -1,0 +1,9 @@
+export const metadata = { title: "Stranger Todo" };
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/fixtures/install-seam/app/app/page.tsx
+++ b/fixtures/install-seam/app/app/page.tsx
@@ -1,0 +1,16 @@
+import { listTodos } from "../lib/todos";
+
+export const dynamic = "force-dynamic";
+
+export default function Home() {
+  return (
+    <main>
+      <h1>Todos</h1>
+      <ul>
+        {listTodos().map((todo) => (
+          <li key={todo.id}>{todo.title}</li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/fixtures/install-seam/app/lib/scripted-model.ts
+++ b/fixtures/install-seam/app/lib/scripted-model.ts
@@ -1,0 +1,55 @@
+/**
+ * The one double in this app, and the one a test genuinely cannot avoid:
+ * Anthropic's API. Everything between the caller and this model — the tool
+ * pack, the guard, the actions runtime, /api/todos — stays real.
+ *
+ * This is the repo's own scripted-model dialect (fixtures/test-kit's
+ * `stream-turns.ts`, and the `TurnSpec` wire form
+ * fixtures/integration-browser pushes over HTTP), ported here because a
+ * stranger installs published packages: it cannot import a private workspace
+ * fixture, and `@vendoai/apps/testing` pulls `vitest` into the module graph,
+ * which a running server cannot load. `ai/test` is the published primitive
+ * underneath all three, so that is what this uses.
+ */
+import { MockLanguageModelV3, simulateReadableStream } from "ai/test";
+
+type StreamPart = Awaited<ReturnType<MockLanguageModelV3["doStream"]>>["stream"] extends ReadableStream<infer Part>
+  ? Part
+  : never;
+
+const ZERO_USAGE = {
+  inputTokens: { total: 0, noCache: 0, cacheRead: 0, cacheWrite: 0 },
+  outputTokens: { total: 0, text: 0, reasoning: 0 },
+} as const;
+
+/** One of the model's moves, as it travels in a request body. */
+export type TurnSpec =
+  | { kind: "text"; text: string }
+  | { kind: "tool"; name: string; input: unknown };
+
+function expand(turn: TurnSpec, index: number): StreamPart[] {
+  if (turn.kind === "tool") {
+    return [
+      { type: "tool-call", toolCallId: `call_${index + 1}`, toolName: turn.name, input: JSON.stringify(turn.input) },
+      { type: "finish", usage: ZERO_USAGE, finishReason: { unified: "tool-calls", raw: undefined } },
+    ];
+  }
+  const id = `text_${index + 1}`;
+  return [
+    { type: "text-start", id },
+    { type: "text-delta", id, delta: turn.text },
+    { type: "text-end", id },
+    { type: "finish", usage: ZERO_USAGE, finishReason: { unified: "stop", raw: undefined } },
+  ];
+}
+
+export function scriptedModel(script: readonly TurnSpec[]): MockLanguageModelV3 {
+  const remaining = script.map(expand);
+  return new MockLanguageModelV3({
+    doStream: async () => {
+      const chunks = remaining.shift();
+      if (chunks === undefined) throw new Error("scripted model exhausted");
+      return { stream: simulateReadableStream({ chunks }) };
+    },
+  });
+}

--- a/fixtures/install-seam/app/lib/todos.ts
+++ b/fixtures/install-seam/app/lib/todos.ts
@@ -1,0 +1,25 @@
+/** The stranger app's entire domain: a todo list in memory. Seeded at module
+ *  load so a fresh dev server always answers the same three rows, which is what
+ *  the install-seam assertions read back through the agent. */
+
+export interface Todo {
+  id: string;
+  title: string;
+  done: boolean;
+}
+
+const todos: Todo[] = [
+  { id: "todo_1", title: "Renew the passport", done: false },
+  { id: "todo_2", title: "Book the dentist", done: false },
+  { id: "todo_3", title: "Water the fig tree", done: true },
+];
+
+export function listTodos(done?: boolean): Todo[] {
+  return done === undefined ? [...todos] : todos.filter((todo) => todo.done === done);
+}
+
+export function createTodo(title: string): Todo {
+  const todo: Todo = { id: `todo_${todos.length + 1}`, title, done: false };
+  todos.push(todo);
+  return todo;
+}

--- a/fixtures/install-seam/app/package.json
+++ b/fixtures/install-seam/app/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "stranger-todo-app",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "ai": "6.0.28",
+    "next": "16.2.11",
+    "react": "19.2.4",
+    "react-dom": "19.2.4",
+    "zod": "^3.25.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "@types/react": "^19.2.0",
+    "@types/react-dom": "^19.2.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/fixtures/install-seam/app/tsconfig.json
+++ b/fixtures/install-seam/app/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "ES2022"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": { "@/*": ["./*"] }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/fixtures/install-seam/package.json
+++ b/fixtures/install-seam/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@vendoai-fixtures/install-seam",
+  "version": "0.0.0",
+  "private": true,
+  "description": "The install seam's permanent stranger: pack the publish set, `pnpm add` the tarballs into a Next todo app that has never heard of this monorepo, run the real `vendo init`, boot it, and drive one deterministic turn that answers out of the app's own API and writes back into it.",
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.6.0",
+    "vitest": "^3.2.6"
+  }
+}

--- a/fixtures/install-seam/src/pack.ts
+++ b/fixtures/install-seam/src/pack.ts
@@ -1,0 +1,129 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { run } from "./process.js";
+
+/**
+ * The publish set, packed into tarballs — the same discovery-by-manifest-name
+ * rule the corpus harness and the Lane E journey use (`@vendoai/telemetry`
+ * lives in `packages/vendo-telemetry`, so directory names cannot be trusted).
+ *
+ * The stranger installs THESE, never a `workspace:` link and never a source
+ * import: a link would resolve the umbrella's inter-package deps through the
+ * monorepo, which is the one thing a published install never gets to do.
+ */
+export const VENDO_PACKAGE_NAMES = [
+  "@vendoai/core",
+  "@vendoai/store",
+  "@vendoai/actions",
+  "@vendoai/guard",
+  "@vendoai/knowledge",
+  "@vendoai/mcp",
+  "@vendoai/apps",
+  "@vendoai/automations",
+  "@vendoai/harnesses",
+  "@vendoai/agents",
+  "@vendoai/ui",
+  "@vendoai/telemetry",
+  "@vendoai/vendo",
+  "vendoai",
+] as const;
+
+/** What the stranger declares itself. Everything else arrives as a transitive
+ *  dependency — pinned to a tarball by the overrides, never the registry. */
+export const DIRECT_DEPENDENCIES = ["@vendoai/vendo"] as const;
+
+export interface Tarball {
+  name: string;
+  version: string;
+  fileName: string;
+}
+
+export interface Packed {
+  vendorDir: string;
+  tarballs: Tarball[];
+}
+
+/** Package name → the version this workspace packed for it. Not one shared
+ *  number: `@vendoai/telemetry` versions independently of the umbrella. */
+export function packedVersions(packed: Packed): Record<string, string> {
+  return Object.fromEntries(packed.tarballs.map((tarball) => [tarball.name, tarball.version]));
+}
+
+function npmPackFileName(name: string, version: string): string {
+  const base = name.startsWith("@") ? name.slice(1).replace("/", "-") : name;
+  return `${base}-${version}.tgz`;
+}
+
+/** Packs the publish set from the BUILT workspace into destDir. */
+export async function packWorkspace(workspaceRoot: string, destDir: string): Promise<Packed> {
+  if (workspaceRoot.includes(" ") || destDir.includes(" ")) {
+    throw new Error("the install seam needs space-free paths (file: specs)");
+  }
+  await fs.mkdir(destDir, { recursive: true });
+
+  const byName = new Map<string, { dir: string; version: string }>();
+  for (const entry of await fs.readdir(path.join(workspaceRoot, "packages"), { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const dir = path.join(workspaceRoot, "packages", entry.name);
+    try {
+      const pkg = JSON.parse(await fs.readFile(path.join(dir, "package.json"), "utf8")) as {
+        name?: string;
+        version?: string;
+      };
+      if (typeof pkg.name === "string" && typeof pkg.version === "string") {
+        byName.set(pkg.name, { dir, version: pkg.version });
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  const tarballs: Tarball[] = [];
+  for (const name of VENDO_PACKAGE_NAMES) {
+    const found = byName.get(name);
+    if (found === undefined) throw new Error(`workspace is missing publishable package ${name}`);
+    const fileName = npmPackFileName(name, found.version);
+    await run("pnpm", ["-C", found.dir, "pack", "--pack-destination", destDir], { cwd: workspaceRoot });
+    await fs.access(path.join(destDir, fileName));
+    tarballs.push({ name, version: found.version, fileName });
+  }
+
+  return { vendorDir: destDir, tarballs };
+}
+
+/** `file:` specs are relative to the package that declares them. */
+export function fileSpec(packed: Packed, name: string): string {
+  const tarball = packed.tarballs.find((entry) => entry.name === name);
+  if (tarball === undefined) throw new Error(`nothing packed for ${name}`);
+  return `file:vendor/${tarball.fileName}`;
+}
+
+/**
+ * Copies the tarballs into `<target>/vendor` and pins the WHOLE closure.
+ *
+ * The pin is not optional and it is not cosmetic: `pnpm pack` rewrites the
+ * umbrella's `workspace:*` inter-deps to plain versions, which resolve from the
+ * npm registry. Without the overrides a stranger would install the umbrella's
+ * tarball around twelve PUBLISHED packages and the suite would prove nothing
+ * about this commit. pnpm 11 stopped reading `pnpm.overrides` out of
+ * package.json, so they go in the scaffold's own pnpm-workspace.yaml.
+ */
+export async function vendorInto(targetDir: string, packed: Packed): Promise<void> {
+  const vendorDir = path.join(targetDir, "vendor");
+  await fs.mkdir(vendorDir, { recursive: true });
+  for (const tarball of packed.tarballs) {
+    await fs.copyFile(path.join(packed.vendorDir, tarball.fileName), path.join(vendorDir, tarball.fileName));
+  }
+  const overrides = packed.tarballs
+    .map((tarball) => `  "${tarball.name}": "file:vendor/${tarball.fileName}"`)
+    .join("\n");
+  // pnpm 11 fails an install whose dependencies carry unapproved build scripts.
+  // These two are the ones the umbrella's tree brings and genuinely needs
+  // (esbuild and sharp both fetch a platform binary in theirs), so a real
+  // stranger has to approve them too — noted rather than hidden.
+  const allowBuilds = ["esbuild", "sharp"].map((name) => `  ${name}: true`).join("\n");
+  await fs.writeFile(
+    path.join(targetDir, "pnpm-workspace.yaml"),
+    `overrides:\n${overrides}\nallowBuilds:\n${allowBuilds}\n`,
+  );
+}

--- a/fixtures/install-seam/src/process.ts
+++ b/fixtures/install-seam/src/process.ts
@@ -1,0 +1,60 @@
+import { spawn } from "node:child_process";
+import { createServer } from "node:net";
+
+export interface CommandResult {
+  code: number | null;
+  output: string;
+}
+
+/** Runs a command to completion, capturing merged stdout/stderr. */
+export function run(
+  command: string,
+  args: readonly string[],
+  opts: { cwd: string; env?: NodeJS.ProcessEnv },
+): Promise<CommandResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: opts.cwd,
+      env: opts.env ?? process.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let output = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => { output += chunk; });
+    child.stderr.on("data", (chunk: string) => { output += chunk; });
+    child.on("error", reject);
+    child.on("close", (code) => resolve({ code, output }));
+  });
+}
+
+/** Throws with the captured output on a non-zero exit — the failure message a
+ *  reader can act on, instead of a bare exit code. */
+export async function checked(step: string, result: Promise<CommandResult>): Promise<CommandResult> {
+  const settled = await result;
+  if (settled.code !== 0) {
+    throw new Error(`${step} exited ${settled.code}:\n${settled.output.slice(-6000)}`);
+  }
+  return settled;
+}
+
+/** The fixture-suite port rule: let the OS name a free one, then hand the
+ *  number to the child. */
+export function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const probe = createServer();
+    probe.on("error", reject);
+    probe.listen(0, "127.0.0.1", () => {
+      const address = probe.address();
+      if (address === null || typeof address === "string") {
+        probe.close();
+        reject(new Error("could not reserve a port"));
+        return;
+      }
+      const { port } = address;
+      probe.close(() => resolve(port));
+    });
+  });
+}
+
+export const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));

--- a/fixtures/install-seam/src/stranger.ts
+++ b/fixtures/install-seam/src/stranger.ts
@@ -1,0 +1,411 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { createServer, type Server } from "node:http";
+import { createWriteStream, promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { checked, freePort, run, sleep, type CommandResult } from "./process.js";
+import { DIRECT_DEPENDENCIES, fileSpec, packedVersions, packWorkspace, vendorInto, type Packed } from "./pack.js";
+
+export const workspaceRoot = path.resolve(fileURLToPath(new URL("../../../", import.meta.url)));
+const appSource = path.join(workspaceRoot, "fixtures/install-seam/app");
+const vendoCli = path.join(workspaceRoot, "packages/vendo/bin/vendo.mjs");
+
+/** A key-shaped string that is not a key. The BYO rung only has to RESOLVE for
+ *  init to write an explicit `models` line and install the matching provider;
+ *  nothing in this suite ever calls that model, so nothing ever presents it. */
+const FAKE_PROVIDER_KEY = "sk-ant-api03-install-seam-fixture-not-a-real-key";
+
+/** One of the model's moves, in the wire form the stranger's chat route
+ *  accepts (`app/lib/scripted-model.ts`). */
+export type TurnSpec =
+  | { kind: "text"; text: string }
+  | { kind: "tool"; name: string; input: unknown };
+
+export interface Todo {
+  id: string;
+  title: string;
+  done: boolean;
+}
+
+export interface ExtractedTool {
+  name: string;
+  risk?: string;
+  binding: { kind: string; method?: string; path?: string };
+}
+
+export interface Stranger {
+  scaffoldDir: string;
+  /** Package name → the version this workspace packed for it. */
+  packedVersions: Record<string, string>;
+  baseUrl: string;
+  /** `pnpm add <tarballs>` — assertion 1. */
+  add: CommandResult;
+  /** `vendo init …` — assertion 2. */
+  init: CommandResult;
+  /** `tsc --noEmit` over the app INCLUDING what init generated — assertion 3. */
+  typecheck: CommandResult;
+  /** Every dependency name/spec the scaffold declares after install + init. */
+  declaredDependencies: Record<string, string>;
+  /** The scaffold's pnpm-lock.yaml — assertion 5 reads provenance out of it. */
+  lockfile: string;
+  /** Entries the isolated HOME grew that belong to Vendo (must be none). */
+  vendoHomeEntries: string[];
+  /** Entries in init's isolated cwd (must be none). */
+  strayCwdEntries: string[];
+  /** Every request that reached the stand-in Vendo Cloud (must be none). */
+  cloudRequests: string[];
+  /** The scaffold's .env.local, or "" when init wrote none. */
+  envLocal: string;
+  /** What init's extraction wrote into `.vendo/tools.json`. */
+  tools: ExtractedTool[];
+  /** The agent-visible name of the tool bound to one of the stranger's own
+   *  routes — never guessed, always read back off the catalog init wrote. */
+  toolFor(method: string, routePath: string): string;
+  /** One turn through the stranger's own agent loop. Resolves to the streamed
+   *  UI message body. */
+  chat(prompt: string, script: TurnSpec[]): Promise<string>;
+  /** Drives ONE host tool to an executed result: script the call, and if the
+   *  guard parks it, approve it over the wire the embeds use and let the loop
+   *  run it. Resolves to the stream that carries the tool's real output. */
+  callTool(prompt: string, toolName: string, input: unknown): Promise<string>;
+  /** The stranger's own API, read over real HTTP. */
+  todos(): Promise<Todo[]>;
+}
+
+async function copyApp(destination: string): Promise<void> {
+  await fs.cp(appSource, destination, { recursive: true });
+}
+
+/**
+ * A stand-in for the Vendo console that answers nothing and remembers
+ * everything. Init's cloud paths all resolve their base from
+ * `VENDO_CLOUD_URL`, so a request recorded here is a key-mint attempt — which
+ * is how "asks before accounts" is asserted as an absence rather than as the
+ * lack of a string in some output.
+ */
+async function startCloudRecorder(): Promise<{ url: string; requests: string[]; close(): Promise<void> }> {
+  const requests: string[] = [];
+  const port = await freePort();
+  const server: Server = createServer((req, res) => {
+    requests.push(`${req.method ?? "?"} ${req.url ?? "?"}`);
+    res.writeHead(503, { "content-type": "application/json" });
+    res.end('{"error":"the install seam allows no cloud calls"}');
+  });
+  await new Promise<void>((resolve) => server.listen(port, "127.0.0.1", resolve));
+  return {
+    url: `http://127.0.0.1:${port}`,
+    requests,
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}
+
+/**
+ * The stranger's environment: this machine's, minus every key and every
+ * package-manager setting that would change the install's posture, plus
+ * exactly what the run means to hand it.
+ */
+function strangerEnv(home: string, overrides: Record<string, string | undefined>): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  for (const name of [
+    "VENDO_API_KEY",
+    "VENDO_CLOUD_URL",
+    "VENDO_DEV_CREDENTIAL",
+    "VENDO_MODEL",
+    "VENDO_MODEL_APPS",
+    "VENDO_MODEL_REVIEW",
+    "VENDO_MODEL_JUDGE",
+    "E2B_API_KEY",
+    "COMPOSIO_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "GOOGLE_GENERATIVE_AI_API_KEY",
+    "VENDO_STORE_ENCRYPTION_KEY",
+  ]) {
+    delete env[name];
+  }
+  // The suite runs under pnpm, which exports its own config as npm_config_*
+  // (a minimum-release-age window among it). A fresh user's app gets a clean
+  // package-manager environment.
+  for (const name of Object.keys(env)) {
+    if (name.toLowerCase().startsWith("npm_") || name === "NODE_ENV" || name === "PNPM_HOME") delete env[name];
+  }
+  env["HOME"] = home;
+  env["USERPROFILE"] = home;
+  env["npm_config_min_release_age"] = "0";
+  // The isolated HOME is there to make "init wrote nothing outside the app"
+  // checkable, not to force a cold download of 400 packages on every run. The
+  // package manager's own caches are pnpm's state, never Vendo's, so they live
+  // outside it and survive between runs.
+  env["npm_config_store_dir"] = path.join(tmpdir(), "vendo-install-seam-store");
+  env["COREPACK_HOME"] = path.join(tmpdir(), "vendo-install-seam-corepack");
+  env["NEXT_TELEMETRY_DISABLED"] = "1";
+  env["VENDO_TELEMETRY_DISABLED"] = "1";
+  env["DO_NOT_TRACK"] = "1";
+  for (const [name, value] of Object.entries(overrides)) {
+    if (value !== undefined) env[name] = value;
+  }
+  return env;
+}
+
+/**
+ * Waits for the stranger's dev server, with NO wall-clock budget of its own.
+ * The test's timeout is the hang detector; a tighter inner deadline would be a
+ * second, invisible speed limit that reports a product bug on a busy machine.
+ * A crashed child is a real signal rather than a clock, so that still fails
+ * immediately.
+ */
+async function waitForServer(baseUrl: string, dev: ChildProcess, logFile: string): Promise<void> {
+  for (;;) {
+    if (dev.exitCode !== null) {
+      const log = await fs.readFile(logFile, "utf8").catch(() => "");
+      throw new Error(`dev server exited ${dev.exitCode} before answering:\n${log.slice(-6000)}`);
+    }
+    const response = await fetch(`${baseUrl}/api/todos`).catch(() => null);
+    if (response !== null && response.status < 500) return;
+    await sleep(500);
+  }
+}
+
+let packedOnce: Promise<Packed> | null = null;
+function packOnce(): Promise<Packed> {
+  packedOnce ??= (async () => {
+    const dest = await fs.mkdtemp(path.join(tmpdir(), "vendo-install-seam-pack-"));
+    return packWorkspace(workspaceRoot, dest);
+  })();
+  return packedOnce;
+}
+
+/**
+ * The whole install seam, once: pack the publish set → scaffold a stranger app
+ * in a temp dir → `pnpm add` the tarballs → `vendo init` → typecheck → boot.
+ *
+ * Everything happens OUTSIDE the workspace, in `os.tmpdir()`. That is also what
+ * keeps the dist-dir law satisfied by construction: the stranger's `.next` can
+ * never be a child (or a parent) of any directory a repo build wipes.
+ */
+export async function bootStranger(artifactsDir: string): Promise<{ stranger: Stranger; stop(): Promise<void> }> {
+  await fs.mkdir(artifactsDir, { recursive: true });
+  const log = (name: string): string => path.join(artifactsDir, name);
+  const writeLog = async (name: string, body: string): Promise<void> => { await fs.writeFile(log(name), body); };
+
+  const scaffoldDir = await fs.mkdtemp(path.join(tmpdir(), "vendo-install-seam-app-"));
+  // Init runs with an isolated HOME and an isolated, empty cwd, so "wrote
+  // nothing outside the fixture" is checkable rather than assumed.
+  const home = await fs.mkdtemp(path.join(tmpdir(), "vendo-install-seam-home-"));
+  const elsewhere = await fs.mkdtemp(path.join(tmpdir(), "vendo-install-seam-cwd-"));
+
+  const cloud = await startCloudRecorder();
+  const port = await freePort();
+  const baseUrl = `http://127.0.0.1:${port}`;
+  const env = strangerEnv(home, {
+    ANTHROPIC_API_KEY: FAKE_PROVIDER_KEY,
+    VENDO_CLOUD_URL: cloud.url,
+  });
+
+  let dev: ChildProcess | null = null;
+  const stop = async (): Promise<void> => {
+    if (dev !== null && dev.exitCode === null) {
+      dev.kill("SIGTERM");
+      await Promise.race([new Promise((resolve) => dev!.once("close", resolve)), sleep(10_000)]);
+      if (dev.exitCode === null) dev.kill("SIGKILL");
+    }
+    await cloud.close();
+    if (process.env.VENDO_INSTALL_SEAM_KEEP === "1") {
+      console.log(`VENDO_INSTALL_SEAM_KEEP=1 — stranger retained at ${scaffoldDir}`);
+      return;
+    }
+    for (const dir of [scaffoldDir, home, elsewhere]) {
+      await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+    }
+  };
+
+  try {
+    // The tarballs are only as good as `dist/`, and a pack of an unbuilt
+    // package succeeds — it just ships an empty one. Say so here instead of
+    // three minutes later, as a module-not-found inside a Next dev server.
+    await fs.access(path.join(workspaceRoot, "packages/vendo/dist/cli.js")).catch(() => {
+      throw new Error("the workspace is not built — run `pnpm build` before the install seam");
+    });
+    const packed = await packOnce();
+    await copyApp(scaffoldDir);
+    await vendorInto(scaffoldDir, packed);
+
+    // Assertion 1: the BUILT packages install into a stranger. `-w` because
+    // the overrides above make the scaffold its own pnpm workspace root and
+    // pnpm 11 refuses an implicit root add.
+    const add = await checked(
+      "pnpm add",
+      run(
+        "pnpm",
+        ["add", "-w", ...DIRECT_DEPENDENCIES.map((name) => fileSpec(packed, name))],
+        { cwd: scaffoldDir, env },
+      ),
+    );
+    await writeLog("add.log", add.output);
+
+    // Assertion 2: one non-interactive init, answered entirely by flags.
+    // `--yes` and NOT `--byo`: an unattended run that already has a working
+    // local key is exactly the run that must not quietly mint a cloud account.
+    const init = await run(
+      process.execPath,
+      [
+        vendoCli,
+        "init",
+        scaffoldDir,
+        "--yes",
+        "--no-ai",
+        "--no-check",
+        "--framework", "next",
+        "--auth", "none",
+        "--use-case", "agent-loop",
+        "--base-url", baseUrl,
+      ],
+      { cwd: elsewhere, env },
+    );
+    await writeLog("init.log", init.output);
+
+    // Assertion 3: the app compiles WITH what init generated.
+    const typecheck = await run(
+      path.join(scaffoldDir, "node_modules/.bin/tsc"),
+      ["--noEmit"],
+      { cwd: scaffoldDir, env },
+    );
+    await writeLog("typecheck.log", typecheck.output);
+
+    const declaredDependencies = await readDeclaredDependencies(scaffoldDir);
+    const lockfile = await fs.readFile(path.join(scaffoldDir, "pnpm-lock.yaml"), "utf8");
+    const envLocal = await fs.readFile(path.join(scaffoldDir, ".env.local"), "utf8").catch(() => "");
+    const vendoHomeEntries = (await fs.readdir(home).catch(() => []))
+      .filter((entry) => entry.toLowerCase().includes("vendo"));
+    const strayCwdEntries = await fs.readdir(elsewhere).catch(() => []);
+    const tools = await readExtractedTools(scaffoldDir);
+
+    // Straight through the next bin: `pnpm dev` would fire init's `predev`
+    // hook, and a re-extraction in the middle of the boot is not what this
+    // suite is measuring.
+    const devLog = log("dev.log");
+    const devLogStream = createWriteStream(devLog);
+    dev = spawn(
+      process.execPath,
+      [path.join(scaffoldDir, "node_modules/next/dist/bin/next"), "dev", "--port", String(port)],
+      { cwd: scaffoldDir, env, stdio: ["ignore", "pipe", "pipe"] },
+    );
+    dev.stdout!.on("data", (chunk) => devLogStream.write(chunk));
+    dev.stderr!.on("data", (chunk) => devLogStream.write(chunk));
+    dev.once("close", () => devLogStream.end());
+    await waitForServer(baseUrl, dev, devLog);
+
+    let turn = 0;
+    const stranger: Stranger = {
+      scaffoldDir,
+      packedVersions: packedVersions(packed),
+      baseUrl,
+      add,
+      init,
+      typecheck,
+      declaredDependencies,
+      lockfile,
+      vendoHomeEntries,
+      strayCwdEntries,
+      cloudRequests: cloud.requests,
+      envLocal,
+      tools,
+      toolFor(method, routePath) {
+        const found = tools.find((tool) =>
+          tool.binding.kind === "route" && tool.binding.method === method && tool.binding.path === routePath);
+        if (found === undefined) {
+          throw new Error(
+            `init extracted no tool for ${method} ${routePath}; catalog: ${JSON.stringify(tools.map((tool) => tool.name))}`,
+          );
+        }
+        return `vendo_${found.name}`;
+      },
+      async chat(prompt, script) {
+        turn += 1;
+        const response = await fetch(`${baseUrl}/api/chat`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            id: `turn-${turn}`,
+            messages: [{ id: `m${turn}`, role: "user", parts: [{ type: "text", text: prompt }] }],
+            script,
+          }),
+        });
+        const body = await response.text();
+        await writeLog(`turn-${turn}.log`, body);
+        if (response.status !== 200) throw new Error(`chat turn ${turn} returned ${response.status}:\n${body}`);
+        return body;
+      },
+      async callTool(prompt, toolName, input) {
+        const script: TurnSpec[] = [
+          { kind: "tool", name: toolName, input },
+          { kind: "text", text: "Done." },
+        ];
+        // A keyless install grades nothing, so the shipped posture is "ungraded
+        // asks". Approving with a STANDING tool grant is what a person does in
+        // <VendoApprovalEmbed>; the second call then runs unattended and its
+        // real output comes back through the loop. A posture that already runs
+        // the call unattended never enters the branch, so this asserts the
+        // outcome without pinning which of the two the product does today.
+        let body = await stranger.chat(prompt, script);
+        const parked = approvalIdIn(body);
+        if (parked === null) return body;
+        const decided = await fetch(`${baseUrl}/api/vendo/approvals/decide`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            ids: [parked],
+            decision: { approve: true, remember: { scope: { kind: "tool" }, duration: "standing" } },
+          }),
+        });
+        if (decided.status !== 200) {
+          throw new Error(`approving ${parked} returned ${decided.status}: ${await decided.text()}`);
+        }
+        body = await stranger.chat(prompt, script);
+        const stillParked = approvalIdIn(body);
+        if (stillParked !== null) {
+          throw new Error(`${toolName} parked again after a standing grant (${stillParked})`);
+        }
+        return body;
+      },
+      async todos() {
+        const response = await fetch(`${baseUrl}/api/todos`);
+        const body = (await response.json()) as { todos: Todo[] };
+        return body.todos;
+      },
+    };
+    return { stranger, stop };
+  } catch (error) {
+    await stop();
+    throw error;
+  }
+}
+
+/** The approval the guard parked this turn's tool call behind, or null when it
+ *  ran. The envelope is the product's own `vendo/approval-ref@1`. */
+function approvalIdIn(streamBody: string): string | null {
+  if (!streamBody.includes("vendo/approval-ref@1")) return null;
+  const id = /"approvalId":"(apr_[^"]+)"/.exec(streamBody)?.[1];
+  if (id === undefined) throw new Error(`an approval-ref envelope carried no approvalId:\n${streamBody.slice(0, 2000)}`);
+  return id;
+}
+
+async function readExtractedTools(scaffoldDir: string): Promise<ExtractedTool[]> {
+  const raw = await fs.readFile(path.join(scaffoldDir, ".vendo/tools.json"), "utf8").catch(() => null);
+  if (raw === null) return [];
+  return ((JSON.parse(raw) as { tools?: ExtractedTool[] }).tools ?? []);
+}
+
+const DEPENDENCY_SECTIONS = ["dependencies", "devDependencies", "optionalDependencies"] as const;
+
+async function readDeclaredDependencies(scaffoldDir: string): Promise<Record<string, string>> {
+  const pkg = JSON.parse(await fs.readFile(path.join(scaffoldDir, "package.json"), "utf8")) as Record<string, unknown>;
+  const declared: Record<string, string> = {};
+  for (const section of DEPENDENCY_SECTIONS) {
+    for (const [name, spec] of Object.entries((pkg[section] as Record<string, string> | undefined) ?? {})) {
+      declared[name] = spec;
+    }
+  }
+  return declared;
+}

--- a/fixtures/install-seam/tests/install-seam.e2e.test.ts
+++ b/fixtures/install-seam/tests/install-seam.e2e.test.ts
@@ -1,0 +1,114 @@
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { bootStranger, workspaceRoot, type Stranger } from "../src/stranger.js";
+
+/**
+ * The install seam, with a permanent stranger.
+ *
+ * Everything a paid manual audit round used to walk by hand, once, per release:
+ * pack the publish set → `pnpm add` the tarballs into an app that has never
+ * heard of this monorepo → `vendo init` → typecheck → boot → ask the agent a
+ * question only the app's own API can answer, and have it write one back.
+ *
+ * There is exactly ONE double in the chain, and it is the one a test genuinely
+ * cannot call: the model. Its moves arrive in the request body and are replayed
+ * by `@vendoai/apps/testing`. The package under test is a real tarball, the CLI
+ * is the real binary, the server is a real `next dev`, and `/api/todos` is a
+ * real route over real HTTP.
+ *
+ * These are OUTCOME assertions. Nothing here pins init's printed prose, so the
+ * suite is indifferent to the init-output redesign landing before or after it.
+ */
+
+/** npm's own package-name grammar. The `@/lib` class of bug — a path alias
+ *  mistaken for a package and shelled at a package manager — fails it. */
+const NPM_NAME = /^(?:@[a-z0-9-*~][a-z0-9-*._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/;
+
+/** A lockfile key for one of this monorepo's packages, and how it resolved. */
+const LOCKED_VENDO = /^ {2}'?(vendoai|@vendoai\/[a-z-]+)@(.+?)'?:$/gm;
+
+const SEEDED = "Renew the passport";
+
+let stranger: Stranger;
+let stop: () => Promise<void>;
+
+beforeAll(async () => {
+  const booted = await bootStranger(
+    process.env["VENDO_INSTALL_SEAM_ARTIFACTS"]
+      ?? path.join(workspaceRoot, "fixtures/install-seam/.artifacts"),
+  );
+  stranger = booted.stranger;
+  stop = booted.stop;
+});
+
+afterAll(async () => {
+  await stop?.();
+});
+
+describe("the install seam", () => {
+  it("installs the built packages into a stranger, declaring only real npm packages", () => {
+    expect(stranger.add.code).toBe(0);
+    for (const [name, spec] of Object.entries(stranger.declaredDependencies)) {
+      expect(name, `${name} is not a package name npm could resolve`).toMatch(NPM_NAME);
+      expect(spec, `${name} is declared as a workspace link, not an installed package`)
+        .not.toMatch(/^(link:|workspace:)/);
+    }
+    // The umbrella really is declared — an empty dependency map would pass the
+    // loop above without proving anything.
+    expect(Object.keys(stranger.declaredDependencies)).toContain("@vendoai/vendo");
+  });
+
+  it("runs init to completion without writing outside the app or minting an account", () => {
+    expect(stranger.init.code, stranger.init.output.slice(-4000)).toBe(0);
+    // "Asks before accounts", asserted as an absence: an unattended init that
+    // already has a working local key reached the console zero times.
+    expect(stranger.cloudRequests).toEqual([]);
+    expect(stranger.envLocal).not.toMatch(/VENDO_API_KEY/);
+    // Nothing landed in the isolated HOME (~/.vendo holds the cloud session and
+    // pending claims) or in the directory init was invoked from.
+    expect(stranger.vendoHomeEntries).toEqual([]);
+    expect(stranger.strayCwdEntries).toEqual([]);
+  });
+
+  it("generates a composition that compiles", () => {
+    expect(stranger.typecheck.code, stranger.typecheck.output.slice(-4000)).toBe(0);
+  });
+
+  it("answers from the app's own API, and writes back to it", async () => {
+    const list = stranger.toolFor("GET", "/api/todos");
+    const create = stranger.toolFor("POST", "/api/todos");
+
+    // A read the model cannot fake: the seeded row exists only behind
+    // /api/todos, so its title reaches the client only if init's extraction,
+    // the generated wiring, the guard, the approval wire and the actions
+    // runtime all worked, over real HTTP, against the app's own route.
+    const read = await stranger.callTool("What is on my todo list?", list, {});
+    expect(read).toContain(SEEDED);
+
+    // And a write lands where the app's own API can see it.
+    const title = "Buy fig tree fertiliser";
+    await stranger.callTool(`Add "${title}" to my todos.`, create, { title });
+    expect((await stranger.todos()).map((todo) => todo.title)).toContain(title);
+  });
+
+  it("resolves every @vendoai package from the packed tarballs, at the packed version", () => {
+    const locked = [...stranger.lockfile.matchAll(LOCKED_VENDO)];
+    expect(locked.length, "the lockfile records no @vendoai packages at all").toBeGreaterThan(0);
+    for (const [, name, spec] of locked) {
+      const packed = stranger.packedVersions[name!];
+      expect(packed, `${name} is in the stranger's tree but was never packed`).toBeDefined();
+      // Provenance, not just a version string: a registry copy could carry the
+      // same number and prove nothing about this commit.
+      expect(spec, `${name} did not resolve to a packed tarball`).toMatch(/^file:vendor\//);
+      expect(spec, `${name} resolved to a tarball that is not ${packed}`).toContain(`-${packed}.tgz`);
+    }
+    // The whole umbrella closure really is in there. `vendoai` is excluded: it
+    // is the bare alias a host may install INSTEAD of @vendoai/vendo, so
+    // nothing pulls it in transitively and its absence is correct.
+    const resolved = new Set(locked.map(([, name]) => name!));
+    for (const name of Object.keys(stranger.packedVersions)) {
+      if (name === "vendoai") continue;
+      expect([...resolved], `${name} never reached the stranger's tree`).toContain(name);
+    }
+  });
+});

--- a/fixtures/install-seam/tsconfig.json
+++ b/fixtures/install-seam/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "noEmit": true
+  },
+  // `app/` is the stranger's OWN source. It compiles against the tarballs the
+  // suite installs into a temp dir, never against this workspace — typechecking
+  // it here would resolve `@vendoai/*` through the monorepo, which is exactly
+  // the shortcut this fixture exists to rule out. Its real typecheck is
+  // assertion 3, run inside the scaffold after init.
+  "include": ["src", "tests", "vitest.config.ts"]
+}

--- a/fixtures/install-seam/vitest.config.ts
+++ b/fixtures/install-seam/vitest.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    // Worker caps live in config, not only in the root scripts: a cap on a
+    // command line applies only when someone types that command, so a bare
+    // `npx vitest`, an IDE runner and a debug run all escape it. Env
+    // (VITEST_MIN/MAX_FORKS, VITEST_MIN/MAX_THREADS) still wins, so CI is
+    // unchanged. Both halves are required — vitest defaults the min to the CPU
+    // count independently of the max, and a max-only cap makes Tinypool throw
+    // before a single test runs.
+    poolOptions: {
+      forks: { minForks: 1, maxForks: 2 },
+      threads: { minThreads: 1, maxThreads: 2 },
+    },
+    include: ["tests/**/*.e2e.test.ts"],
+    // One pack, one scaffold, one dev server, shared by every assertion.
+    fileParallelism: false,
+    // The whole seam runs inside the beforeAll hook: pack → install → init →
+    // typecheck → boot. Installs and Next's first compile dominate, and this
+    // timeout is the ONLY hang detector in the suite — no poll inside it
+    // carries a tighter wall-clock budget of its own.
+    testTimeout: 20 * 60 * 1000,
+    hookTimeout: 20 * 60 * 1000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -574,6 +574,18 @@ importers:
         specifier: ^5.6.0
         version: 5.9.3
 
+  fixtures/install-seam:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.20.0
+      typescript:
+        specifier: ^5.6.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.6
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@22.20.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
+
   fixtures/integration:
     dependencies:
       '@vendoai/actions':

--- a/scripts/dependency-guard.mjs
+++ b/scripts/dependency-guard.mjs
@@ -294,8 +294,17 @@ function* sourceFiles(dir) {
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     if (GENERATED_DIRS.has(entry.name)) continue;
     const p = join(dir, entry.name);
-    if (entry.isDirectory()) yield* sourceFiles(p);
-    else if (/\.(ts|tsx|mts|cts|js|mjs|cjs|jsx)$/.test(entry.name)) yield p;
+    if (entry.isDirectory()) {
+      // A nested directory carrying its OWN manifest is a different package's
+      // source, and its imports are declared there. fixtures/install-seam/app
+      // is the case: the stranger app the install-seam suite copies to a temp
+      // dir and installs the packed tarballs into. Its `@vendoai/vendo` import
+      // resolves from a registry-shaped tree by design — declaring it in the
+      // suite's manifest would give it the workspace link that whole fixture
+      // exists to rule out.
+      if (existsSync(join(p, "package.json"))) continue;
+      yield* sourceFiles(p);
+    } else if (/\.(ts|tsx|mts|cts|js|mjs|cjs|jsx)$/.test(entry.name)) yield p;
   }
 }
 

--- a/turbo.json
+++ b/turbo.json
@@ -16,6 +16,19 @@
     // before @vendoai/ui:build and the template build dies on an unresolvable @vendoai/ui.
     "@vendoai/apps#test": { "dependsOn": ["^build", "build", "@vendoai/box-template#build"], "env": ["CI", "POSTGRES_URL", "VITEST_MIN_FORKS", "VITEST_MAX_FORKS", "VITEST_MIN_THREADS", "VITEST_MAX_THREADS"] },
     "@vendoai/apps#test:coverage": { "dependsOn": ["^build", "build", "@vendoai/box-template#build"], "outputs": ["coverage/**"], "env": ["CI", "POSTGRES_URL", "VITEST_MIN_FORKS", "VITEST_MAX_FORKS", "VITEST_MIN_THREADS", "VITEST_MAX_THREADS"] },
+    // The install seam packs the WHOLE publish set off disk and runs the real
+    // CLI, so its inputs are every packages/* dist — none of which turbo can
+    // see, because the fixture deliberately declares no workspace dependency
+    // (a `workspace:` edge is the exact shortcut it exists to rule out).
+    // `vendoai#build` is the closure in one edge: the alias depends on the
+    // umbrella, which depends on every block. `cache: false` because a task
+    // whose real inputs are outside the graph must never replay a stale pass —
+    // that is how a green suite becomes a blind fixture.
+    "@vendoai-fixtures/install-seam#test": {
+      "dependsOn": ["vendoai#build"],
+      "cache": false,
+      "env": ["CI", "VITEST_MIN_FORKS", "VITEST_MAX_FORKS", "VITEST_MIN_THREADS", "VITEST_MAX_THREADS"]
+    },
     "conformance": { "dependsOn": ["^build", "build"], "env": ["CI", "POSTGRES_URL"] },
     "typecheck": { "dependsOn": ["^build"] },
     "lint": {},


### PR DESCRIPTION
The chain from "published package" to "the agent answers out of the host's own API" was exercised only by paid manual audit rounds. This is that walk, automated and deterministic — a stranger app that has never heard of this monorepo, installed from real tarballs, set up by the real CLI, booted, and asked a question only its own database can answer.

## What runs

A minimal Next todo app (`fixtures/install-seam/app`) is copied to a temp dir outside the workspace, then:

`pnpm add` the packed publish set → `vendo init --yes …` → `tsc --noEmit` → `next dev` → one scripted turn that reads `/api/todos`, one that writes to it.

The only double is the model — the one counterparty a test genuinely cannot call. Its moves travel in the request body in the repo's own scripted-turn dialect (`ai/test`'s `MockLanguageModelV3` + `simulateReadableStream`, the primitive under `fixtures/test-kit/src/stream-turns.ts` and `fixtures/integration-browser/e2e/harness/model.ts`). Everything else is the real thing: a real tarball, the real `bin/vendo.mjs`, a real dev server, real HTTP.

## Assertions

| # | Guarantee | How it is asserted |
|---|---|---|
| 1 | The built packages install into a stranger, and package.json gains no dependency that is not a real npm package | `pnpm add` exits 0; every declared dependency name matches npm's grammar and no spec starts with `link:`/`workspace:` |
| 2 | Init completes non-interactively, writes nothing outside the app, and mints no cloud account unless asked | exit 0; **zero** requests reach a recording stand-in console bound to `VENDO_CLOUD_URL`; no `VENDO_API_KEY` in `.env.local`; an isolated `HOME` grows no `~/.vendo`; init's cwd stays empty |
| 3 | The generated composition compiles | `tsc --noEmit` inside the scaffold, after init |
| 4 | The agent answers from the app's own API, and writes back to it | a seeded todo title reaches the client through the loop; a scripted create lands in a plain `GET /api/todos` |
| 5 | Every `@vendoai/*` came from this commit | every lockfile entry resolves to `file:vendor/…tgz` **and** carries that package's own packed version |

Assertion 2 uses `--yes` and deliberately **not** `--byo`: an unattended run that already has a working local key is exactly the run that must not quietly mint an account.

Assertion 4 is posture-agnostic. A keyless install grades nothing, so today the guard parks every call; the harness approves it over `POST /api/vendo/approvals/decide` with a standing tool grant — the embed's own path — and the second call runs unattended. If a future posture runs the call straight away, that branch is simply never entered. Nothing here pins init's printed prose either, so this is **indifferent to the init-output redesign landing before or after it**. Nothing in this PR depends on that slice.

## The bug it found on its first real run

`vendo init` was installing your tsconfig path alias as an npm package. The wire route init generates imports `@/lib/vendo`; the import scanner read that as the scoped package `@/lib` and shelled `pnpm add @/lib` at the app, leaving `"lib": "link:@/lib"` in package.json pointing at nothing. It reproduces on **every `create-next-app` host** — the default `@/*` alias is all it takes.

**Already fixed on main by #1510**, which added the `@/` guard in `importedPackages` (`packages/vendo/src/cli/provider-deps.ts`). This branch carries no production change: it is the regression net that would have caught it, and now keeps it caught. Verified in both directions on main's guard alone — green with it, and red with the exact `link:@/lib` failure when the guard is removed.

## Red-provable

Each command was run; each reds the named assertion and nothing else it does not touch.

| Assertion | Break it with | Observed failure |
|---|---|---|
| 1 | delete `|| specifier.startsWith("@/")` from `importedPackages` (`packages/vendo/src/cli/provider-deps.ts`), then `pnpm turbo run build --filter=vendoai...` | `lib is declared as a workspace link, not an installed package: expected 'link:@/lib' …` |
| 2 | `sed -i '' 's\|"--yes",\|"--yes", "--cloud-key", "vnd_0123456789abcdef0123456789abcdef01234567",\|' fixtures/install-seam/src/stranger.ts` | `expected 'VENDO_API_KEY=vnd_…' not to match /VENDO_API_KEY/` |
| 3 | `printf '\nexport const broken: number = "x";\n' >> fixtures/install-seam/app/lib/todos.ts` | `lib/todos.ts(27,14): error TS2322: Type 'string' is not assignable to type 'number'` |
| 4 | `sed -i '' 's\|todos: listTodos(done === null ? undefined : done === "true")\|todos: []\|' fixtures/install-seam/app/app/api/todos/route.ts` | `expected 'data: {"type":"start"}…' to contain 'Renew the passport'` |
| 5 | drop one package from the overrides in `vendorInto` (`src/pack.ts`) | `@vendoai/core did not resolve to a packed tarball: expected '0.29.1' to match /^file:vendor\//` |

Assertion 5's break is the sharp one: the packed version **is** on npm, so the registry copy carries the right version number and a version-only check would have waved it through. Provenance is what catches it. (Versions are read off disk at pack time, so the release to 0.31.0 mid-review needed no edit here.)

## What was reused

- **`fixtures/existing-agents-e2e/src/{journey,local-pack}.ts`** — the whole shape: pack the publish set by manifest name (not directory name), vendor into the scaffold, pin the closure, scrub `npm_config_*`/posture keys out of the environment, run the CLI straight through `bin/vendo.mjs`, boot via the `next` bin (never `pnpm dev`, which fires init's `predev` hook), SIGTERM→SIGKILL teardown.
- **The e2e fixture-suite conventions** — `freePort()` off a `net` server on port 0, `fileParallelism: false`, min *and* max worker caps in the config rather than only on a command line.
- **`fixtures/test-kit/src/stream-turns.ts` + `fixtures/integration-browser/e2e/harness/model.ts`** — the scripted-turn stream-part dialect and the `TurnSpec` wire form. Ported rather than imported: a stranger installs published packages and cannot reach a private workspace fixture.
- **The `orphans` leg's rationale** in `.github/workflows/ci.yml` — for why a suite whose inputs are not in turbo's graph must be unguarded.

Not touched: `corpus/`.

## Repo laws

- **Dist dirs**: the whole run happens in `os.tmpdir()`. The stranger's `.next` cannot be a child or a parent of anything a repo build wipes.
- **Poll budgets**: `waitForServer` has *no* wall-clock deadline of its own — the test timeout is the only hang detector. A crashed child is a real signal, not a clock, so a dead server still fails immediately.
- **No stub on either side**: the tarball is packed from the build, the CLI is the real binary, the server is real, `/api/todos` is hit over real HTTP.
- **CI job names**: `ci`, `integration`, `conformance`, `audit` are untouched. This is a fifth `integration-legs` matrix entry; the `integration` aggregate keeps its name.

## Notes

- Its own leg rather than a passenger on `orphans`: it is the slowest of the always-on suites (~35 s warm locally, ~100 s under load; cold in CI it pays a full `pnpm` install), and a leg of its own costs wall time only if it becomes the longest.
- Its turbo task is `cache: false` and depends on `vendoai#build`. Its real inputs are every `packages/*/dist`, which turbo cannot see, and a task like that must never replay a stale pass.
- `scripts/dependency-guard.mjs` now skips a nested directory carrying its own `package.json`. `fixtures/install-seam/app` is one: its `@vendoai/vendo` import resolves from a registry-shaped tree by design.
