### PR TITLE
fix(automations): an interval's cursor advances by the window that came due, not by the clock the tick read

### DIFF
--- a/.changeset/schedule-cursor-scheduled-time.md
+++ b/.changeset/schedule-cursor-scheduled-time.md
@@ -1,0 +1,22 @@
+---
+"@vendoai/automations": patch
+---
+
+An interval schedule's cursor advances by the window that came DUE, not by the
+clock the tick happened to read. `packages/automations/src/ingestion-surface.ts`
+wrote `lastFiredAt = atIso` — an observed instant, read after `ready()`, auth and
+a store round trip — so every fire re-anchored the NEXT window to itself and
+added its own second-or-so of latency to the one behind it. Any interval that is
+a multiple of the heartbeat period then walked out of phase until a window landed
+just under due and slipped a whole cycle: `{ every: "1m" }` under a once-a-minute
+heartbeat fired every OTHER minute against Vendo Cloud (observed gaps 2m, 2m, 2m,
+1m). An `every` now advances by whole windows from the last scheduled fire.
+
+Cron is untouched, because a cron cursor cannot drift this way: croner re-anchors
+to the pattern's own grid, and an observed time always sits in the same gap
+between occurrences as the window it fired, so it reads identically to that
+window forever. Collapse is unchanged — a backlog of missed windows is still
+exactly one run on the most recent window, never back-filled or rapid-fired to
+catch up — as are the compare-and-swap claim and the `at` one-shot. The cursor row
+keeps its shape, so rows in the wild carrying an observed timestamp are read as
+before and land back on phase on their first fire.

--- a/packages/automations/src/ingestion-surface.ts
+++ b/packages/automations/src/ingestion-surface.ts
@@ -61,8 +61,10 @@ const createTickDoor = (deps: IngestionSurfaceDeps): Pick<AutomationsEngine, "ti
         const next = new Cron(record.when.cron, { timezone, paused: true }).nextRun(new Date(cursor.lastFiredAt));
         if (next !== null && next.getTime() <= at.getTime()) scheduledFor = next.toISOString();
       } else if (record.when.every !== undefined) {
-        const due = Date.parse(cursor.lastFiredAt) + (durationMs(record.when.every) as number);
-        if (due <= at.getTime()) scheduledFor = new Date(due).toISOString();
+        const every = durationMs(record.when.every) as number;
+        const last = Date.parse(cursor.lastFiredAt);
+        const windows = Math.floor((at.getTime() - last) / every);
+        if (windows >= 1) scheduledFor = new Date(last + windows * every).toISOString();
       } else if (
         record.when.at !== undefined
         && cursor.firedAt === undefined
@@ -76,7 +78,13 @@ const createTickDoor = (deps: IngestionSurfaceDeps): Pick<AutomationsEngine, "ti
       }
       const nextCursor = {
         ...cursor,
-        lastFiredAt: atIso,
+        // An interval advances by the window that came DUE, never by the clock
+        // this tick read: an observed time re-anchors the next window to itself,
+        // so every fire's own latency lands on the one after it until a window
+        // slips under the heartbeat and a whole cycle is lost. A cron cursor
+        // needs no such care — the observed time and the window it fired always
+        // sit in the same gap between occurrences, so croner reads them alike.
+        lastFiredAt: record.when.every === undefined ? atIso : scheduledFor,
         ...(record.when.at === undefined ? {} : { firedAt: atIso }),
       };
       // THE claim, and the whole reason a duplicate tick fires nothing: two ticks

