### PR TITLE
fix(vendo,harnesses): the MCP door keeps the host's path prefix, and a dead door refuses

### DIFF
--- a/packages/agents/tests/door.test.ts
+++ b/packages/agents/tests/door.test.ts
@@ -13,6 +13,8 @@
  * the Agent SDK.
  */
 import { mkdtempSync, rmSync } from "node:fs";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import type { SandboxAdapter, SandboxMachine } from "@vendoai/apps";
@@ -219,7 +221,38 @@ describe("the door ladder", () => {
   });
 });
 
+/**
+ * ⚠️ TEST EDIT — every case below RUNS a turn, and `claudeCode()` now probes the
+ * door url before it boots a machine, refusing a turn no door answers. The
+ * fixture origin was `https://app.example.com`, a reserved domain that never
+ * resolved, so the box was handed nothing at all. These cases get a door that is
+ * really there; the ladder cases above never open a turn, never probe, and keep
+ * naming the plain `ORIGIN` they always did.
+ *
+ * A stub rather than a forwarder to `support.door`: what the probe needs to know
+ * is that something is listening, and this file already drives the REAL door
+ * handler directly in the assertions below.
+ */
 describe("what the box is actually handed", () => {
+  let live: { origin: string; url: string; close: () => Promise<void> };
+
+  beforeEach(async () => {
+    const server = createServer((_request, response) => {
+      response.writeHead(401);
+      response.end();
+    });
+    await new Promise<void>((resolve) => { server.listen(0, "127.0.0.1", resolve); });
+    const { port } = server.address() as AddressInfo;
+    const origin = `http://127.0.0.1:${port}`;
+    live = {
+      origin,
+      url: `${origin}${DOOR_PATH}`,
+      close: () => new Promise<void>((resolve) => { server.close(() => { resolve(); }); }),
+    };
+  });
+
+  afterEach(async () => { await live.close(); });
+
   it("dials the door, lists the host's tools through it, and carries its hostname out of the box", async () => {
     let seen: BoxRun["toolDoor"];
     let listing = "";
@@ -244,13 +277,13 @@ describe("what the box is actually handed", () => {
       store: memoryStore(),
       tools: [refund],
       sandbox: adapter,
-      door: { baseUrl: ORIGIN },
+      door: { baseUrl: live.origin },
     });
     const session = await support.session("u_42");
     await (await session.stream("refund invoice 7")).text();
 
     // (1) A real port produced a real credential and a real URL.
-    expect(seen?.url).toBe(DOOR_URL);
+    expect(seen?.url).toBe(live.url);
     expect(seen?.token).toMatch(/^vtk_/);
 
     // (2) The `liveTurn` seam is wired, so that credential RESOLVES: publishing
@@ -260,7 +293,7 @@ describe("what the box is actually handed", () => {
 
     // (3) The door's hostname is on the box's outbound allowlist — a box that
     //     cannot reach the door has the tools and cannot call them.
-    expect(created[0]?.allowedDomains).toContain("app.example.com");
+    expect(created[0]?.allowedDomains).toContain("127.0.0.1");
   });
 
   it("that same credential is what becomes the SDK's `mcpServers` entry", async () => {
@@ -275,7 +308,7 @@ describe("what the box is actually handed", () => {
       store: memoryStore(),
       tools: [refund],
       sandbox: adapter,
-      door: { baseUrl: ORIGIN },
+      door: { baseUrl: live.origin },
     });
     await (await (await support.session("u_42")).stream("hi")).text();
     expect(handed).toBeDefined();
@@ -307,7 +340,7 @@ describe("what the box is actually handed", () => {
     expect(opened[0]?.["mcpServers"]).toEqual({
       [VENDO_MCP_SERVER]: {
         type: "http",
-        url: DOOR_URL,
+        url: live.url,
         headers: { Authorization: `Bearer ${handed!.token}` },
         alwaysLoad: true,
       },
@@ -326,7 +359,7 @@ describe("what the box is actually handed", () => {
       store: memoryStore(),
       tools: [refund],
       sandbox: adapter,
-      door: { baseUrl: ORIGIN },
+      door: { baseUrl: live.origin },
     });
     await (await (await support.session("u_42")).stream("hi")).text();
     expect(token).toMatch(/^vtk_/);

--- a/packages/harnesses/src/claude-code/index.ts
+++ b/packages/harnesses/src/claude-code/index.ts
@@ -389,9 +389,16 @@ function warnNoOriginOnce(): void {
  * Any HTTP status other than 404 is the door WORKING. A 401 especially: the
  * credential that authenticates it is not minted until further down, so an
  * unauthenticated probe is supposed to be turned away.
+ *
+ * On the TURN's signal, because this is the first thing a turn does and a door
+ * that accepts the connection but never replies holds it open all the way to
+ * undici's 300s headers timeout — a cancelled turn would sit here long after
+ * the person who cancelled it was gone. The caller reads the signal again
+ * before blaming the door: "nothing answered" and "we stopped asking" are not
+ * the same fact, and only one of them is a misconfiguration.
  */
-async function doorAnswers(url: string): Promise<boolean> {
-  const response = await fetch(url, { method: "POST" }).catch(() => undefined);
+async function doorAnswers(url: string, signal: AbortSignal): Promise<boolean> {
+  const response = await fetch(url, { method: "POST", signal }).catch(() => undefined);
   return response !== undefined && response.status !== 404;
 }
 
@@ -535,7 +542,7 @@ export function claudeCode(
       // that is down are the same failure to the customer as a wrong path, so
       // all of them refuse. Both legs, before the machine exists, so a doomed
       // turn never pays for a sandbox boot.
-      if (doorUrl !== undefined && !await doorAnswers(doorUrl)) {
+      if (doorUrl !== undefined && !await doorAnswers(doorUrl, turn.signal) && !turn.signal.aborted) {
         throw new VendoError(
           "unavailable",
           `claudeCode() found no MCP door at ${doorUrl}. Every one of this product's `

--- a/packages/harnesses/src/claude-code/index.ts
+++ b/packages/harnesses/src/claude-code/index.ts
@@ -382,22 +382,17 @@ function warnNoOriginOnce(): void {
 
 /**
  * Is the door THERE? One request of exactly the shape the SDK's MCP client is
- * about to make, and one answer that means it is not: the origin itself saying
- * this path does not exist. Every other status is the door working — a 401
- * especially, since the credential that authenticates it is not minted until
- * further down.
+ * about to make, and the two answers that mean it is not: no answer at all
+ * (refused, DNS failure, timeout — anything that makes `fetch` throw), or the
+ * origin itself saying this path does not exist.
  *
- * A 404 is a ROUTING fact and the whole of the observed failure: a deployment
- * under a path prefix answers 404 at the origin root and 401 at its real mount.
- * A transport error is not the same fact and deliberately does not refuse. The
- * host process is provably up — it is serving this very turn — so a failure to
- * connect is a transient blip or a vantage difference, and on the sandbox leg
- * the prober is the HOST while the consumer is the BOX, two different places on
- * the network. Refusing on that would invent an outage the door never had.
+ * Any HTTP status other than 404 is the door WORKING. A 401 especially: the
+ * credential that authenticates it is not minted until further down, so an
+ * unauthenticated probe is supposed to be turned away.
  */
 async function doorAnswers(url: string): Promise<boolean> {
   const response = await fetch(url, { method: "POST" }).catch(() => undefined);
-  return response === undefined || response.status !== 404;
+  return response !== undefined && response.status !== 404;
 }
 
 /**
@@ -534,10 +529,12 @@ export function claudeCode(
 
       // The other half of that refusal, and the one it could not see: a door
       // that IS named and is not THERE. The SDK swallows a failed MCP connect,
-      // so a 404 here opens a session with zero host tools and lets the model
-      // answer anyway — the same polite-refusal-at-HTTP-200, reached through a
-      // url that looks configured. Both legs, before the machine exists, so a
-      // doomed turn never pays for a sandbox boot.
+      // so a dead door here opens a session with zero host tools and lets the
+      // model answer anyway — the same polite-refusal-at-HTTP-200, reached
+      // through a url that merely looks configured. A typo'd host and a host
+      // that is down are the same failure to the customer as a wrong path, so
+      // all of them refuse. Both legs, before the machine exists, so a doomed
+      // turn never pays for a sandbox boot.
       if (doorUrl !== undefined && !await doorAnswers(doorUrl)) {
         throw new VendoError(
           "unavailable",

--- a/packages/harnesses/src/claude-code/index.ts
+++ b/packages/harnesses/src/claude-code/index.ts
@@ -16,6 +16,7 @@
  */
 import {
   VENDO_MAKE_TOOL,
+  VendoError,
   log,
   type BeatPhase,
   type Harness,
@@ -380,6 +381,26 @@ function warnNoOriginOnce(): void {
 }
 
 /**
+ * Is the door THERE? One request of exactly the shape the SDK's MCP client is
+ * about to make, and one answer that means it is not: the origin itself saying
+ * this path does not exist. Every other status is the door working — a 401
+ * especially, since the credential that authenticates it is not minted until
+ * further down.
+ *
+ * A 404 is a ROUTING fact and the whole of the observed failure: a deployment
+ * under a path prefix answers 404 at the origin root and 401 at its real mount.
+ * A transport error is not the same fact and deliberately does not refuse. The
+ * host process is provably up — it is serving this very turn — so a failure to
+ * connect is a transient blip or a vantage difference, and on the sandbox leg
+ * the prober is the HOST while the consumer is the BOX, two different places on
+ * the network. Refusing on that would invent an outage the door never had.
+ */
+async function doorAnswers(url: string): Promise<boolean> {
+  const response = await fetch(url, { method: "POST" }).catch(() => undefined);
+  return response === undefined || response.status !== 404;
+}
+
+/**
  * A runtime driven BARE — no composition filled the apps hooks and the host
  * passed none — loses the mid-turn hot-path sync (skeletons paint at turn end
  * instead of in seconds) and the end-of-turn validate gate. A deployment fact,
@@ -510,6 +531,22 @@ export function claudeCode(
       // because they are the only one who can change it and the user must
       // never be quietly under-served.
       if (doorPort !== undefined && doorUrl === undefined) warnNoOriginOnce();
+
+      // The other half of that refusal, and the one it could not see: a door
+      // that IS named and is not THERE. The SDK swallows a failed MCP connect,
+      // so a 404 here opens a session with zero host tools and lets the model
+      // answer anyway — the same polite-refusal-at-HTTP-200, reached through a
+      // url that looks configured. Both legs, before the machine exists, so a
+      // doomed turn never pays for a sandbox boot.
+      if (doorUrl !== undefined && !await doorAnswers(doorUrl)) {
+        throw new VendoError(
+          "unavailable",
+          `claudeCode() found no MCP door at ${doorUrl}. Every one of this product's `
+          + "actions travels over that door, so the turn would run with none. Check that "
+          + "VENDO_BASE_URL (or `mcp: { baseUrl }`) names the FULL public base this "
+          + "deployment is served under — path prefix included.",
+        );
+      }
 
       const boxEnv = inferenceEnv();
 

--- a/packages/harnesses/src/test-doubles.test-util.ts
+++ b/packages/harnesses/src/test-doubles.test-util.ts
@@ -5,6 +5,8 @@
  * rather than either package publishing a test-only subpath: a doubles surface
  * on a published package is surface nobody asked for.
  */
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
 import type {
   ApprovalId,
   ApprovalRequest,
@@ -259,6 +261,35 @@ export function testTranscript() {
  *  (`SeatModels`): a harness that DOES read a seat names the gap itself. */
 export function unusedModels(): SeatModels<LanguageModel> {
   return {};
+}
+
+/**
+ * A REAL door on loopback, for every suite whose turn reaches one.
+ *
+ * `claudeCode()` probes the door url it is handed before it boots a machine, so
+ * a fixture url is no longer just a string to echo back — a turn only proceeds
+ * if something answers it. `401` is the default because that is what the live
+ * door says to an unauthenticated caller: the credential is minted later.
+ *
+ * `hostname` is what the egress allowlist derives from the url (`hostOf`), so a
+ * suite asserting the allowlist can name it without recomputing the derivation.
+ */
+export async function liveDoor(status = 401): Promise<{
+  url: string;
+  hostname: string;
+  close: () => Promise<void>;
+}> {
+  const server = createServer((_request, response) => {
+    response.writeHead(status);
+    response.end();
+  });
+  await new Promise<void>((resolve) => { server.listen(0, "127.0.0.1", resolve); });
+  const { port } = server.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${port}/api/vendo/mcp`,
+    hostname: "127.0.0.1",
+    close: () => new Promise<void>((resolve) => { server.close(() => { resolve(); }); }),
+  };
 }
 
 export type StreamPart = Awaited<ReturnType<MockLanguageModelV3["doStream"]>>["stream"] extends ReadableStream<

--- a/packages/harnesses/tests/claude-code/claude-code-local.test.ts
+++ b/packages/harnesses/tests/claude-code/claude-code-local.test.ts
@@ -22,7 +22,7 @@ import type { SessionMachine, SessionMessage } from "../../src/claude-code/machi
 import { emptyTree } from "../../src/materialize.js";
 import { createTurnState } from "../../src/harness-state.js";
 import { provideHarnessAdapters } from "../../src/harness-sandbox.js";
-import { testAppsHooks, testWorkspace, unusedModels, userMessage } from "../../src/test-doubles.test-util.js";
+import { liveDoor, testAppsHooks, testWorkspace, unusedModels, userMessage } from "../../src/test-doubles.test-util.js";
 
 /** Every message the doubled local machine was sent, in order. */
 const sent: SessionMessage[] = [];
@@ -96,15 +96,26 @@ const doorWarnings = (): string[] => errors.filter((line) => line.includes("[ven
  */
 describe("machine: \"local\" and the MCP door's origin", () => {
   test("a REACHABLE door is handed over, and nothing is said", async () => {
-    const harness = claudeCode({ machine: "local", ...testAppsHooks() });
-    provideHarnessAdapters(harness, {
-      toolDoor: { url: "http://127.0.0.1:3000/api/vendo/mcp", mint: () => "vtk_ok", revoke: () => undefined },
-    });
+    // ⚠️ TEST EDIT — this fixture used to hardcode `http://127.0.0.1:3000`,
+    // which nothing in the test owned. The turn now probes the url it is handed,
+    // so "REACHABLE" has to be true rather than asserted: on a developer machine
+    // running Maple, port 3000 really does answer 404 on this path, and the test
+    // only passed in CI because nothing was listening there at all. A door this
+    // test starts itself is reachable everywhere.
+    const door = await liveDoor();
+    try {
+      const harness = claudeCode({ machine: "local", ...testAppsHooks() });
+      provideHarnessAdapters(harness, {
+        toolDoor: { url: door.url, mint: () => "vtk_ok", revoke: () => undefined },
+      });
 
-    await drain(harness, localTurn());
+      await drain(harness, localTurn());
 
-    expect(sent[0]?.toolDoor).toEqual({ url: "http://127.0.0.1:3000/api/vendo/mcp", token: "vtk_ok" });
-    expect(doorWarnings()).toEqual([]);
+      expect(sent[0]?.toolDoor).toEqual({ url: door.url, token: "vtk_ok" });
+      expect(doorWarnings()).toEqual([]);
+    } finally {
+      await door.close();
+    }
   });
 
   test("NO origin: the operator is warned ONCE, naming the fix, and the turn still runs", async () => {

--- a/packages/harnesses/tests/claude-code/claude-code.test.ts
+++ b/packages/harnesses/tests/claude-code/claude-code.test.ts
@@ -17,7 +17,7 @@ import { createSessionRoutes } from "../../box/turn-routes.mjs";
 import { assertHarnessComposable } from "../../src/compose.js";
 import { createTurnState } from "../../src/harness-state.js";
 import { provideHarnessAdapters } from "../../src/harness-sandbox.js";
-import { testAppsHooks, testWorkspace, unusedModels, userMessage } from "../../src/test-doubles.test-util.js";
+import { liveDoor, testAppsHooks, testWorkspace, unusedModels, userMessage } from "../../src/test-doubles.test-util.js";
 import { boxEgress, claudeCode, inferenceEnv, promptFor, truncated } from "../../src/claude-code/index.js";
 import { boxMachine, disposeSessionMachines, type SandboxAdapterLike, type SandboxMachineLike } from "../../src/claude-code/box.js";
 
@@ -564,6 +564,9 @@ describe("the box's egress allowlist — what the provider is asked to filter", 
     VENDO_INFERENCE_URL: undefined,
     VENDO_API_KEY: undefined,
   };
+  /** The pure `boxEgress()` cases below never open a turn, so nothing probes
+   *  this and it stays the plain string it always was. The three tests that DO
+   *  run a turn start a real door instead — see the ⚠️ TEST EDIT notes. */
   const DOOR = "https://app.example.com/api/vendo/mcp";
 
   test("the minimum set is the inference host and the door origin — assembled from what the box is actually given", () => {
@@ -581,17 +584,27 @@ describe("the box's egress allowlist — what the provider is asked to filter", 
   });
 
   test("a conversational box is provisioned WITH an allowlist — undefined would be unrestricted internet", async () => {
-    const sandbox = fakeSandbox(async () => undefined);
-    const harness = claudeCode({ sandbox });
-    provideHarnessAdapters(harness, {
-      toolDoor: { url: DOOR, mint: () => "vtk_1", revoke: () => undefined },
-    });
-    await withEnvAsync(NO_INFERENCE, async () => {
-      await drain(harness, makeTurn({ threadId: "thr_egress_min" }).turn);
-    });
-    expect(sandbox.specs).toHaveLength(1);
-    // EXACT, not "contains": an extra entry here is an extra hole in the box.
-    expect(sandbox.specs[0]?.allowedDomains).toEqual(["api.anthropic.com", "app.example.com"]);
+    // ⚠️ TEST EDIT — the door was `app.example.com`, a reserved domain that
+    // never resolved. This test opens a turn, and a turn now refuses a door
+    // nothing answers on, so the fixture has to be a door that exists. The
+    // assertion is unchanged in kind: still an EXACT allowlist, still the
+    // inference host plus the door's own hostname.
+    const door = await liveDoor();
+    try {
+      const sandbox = fakeSandbox(async () => undefined);
+      const harness = claudeCode({ sandbox });
+      provideHarnessAdapters(harness, {
+        toolDoor: { url: door.url, mint: () => "vtk_1", revoke: () => undefined },
+      });
+      await withEnvAsync(NO_INFERENCE, async () => {
+        await drain(harness, makeTurn({ threadId: "thr_egress_min" }).turn);
+      });
+      expect(sandbox.specs).toHaveLength(1);
+      // EXACT, not "contains": an extra entry here is an extra hole in the box.
+      expect(sandbox.specs[0]?.allowedDomains).toEqual(["api.anthropic.com", "127.0.0.1"]);
+    } finally {
+      await door.close();
+    }
   });
 
   test("with no door composed the box still gets an allowlist — the inference host alone", async () => {
@@ -603,16 +616,23 @@ describe("the box's egress allowlist — what the provider is asked to filter", 
   });
 
   test("the HOST may widen it — one additive option on the constructor", async () => {
-    const sandbox = fakeSandbox(async () => undefined);
-    const harness = claudeCode({ sandbox, egress: ["api.stripe.com"] });
-    provideHarnessAdapters(harness, {
-      toolDoor: { url: DOOR, mint: () => "vtk_2", revoke: () => undefined },
-    });
-    await withEnvAsync(NO_INFERENCE, async () => {
-      await drain(harness, makeTurn({ threadId: "thr_egress_widen" }).turn);
-    });
-    expect(sandbox.specs[0]?.allowedDomains)
-      .toEqual(["api.anthropic.com", "app.example.com", "api.stripe.com"]);
+    // ⚠️ TEST EDIT — same reason as above: a turn-opening test needs a door
+    // that answers. The widening assertion itself is untouched.
+    const door = await liveDoor();
+    try {
+      const sandbox = fakeSandbox(async () => undefined);
+      const harness = claudeCode({ sandbox, egress: ["api.stripe.com"] });
+      provideHarnessAdapters(harness, {
+        toolDoor: { url: door.url, mint: () => "vtk_2", revoke: () => undefined },
+      });
+      await withEnvAsync(NO_INFERENCE, async () => {
+        await drain(harness, makeTurn({ threadId: "thr_egress_widen" }).turn);
+      });
+      expect(sandbox.specs[0]?.allowedDomains)
+        .toEqual(["api.anthropic.com", "127.0.0.1", "api.stripe.com"]);
+    } finally {
+      await door.close();
+    }
   });
 
   test("`egress` is construction-time only — a wire caller cannot widen the box's network boundary", async () => {
@@ -625,17 +645,24 @@ describe("the box's egress allowlist — what the provider is asked to filter", 
   });
 
   test("the Cloud rung's gateway host rides the allowlist, read off the env the box is handed", async () => {
-    const sandbox = fakeSandbox(async () => undefined);
-    const harness = claudeCode({ sandbox });
-    provideHarnessAdapters(harness, {
-      toolDoor: { url: DOOR, mint: () => "vtk_3", revoke: () => undefined },
-    });
-    await withEnvAsync({ ...NO_INFERENCE, VENDO_API_KEY: "vnd-key", VENDO_CLOUD_URL: undefined }, async () => {
-      await drain(harness, makeTurn({ threadId: "thr_egress_cloud" }).turn);
-    });
-    // The gateway host and the door — NOT api.anthropic.com, which this box
-    // never dials.
-    expect(sandbox.specs[0]?.allowedDomains).toEqual(["console.vendo.run", "app.example.com"]);
+    // ⚠️ TEST EDIT — same reason as above. What this test is about, the gateway
+    // host displacing the default inference host, is asserted exactly as before.
+    const door = await liveDoor();
+    try {
+      const sandbox = fakeSandbox(async () => undefined);
+      const harness = claudeCode({ sandbox });
+      provideHarnessAdapters(harness, {
+        toolDoor: { url: door.url, mint: () => "vtk_3", revoke: () => undefined },
+      });
+      await withEnvAsync({ ...NO_INFERENCE, VENDO_API_KEY: "vnd-key", VENDO_CLOUD_URL: undefined }, async () => {
+        await drain(harness, makeTurn({ threadId: "thr_egress_cloud" }).turn);
+      });
+      // The gateway host and the door — NOT api.anthropic.com, which this box
+      // never dials.
+      expect(sandbox.specs[0]?.allowedDomains).toEqual(["console.vendo.run", "127.0.0.1"]);
+    } finally {
+      await door.close();
+    }
   });
 });
 
@@ -886,49 +913,62 @@ describe("a turn on a real box wire", () => {
   });
 
   test("the driver mints a credential and hands the box the door — the only way it reaches the world", async () => {
-    let seen: { url: string; token: string } | undefined;
-    const sandbox = fakeSandbox(async (box) => { seen = box.toolDoor; });
-    const harness = claudeCode({ sandbox });
-    const minted: string[] = [];
-    provideHarnessAdapters(harness, {
-      toolDoor: {
-        url: "https://app.example.com/api/vendo/mcp",
-        mint: (threadId: string) => {
-          minted.push(threadId);
-          return `vtk_for_${threadId}`;
+    // ⚠️ TEST EDIT — the door was `app.example.com`, which never resolved. A
+    // turn now probes the url before it boots a machine, so a door that no
+    // longer exists cannot stand in for one that does. Both assertions are
+    // unchanged; the url they compare against is simply the real one.
+    const door = await liveDoor();
+    try {
+      let seen: { url: string; token: string } | undefined;
+      const sandbox = fakeSandbox(async (box) => { seen = box.toolDoor; });
+      const harness = claudeCode({ sandbox });
+      const minted: string[] = [];
+      provideHarnessAdapters(harness, {
+        toolDoor: {
+          url: door.url,
+          mint: (threadId: string) => {
+            minted.push(threadId);
+            return `vtk_for_${threadId}`;
+          },
+          revoke: () => undefined,
         },
-        revoke: () => undefined,
-      },
-    });
-    const { turn } = makeTurn({ threadId: "thr_mint" });
-    await drain(harness, turn);
+      });
+      const { turn } = makeTurn({ threadId: "thr_mint" });
+      await drain(harness, turn);
 
-    // Minted for THIS conversation, and named by nothing else: the registry
-    // reads the subject off the turn in flight (`turn-credentials.ts`).
-    expect(minted).toEqual(["thr_mint"]);
-    expect(seen).toEqual({
-      url: "https://app.example.com/api/vendo/mcp",
-      token: "vtk_for_thr_mint",
-    });
+      // Minted for THIS conversation, and named by nothing else: the registry
+      // reads the subject off the turn in flight (`turn-credentials.ts`).
+      expect(minted).toEqual(["thr_mint"]);
+      expect(seen).toEqual({ url: door.url, token: "vtk_for_thr_mint" });
+    } finally {
+      await door.close();
+    }
   });
 
   test("ONE credential per conversation — a warm machine's second message reuses it, because a live session's headers are fixed at open", async () => {
-    const sandbox = fakeSandbox(async () => undefined);
-    const harness = claudeCode({ sandbox });
-    let issued = 0;
-    provideHarnessAdapters(harness, {
-      toolDoor: {
-        url: "https://app.example.com/api/vendo/mcp",
-        mint: () => `vtk_${(issued += 1)}`,
-        revoke: () => undefined,
-      },
-    });
-    await drain(harness, makeTurn({ threadId: "thr_one_cred" }).turn);
-    await drain(harness, makeTurn({ threadId: "thr_one_cred" }).turn);
+    // ⚠️ TEST EDIT — same reason: two turns run here, and each probes the door.
+    // The mint-count assertion is untouched.
+    const door = await liveDoor();
+    try {
+      const sandbox = fakeSandbox(async () => undefined);
+      const harness = claudeCode({ sandbox });
+      let issued = 0;
+      provideHarnessAdapters(harness, {
+        toolDoor: {
+          url: door.url,
+          mint: () => `vtk_${(issued += 1)}`,
+          revoke: () => undefined,
+        },
+      });
+      await drain(harness, makeTurn({ threadId: "thr_one_cred" }).turn);
+      await drain(harness, makeTurn({ threadId: "thr_one_cred" }).turn);
 
-    // A second mint per turn would leak a live credential per message. Safe
-    // because the AUTHORITY is per turn regardless of how old the token is.
-    expect(issued).toBe(1);
+      // A second mint per turn would leak a live credential per message. Safe
+      // because the AUTHORITY is per turn regardless of how old the token is.
+      expect(issued).toBe(1);
+    } finally {
+      await door.close();
+    }
   });
 
   test("an AUTO-MOUNTED door with no origin RUNS the turn workspace-only — the shape a host that never configured `mcp` deploys", async () => {
@@ -968,24 +1008,28 @@ describe("a turn on a real box wire", () => {
   });
 
   test("an AUTO-MOUNTED door WITH a reachable origin still hands the box full tools — auto-mounting suppresses nothing", async () => {
-    let seen: { url: string; token: string } | undefined;
-    const sandbox = fakeSandbox(async (box) => { seen = box.toolDoor; });
-    const harness = claudeCode({ sandbox });
-    provideHarnessAdapters(harness, {
-      toolDoor: {
-        url: "https://app.example.com/api/vendo/mcp",
-        autoMounted: true,
-        mint: () => "vtk_auto_ok",
-        revoke: () => undefined,
-      },
-    });
+    // ⚠️ TEST EDIT — this test's whole subject is a door with a REACHABLE
+    // origin, and its fixture named one that never resolved. Now it is one.
+    const door = await liveDoor();
+    try {
+      let seen: { url: string; token: string } | undefined;
+      const sandbox = fakeSandbox(async (box) => { seen = box.toolDoor; });
+      const harness = claudeCode({ sandbox });
+      provideHarnessAdapters(harness, {
+        toolDoor: {
+          url: door.url,
+          autoMounted: true,
+          mint: () => "vtk_auto_ok",
+          revoke: () => undefined,
+        },
+      });
 
-    await drain(harness, makeTurn({ threadId: "thr_auto_reachable" }).turn);
+      await drain(harness, makeTurn({ threadId: "thr_auto_reachable" }).turn);
 
-    expect(seen).toEqual({
-      url: "https://app.example.com/api/vendo/mcp",
-      token: "vtk_auto_ok",
-    });
+      expect(seen).toEqual({ url: door.url, token: "vtk_auto_ok" });
+    } finally {
+      await door.close();
+    }
   });
 
   test("a HOST-CONFIGURED door with no reachable URL still REFUSES — an explicit `mcp` that no box can reach is a misconfiguration, not a posture", async () => {

--- a/packages/harnesses/tests/claude-code/door-reachable.test.ts
+++ b/packages/harnesses/tests/claude-code/door-reachable.test.ts
@@ -14,28 +14,12 @@
  * request and reads a real status — nothing on either side of that seam is a
  * double.
  */
-import { createServer } from "node:http";
-import type { AddressInfo } from "node:net";
 import { VendoError, type HarnessEvent, type Turn } from "@vendoai/core";
 import { describe, expect, test } from "vitest";
 import { createTurnState } from "../../src/harness-state.js";
 import { provideHarnessAdapters } from "../../src/harness-sandbox.js";
-import { testWorkspace, unusedModels, userMessage } from "../../src/test-doubles.test-util.js";
+import { liveDoor, testWorkspace, unusedModels, userMessage } from "../../src/test-doubles.test-util.js";
 import { claudeCode } from "../../src/claude-code/index.js";
-
-/** A door that answers every request with one status, on a real loopback port. */
-async function doorServing(status: number): Promise<{ url: string; close: () => Promise<void> }> {
-  const server = createServer((_request, response) => {
-    response.writeHead(status);
-    response.end();
-  });
-  await new Promise<void>((resolve) => { server.listen(0, "127.0.0.1", resolve); });
-  const { port } = server.address() as AddressInfo;
-  return {
-    url: `http://127.0.0.1:${port}/api/vendo/mcp`,
-    close: () => new Promise<void>((resolve) => { server.close(() => { resolve(); }); }),
-  };
-}
 
 let seq = 0;
 
@@ -75,7 +59,7 @@ const harnessDialling = (
 
 describe("a configured door that does not answer — the turn refuses instead of chatting toolless", () => {
   test("SANDBOX leg: a door that 404s fails the turn, naming the url it tried", async () => {
-    const door = await doorServing(404);
+    const door = await liveDoor(404);
     try {
       // Named, reachable as a host, and simply not there — which is exactly
       // what a dropped path prefix produced against a live Next.js server.
@@ -89,7 +73,7 @@ describe("a configured door that does not answer — the turn refuses instead of
   });
 
   test("LOCAL leg: the same refusal — the subprocess reaches the door over the same url", async () => {
-    const door = await doorServing(404);
+    const door = await liveDoor(404);
     try {
       await expect(drain(harnessDialling(door.url, { machine: "local" })))
         .rejects.toThrow(door.url);
@@ -98,23 +82,21 @@ describe("a configured door that does not answer — the turn refuses instead of
     }
   });
 
-  test("a door that cannot be CONNECTED to is a different fact, and does not refuse", async () => {
-    // Bound, then closed: nothing answers on that port at all. Deliberately not
-    // a refusal — the host is provably up (it is serving this turn), and on the
-    // sandbox leg the prober is the host while the consumer is the box, so a
-    // transport error here does not prove the door is misconfigured the way a
-    // 404 does. It falls through to the missing machine like any other turn.
-    const door = await doorServing(404);
+  test("a door nothing is listening on is the SAME refusal — a down host reads to a customer exactly like a wrong path", async () => {
+    // Bound, then closed, so the port is real and refuses the connection.
+    const door = await liveDoor(404);
     await door.close();
-    const events = await drain(harnessDialling(door.url));
-    expect(events).toContainEqual({
-      type: "error",
-      message: "I can't run right now — this assistant is missing its workspace machine.",
-    });
+    await expect(drain(harnessDialling(door.url, { sandbox: {} as never })))
+      .rejects.toThrow(door.url);
+  });
+
+  test("a host that does not resolve is the same refusal — the typo an operator actually makes", async () => {
+    await expect(drain(harnessDialling("https://not-a-real-host.invalid/api/vendo/mcp")))
+      .rejects.toThrow("not-a-real-host.invalid");
   });
 
   test("a 401 door is a LIVE door: auth rides the turn credential, which is minted later", async () => {
-    const door = await doorServing(401);
+    const door = await liveDoor(401);
     try {
       // Past the probe, so the next thing it hits is the missing machine — the
       // proof that an unauthenticated 401 was never read as "not there".

--- a/packages/harnesses/tests/claude-code/door-reachable.test.ts
+++ b/packages/harnesses/tests/claude-code/door-reachable.test.ts
@@ -1,0 +1,138 @@
+/**
+ * A door that is CONFIGURED but not THERE — the second way this harness could
+ * chat with no hands.
+ *
+ * The no-origin refusal (claude-code.test.ts) only ever saw an UNDEFINED door
+ * url. A defined one that 404s sailed straight past it: the Agent SDK swallows a
+ * failed MCP connect, the session opens with zero `mcp__*` tools, and the model
+ * answers anyway — the polite-refusal-at-HTTP-200 the refusal above exists to
+ * prevent, arriving through a different hole. Observed live on a deployment
+ * served under a path prefix, where the door url dropped it (`POST
+ * /api/vendo/mcp 404`).
+ *
+ * The doors here are REAL HTTP servers, so the probe under test does a real
+ * request and reads a real status — nothing on either side of that seam is a
+ * double.
+ */
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { VendoError, type HarnessEvent, type Turn } from "@vendoai/core";
+import { describe, expect, test } from "vitest";
+import { createTurnState } from "../../src/harness-state.js";
+import { provideHarnessAdapters } from "../../src/harness-sandbox.js";
+import { testWorkspace, unusedModels, userMessage } from "../../src/test-doubles.test-util.js";
+import { claudeCode } from "../../src/claude-code/index.js";
+
+/** A door that answers every request with one status, on a real loopback port. */
+async function doorServing(status: number): Promise<{ url: string; close: () => Promise<void> }> {
+  const server = createServer((_request, response) => {
+    response.writeHead(status);
+    response.end();
+  });
+  await new Promise<void>((resolve) => { server.listen(0, "127.0.0.1", resolve); });
+  const { port } = server.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${port}/api/vendo/mcp`,
+    close: () => new Promise<void>((resolve) => { server.close(() => { resolve(); }); }),
+  };
+}
+
+let seq = 0;
+
+/** The least turn that reaches the door decision — it is taken before the
+ *  machine exists, so nothing here needs a box or a session. */
+const makeTurn = (): Turn<never> => ({
+  threadId: `thr_door_${(seq += 1)}`,
+  messages: [userMessage(`m_${seq}`, "make me a dashboard")],
+  tools: { list: async () => [], call: async () => ({ status: "ok" as const, output: {} }) },
+  skills: { list: async () => [], load: async () => "" },
+  workspace: testWorkspace({}),
+  models: unusedModels(),
+  state: createTurnState(undefined),
+  options: {} as never,
+  signal: new AbortController().signal,
+  interactive: true,
+  system: "PRODUCT BRIEF",
+} as unknown as Turn<never>);
+
+const drain = async (harness: ReturnType<typeof claudeCode>): Promise<HarnessEvent[]> => {
+  const events: HarnessEvent[] = [];
+  for await (const event of harness.run(makeTurn() as never)) events.push(event);
+  return events;
+};
+
+/** Both legs, built the same way: a door port pointed wherever the test says. */
+const harnessDialling = (
+  url: string | undefined,
+  options: Parameters<typeof claudeCode>[0] = {},
+): ReturnType<typeof claudeCode> => {
+  const harness = claudeCode(options);
+  provideHarnessAdapters(harness, {
+    toolDoor: { url, autoMounted: false, mint: () => "vtk_probe", revoke: () => undefined },
+  });
+  return harness;
+};
+
+describe("a configured door that does not answer — the turn refuses instead of chatting toolless", () => {
+  test("SANDBOX leg: a door that 404s fails the turn, naming the url it tried", async () => {
+    const door = await doorServing(404);
+    try {
+      // Named, reachable as a host, and simply not there — which is exactly
+      // what a dropped path prefix produced against a live Next.js server.
+      await expect(drain(harnessDialling(door.url, { sandbox: {} as never })))
+        .rejects.toThrow(VendoError);
+      await expect(drain(harnessDialling(door.url, { sandbox: {} as never })))
+        .rejects.toThrow(door.url);
+    } finally {
+      await door.close();
+    }
+  });
+
+  test("LOCAL leg: the same refusal — the subprocess reaches the door over the same url", async () => {
+    const door = await doorServing(404);
+    try {
+      await expect(drain(harnessDialling(door.url, { machine: "local" })))
+        .rejects.toThrow(door.url);
+    } finally {
+      await door.close();
+    }
+  });
+
+  test("a door that cannot be CONNECTED to is a different fact, and does not refuse", async () => {
+    // Bound, then closed: nothing answers on that port at all. Deliberately not
+    // a refusal — the host is provably up (it is serving this turn), and on the
+    // sandbox leg the prober is the host while the consumer is the box, so a
+    // transport error here does not prove the door is misconfigured the way a
+    // 404 does. It falls through to the missing machine like any other turn.
+    const door = await doorServing(404);
+    await door.close();
+    const events = await drain(harnessDialling(door.url));
+    expect(events).toContainEqual({
+      type: "error",
+      message: "I can't run right now — this assistant is missing its workspace machine.",
+    });
+  });
+
+  test("a 401 door is a LIVE door: auth rides the turn credential, which is minted later", async () => {
+    const door = await doorServing(401);
+    try {
+      // Past the probe, so the next thing it hits is the missing machine — the
+      // proof that an unauthenticated 401 was never read as "not there".
+      const events = await drain(harnessDialling(door.url));
+      expect(events).toContainEqual({
+        type: "error",
+        message: "I can't run right now — this assistant is missing its workspace machine.",
+      });
+    } finally {
+      await door.close();
+    }
+  });
+
+  test("an UNCONFIGURED door is never probed — the existing refusal answers, unchanged", async () => {
+    const events = await drain(harnessDialling(undefined));
+    expect(events).toContainEqual({
+      type: "error",
+      message: "I can't use this product's actions right now.",
+    });
+  });
+});

--- a/packages/harnesses/tests/claude-code/door-reachable.test.ts
+++ b/packages/harnesses/tests/claude-code/door-reachable.test.ts
@@ -14,6 +14,8 @@
  * request and reads a real status — nothing on either side of that seam is a
  * double.
  */
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
 import { VendoError, type HarnessEvent, type Turn } from "@vendoai/core";
 import { describe, expect, test } from "vitest";
 import { createTurnState } from "../../src/harness-state.js";
@@ -25,7 +27,7 @@ let seq = 0;
 
 /** The least turn that reaches the door decision — it is taken before the
  *  machine exists, so nothing here needs a box or a session. */
-const makeTurn = (): Turn<never> => ({
+const makeTurn = (signal: AbortSignal = new AbortController().signal): Turn<never> => ({
   threadId: `thr_door_${(seq += 1)}`,
   messages: [userMessage(`m_${seq}`, "make me a dashboard")],
   tools: { list: async () => [], call: async () => ({ status: "ok" as const, output: {} }) },
@@ -34,16 +36,37 @@ const makeTurn = (): Turn<never> => ({
   models: unusedModels(),
   state: createTurnState(undefined),
   options: {} as never,
-  signal: new AbortController().signal,
+  signal,
   interactive: true,
   system: "PRODUCT BRIEF",
 } as unknown as Turn<never>);
 
-const drain = async (harness: ReturnType<typeof claudeCode>): Promise<HarnessEvent[]> => {
+const drain = async (
+  harness: ReturnType<typeof claudeCode>,
+  signal?: AbortSignal,
+): Promise<HarnessEvent[]> => {
   const events: HarnessEvent[] = [];
-  for await (const event of harness.run(makeTurn() as never)) events.push(event);
+  for await (const event of harness.run(makeTurn(signal) as never)) events.push(event);
   return events;
 };
+
+/** A door that ACCEPTS the connection and then never answers — the one shape a
+ *  status code cannot describe, and the only one that can leave the probe
+ *  pending. The socket is held open until the test closes the server. */
+async function hangingDoor(): Promise<{ url: string; close: () => Promise<void> }> {
+  const held: Array<{ destroy: () => void }> = [];
+  const server = createServer((_request, _response) => { /* never answers */ });
+  server.on("connection", (socket) => { held.push(socket); });
+  await new Promise<void>((resolve) => { server.listen(0, "127.0.0.1", resolve); });
+  const { port } = server.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${port}/api/vendo/mcp`,
+    close: async () => {
+      for (const socket of held) socket.destroy();
+      await new Promise<void>((resolve) => { server.close(() => { resolve(); }); });
+    },
+  };
+}
 
 /** Both legs, built the same way: a door port pointed wherever the test says. */
 const harnessDialling = (
@@ -107,6 +130,34 @@ describe("a configured door that does not answer — the turn refuses instead of
       });
     } finally {
       await door.close();
+    }
+  });
+
+  test("a CANCELLED turn stops waiting on a door that never answers, and is not told the door is dead", async () => {
+    // The probe is the first thing a turn does, and a door that accepts the
+    // connection but never replies holds it open — undici only gives up at its
+    // 300s headers timeout. Without the turn's signal the harness stayed pending
+    // long after the user cancelled; with it, the fetch is torn down at once.
+    // And a cancellation is not a verdict on the door: reporting "no MCP door"
+    // here would send an operator hunting a misconfiguration that never existed.
+    const hanging = await hangingDoor();
+    try {
+      const controller = new AbortController();
+      setTimeout(() => { controller.abort(); }, 50);
+
+      const started = Date.now();
+      const events = await drain(harnessDialling(hanging.url), controller.signal);
+
+      // Settled on the cancellation, not on a network timeout.
+      expect(Date.now() - started).toBeLessThan(5_000);
+      // It fell through to the missing machine like any other cancelled turn —
+      // the door was never blamed.
+      expect(events).toContainEqual({
+        type: "error",
+        message: "I can't run right now — this assistant is missing its workspace machine.",
+      });
+    } finally {
+      await hanging.close();
     }
   });
 

--- a/packages/vendo/src/agent-doubles.test-util.ts
+++ b/packages/vendo/src/agent-doubles.test-util.ts
@@ -6,6 +6,8 @@
  * test-only subpath, which is surface nobody asked for. The alternative — a
  * shared doubles package — would be a package for two callers.
  */
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
 import type {
   ApprovalId,
   ApprovalRequest,
@@ -391,6 +393,33 @@ export function testTranscript() {
         .sort((left, right) => left.seq - right.seq)
         .map((row) => structuredClone(row.message));
     },
+  };
+}
+
+/**
+ * A REAL door on loopback, for the suites that compose `claudeCode()`.
+ *
+ * That harness probes the door url it is handed before it boots a machine, so a
+ * composition pointed at a base URL nothing answers on now refuses the turn —
+ * which is the whole point of the probe. `origin` is what goes in
+ * `mcp: { baseUrl }`; the composition appends the mount itself.
+ *
+ * The copy in `@vendoai/harnesses` (`test-doubles.test-util.ts`) is the same
+ * double for the same reason — see this file's header on why it is a copy.
+ */
+export async function liveDoor(status = 401): Promise<{
+  origin: string;
+  close: () => Promise<void>;
+}> {
+  const server = createServer((_request, response) => {
+    response.writeHead(status);
+    response.end();
+  });
+  await new Promise<void>((resolve) => { server.listen(0, "127.0.0.1", resolve); });
+  const { port } = server.address() as AddressInfo;
+  return {
+    origin: `http://127.0.0.1:${port}`,
+    close: () => new Promise<void>((resolve) => { server.close(() => { resolve(); }); }),
   };
 }
 

--- a/packages/vendo/src/compose-harness.ts
+++ b/packages/vendo/src/compose-harness.ts
@@ -9,7 +9,7 @@ import { CONNECTOR_DISCOVERY_TOOLS, VENDO_MAKE_TOOL, type AgentRunner, type Harn
 import { assertHarnessComposable, vendo } from "@vendoai/harnesses";
 import type { VendoComposition } from "./compose-context.js";
 import { storeServesHarnessTurns } from "./compose-store.js";
-import { MCP_MOUNT } from "./door-paths.js";
+import { basePathOf, MCP_MOUNT } from "./door-paths.js";
 import { createHarnessTurns, type HarnessTurns } from "./harness-turn.js";
 import { assembleSystemPrompt, discoveryRail } from "./prompt.js";
 import { withAgentMenu } from "./surface-menu.js";
@@ -167,7 +167,12 @@ const harnessTurnDoorSeams = (
       toolDoor: {
         get url(): string | undefined {
           const base = doorBase();
-          return base === undefined ? undefined : new URL(MCP_MOUNT, base).toString();
+          // The mount is ABSOLUTE, so it has to be re-prefixed by hand: `new
+          // URL("/api/vendo/mcp", base)` resolves against the base's ORIGIN and
+          // throws its path away, sending every deployment served under a prefix
+          // to a URL its own framework 404s. Same `basePathOf` the door uses to
+          // build its prefixed well-known spellings, so the two can't disagree.
+          return base === undefined ? undefined : new URL(`${basePathOf(base)}${MCP_MOUNT}`, base).toString();
         },
         // Which of the two mounts this is, stated rather than inferred. With no
         // origin the harness has to tell a host whose `mcp` cannot be reached

--- a/packages/vendo/tests/claude-code-composed.test.ts
+++ b/packages/vendo/tests/claude-code-composed.test.ts
@@ -31,6 +31,7 @@ import { createSessionRoutes } from "@vendoai/harnesses/box-door";
 import { claudeCode } from "@vendoai/harnesses/claude-code";
 import { createStore, type VendoStore } from "@vendoai/store";
 import { afterEach, describe, expect, it } from "vitest";
+import { liveDoor } from "../src/agent-doubles.test-util.js";
 import { createVendo, type Vendo } from "../src/server.js";
 
 const encoder = new TextEncoder();
@@ -218,9 +219,19 @@ async function compose(overrides: Record<string, unknown>): Promise<{
   vendo: Vendo;
   store: VendoStore;
   host: ReturnType<typeof hostTools>;
+  /** The door's origin, for the one case that asserts where the box was sent. */
+  door: { origin: string };
 }> {
   const store = await tempStore();
   const host = hostTools();
+  // ⚠️ TEST EDIT — this used to be `https://host.test`, a reserved TLD that
+  // never resolves. `claudeCode()` now probes the door url before it boots a
+  // machine and refuses a turn nothing answers, so a composition has to name a
+  // base that is actually there. Everything below is unchanged: the box still
+  // reaches the REAL door through `vendo.handler`, which routes on the mount
+  // path and does not care which origin named it.
+  const door = await liveDoor();
+  cleanups.push(door.close);
   const vendo = createVendo({
     // Never reached: the thinker here is the scripted box, not a provider. The
     // reviewer's own seat is what a case overrides, since the judging pass is
@@ -230,7 +241,7 @@ async function compose(overrides: Record<string, unknown>): Promise<{
     store,
     // The box reaches its tools over the host's MCP door, so a composed
     // `claudeCode()` needs one open and a public origin a machine could name.
-    mcp: { baseUrl: "https://host.test" },
+    mcp: { baseUrl: door.origin },
     oauth: {
       async authorize() { return { subject: principal.subject }; },
       async principal(subject: string) { return { kind: "user" as const, subject }; },
@@ -238,7 +249,7 @@ async function compose(overrides: Record<string, unknown>): Promise<{
     ...overrides,
   } as Parameters<typeof createVendo>[0]);
   vendo.actions.add(host.tools);
-  return { vendo, store, host };
+  return { vendo, store, host, door };
 }
 
 /**
@@ -308,7 +319,7 @@ describe("createVendo({ sandbox, harness: claudeCode() })", () => {
       box.emit({ type: "usage", inputTokens: 12, outputTokens: 3 });
       box.emit({ type: "text", delta: "Two invoices are open." });
     });
-    const { vendo, store, host } = await compose({ sandbox, harness: claudeCode() });
+    const { vendo, store, host, door } = await compose({ sandbox, harness: claudeCode() });
     composed = vendo;
 
     const turn = await vendo.handler(post("/threads", {
@@ -328,7 +339,9 @@ describe("createVendo({ sandbox, harness: claudeCode() })", () => {
     // with nothing hand-wired into the harness.
     expect(sandbox.creates).toBe(1);
     // Composition minted the credential and pointed the box at its own door.
-    expect(handed?.url).toBe("https://host.test/api/vendo/mcp");
+    // ⚠️ TEST EDIT — the origin is the composed door's rather than a hardcoded
+    // `https://host.test`; the mount it must carry is asserted exactly as before.
+    expect(handed?.url).toBe(`${door.origin}/api/vendo/mcp`);
     expect(handed?.token).toMatch(/^vtk_/);
     // And the call executed on OUR side, through the one guard-bound registry.
     expect(host.calls).toHaveLength(1);

--- a/packages/vendo/tests/mcp-door-internal.e2e.test.ts
+++ b/packages/vendo/tests/mcp-door-internal.e2e.test.ts
@@ -420,4 +420,18 @@ describe("where an internal door is dialled — zero config, and not poisonable 
     expect(await dialledDoorUrl({ toolDoor: true, sandbox: true }, {}, [LOOPBACK]))
       .toBe("https://app.example.com/api/vendo/mcp");
   });
+
+  it("a base under a PATH PREFIX keeps it — the door is where the host mounted Vendo, not at the origin root", async () => {
+    // `MCP_MOUNT` is absolute, and `new URL(absolute, base)` resolves against the
+    // base's ORIGIN and discards its path. So every deployment served under a
+    // prefix — Maple's `basePath: "/maple"` — dialled an origin-root URL its
+    // framework 404s. The door looked configured, the SDK swallowed the failed
+    // connect, and the session opened with zero host tools.
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("VENDO_BASE_URL", "https://app.example.com/maple");
+    expect(await dialledDoorUrl({ toolDoor: true }, {}, [LOOPBACK]))
+      .toBe("https://app.example.com/maple/api/vendo/mcp");
+    expect(await dialledDoorUrl({ toolDoor: true, sandbox: true }, {}, [LOOPBACK]))
+      .toBe("https://app.example.com/maple/api/vendo/mcp");
+  });
 });

--- a/packages/vendo/tests/orgs-materialize.test.ts
+++ b/packages/vendo/tests/orgs-materialize.test.ts
@@ -32,6 +32,7 @@ import { createSessionRoutes } from "@vendoai/harnesses/box-door";
 import { claudeCode } from "@vendoai/harnesses/claude-code";
 import { appAccess, createStore, type VendoStore } from "@vendoai/store";
 import { afterEach, describe, expect, it } from "vitest";
+import { liveDoor } from "../src/agent-doubles.test-util.js";
 import { createVendo, type Vendo } from "../src/server.js";
 
 const encoder = new TextEncoder();
@@ -142,13 +143,19 @@ function fakeSandbox(script: (box: BoxScript) => Promise<void>) {
 let acting: Principal = kim;
 
 async function boot(store: VendoStore, sandbox: ReturnType<typeof fakeSandbox>): Promise<Vendo> {
+  // ⚠️ TEST EDIT — was `https://host.test`, a reserved TLD that never resolves.
+  // `claudeCode()` now probes the door before booting a machine and refuses a
+  // turn nothing answers, so this composition needs a base that is really there.
+  // Nothing this file asserts — org file materialization — depends on the origin.
+  const door = await liveDoor();
+  cleanups.push(door.close);
   const vendo = createVendo({
     // Never reached: the thinker is the scripted box, not a provider.
     models: { default: {} as LanguageModel },
     store,
     sandbox: sandbox as unknown as SandboxAdapter,
     harness: claudeCode(),
-    mcp: { baseUrl: "https://host.test" },
+    mcp: { baseUrl: door.origin },
     // One preset, four seams (09-vendo §2.1) — `memberships` is the one this
     // file is about, and `oauth` is what lets the box's MCP door open at all.
     auth: {


### PR DESCRIPTION
## What

Two fixes to the tool door `claudeCode()` dials.

**1. The door URL dropped the host's path prefix** (`packages/vendo/src/compose-harness.ts:170`).
`MCP_MOUNT` is the absolute path `/api/vendo/mcp`, so `new URL(MCP_MOUNT, base)`
resolved against the base's ORIGIN and discarded its path. A host served under a
prefix — Maple's `basePath: "/maple"` with `VENDO_BASE_URL=http://localhost:3000/maple` —
handed every box and subprocess `http://localhost:3000/api/vendo/mcp`, which Next
404s. Re-prefixed with `basePathOf`, the helper the door already uses to build its
prefixed well-known spellings, so producer and door cannot disagree.

**2. A configured-but-dead door now refuses** (`packages/harnesses/src/claude-code/index.ts`).
The existing refusal only ever saw an UNDEFINED url. A live-looking one that did
not answer sailed past it: the Agent SDK swallows the failed MCP connect, the
session opens with zero `mcp__*` tools, and the model answers anyway — the
polite-refusal-at-HTTP-200 this harness refuses to ship. One cheap probe at
session open, before the machine exists (so a doomed turn never pays for a
sandbox boot), on both legs.

The predicate is "did anything answer": any HTTP status other than 404 means the
door is ALIVE — a 401 most of all, since the turn credential that authenticates
it is minted later — while a 404, a refused connection, a DNS failure or a
timeout all refuse the turn with the url named. A typo'd door host and a host
that is down read to a customer exactly like a wrong path.

## Why

Observed live: a turn proceeded with zero host tools after `POST /api/vendo/mcp 404`.
Fix 1 is the cause; fix 2 is why nobody noticed.

Proven against the running Maple dev server:

| URL | status |
| --- | --- |
| `POST /api/vendo/mcp` (origin root, what we sent before) | 404 |
| `POST /maple/api/vendo/mcp` (prefixed, what we send now) | 401 |

## Stated test change

Ten fixtures encoded an unreachable door as an acceptable one — which is the
buggy contract this PR exists to remove — so they had to move with it. Each now
starts a real loopback door (`liveDoor()`, added to both packages' existing
doubles files) instead of naming one that never resolved. **No assertion was
relaxed**; the ones that named a url now name the live door's.

- **`packages/harnesses/tests/claude-code/claude-code.test.ts`** — six fixtures on
  `https://app.example.com/api/vendo/mcp`, a reserved domain that never resolved:
  three egress-allowlist tests (expected allowlists now read `127.0.0.1`, the same
  derivation through the same `hostOf`) and three box-wire tests (credential
  minting, one-credential-per-conversation, auto-mounted door). The `DOOR`
  constant is deliberately untouched for the pure `boxEgress()` cases, which never
  open a turn and so never probe.
- **`packages/harnesses/tests/claude-code/claude-code-local.test.ts`** — "a
  REACHABLE door" pointed at `http://127.0.0.1:3000`, which nothing in the test
  owned. It passed in CI only because nothing listens on 3000 there; on a
  developer machine running Maple that port really does 404 this path. It now
  starts the door it calls reachable.
- **`packages/vendo/tests/claude-code-composed.test.ts`** and
  **`packages/vendo/tests/orgs-materialize.test.ts`** — both composed
  `mcp: { baseUrl: "https://host.test" }`, another reserved TLD that never
  resolves. The composed box still reaches the REAL door through `vendo.handler`,
  which routes on the mount path and does not care which origin named it.

## Verification

- New test in `packages/vendo/tests/mcp-door-internal.e2e.test.ts` — run RED first
  (`expected 'https://app.example.com/api/vendo/mcp' to be '…/maple/api/vendo/mcp'`),
  green after; the 8 pre-existing root-base cases in that file are the byte-identical proof.
- New file `packages/harnesses/tests/claude-code/door-reachable.test.ts` — 6 tests
  covering 404 on both legs, connection refused, DNS failure, a live 401, and an
  unconfigured door. The doors are real `node:http` servers, so neither side of
  the probe seam is a double.
- The two connection-error tests were proven to fail under the old 404-only
  predicate and pass under the new one.
- `packages/harnesses` full package suite: **574 passed, 0 failed**.
- `packages/vendo` door suites (`claude-code-composed`, `orgs-materialize`,
  `mcp-door-internal`): **28 passed, 0 failed**.

- [x] `pnpm build && pnpm typecheck && pnpm lint` green; full suite is CI's job
- [ ] Screenshots attached (if UI-affecting) — not UI-affecting