--- a/packages/automations/tests/schedule-drift.test.ts
+++ b/packages/automations/tests/schedule-drift.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Schedule PHASE: a fired window's cursor is the time that window was DUE, never
+ * the clock the tick happened to read.
+ *
+ * A heartbeat calls tick() once a minute, and the tick spends a jittering second
+ * or so on ready(), auth and a store round trip before it writes the cursor.
+ * Storing that observed time made every fire the anchor for the next one, so the
+ * due time crept later than the heartbeat until a whole window slipped under it
+ * and a `{ every: "1m" }` record fired every OTHER minute (observed against Vendo
+ * Cloud: gaps of 2m, 2m, 2m, 1m).
+ */
+import {
+  type ApprovalId,
+  type AuditEvent,
+  type Guard,
+  type RunContext,
+  type StoreAdapter,
+  type ToolRegistry,
+  type When,
+} from "@vendoai/core";
+import { memoryStoreAdapter } from "@vendoai/core/conformance";
+import { describe, expect, it } from "vitest";
+import { automationsInternals, createAutomations, type AutomationsEngine } from "../src/index.js";
+import { SCHEDULE } from "../src/types.js";
+
+const START = new Date("2026-07-12T12:00:00.000Z");
+const MINUTE = 60_000;
+
+/** What each heartbeat's tick spent before reaching the cursor write. It
+ *  JITTERS, because a tick that gets there QUICKER than the one before it is
+ *  what used to land just under due and lose the window. */
+const LATENCY_MS = [1_000, 1_500, 1_000, 1_500, 1_000, 1_500];
+
+/** The minute each heartbeat was for — what the cursor should hold afterwards. */
+const WINDOWS = LATENCY_MS.map((_, index) => new Date(START.getTime() + (index + 1) * MINUTE).toISOString());
+
+const ctx: RunContext = {
+  principal: { kind: "user", subject: "user_a" },
+  venue: "chat",
+  presence: "present",
+  sessionId: "session_a",
+};
+
+class GuardDouble implements Guard {
+  async check(): Promise<{ action: "run"; decidedBy: "default" }> { return { action: "run", decidedBy: "default" }; }
+  async report(_event: AuditEvent): Promise<void> { return undefined; }
+  async directions(): Promise<string[]> { return []; }
+  onApprovalDecision(_callback: (id: ApprovalId, approved: boolean) => void): () => void { return () => undefined; }
+}
+
+const registry = (): ToolRegistry => ({
+  async descriptors() { return []; },
+  async execute() { return { status: "ok", output: {} }; },
+});
+
+/** A schedule whose cursor `create` anchors at START, so the first heartbeat is
+ *  its first window. */
+const scheduled = async (when: When): Promise<{ store: StoreAdapter; engine: AutomationsEngine; id: string }> => {
+  const store = memoryStoreAdapter();
+  const engine = createAutomations({ tools: registry(), guard: new GuardDouble(), store, now: () => START });
+  const { id } = await automationsInternals(engine).create(
+    { id: "atm_phase", owner: ctx.principal, authoredBy: "code", when, task: { kind: "steps", steps: [] } },
+    ctx,
+  );
+  return { store, engine, id };
+};
+
+/** Six once-a-minute heartbeats: what fired on each, and where the cursor
+ *  landed after it. */
+const heartbeats = async (
+  { store, engine, id }: { store: StoreAdapter; engine: AutomationsEngine; id: string },
+): Promise<{ fired: number[]; cursors: Array<string | undefined> }> => {
+  const fired: number[] = [];
+  const cursors: Array<string | undefined> = [];
+  for (const [index, latency] of LATENCY_MS.entries()) {
+    fired.push((await engine.tick(new Date(START.getTime() + (index + 1) * MINUTE + latency))).length);
+    const cursor = await store.records(SCHEDULE).get(id);
+    cursors.push((cursor?.data as { lastFiredAt?: string } | undefined)?.lastFiredAt);
+  }
+  return { fired, cursors };
+};
+
+describe("schedule phase under a slow tick", () => {
+  it("fires an `every` interval on EVERY window, however long each tick took to get there", async () => {
+    const { fired, cursors } = await heartbeats(await scheduled({ every: "1m" }));
+
+    expect(fired).toEqual([1, 1, 1, 1, 1, 1]);
+    expect(cursors).toEqual(WINDOWS);
+  });
+
+  // The cron equivalent, and the reason only the interval needed fixing: croner
+  // re-anchors to the pattern's own grid, and the clock a tick reads always sits
+  // in the same gap between occurrences as the window it fired, so the same
+  // heartbeat that lost every other `every` window loses no cron window. This
+  // holds the property while the interval beside it changes.
+  it("holds a cron on every window under the same heartbeat", async () => {
+    const { fired } = await heartbeats(await scheduled("* * * * *"));
+
+    expect(fired).toEqual([1, 1, 1, 1, 1, 1]);
+  });
+});


### PR DESCRIPTION
## What

A `{ every: … }` schedule's cursor now advances by the window that came **due**, not by the clock the tick happened to read.

`packages/automations/src/ingestion-surface.ts` wrote `lastFiredAt = atIso` — an observed instant, read after `ready()`, auth and a store round trip. Every fire therefore re-anchored the *next* window to itself and added its own second-or-so of latency to the one behind it. An interval that is a multiple of the heartbeat period walked out of phase until a window landed just under due and slipped a whole cycle: `{ every: "1m" }` under a once-a-minute heartbeat fired every **other** minute against Vendo Cloud (observed gaps 2m, 2m, 2m, 1m).

Six functional lines:

- the `every` branch computes whole elapsed windows from the last scheduled fire (`Math.floor((at - last) / every)`) and fires the most recent one;
- the cursor stores that window instead of `atIso`.

Deliberately **not** changed:

- **Collapse** — a backlog of missed windows is still exactly one run, on the most recent window, never back-filled and never rapid-fired to catch up. The existing tests that pin this (`engine.test.ts` "collapses missed windows", `schedule-extra.e2e.test.ts` "collapses a cron backlog") are untouched and green.
- **The compare-and-swap / insertIfAbsent claim** — only the value written changed.
- **The `at` one-shot** — a one-shot has no next window, so it still records the tick that fired it.
- **The cursor row's shape** — no migration. Rows in the wild carrying an observed timestamp are read exactly as before and land back on phase on their first fire.
- **Cron.** A cron cursor cannot drift this way, so it needed nothing (see below).

## Why cron was left alone

The brief also asked for the cron cursor to hold the occurrence that made the record due. It turns out that is a no-op: an observed time and the window it fired **always sit in the same gap between occurrences**, so croner's `nextRun` returns the identical answer for either, forever. `o_last` is by definition the latest occurrence ≤ `at`, so the next occurrence is > `at`, so `nextRun(atIso) === nextRun(o_last)` always — confirmed empirically, and the cron test below is green on unfixed code.

Making the cron cursor the *most recent* due occurrence anyway would have needed a forward walk over the whole backlog (croner 9 — the version all three packages pin — has no backward occurrence API; `previousRuns` arrived in croner 10). With a `timezone` set, which this code always passes, croner 9's `nextRun` costs **~670µs per call** versus ~4µs without: a per-minute cron whose cursor went stale over a long disarm would then block a tick for tens of seconds inside the collapse. Not worth paying for a change with no behavioural effect.

## Verification

Test-first, both tests new — no existing test file was modified.

| Test | Against unfixed code |
| --- | --- |
| `every` fires on every window under a jittering 1–1.5s tick latency | **RED** — `[1, 1, 0, 1, 0, 1]`, the audit's 2-minute gaps |
| cron `* * * * *` holds every window under the same heartbeat | GREEN — the property this PR preserves rather than fixes |

Local gate, this worktree:

- `pnpm build` — 22/22 tasks
- `pnpm test:affected` — 33/34 tasks. `@vendoai/automations` 6/6 files (117 tests), `@vendoai-fixtures/automations-e2e` 18 passed / 1 skipped including all three collapse/one-shot e2e tests. The one failure is `@vendoai/vendo`, on two files that fail with `ENOENT … /Users/yousefh/Desktop/Cool%20Code/…` — they build filesystem paths from `import.meta.url`'s `pathname`, and this worktree lives under a directory with a space in its name. Environmental; CI's checkout has no space.
- `pnpm typecheck` — 43/43 tasks
- `pnpm lint` — clean (4 pre-existing `demo-bank` warnings, 0 errors)

An earlier run of the same suite reported `@vendoai/agents` and `@vendoai/genbench` red on `Test timed out in 30000ms`; both are 25/25 and 22/22 green on a re-run once the machine was quiet (load average was 160 from sibling worktrees).

- [x] `pnpm build && pnpm test:affected && pnpm typecheck && pnpm lint` green on the touched scope
- [ ] Screenshots attached (if UI-affecting) — n/a


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Interval schedules now advance their cursor by the window that came due instead of the tick’s observed time in `@vendoai/automations`. This removes phase drift that could make `{ every: "1m" }` fire every other minute under heartbeat latency; each window now fires once.

- Review notes:
  - Core change: in packages/automations/src/ingestion-surface.ts, compute elapsed windows since `lastFiredAt` and set the cursor to the latest due window; compare-and-swap path unchanged.
  - Behavior intentionally unchanged: collapse (still runs only the most recent window), cron schedules, and one-shot `at`.
  - Tests added: packages/automations/tests/schedule-drift.test.ts verifies interval under jitter and confirms cron unaffected.
  - No data/API changes: cursor row shape unchanged; existing cursors realign on next run. No migration or config changes.

<sup>Written for commit 975ca8e6213021ec4f00ec008a7945f19a932803. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1521?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

