### PR TITLE
docs(vendo): init stops printing placeholder broker secrets, and the door pages teach tokenFor

### DIFF
--- a/docs-site/agents/index.mdx
+++ b/docs-site/agents/index.mdx
@@ -360,10 +360,12 @@ Once the use case is `mcp`, two more questions come back on that run for you to
 relay. Who runs the OAuth plumbing: Vendo can host it at a stable
 `yourcompany.mcp.vendo.run` so none of it sits on your human's domain
 (`--posture broker`, and it uses their Vendo Cloud account), or their app can
-serve it itself with zero config (`--posture local`). And whether their own
-backend will call these tools machine to machine, like a nightly job, which
-sets up a service key (`--service-key`). Answer both as flags on the next run;
-3 is always yours.
+serve it itself with zero config (`--posture local`). And, on the local posture
+only, whether their own backend will call these tools machine to machine, like a
+nightly job, which sets up a service key (`--service-key`) — a Cloud-fronted door
+provisions its own, so pairing `--service-key` with `--posture broker` exits `1`
+rather than discarding the key. Answer as flags on the next run; 3 is always
+yours.
 
 1. **`mcp: true` plus the OAuth adapter.** Written by `--use-case mcp`; add it
    to the `createVendo({...})` init wrote otherwise. The door mints its own

--- a/docs-site/outside-agents/quickstart.mdx
+++ b/docs-site/outside-agents/quickstart.mdx
@@ -30,11 +30,31 @@ pnpm exec vendo init
 </CodeGroup>
 
 Answer the first question — *How will people use your agent?* — with **From
-outside AI apps over MCP**. Answer the dev-URL question with the origin your
-dev server actually prints.
+outside agents over MCP — Claude, ChatGPT, Cursor, or any MCP agent
+(experimental)**. That option is labelled experimental; the door itself is what
+this page proves.
 
-Init writes three things: `mcp: true` into the composition it creates, the
-origin-root discovery route beside it, and `VENDO_BASE_URL` into `.env.local`.
+Then *Where does this app run in dev?* — the origin your dev server actually
+prints, `http://localhost:3000` or whatever port it names.
+
+<Warning>
+**This answer decides which sign-in postures are open to you.** Vendo Cloud
+registers this origin as your tenant's forwarding address and refuses one that
+is not `https`, so a `localhost` answer and the Cloud broker cannot go together
+— init refuses the pair rather than writing a door that dies on its first
+request. On `localhost`, take **Local** at the posture question below. To run
+the Cloud broker in dev, give an https tunnel's origin here instead.
+</Warning>
+
+Init then asks a few more questions that are not this page's business — the AI
+judgment pass, an `actAs` confirmation, and any theme slots it could not read
+confidently. Their defaults are fine; press Enter through them.
+
+Init writes the wiring: `mcp: true` into the composition it creates, the
+origin-root discovery route beside it, `VENDO_BASE_URL` into `.env.local`, a
+`.vendo/` directory holding the tool catalog, judgments, policy, overrides and
+theme, and a `predev` hook. It also installs `ai` and `@ai-sdk/anthropic`. The
+closing line counts the files it wrote.
 
 ```ts lib/vendo.ts focus={5}
 import { authJs } from "@vendoai/vendo/auth/auth-js";
@@ -53,8 +73,8 @@ door without one. [Auth](/production/auth) lists them.
 <Note>
 **Checkpoint.** `lib/vendo.ts` says `mcp: true`,
 `app/.well-known/[...vendo]/route.ts` exists, and `.env.local` has a
-`VENDO_BASE_URL` line. If init printed a warning instead, it names the missing
-auth preset — fix that and re-run.
+`VENDO_BASE_URL` line. If init refused instead, the message names the reason and
+the way out — a missing auth preset, or the http-origin-with-Cloud pair above.
 </Note>
 
 </Step>
@@ -80,7 +100,9 @@ client discovers your sign-in without being told about it.
 <Note>
 **Checkpoint.** A `401` with a `www-authenticate` header naming your own origin.
 A `404` means the app is not serving `/api/vendo/mcp` — check that init's wire
-route landed. A `200` means something else is answering that path.
+route landed. A `200` means something else is answering that path. A `501` means
+the door is open but its Cloud tenant could not be provisioned — the usual cause
+is a `VENDO_BASE_URL` that is not https, which is the pair Step 1 warns about.
 </Note>
 
 </Step>
@@ -107,8 +129,13 @@ For Claude Code, the plugin is one command:
 <Note>
 **Checkpoint.** The client lists your tools, and a read runs and comes back with
 *your own* data. A write parks for approval instead of executing — that is the
-guard, not a failure. [How the door works](/outside-agents/how-the-door-works)
-covers what the agent sees and what happens on the way to your API.
+guard, not a failure.
+
+If a tool answers `not-implemented`, the cause is almost always a missing
+`actAs` — the door has no auth material to call your API with. Note that a
+broker that could not provision reports the same code, so check Step 2's `curl`
+before you go looking at `actAs`.
+[How the door works](/outside-agents/how-the-door-works) explains both.
 </Note>
 
 </Step>
@@ -157,7 +184,9 @@ all — is refused at mint rather than handing you a token that dies on the firs
 tool call.
 
 <Note>
-**Checkpoint.** `tokenFor` returns a `vmat_…` string. Feed it to a stock MCP
+**Checkpoint.** `tokenFor` returns a token string. Its shape tells you which
+posture minted it: `vmat_…` from your own door on the local posture, a raw JWT
+(`eyJhbG…`) from the broker on Vendo Cloud. Both are correct — feed it to a stock MCP
 client — [Your own agent](/outside-agents/your-own-agent) is the whole loop —
 and the call lands in your product under the user you named.
 </Note>
@@ -173,15 +202,17 @@ answers, and the door's URL is the same either way — it derives from
 `VENDO_BASE_URL` and never from a broker, so switching later invalidates nothing
 your users already configured.
 
-**Your app serves it (default, no key).** Everything above already did this.
-Your app is the authorization server, your login is the sign-in, and nothing
-leaves your origin. This is the zero-config path and it is complete.
+**Local — your app serves its own OAuth (default, no key).** Everything above
+already did this. Your app is the authorization server, your login is the
+sign-in, and nothing leaves your origin. Zero config, and it works on `http`, so
+this is the posture for local development.
 
-**Vendo Cloud fronts it (one answer).** With a `VENDO_API_KEY` in hand, init
-asks one more question — *Who should run the OAuth plumbing?* — and answering
-**Vendo hosts the OAuth plumbing** moves the OAuth surface off your domain to a
-stable `yourcompany.mcp.vendo.run` tenant that Vendo provisions on first use.
-There is nothing to copy: no console visit, no environment values, no keys.
+**Vendo Cloud broker (one answer).** With a `VENDO_API_KEY` in hand, init asks
+one more question — *How should outside agents sign in?* — and answering **Vendo
+Cloud broker** moves the OAuth surface off your domain to a stable
+`yourcompany.mcp.vendo.run` tenant that Vendo provisions on first use. There is
+nothing to copy: no console visit, no environment values, no keys. It needs an
+https `VENDO_BASE_URL`, per the warning in Step 1.
 
 To front the door with a broker you run yourself, set both values where you
 deploy. An explicit override always wins over the Cloud default.

--- a/docs-site/outside-agents/quickstart.mdx
+++ b/docs-site/outside-agents/quickstart.mdx
@@ -34,6 +34,10 @@ outside agents over MCP — Claude, ChatGPT, Cursor, or any MCP agent
 (experimental)**. That option is labelled experimental; the door itself is what
 this page proves.
 
+Next it confirms the auth preset it detected — *Should the agent act as your
+signed-in … user?* — which is what wires `actAs`, and then asks where your model
+key comes from.
+
 Then *Where does this app run in dev?* — the origin your dev server actually
 prints, `http://localhost:3000` or whatever port it names.
 
@@ -46,15 +50,16 @@ request. On `localhost`, take **Local** at the posture question below. To run
 the Cloud broker in dev, give an https tunnel's origin here instead.
 </Warning>
 
-Init then asks a few more questions that are not this page's business — the AI
-judgment pass, an `actAs` confirmation, and any theme slots it could not read
+After the posture question below, init asks a few more that are not this page's
+business — the AI judgment pass, and any theme slots it could not read
 confidently. Their defaults are fine; press Enter through them.
 
 Init writes the wiring: `mcp: true` into the composition it creates, the
-origin-root discovery route beside it, `VENDO_BASE_URL` into `.env.local`, a
+origin-root discovery route beside it, `VENDO_BASE_URL` into `.env.local`, and a
 `.vendo/` directory holding the tool catalog, judgments, policy, overrides and
-theme, and a `predev` hook. It also installs `ai` and `@ai-sdk/anthropic`. The
-closing line counts the files it wrote.
+theme. It adds two package scripts — `predev` and `prebuild`, both running
+`vendo sync` so the catalog cannot drift from your code — and installs `ai` and
+`@ai-sdk/anthropic`. The closing line counts the files it wrote.
 
 ```ts lib/vendo.ts focus={5}
 import { authJs } from "@vendoai/vendo/auth/auth-js";
@@ -131,9 +136,12 @@ For Claude Code, the plugin is one command:
 ```
 
 <Note>
-**Checkpoint.** The client lists your tools, and a read runs and comes back with
-*your own* data. A write parks for approval instead of executing — that is the
-guard, not a failure.
+**Checkpoint.** The client lists your tools, and a call runs and comes back with
+*your own* data. Reads and writes both execute — nothing parks, and that is
+correct on a fresh install. The policy init writes to `.vendo/policy.json` asks
+on one thing only, `risk: destructive`, and a young app often has no tool graded
+that way. Approvals are a policy you opt into, not a default the door imposes:
+edit that file when you want a call to wait for a person.
 
 If a tool answers `not-implemented`, that means a missing `actAs` — the door has
 no auth material to call your API with. A Cloud problem never looks like this;

--- a/docs-site/outside-agents/quickstart.mdx
+++ b/docs-site/outside-agents/quickstart.mdx
@@ -1,20 +1,19 @@
 ---
 title: "From outside agents"
-description: "Your product, driven from your own agent, as one of your users."
+description: "Turn your app into an MCP server that Claude, ChatGPT, Cursor and your own backend drive as one of your users."
 sidebarTitle: "Quickstart"
 ---
 
 ## Quickstart
 
-A door, a token, and your agent. `npx vendo init` writes the door, and the
-console holds the key.
+`npx vendo init` turns your app into an MCP server. Outside agents connect
+through your own login; your own backend gets a token from one method.
+
+Four steps, each with a checkpoint. Do not move on until the checkpoint passes.
 
 <Steps>
 
-<Step title="Install and run init">
-
-One package, then the setup command from the [quickstart](/): it reads your
-repo, then asks.
+<Step title="Run init">
 
 <CodeGroup>
 
@@ -30,190 +29,179 @@ pnpm exec vendo init
 
 </CodeGroup>
 
-Its first question is **How will people use your agent?** — answer **From
-outside agents over MCP**, and it writes everything this page walks through.
+Answer the first question — *How will people use your agent?* — with **From
+outside AI apps over MCP**. Answer the dev-URL question with the origin your
+dev server actually prints.
 
-That answer is also what adds init's MCP-only questions. There is always one:
-whether your own backend will call these tools machine to machine, which is the
-service key. The posture question — who runs the OAuth plumbing — joins it only
-when a Vendo Cloud key is already in hand, because a keyless run cannot reach a
-broker, so init settles on the local posture and asks about the service key
-alone.
+Init writes three things: `mcp: true` into the composition it creates, the
+origin-root discovery route beside it, and `VENDO_BASE_URL` into `.env.local`.
 
-</Step>
+```ts lib/vendo.ts focus={5}
+import { authJs } from "@vendoai/vendo/auth/auth-js";
+import { createVendo } from "@vendoai/vendo/server";
 
-<Step title="Open the door">
-
-`mcp` turns your app into an MCP server. With a Cloud account, `init` offers
-the **broker** posture: keys managed in the console, a stable tenant URL, and
-the OAuth surface off your domain.
-
-Is the agent your own, driven from your own backend with no browser in the loop
-— or is your stack one the broker posture does not fit? Take the **local**
-posture instead:
-
-```bash
-npx vendo init --use-case mcp --posture local --service-key
-```
-
-Everything then stays on your origin — no broker, no console, no browser — and
-the token exchange in the next step is served by your own app. Both flags answer
-questions init asks only on the MCP use case, so `--use-case mcp` has to ride
-along; without it init stops and says so.
-
-Otherwise, take the broker. The door then trusts that broker.
-
-```ts src/vendo/server.ts focus={3}
 export const vendo = createVendo({
   auth: authJs(),
   mcp: true,
 });
 ```
 
-Two things have to be true before the door opens.
+`auth` has to be a preset that carries the oauth half — `clerk()`, `authJs()`,
+`supabase()` or `auth0()`. Plain `jwt()` does not, and init refuses to write the
+door without one. [Auth](/production/auth) lists them.
 
-`auth` must be a preset that carries the oauth half: `clerk()`, `authJs()`,
-`supabase()`, or `auth0()`. Plain `jwt()` does not, and `init` writes nothing
-without one.
-
-`VENDO_BASE_URL` must name the public origin your agent actually reaches.
-Discovery, issuer, and token audience all derive from it.
-
-Two more values name the broker. They are the operator's, set where you deploy
-and never in the composition.
-
-```bash .env focus={3-4}
-VENDO_BASE_URL=https://app.maple.com
-# both values live on the console's MCP page
-VENDO_MCP_BROKER_URL=https://maple.mcp.vendo.run/mcp
-VENDO_MCP_FEDERATION_SECRET=<secret>
-```
-
-Two routes come with it, both written by `init`.
-
-| Route | What it is |
-| --- | --- |
-| `/api/vendo/mcp` | the door your agent connects to |
-| `/.well-known/oauth-*` | discovery, at your origin root, naming your broker |
-
-A broker-fronted door serves no token endpoint of its own. The exchange lives
-in the broker, in the next step.
+<Note>
+**Checkpoint.** `lib/vendo.ts` says `mcp: true`,
+`app/.well-known/[...vendo]/route.ts` exists, and `.env.local` has a
+`VENDO_BASE_URL` line. If init printed a warning instead, it names the missing
+auth preset — fix that and re-run.
+</Note>
 
 </Step>
 
-<Step title="Mint a user-bound token">
+<Step title="Check the door answers">
 
-The key is made once, in the console, under **Keys → Service keys**. It lives
-in the broker, so that is where your backend spends it.
+Start your app and ask the door who it is. It should refuse you, and say where
+to go and sign in.
 
-No browser to bounce through. Your backend trades that key plus one of *your
-own* user ids for a short-lived token, RFC 8693, at your tenant's `/token`.
-
-```bash your-backend.sh focus={5}
-curl -s https://maple.mcp.vendo.run/token \
-  -d grant_type=urn:ietf:params:oauth:grant-type:token-exchange \
-  -d client_id=vendo-service \
-  -d client_secret="$SERVICE_KEY" \
-  -d subject_token=user_1904 \
-  -d subject_token_type=urn:vendo:params:oauth:token-type:user-id
+```bash
+curl -si http://localhost:3000/api/vendo/mcp | head -3
 ```
 
-```json response focus={4}
-{
-  "access_token": "vmat_…",
-  "token_type": "Bearer",
-  "expires_in": 600,
-  "scope": "read write"
+```http response focus={1,3}
+HTTP/1.1 401 Unauthorized
+content-type: application/json
+www-authenticate: Bearer resource_metadata="http://localhost:3000/.well-known/oauth-protected-resource/api/vendo/mcp"
+```
+
+That `401` is the door working. The `www-authenticate` header is how every MCP
+client discovers your sign-in without being told about it.
+
+<Note>
+**Checkpoint.** A `401` with a `www-authenticate` header naming your own origin.
+A `404` means the app is not serving `/api/vendo/mcp` — check that init's wire
+route landed. A `200` means something else is answering that path.
+</Note>
+
+</Step>
+
+<Step title="Connect an outside agent">
+
+Your users' setup page ships with the door. Open it in a browser:
+
+```
+http://localhost:3000/api/vendo/mcp/connect
+```
+
+It carries the copy-paste config for Claude, ChatGPT and Cursor. Paste one in,
+sign in with your app's own login when the client bounces you there, and ask it
+to do something.
+
+For Claude Code, the plugin is one command:
+
+```
+/plugin marketplace add runvendo/vendo
+/plugin install vendo@vendo
+```
+
+<Note>
+**Checkpoint.** The client lists your tools, and a read runs and comes back with
+*your own* data. A write parks for approval instead of executing — that is the
+guard, not a failure. [How the door works](/outside-agents/how-the-door-works)
+covers what the agent sees and what happens on the way to your API.
+</Note>
+
+</Step>
+
+<Step title="Mint a token for your own backend">
+
+A backend agent has no browser to bounce through, so it asks your composition
+for a token instead. One method, two ways to call it.
+
+It exchanges a service key to do that. On Vendo Cloud the key is provisioned
+with your tenant and there is nothing to do. On the zero-key posture you declare
+one — `npx vendo init --service-key` writes it, and
+[Service keys](/outside-agents/service-keys-and-broker) is the whole story.
+Without one, `tokenFor` says so and names the variable to set.
+
+Inside a request, pass the request — `tokenFor` reads who is signed in from the
+session cookie, the same way your own pages do:
+
+```ts app/api/agent/route.ts focus={6}
+import { vendo } from "@/lib/vendo";
+
+export async function POST(request: Request) {
+  const accessToken = await vendo.tokenFor(request);
+  // …hand it to your agent
+  return Response.json({ ok: true });
 }
 ```
 
-Ten minutes, bound to `user_1904`, with no refresh token to rotate or revoke.
-When it lapses, exchange again.
+Headless — a cron job, a queue worker, anything with no request in hand — pass
+the user id your own product spells:
 
-Every call your agent makes with it runs *as that user*, through the same
-guard, policy, and audit your own UI answers to.
+```ts jobs/nightly.ts focus={3}
+import { vendo } from "@/lib/vendo";
 
-A subject your product has never heard of is not rejected here. It dies at the
-first real tool call, the same kill switch every other grant answers to.
-
-<Warning>
-  **On Auth.js v5, `session.user.id` is `undefined` until you add a callback.**
-  The subject the door resolves for an Auth.js session is the session token's
-  `sub`, but a v5 session hands your own code only `name`, `email`, and `image`.
-  A backend that reads `session.user.id` for `subject_token` therefore posts
-  `undefined`, the exchange mints a token happily, and the first tool call
-  401s. Copy `sub` across once, in the `NextAuth({ … })` config your
-  `auth.ts` exports:
-
-  ```ts auth.ts
-  callbacks: {
-    session({ session, token }) {
-      session.user.id = token.sub!;
-      return session;
-    },
-  },
-  ```
-
-  That is the JWT session strategy, which is the default without a database
-  adapter. With an adapter the session callback gets `user` instead, and
-  `user.id` is already the subject.
-</Warning>
-
-On the **local** posture — the branch in the step above — none of this lives in
-the console. Init writes the key into your own composition, and the door serves
-the exchange itself:
-
-```ts src/vendo/server.ts focus={3}
-export const vendo = createVendo({
-  auth: authJs(),
-  mcp: { serviceAuth: { keys: [process.env.VENDO_SERVICE_KEY!] } },
-});
+const accessToken = await vendo.tokenFor("user_1904");
 ```
 
-Same RFC 8693 body as above, posted to `https://app.maple.com/api/vendo/mcp/token`.
-A key is any opaque string, and rotation is listing both until the old one is
-out of use.
+The token lasts ten minutes, is bound to that one person, and has no refresh
+path. Every call made with it runs *as that user*, through the same guard,
+policy and audit your own UI answers to. Under the hood it is an RFC 8693
+`urn:ietf:params:oauth:grant-type:token-exchange`, which you never have to spell
+yourself.
 
-</Step>
+A subject that is not a real id — blank, `null`, `undefined`, or not a string at
+all — is refused at mint rather than handing you a token that dies on the first
+tool call.
 
-<Step title="Wire it into your agent">
-
-Streamable HTTP at the door's URL, the token on the `authorization` header. A
-stock MCP client, no Vendo import: the door's own listing is the tool set.
-
-That URL is your app's, derived from `VENDO_BASE_URL` and never from the
-broker. It does not move when the posture does.
-
-```js acme-agent.mjs focus={7}
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
-
-const client = new Client({ name: "acme-agent", version: "1.0.0" });
-await client.connect(new StreamableHTTPClientTransport(
-  new URL("https://app.maple.com/api/vendo/mcp"),
-  { requestInit: { headers: { authorization: `Bearer ${accessToken}` } } },
-));
-```
-
-From here the loop is ordinary: list the tools, hand them to your model, call
-them. What is not ordinary is who the calls belong to.
-
-A write still stops at your guard and waits for the person. The audit row names
-the key that acted.
-
-Words go back to your agent. The change lands in your product, under the user
-you named.
-
-Full client wiring, including sessions and retries, is in
-[Your own agent](/outside-agents/your-own-agent).
+<Note>
+**Checkpoint.** `tokenFor` returns a `vmat_…` string. Feed it to a stock MCP
+client — [Your own agent](/outside-agents/your-own-agent) is the whole loop —
+and the call lands in your product under the user you named.
+</Note>
 
 </Step>
 
 </Steps>
 
-## Where to go next
+## Who runs the sign-in
 
-The door is set. These three go deeper on it.
+The door needs an OAuth authorization server in front of it. There are two
+answers, and the door's URL is the same either way — it derives from
+`VENDO_BASE_URL` and never from a broker, so switching later invalidates nothing
+your users already configured.
+
+**Your app serves it (default, no key).** Everything above already did this.
+Your app is the authorization server, your login is the sign-in, and nothing
+leaves your origin. This is the zero-config path and it is complete.
+
+**Vendo Cloud fronts it (one answer).** With a `VENDO_API_KEY` in hand, init
+asks one more question — *Who should run the OAuth plumbing?* — and answering
+**Vendo hosts the OAuth plumbing** moves the OAuth surface off your domain to a
+stable `yourcompany.mcp.vendo.run` tenant that Vendo provisions on first use.
+There is nothing to copy: no console visit, no environment values, no keys.
+
+To front the door with a broker you run yourself, set both values where you
+deploy. An explicit override always wins over the Cloud default.
+
+```bash .env
+VENDO_MCP_BROKER_URL=https://broker.example.com/mcp
+VENDO_MCP_FEDERATION_SECRET=…
+```
+
+Upgrading a deployment that already has `VENDO_API_KEY` and `mcp: true` moves
+its door from local to Cloud-brokered — declare those two variables yourself, or
+pass `mcp.serviceAuth`, to keep it where it is.
+
+## When you deploy
+
+Set `VENDO_BASE_URL` on your platform to the public origin your app answers on.
+Discovery, issuer and token audience all derive from it, and a door pointed at
+the wrong origin surfaces hours later as *"Claude can't find my server"*.
+
+## Where to go next
 
 <CardGroup cols={3}>
   <Card title="How the door works" href="/outside-agents/how-the-door-works">
@@ -221,14 +209,14 @@ The door is set. These three go deeper on it.
 
     `mcp + oauth + actAs`
   </Card>
-  <Card title="Service keys & broker" href="/outside-agents/service-keys-and-broker">
-    Rotating keys, the audit's `svc:` attribution, and the hosted broker.
+  <Card title="Your own agent" href="/outside-agents/your-own-agent">
+    The stock MCP client, one session per conversation, and the whole loop.
 
-    `grant_type=token-exchange`
+    `tokenFor`
   </Card>
-  <Card title="API tools" href="/capabilities/api-tools">
-    The menu your agent sees, and the risk grade behind each call.
+  <Card title="Service keys & broker" href="/outside-agents/service-keys-and-broker">
+    Where the key lives, the audit's `svc:` attribution, and rotation.
 
-    `.vendo/overrides.json`
+    `svc:<hash8>`
   </Card>
 </CardGroup>

--- a/docs-site/outside-agents/quickstart.mdx
+++ b/docs-site/outside-agents/quickstart.mdx
@@ -100,9 +100,13 @@ client discovers your sign-in without being told about it.
 <Note>
 **Checkpoint.** A `401` with a `www-authenticate` header naming your own origin.
 A `404` means the app is not serving `/api/vendo/mcp` — check that init's wire
-route landed. A `200` means something else is answering that path. A `501` means
-the door is open but its Cloud tenant could not be provisioned — the usual cause
-is a `VENDO_BASE_URL` that is not https, which is the pair Step 1 warns about.
+route landed. A `200` means something else is answering that path.
+
+If you are on the Cloud posture, two more answers are worth knowing. A `400`
+with `"code":"validation"` is Vendo Cloud refusing to provision your tenant, and
+it repeats the console's own reason and docs link — read the message, it names
+the fix. A `503` with `"code":"unavailable"` is Cloud itself failing, not your
+wiring.
 </Note>
 
 </Step>
@@ -131,11 +135,10 @@ For Claude Code, the plugin is one command:
 *your own* data. A write parks for approval instead of executing — that is the
 guard, not a failure.
 
-If a tool answers `not-implemented`, the cause is almost always a missing
-`actAs` — the door has no auth material to call your API with. Note that a
-broker that could not provision reports the same code, so check Step 2's `curl`
-before you go looking at `actAs`.
-[How the door works](/outside-agents/how-the-door-works) explains both.
+If a tool answers `not-implemented`, that means a missing `actAs` — the door has
+no auth material to call your API with. A Cloud problem never looks like this;
+it answers `400` or `503` with its own reason, per Step 2.
+[How the door works](/outside-agents/how-the-door-works) explains `actAs`.
 </Note>
 
 </Step>

--- a/docs-site/outside-agents/service-keys-and-broker.mdx
+++ b/docs-site/outside-agents/service-keys-and-broker.mdx
@@ -1,13 +1,14 @@
 ---
 title: "Service keys & broker"
-description: "Rotating keys, the audit's svc: attribution, and the hosted broker that mints user-bound tokens for your backend."
+description: "The one long-lived credential behind tokenFor: where it lives on each posture, how the audit attributes it, and how to rotate it."
 sidebarTitle: "Service keys & broker"
 ---
 
 A service key is the one long-lived credential in this path. It never touches
-your agent, and it never leaves your backend.
+your agent, and it never leaves your backend. `vendo.tokenFor()` spends it for
+you — this page is what is behind that call.
 
-<svg viewBox="0 0 760 118" role="img" aria-label="A service key path: the console, the broker token endpoint, a ten-minute bearer, your door" style={{ width: "100%", height: "auto", margin: "1.5rem 0" }}>
+<svg viewBox="0 0 760 118" role="img" aria-label="A service key path: the key, the token exchange, a ten-minute bearer, your door" style={{ width: "100%", height: "auto", margin: "1.5rem 0" }}>
   <g fill="none" stroke="currentColor" strokeOpacity="0.2">
     <rect x="1" y="1" width="164" height="52" rx="11" />
     <rect x="199" y="1" width="164" height="52" rx="11" />
@@ -22,12 +23,12 @@ your agent, and it never leaves your backend.
   </g>
   <g fill="currentColor" fontSize="13.5" fontWeight="600" textAnchor="middle">
     <text x="83" y="32">Service key</text>
-    <text x="281" y="32">Broker /token</text>
+    <text x="281" y="32">tokenFor()</text>
     <text x="479" y="32">10-minute bearer</text>
     <text x="677" y="32">Your door</text>
   </g>
   <g fill="currentColor" fillOpacity="0.55" fontSize="11.5" textAnchor="middle">
-    <text x="83" y="76">created once, in the console</text>
+    <text x="83" y="76">lives in your backend</text>
     <text x="281" y="76">RFC 8693 exchange</text>
     <text x="479" y="76">bound to one user id</text>
     <text x="677" y="76">verifies the signature</text>
@@ -36,80 +37,40 @@ your agent, and it never leaves your backend.
 
 ## Where the key lives
 
-Create it in the console under **Keys → Service keys**. The key lands in the
-broker, so the broker is where your backend spends it.
+**On a local door (no key).** The key is any opaque string you generate. It
+lives in your own environment as `VENDO_SERVICE_KEY`, the composition lists it,
+and `vendo init --service-key` writes both for you — this is what it generates:
 
-The door never sees the key. It only ever sees the short-lived token the broker
-minted from it.
+```ts lib/vendo.ts focus={8}
+import { authJs } from "@vendoai/vendo/auth/auth-js";
+import { createVendo, guard } from "@vendoai/vendo/server";
 
-That is the broker posture. A **local** door has no console in the path: the key
-is any opaque string you generate, it lives in your own environment as
-`VENDO_SERVICE_KEY`, the composition lists it under
-`mcp: { serviceAuth: { keys: [...] } }`, and `vendo init --service-key` writes
-one for you.
+const serviceKey = process.env.VENDO_SERVICE_KEY ?? "";
 
-## The exchange
-
-One form post, RFC 8693, at your tenant's `/token`.
-
-```bash focus={5}
-curl -s https://maple.mcp.vendo.run/token \
-  -d grant_type=urn:ietf:params:oauth:grant-type:token-exchange \
-  -d client_id=vendo-service \
-  -d client_secret="$VENDO_SERVICE_KEY" \
-  -d subject_token=user_1904 \
-  -d subject_token_type=urn:vendo:params:oauth:token-type:user-id
+export const vendo = createVendo({
+  auth: authJs(),
+  guard: guard({ policy: {} }),
+  mcp: serviceKey === "" ? true : { serviceAuth: { keys: [serviceKey] } },
+});
 ```
 
-That URL is the broker's. On a local door the same body goes to your own origin,
-where the door serves the endpoint itself:
+The empty-string fallback is deliberate: a door with no key still opens for
+browser-based agents, it just cannot mint for your backend. More than one key
+can be live at once, which is what makes rotation a deploy rather than an
+outage.
 
-```bash focus={1}
-curl -s https://app.maple.com/api/vendo/mcp/token \
-  -d grant_type=urn:ietf:params:oauth:grant-type:token-exchange \
-  -d client_id=vendo-service \
-  -d client_secret="$VENDO_SERVICE_KEY" \
-  -d subject_token=user_1904 \
-  -d subject_token_type=urn:vendo:params:oauth:token-type:user-id
-```
+**On Vendo Cloud.** The key is provisioned with your tenant on first use — init
+does not ask, and there is nothing to copy. The console lists it, and rotates
+and revokes it.
 
-The URL is the only difference. Every field below, the answer, the ten-minute
-life, and the `svc:` attribution are the same on both postures.
-
-| Field | Value |
-| --- | --- |
-| `grant_type` | `urn:ietf:params:oauth:grant-type:token-exchange` |
-| `client_id` | `vendo-service`, always |
-| `client_secret` | your service key |
-| `subject_token` | one of *your* user ids |
-| `subject_token_type` | `urn:vendo:params:oauth:token-type:user-id` |
-| `resource` | optional, and must identify this MCP server if sent |
-
-Which value is *your* user id is whatever your own `principal()` resolves for
-that person. On Auth.js v5 that is the session token's `sub`, and
-`session.user.id` is `undefined` until you copy it across — the three-line
-callback, and the 401 it saves you, are in the token-minting step of the
-[quickstart](/outside-agents/quickstart).
-
-The answer is an ordinary OAuth token response.
-
-```json focus={5}
-{
-  "access_token": "vmat_…",
-  "issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
-  "token_type": "Bearer",
-  "expires_in": 600,
-  "scope": "read write"
-}
-```
-
-Ten minutes, and no refresh token. There is nothing outstanding to rotate or
-revoke once it lapses, so a backend that still has work to do exchanges again.
+Either way your agent never sees the key. It only ever gets the short-lived
+token minted from it, and `tokenFor` is the only place your own code touches
+either.
 
 ## Who the audit says acted
 
-The exchange binds two identities to every call the token makes: the person
-named in `subject_token`, and the key that asked.
+The exchange binds two identities to every call the token makes: the person the
+token names, and the key that asked.
 
 The key rides as a client id of the form `svc:<hash8>`, the first eight hex of
 the presented key's digest. The audit row names which key acted without the key
@@ -120,33 +81,31 @@ approval, and the approval names the tool and the user, not the agent.
 
 ## Rotating a key
 
-More than one key can be live at once, which makes rotation a deploy rather
-than an outage.
-
 <Steps>
   <Step title="Create the replacement">
-    A new key in the console, alongside the one you are retiring.
+    A new key alongside the one you are retiring — a second entry in
+    `serviceAuth.keys` on a local door, or a new key in the console on Cloud.
   </Step>
   <Step title="Ship it">
     Update `VENDO_SERVICE_KEY` where your backend runs and deploy.
   </Step>
   <Step title="Retire the old one">
-    Delete it in the console. Tokens it already minted keep working until they
-    expire, which is at most ten minutes.
+    Drop it from the list, or delete it in the console. Tokens it already minted
+    keep working until they expire, which is at most ten minutes.
   </Step>
 </Steps>
 
-## When the exchange refuses
+## When the mint refuses
 
 | Answer | What it means |
 | --- | --- |
-| `invalid_client` | wrong `client_id`, unknown key, or retired key |
-| `invalid_request` | a missing `subject_token`, or a `subject_token_type` that is not the user-id URN |
-| `invalid_target` | the `resource` you sent does not identify this MCP server |
+| `invalid_client` | unknown key, or a retired one |
+| `invalid_request` | a subject that is not a real id — `tokenFor` refuses it before it asks |
+| `invalid_target` | the `resource` sent does not identify this MCP server |
 | `401` on the first tool call | the subject is not a user your product recognizes |
 
-The first row is deliberately one answer for three causes. Anything narrower
-would tell whoever is guessing which half of the credential they got right.
+The first row is deliberately one answer for two causes. Anything narrower would
+tell whoever is guessing which half of the credential they got right.
 
 The `401` is the one that looks like a key problem and is not. The exchange
 never checks the user id, so a token for a stranger mints fine and dies at
@@ -154,19 +113,21 @@ never checks the user id, so a token for a stranger mints fine and dies at
 
 ## What the broker owns
 
-Two environment variables put the broker in front of your door. Both live on
-the console's MCP page.
+A broker is an authorization server in front of your door. On Cloud, your
+`VENDO_API_KEY` is the whole configuration — the runtime reads the broker URL
+and the federation secret from Cloud and provisions the tenant on first use.
 
-```bash .env focus={1-2}
-VENDO_MCP_BROKER_URL=https://maple.mcp.vendo.run/mcp
-VENDO_MCP_FEDERATION_SECRET=<secret>
+To point at a broker you run yourself, set both values where you deploy. An
+explicit override always wins over the Cloud default.
+
+```bash .env
+VENDO_MCP_BROKER_URL=https://broker.example.com/mcp
+VENDO_MCP_FEDERATION_SECRET=…
 ```
 
-`VENDO_MCP_BROKER_URL` decides two things at once. Its origin becomes the
-issuer your door trusts, and the URL itself becomes the audience every token
-must carry.
-
-The door then stops serving `/authorize`, `/token`, and `/register`, and
+`VENDO_MCP_BROKER_URL` decides two things at once. Its origin becomes the issuer
+your door trusts, and the URL itself becomes the audience every token must
+carry. The door then stops serving `/authorize`, `/token` and `/register`, and
 verifies each inbound bearer as a JWT the broker signed. Keys come from the
 issuer's own metadata, so ordinary rotation at the broker needs nothing from
 you.
@@ -175,13 +136,7 @@ you.
 owns the sign-in surface and your app owns the users, and that shared secret is
 how the two agree on an answer.
 
-<Warning>
-  Broker mode is declared, never discovered. A `VENDO_MCP_BROKER_URL` that is
-  not an absolute `http(s)` URL, or that carries credentials or a fragment,
-  fails at composition rather than dropping quietly to a door with no broker in
-  front of it.
-</Warning>
-
-The broker reaches your door over the public internet, so `VENDO_BASE_URL` has
-to name a deployed HTTPS origin. Everything else about the door is unchanged by
-the posture, the client URL included.
+A broker reaches your door over the public internet, so `VENDO_BASE_URL` has to
+name a deployed HTTPS origin. Everything else about the door is unchanged by the
+posture, the client URL included — see the
+[quickstart](/outside-agents/quickstart) for both postures end to end.

--- a/docs-site/outside-agents/service-keys-and-broker.mdx
+++ b/docs-site/outside-agents/service-keys-and-broker.mdx
@@ -136,7 +136,16 @@ you.
 owns the sign-in surface and your app owns the users, and that shared secret is
 how the two agree on an answer.
 
-A broker reaches your door over the public internet, so `VENDO_BASE_URL` has to
-name a deployed HTTPS origin. Everything else about the door is unchanged by the
-posture, the client URL included — see the
+`VENDO_BASE_URL` has to name an HTTPS origin either way — Vendo Cloud refuses to
+register a forwarding address that is not https, and init refuses that pair
+before it writes.
+
+Who has to *reach* that origin depends on the path. Signing a person in is a
+browser redirect: the broker sends the user's own browser to your door's
+`/federate`, and the door reads their session cookie there, so the door has to
+be reachable by whoever signs in — public for a public agent's users. The
+backend-agent path reaches nothing inward: `tokenFor` calls the broker outbound
+from your own backend, so a private HTTPS origin your backend and agent can
+already reach is enough for it. Everything else about the door is unchanged by
+the posture, the client URL included — see the
 [quickstart](/outside-agents/quickstart) for both postures end to end.

--- a/docs-site/outside-agents/your-own-agent.mdx
+++ b/docs-site/outside-agents/your-own-agent.mdx
@@ -1,55 +1,61 @@
 ---
 title: "Your own agent"
-description: "Wire the door into an agent you already run: one stock MCP client, one bearer, one session per conversation."
+description: "Wire the door into an agent you already run: one stock MCP client, one token from tokenFor, one session per conversation."
 sidebarTitle: "Your own agent"
 ---
 
-Nothing here imports Vendo. The door speaks MCP over streamable HTTP, so an
-agent you already run reaches it with the client SDK you already have.
+Your agent imports nothing from Vendo. The door speaks MCP over streamable
+HTTP, so the client SDK you already have reaches it. The only Vendo-shaped part
+is the bearer, and that is one method call.
 
-## The connection
+## Get the token
 
-One URL and one header. The URL is your app's, derived from `VENDO_BASE_URL`,
-and the header carries the user-bound token from the exchange.
+Ask your composition. Pass a request and it reads who is signed in from the
+session cookie; pass a user id and it acts as that person.
 
-```js acme-agent.mjs focus={7}
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+```ts agent.ts focus={4}
+import { vendo } from "@/lib/vendo";
 
-const client = new Client({ name: "acme-agent", version: "1.0.0" });
-await client.connect(new StreamableHTTPClientTransport(
-  new URL("https://app.maple.com/api/vendo/mcp"),
-  { requestInit: { headers: { authorization: `Bearer ${accessToken}` } } },
-));
-```
-
-The path is fixed at `/api/vendo/mcp` under your own origin. It never points at
-the broker, so switching posture later invalidates nothing you configured here.
-
-## Getting the token
-
-Your backend mints one token per user it is acting for. The exchange is a form
-post, so any HTTP client does it.
-
-```ts token.ts focus={8-9}
-export async function tokenFor(userId: string): Promise<string> {
-  const response = await fetch("https://maple.mcp.vendo.run/token", {
-    method: "POST",
-    body: new URLSearchParams({
-      grant_type: "urn:ietf:params:oauth:grant-type:token-exchange",
-      client_id: "vendo-service",
-      client_secret: process.env.VENDO_SERVICE_KEY!,
-      subject_token: userId,
-      subject_token_type: "urn:vendo:params:oauth:token-type:user-id",
-    }),
-  });
-  const { access_token } = await response.json();
-  return access_token;
+export async function runForRequest(request: Request) {
+  const accessToken = await vendo.tokenFor(request);
+  // …
 }
 ```
 
-`subject_token` is one of *your* user ids, spelled the way your product spells
-it. Everything the agent does with the token is attributed to that person.
+```ts jobs/nightly.ts focus={3}
+import { vendo } from "@/lib/vendo";
+
+const accessToken = await vendo.tokenFor("user_1904");
+```
+
+The id is one of *your* user ids, spelled the way your product spells it —
+whatever your own `principal()` resolves for that person. Everything the agent
+does with the token is attributed to them.
+
+A subject that is not a real id — blank, `null`, `undefined`, or not a string at
+all — is refused here rather than minting a token that dies on the first tool
+call.
+
+## Connect
+
+One URL and one header.
+
+```ts agent.ts focus={9}
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+export async function connect(accessToken: string): Promise<Client> {
+  const client = new Client({ name: "acme-agent", version: "1.0.0" });
+  await client.connect(new StreamableHTTPClientTransport(
+    new URL(`${process.env.VENDO_BASE_URL}/api/vendo/mcp`),
+    { requestInit: { headers: { authorization: `Bearer ${accessToken}` } } },
+  ));
+  return client;
+}
+```
+
+The path is fixed at `/api/vendo/mcp` under your own origin. It never points at
+a broker, so switching sign-in posture later invalidates nothing here.
 
 ## One session per conversation
 
@@ -57,16 +63,16 @@ Connect once and keep the client for the whole conversation. The door pins each
 MCP session to the subject and client id that opened it, and answers
 `404 Session not found` if either moves.
 
-This matters most for approvals. A parked call resumes only when the retry
-lands on the same session, so an agent that reconnects per call parks forever.
+This matters most for approvals. A parked call resumes only when the retry lands
+on the same session, so an agent that reconnects per call parks forever.
 
-## Reading the result
+## Read the result
 
-The door never fails a tool call as a protocol error, because a retry on a
-protocol error would re-execute a write that already happened. Everything
-arrives in-band.
+The door never fails a tool call as a protocol error — a retry on a protocol
+error would re-execute a write that already happened. Everything arrives
+in-band.
 
-```js focus={3-6}
+```ts focus={3-6}
 const result = await client.callTool({ name: "host_setCardLimit", arguments: args });
 
 if (result.isError) {
@@ -78,8 +84,8 @@ return result.structuredContent;
 ```
 
 Hand that text back to your model as the tool result. It already says what
-happened and what the next move is, which is enough for the model to retry or
-to tell the person.
+happened and what the next move is, which is enough for the model to retry or to
+tell the person.
 
 Successful calls carry the output twice: as text for the model, and as
 `structuredContent` for your own code.
@@ -87,18 +93,14 @@ Successful calls carry the output twice: as text for the model, and as
 ## When ten minutes runs out
 
 A token lasts ten minutes and has no refresh path. An expired one answers `401`
-with a `WWW-Authenticate` challenge on the next request.
-
-Exchange again and reconnect. For work that runs longer than one token,
-mint per unit of work rather than holding one open.
+with a `WWW-Authenticate` challenge on the next request. Call `tokenFor` again
+and reconnect — for work that runs longer than one token, mint per unit of work
+rather than holding one open.
 
 ## The whole loop
 
-List the tools, hand them to your model, call what it picks, feed the result
-back. The only Vendo-shaped part is the bearer.
-
-```js acme-agent.mjs focus={1-2}
-const accessToken = await tokenFor("user_1904");
+```ts agent.ts focus={1}
+const accessToken = await vendo.tokenFor("user_1904");
 const client = await connect(accessToken);
 
 const { tools } = await client.listTools();

--- a/docs-site/outside-agents/your-own-agent.mdx
+++ b/docs-site/outside-agents/your-own-agent.mdx
@@ -38,6 +38,20 @@ call.
 
 ## Connect
 
+The client is the stock MCP SDK, which is your install, not Vendo's:
+
+<CodeGroup>
+
+```bash npm
+npm install @modelcontextprotocol/sdk
+```
+
+```bash pnpm
+pnpm add @modelcontextprotocol/sdk
+```
+
+</CodeGroup>
+
 One URL and one header.
 
 ```ts agent.ts focus={9}

--- a/docs-site/reference/vendo-init.mdx
+++ b/docs-site/reference/vendo-init.mdx
@@ -166,7 +166,7 @@ The answer flags are the ones init already has: `--use-case`, `--auth`, `--cloud
 
 `--cloud-key` and `--byo` answer the same question, as do `--ai` and `--no-ai` and `--check` and `--no-check`. Passing both halves of a pair exits `1`.
 
-`--posture` or `--service-key` without `--use-case mcp` exits `1` rather than being silently ignored. `--ai-polish` is the older spelling of `--ai`.
+`--posture` or `--service-key` without `--use-case mcp` exits `1` rather than being silently ignored, and so does `--service-key` with `--posture broker`: a Cloud-fronted door provisions its own key, so accepting one there would discard it. `--ai-polish` is the older spelling of `--ai`.
 
 <Warning>
   `--base-url` is a DEV URL: it lands in `.env.local` as `VENDO_BASE_URL`, which is what your own agent loop, any backend process, and the MCP door need before their first tool call. Production is never set here — set `VENDO_BASE_URL` in your hosting platform's environment settings when you deploy. A deployed URL in `.env.local` would repoint local dev's discovery, callbacks, and credential forwarding at the deployed origin.

--- a/packages/vendo/src/cli.ts
+++ b/packages/vendo/src/cli.ts
@@ -209,6 +209,16 @@ async function initCommand(args: string[]): Promise<number> {
   if ((posture !== undefined || serviceKey) && useCase !== "mcp") {
     problems.push(`${posture === undefined ? "--service-key" : "--posture"} only applies to --use-case mcp (pass --use-case mcp, or drop it)`);
   }
+  // …and the same rule inside the MCP path: a broker-fronted door's key is
+  // provisioned with the tenant, so taking one here would discard it and leave
+  // the caller — usually a coding agent relaying answers — believing it landed.
+  if (serviceKey && posture === "broker") {
+    problems.push(
+      "--service-key does not apply to --posture broker: a Cloud-fronted door's service key is provisioned "
+      + "with the tenant on first use, so this one would be discarded. Drop --service-key, or pass --posture "
+      + "local to declare your own (https://docs.vendo.run/outside-agents/service-keys-and-broker)",
+    );
+  }
   if (args.includes("--check") && args.includes("--no-check")) {
     problems.push("--check and --no-check answer the same question — pass one or the other");
   }

--- a/packages/vendo/src/cli.ts
+++ b/packages/vendo/src/cli.ts
@@ -7,6 +7,7 @@ import { runConfig } from "./cli/config.js";
 import { runDoctor } from "./cli/doctor.js";
 import { runEject } from "./cli/eject.js";
 import { runInit, type InitOptions } from "./cli/init.js";
+import { SERVICE_KEY_ON_BROKER } from "./cli/init-mcp.js";
 import { runKnowledge } from "./cli/knowledge/index.js";
 import { runMcp } from "./cli/mcp/index.js";
 import { CLI_VERSION } from "./cli/shared.js";
@@ -213,11 +214,7 @@ async function initCommand(args: string[]): Promise<number> {
   // provisioned with the tenant, so taking one here would discard it and leave
   // the caller — usually a coding agent relaying answers — believing it landed.
   if (serviceKey && posture === "broker") {
-    problems.push(
-      "--service-key does not apply to --posture broker: a Cloud-fronted door's service key is provisioned "
-      + "with the tenant on first use, so this one would be discarded. Drop --service-key, or pass --posture "
-      + "local to declare your own (https://docs.vendo.run/outside-agents/service-keys-and-broker)",
-    );
+    problems.push(`--service-key does not apply to --posture broker: ${SERVICE_KEY_ON_BROKER}`);
   }
   if (args.includes("--check") && args.includes("--no-check")) {
     problems.push("--check and --no-check answer the same question — pass one or the other");

--- a/packages/vendo/src/cli/init-mcp.ts
+++ b/packages/vendo/src/cli/init-mcp.ts
@@ -21,9 +21,9 @@ import { MCP_MOUNT } from "../door-paths.js";
 import type { AuthMatch } from "./init-auth.js";
 import { compositionModuleSource, type ScaffoldModel } from "./init-scaffolds.js";
 
-/** Which authorization server fronts the door. DECLARED by the operator and
-    nothing else (10-mcp §3.1) — init prints environment lines, it never
-    discovers posture and never reaches a broker to find out. */
+/** Which authorization server fronts the door. ANSWERED by the operator and
+    nothing else (10-mcp §3.1) — init writes the posture into the composition,
+    it never discovers one and never reaches a broker to find out. */
 export type McpPosture = "local" | "broker";
 
 export interface McpPlanInput {
@@ -120,8 +120,6 @@ export interface McpPlan {
       discovery points at the wrong origin surfaces hours later as "Claude can't
       find my server". */
   steps: string[];
-  /** Environment lines the operator sets where they deploy (broker posture). */
-  envLines: string[];
   /** The provider and file of the `models` line this plan wrote — the
       composition module, never the route it replaced. The caller's closing
       summary names this file, so it can never point a reader at a route that
@@ -133,23 +131,18 @@ export interface McpPlan {
 }
 
 /** The plan's closing block, as a pretty run reads it: each step numbered by
-    its headline, its detail indented under it, and the environment values as a
-    closing group under one sentence that says where they go. A flat list of
+    its headline and its detail indented under it. A flat list of
     `headline\ndetail` strings reads as a wall — the numbers and the indent are
     what make it read as steps. (Plain runs print the same strings unnumbered:
     the newline becomes an indent and nothing else, since a plain transcript is
     parsed as often as it is read.) */
-export function mcpStepLines(plan: Pick<McpPlan, "steps" | "envLines">): string[] {
+export function mcpStepLines(plan: Pick<McpPlan, "steps">): string[] {
   const lines: string[] = [];
   plan.steps.forEach((step, index) => {
     const [headline, ...detail] = step.split("\n");
     lines.push(`${index + 1}. ${headline}`);
     for (const rest of detail) lines.push(`   ${rest}`);
   });
-  if (plan.envLines.length > 0) {
-    lines.push("", "Set where you deploy — both values live on the console's MCP page:");
-    for (const env of plan.envLines) lines.push(`   ${env}`);
-  }
   return lines;
 }
 
@@ -194,10 +187,20 @@ const KEYLESS_SIGN_IN =
   + "to front it with an external authorization server (e.g. Vendo Cloud's broker) — "
   + "same client URL either way.";
 
+/** The Cloud sign-in pointer, and the reason this path prints no environment
+    values at all: the runtime reads the broker URL and the federation secret
+    from Cloud and provisions the tenant on first use, so there is nothing for
+    the operator to copy. The two variables survive as an explicit override,
+    which — adapter rule — always wins over the Cloud default. */
+const CLOUD_SIGN_IN =
+  "Sign-in: Vendo Cloud fronts the door — your VENDO_API_KEY provisions the tenant on first use, "
+  + "so there is nothing to copy. Set VENDO_MCP_BROKER_URL and VENDO_MCP_FEDERATION_SECRET to point "
+  + "at a broker of your own instead — same client URL either way.";
+
 export function planMcp(input: McpPlanInput): McpPlan {
   const { root, appDir, composition, framework, authWired, serverActions, cloudKey, posture, serviceKey, baseUrl } = input;
   const models = input.models ?? null;
-  const refuse = (why: string): McpPlan => ({ changes: [], compositionSource: null, steps: [], envLines: [], modelWritten: null, blocked: why });
+  const refuse = (why: string): McpPlan => ({ changes: [], compositionSource: null, steps: [], modelWritten: null, blocked: why });
 
   if (framework !== "next") {
     return refuse(
@@ -239,11 +242,12 @@ export function planMcp(input: McpPlanInput): McpPlan {
     `Point any MCP client at \`${clientBase}${MCP_MOUNT}\`\nyour users' setup page ships free at \`${MCP_MOUNT}/connect\` — copy for Claude · ChatGPT · Cursor included`,
     "Claude Code: `/plugin marketplace add runvendo/vendo` then `/plugin install vendo@vendo`",
   ];
-  if (!cloudKey) steps.push(KEYLESS_SIGN_IN);
-  if (serviceKey) {
-    steps.push(serviceAuth
-      ? `Your backend exchanges \`VENDO_SERVICE_KEY\` at \`${clientBase}${MCP_MOUNT}/token\`\nfor a 10-minute token acting as a named user — svc: attribution in the audit`
-      : "Create the service key on the console's keys page (Service keys)\nit lands in the broker — exchange it at `<your tenant URL>/token`");
+  if (posture === "broker") steps.push(CLOUD_SIGN_IN);
+  else if (!cloudKey) steps.push(KEYLESS_SIGN_IN);
+  // Only the local door has a step here: Cloud provisions the service key
+  // itself, and the console is where it is listed, rotated and revoked.
+  if (serviceAuth) {
+    steps.push(`Your backend exchanges \`VENDO_SERVICE_KEY\` at \`${clientBase}${MCP_MOUNT}/token\`\nfor a 10-minute token acting as a named user — svc: attribution in the audit`);
   }
 
   return {
@@ -254,11 +258,5 @@ export function planMcp(input: McpPlanInput): McpPlan {
       : {}),
     modelWritten: models === null ? null : { provider: models.provider, path: relative(root, composition).split(sep).join("/") },
     steps,
-    envLines: posture === "broker"
-      ? [
-          "`VENDO_MCP_BROKER_URL=<your tenant MCP endpoint>`",
-          "`VENDO_MCP_FEDERATION_SECRET=<secret>`",
-        ]
-      : [],
   };
 }

--- a/packages/vendo/src/cli/init-mcp.ts
+++ b/packages/vendo/src/cli/init-mcp.ts
@@ -146,6 +146,16 @@ export function mcpStepLines(plan: Pick<McpPlan, "steps">): string[] {
   return lines;
 }
 
+/** Why a service key cannot ride the broker posture, in the ONE voice both
+    refusals speak: `cli.ts` catches the flag pair it can read off argv, and
+    init catches a posture chosen at the select, which never reaches argv. The
+    lead-in differs because the user did two different things; the explanation
+    and the way out must not. */
+export const SERVICE_KEY_ON_BROKER =
+  "a Cloud-fronted door's service key is provisioned with the tenant on first use, so this one would be "
+  + "discarded. Drop --service-key, or pass --posture local to declare your own "
+  + "(https://docs.vendo.run/outside-agents/service-keys-and-broker)";
+
 /** A fresh service key: 32 random bytes, hex. `planMcp` mints one itself when
     the answers call for it AND the host has none to reuse; this is separately
     callable so the shape can be asserted without a plan. */

--- a/packages/vendo/src/cli/init-mcp.ts
+++ b/packages/vendo/src/cli/init-mcp.ts
@@ -156,6 +156,17 @@ export const SERVICE_KEY_ON_BROKER =
   + "discarded. Drop --service-key, or pass --posture local to declare your own "
   + "(https://docs.vendo.run/outside-agents/service-keys-and-broker)";
 
+/** Why a Cloud-fronted door cannot stand on an http origin. Cloud registers
+    `VENDO_BASE_URL` as the tenant's forwarding address and refuses one that is
+    not https, so the two answers used to pass init, print `Wired`, and leave a
+    door that died on its first request. Same shape as the refusal above: the
+    lead-in names the origin, this says why and how out. */
+export const BROKER_NEEDS_HTTPS =
+  "Vendo Cloud registers that origin as the tenant's forwarding address and refuses one that is not https, "
+  + "so this door would be written now and fail on its first request. Take the local posture — zero config, "
+  + "and it works on http — or re-run with --base-url set to an https origin "
+  + "(https://docs.vendo.run/outside-agents/quickstart)";
+
 /** A fresh service key: 32 random bytes, hex. `planMcp` mints one itself when
     the answers call for it AND the host has none to reuse; this is separately
     callable so the shape can be asserted without a plan. */

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -1002,8 +1002,11 @@ async function planMcpScaffold(input: {
     posture = (await select("How should outside agents sign in?", POSTURE_OPTIONS)) as McpPosture;
   }
 
+  // Local doors only. A Cloud-fronted door's service key is provisioned with
+  // the tenant and listed, rotated and revoked in the console, so asking here
+  // would offer a decision init cannot act on.
   let serviceKey = options.serviceKey === true;
-  if (options.serviceKey === undefined && !ask) {
+  if (options.serviceKey === undefined && !ask && posture === "local") {
     const confirm = options.confirmAuth ?? (pretty === null ? askYesNo : pretty.confirm);
     serviceKey = await confirm("Will your own backend call these tools machine-to-machine?", false);
   }
@@ -2156,7 +2159,7 @@ async function finishRun(input: {
     // A step is `headline\ndetail`: the pretty block numbers and indents it,
     // and a plain transcript keeps the detail on its own indented line.
     if (pretty === null) {
-      for (const line of [...mcp.steps, ...mcp.envLines]) output.log(`  ${line.replace(/\n/g, "\n    ")}`);
+      for (const line of mcp.steps) output.log(`  ${line.replace(/\n/g, "\n    ")}`);
     } else pretty.block("Steps that are yours", mcpStepLines(mcp), "◇");
   }
 

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -9,7 +9,7 @@ import { detectDepVersions, installedAiVersion } from "./dep-versions.js";
 import { AUTH_MD_URL, ensureEnvLocalIgnored, runCloudStep, upsertEnvLocal, type CloudStepOptions } from "./cloud-init.js";
 import { runDoctor } from "./doctor.js";
 import type { InitPolishSeam } from "./init-judgment.js";
-import { mcpStepLines, planMcp, wellFormedServiceKey, type McpPosture } from "./init-mcp.js";
+import { mcpStepLines, planMcp, SERVICE_KEY_ON_BROKER, wellFormedServiceKey, type McpPosture } from "./init-mcp.js";
 import { initQuestions } from "./init-questions.js";
 import { rendererFlowOptions, runSyncFlow, writeFonts, type SyncFlowResult } from "./sync-flow.js";
 import { BRIEF_TEMPLATE } from "./extract/stages.js";
@@ -1000,6 +1000,14 @@ async function planMcpScaffold(input: {
   if (options.posture === undefined && cloudKey && !ask) {
     const select = options.selectUseCase ?? (pretty === null ? plainSelect : pretty.select);
     posture = (await select("How should outside agents sign in?", POSTURE_OPTIONS)) as McpPosture;
+  }
+
+  // `cli.ts` refuses the flag pair it can read off argv. A posture chosen at
+  // the SELECT never reaches argv, so the same mistake arrived here and the key
+  // was dropped in silence — the one path where a user could still believe it
+  // landed. Same explanation, same way out, one lead-in for each arrival.
+  if (options.serviceKey === true && posture === "broker") {
+    throw new VendoError("validation", `--service-key does not apply to the broker posture you chose: ${SERVICE_KEY_ON_BROKER}`);
   }
 
   // Local doors only. A Cloud-fronted door's service key is provisioned with

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -9,7 +9,7 @@ import { detectDepVersions, installedAiVersion } from "./dep-versions.js";
 import { AUTH_MD_URL, ensureEnvLocalIgnored, runCloudStep, upsertEnvLocal, type CloudStepOptions } from "./cloud-init.js";
 import { runDoctor } from "./doctor.js";
 import type { InitPolishSeam } from "./init-judgment.js";
-import { mcpStepLines, planMcp, SERVICE_KEY_ON_BROKER, wellFormedServiceKey, type McpPosture } from "./init-mcp.js";
+import { BROKER_NEEDS_HTTPS, mcpStepLines, planMcp, SERVICE_KEY_ON_BROKER, wellFormedServiceKey, type McpPosture } from "./init-mcp.js";
 import { initQuestions } from "./init-questions.js";
 import { rendererFlowOptions, runSyncFlow, writeFonts, type SyncFlowResult } from "./sync-flow.js";
 import { BRIEF_TEMPLATE } from "./extract/stages.js";
@@ -1008,6 +1008,12 @@ async function planMcpScaffold(input: {
   // landed. Same explanation, same way out, one lead-in for each arrival.
   if (options.serviceKey === true && posture === "broker") {
     throw new VendoError("validation", `--service-key does not apply to the broker posture you chose: ${SERVICE_KEY_ON_BROKER}`);
+  }
+  // The other pair that cannot work, caught HERE because this is the first
+  // point where both answers are known: the origin was captured before the
+  // posture was asked. Silence cost a live proof a dead door and a `Wired`.
+  if (posture === "broker" && baseUrl !== null && !baseUrl.startsWith("https://")) {
+    throw new VendoError("validation", `The Vendo Cloud broker cannot front a door at ${baseUrl}: ${BROKER_NEEDS_HTTPS}`);
   }
 
   // Local doors only. A Cloud-fronted door's service key is provisioned with

--- a/packages/vendo/src/cli/provider-deps.ts
+++ b/packages/vendo/src/cli/provider-deps.ts
@@ -355,9 +355,19 @@ export async function ensureVendoPackage(options: { root: string; output: Output
   }
 }
 
+/** npm's grammar for a publishable package name. The last gate before a
+    specifier becomes something to install, and the one a tsconfig PATH ALIAS
+    fails: `@/lib/vendo` is bare by every other test — no leading dot, slash or
+    `node:` — but its scope is EMPTY, and no npm name may have that. Without
+    this, init derived `@/lib` from its own generated import and `pnpm add`
+    wrote `"lib": "link:@/lib"` into the host's dependencies, where nothing
+    downstream flagged it. Checking the NAME rather than listing aliases is what
+    makes the next alias (`@/components`, `@/server`) fail here too. */
+const PACKAGE_NAME = /^(?:@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/;
+
 /** Every BARE package a generated module imports, deduped: `@scope/name` or
  *  `name`, subpath dropped. Relative and absolute specifiers are not packages,
- *  and neither are node builtins. */
+ *  neither are node builtins, and neither is anything npm could not name. */
 function importedPackages(source: string): string[] {
   const found = new Set<string>();
   const specifiers = /(?:^|[\s;}])(?:import|export)\s[^;]*?from\s*["']([^"']+)["']|\bimport\s*\(\s*["']([^"']+)["']/g;
@@ -365,7 +375,8 @@ function importedPackages(source: string): string[] {
     const specifier = match[1] ?? match[2] ?? "";
     if (specifier === "" || specifier.startsWith(".") || specifier.startsWith("/") || specifier.startsWith("node:")) continue;
     const parts = specifier.split("/");
-    found.add(specifier.startsWith("@") ? parts.slice(0, 2).join("/") : parts[0]!);
+    const name = specifier.startsWith("@") ? parts.slice(0, 2).join("/") : parts[0]!;
+    if (PACKAGE_NAME.test(name)) found.add(name);
   }
   return [...found];
 }

--- a/packages/vendo/tests/cli.test.ts
+++ b/packages/vendo/tests/cli.test.ts
@@ -97,10 +97,12 @@ describe("vendo CLI commands", () => {
 
     // Every option but the models answer, so this stays init's ask pass: it
     // writes nothing and hands back the one question still open. (`--ai` is
-    // absent because the AI-flag test owns it.)
+    // absent because the AI-flag test owns it.) The posture is `local` because
+    // that is the one `--service-key` belongs to — a Cloud-fronted door
+    // provisions its own, and the pair is refused below.
     expect(await main(["init", root, "--agent", "--yes", "--force",
       "--auth", "clerk", "--framework", "next", "--theme", "accent=#7c3bed",
-      "--use-case", "mcp", "--base-url", "https://app.acme.com", "--posture", "broker",
+      "--use-case", "mcp", "--base-url", "https://app.acme.com", "--posture", "local",
       "--service-key", "--no-check"])).toBe(0);
 
     expect(await readdir(root)).toEqual([]); // the ask pass wrote nothing
@@ -161,6 +163,14 @@ describe("vendo CLI commands", () => {
     expect(error.mock.calls.flat().join("\n")).toContain("--posture only applies to --use-case mcp");
     expect(await main(["init", root, "--service-key"])).toBe(1);
     expect(error.mock.calls.flat().join("\n")).toContain("--service-key only applies to --use-case mcp");
+
+    // A Cloud-fronted door provisions its own key, so a key passed here has
+    // nowhere to land. It is refused rather than dropped — the agent relay
+    // sends both answers together, and a discarded one reads as accepted.
+    expect(await main(["init", root, "--use-case", "mcp", "--posture", "broker", "--service-key"])).toBe(1);
+    expect(error.mock.calls.flat().join("\n")).toContain("--service-key does not apply to --posture broker");
+    expect(error.mock.calls.flat().join("\n")).toContain("provisioned with the tenant on first use");
+    expect(error.mock.calls.flat().join("\n")).toContain("https://docs.vendo.run/outside-agents/service-keys-and-broker");
 
     expect(await main(["init", root, "--check", "--no-check"])).toBe(1);
     expect(error.mock.calls.flat().join("\n")).toContain("--check and --no-check answer the same question");

--- a/packages/vendo/tests/cli/init-mcp.test.ts
+++ b/packages/vendo/tests/cli/init-mcp.test.ts
@@ -95,13 +95,15 @@ describe("planMcp — the service key", () => {
   // serviceAuth is local-door mechanics: the RFC 8693 exchange lives at the
   // door's own /token, which a broker-fronted door does not serve — and an
   // explicit local serviceAuth beats the env default, so generating one here
-  // would quietly hold the door LOCAL against the posture just chosen.
-  it("generates nothing under broker posture and points at the console instead", () => {
+  // would quietly hold the door LOCAL against the posture just chosen. Cloud
+  // provisions the broker's own key with the tenant, so there is no step here
+  // either: nothing for the operator to create, copy or paste.
+  it("generates nothing and says nothing under broker posture — Cloud provisions the key", () => {
     const broker = plan({ serviceKey: true, posture: "broker" });
     expect(broker.serviceKeyValue).toBeUndefined();
     expect(broker.compositionSource).toContain("mcp: true,");
     expect(broker.compositionSource).not.toContain("serviceAuth");
-    expect(broker.steps.at(-1)).toContain("console's keys page");
+    expect(broker.steps.join("\n")).not.toContain("VENDO_SERVICE_KEY");
   });
 
   it("says nothing about service keys when the answer was no", () => {
@@ -142,12 +144,15 @@ describe("planMcp — the two steps that stay the user's", () => {
 });
 
 describe("planMcp — the sign-in posture", () => {
-  it("prints the operator's two broker lines under broker posture, and nothing under local", () => {
-    expect(plan({ posture: "broker" }).envLines).toEqual([
-      "`VENDO_MCP_BROKER_URL=<your tenant MCP endpoint>`",
-      "`VENDO_MCP_FEDERATION_SECRET=<secret>`",
-    ]);
-    expect(plan().envLines).toEqual([]);
+  // The broker posture used to close on two placeholder environment values the
+  // operator had to go and look up. Cloud reads both itself and provisions the
+  // tenant on first use, so a placeholder printed here is a step that no longer
+  // exists — and a `<secret>` on screen is what made this path feel like setup.
+  it("prints no placeholder environment values under broker posture — Cloud provisions the tenant", () => {
+    const broker = plan({ posture: "broker" }).steps.join("\n");
+    expect(broker).not.toContain("<secret>");
+    expect(broker).not.toMatch(/VENDO_MCP_(BROKER_URL|FEDERATION_SECRET)=/);
+    expect(broker).toContain("provisions the tenant on first use");
   });
 
   // The posture select only appears when a Cloud key is in hand; a keyless run
@@ -176,18 +181,6 @@ describe("mcpStepLines — the closing block reads as steps, not a wall", () => 
       expect(at).toBeGreaterThanOrEqual(0);
       expect(lines.slice(at + 1, at + 1 + detail.length)).toEqual(detail.map((rest) => `   ${rest}`));
     }
-  });
-
-  it("closes with the env values as their own group, and skips the group under local", () => {
-    const broker = plan({ posture: "broker" });
-    const lines = mcpStepLines(broker);
-    const at = lines.indexOf("");
-    // A blank line, one sentence saying where they go, then the values.
-    expect(at).toBeGreaterThan(0);
-    expect(lines[at + 1]).toContain("Set where you deploy");
-    expect(lines.slice(at + 2)).toEqual(broker.envLines.map((env) => `   ${env}`));
-    // Local posture has no env lines, so it gets no group and no blank line.
-    expect(mcpStepLines(plan()).filter((line) => line === "")).toEqual([]);
   });
 });
 

--- a/packages/vendo/tests/cli/init.test.ts
+++ b/packages/vendo/tests/cli/init.test.ts
@@ -2819,6 +2819,53 @@ describe("the five questions", () => {
       .toMatchObject({ status: "ok", message: expect.stringContaining("VENDO_BASE_URL is set") });
   });
 
+  // The flag pair is refused in cli.ts, which reads argv. A posture CHOSEN at
+  // the select never reaches argv, so the same mistake arrived here silently
+  // and the key was dropped — the one path where a user could still believe it
+  // landed. Same refusal, same words, whichever way they got here.
+  it("refuses a service key when the broker posture is chosen at the select, not only when it is a flag", async () => {
+    const root = await fixture();
+    const sink = output();
+    expect(await run(root, sink, {
+      useCase: "mcp",
+      auth: "clerk",
+      baseUrl: "http://localhost:3000",
+      interactive: true,
+      serviceKey: true,
+      cloud: { cloudProbe: async () => ({ present: true, ok: true, unlocks: [] as readonly string[] }) },
+      selectUseCase: async () => "broker",
+      askText: async (_question, _hint, prefill) => prefill ?? "",
+      confirmAuth: async () => false,
+      confirmCheck: async () => false,
+      confirmZodBump: async () => false,
+    })).toBe(1);
+
+    const errors = sink.errors.join("\n");
+    expect(errors).toContain("--service-key does not apply");
+    expect(errors).toContain("provisioned with the tenant on first use");
+    expect(errors).toContain("https://docs.vendo.run/outside-agents/service-keys-and-broker");
+    // It refuses INSTEAD of writing: no composition landed on the way out.
+    expect(await readdir(root)).not.toContain("lib");
+
+    // The control: the SAME broker posture with no key asked for is the
+    // recommended Cloud path and still writes. The guard fires on the key, not
+    // on the posture.
+    const cloudOnly = await fixture();
+    expect(await run(cloudOnly, output(), {
+      useCase: "mcp",
+      auth: "clerk",
+      baseUrl: "http://localhost:3000",
+      interactive: true,
+      cloud: { cloudProbe: async () => ({ present: true, ok: true, unlocks: [] as readonly string[] }) },
+      selectUseCase: async () => "broker",
+      askText: async (_question, _hint, prefill) => prefill ?? "",
+      confirmAuth: async () => false,
+      confirmCheck: async () => false,
+      confirmZodBump: async () => false,
+    })).toBe(0);
+    expect(await readdir(cloudOnly)).toContain("lib");
+  });
+
   it("offers the doctor check only when nothing is left to paste, and never changes the exit code", async () => {
     // A run that still owes the mount paste: doctor would grade that paste,
     // so offering the check would fail a run that did nothing wrong.

--- a/packages/vendo/tests/cli/init.test.ts
+++ b/packages/vendo/tests/cli/init.test.ts
@@ -2849,12 +2849,13 @@ describe("the five questions", () => {
 
     // The control: the SAME broker posture with no key asked for is the
     // recommended Cloud path and still writes. The guard fires on the key, not
-    // on the posture.
+    // on the posture. (An https origin, because Cloud refuses to front any
+    // other — the refusal directly below.)
     const cloudOnly = await fixture();
     expect(await run(cloudOnly, output(), {
       useCase: "mcp",
       auth: "clerk",
-      baseUrl: "http://localhost:3000",
+      baseUrl: "https://app.acme.com",
       interactive: true,
       cloud: { cloudProbe: async () => ({ present: true, ok: true, unlocks: [] as readonly string[] }) },
       selectUseCase: async () => "broker",
@@ -2864,6 +2865,39 @@ describe("the five questions", () => {
       confirmZodBump: async () => false,
     })).toBe(0);
     expect(await readdir(cloudOnly)).toContain("lib");
+  });
+
+  // The blocker a live proof against production Cloud hit: Cloud registers
+  // VENDO_BASE_URL as the tenant's forwarding address and answers
+  // `400 The forwarding address must be an https:// URL`, so the dev origin the
+  // previous question just captured and the Cloud posture cannot coexist. The
+  // pair used to pass init and print `Wired (5 files)` over a door that was
+  // already dead.
+  it("refuses the Cloud broker posture on an http origin instead of writing a door that cannot work", async () => {
+    const root = await fixture();
+    const sink = output();
+    expect(await run(root, sink, {
+      useCase: "mcp",
+      auth: "clerk",
+      baseUrl: "http://localhost:3004",
+      interactive: true,
+      cloud: { cloudProbe: async () => ({ present: true, ok: true, unlocks: [] as readonly string[] }) },
+      selectUseCase: async () => "broker",
+      askText: async (_question, _hint, prefill) => prefill ?? "",
+      confirmAuth: async () => false,
+      confirmCheck: async () => false,
+      confirmZodBump: async () => false,
+    })).toBe(1);
+
+    const errors = sink.errors.join("\n");
+    // It names the origin it refused, why Cloud refuses it, and both ways out.
+    expect(errors).toContain("http://localhost:3004");
+    expect(errors).toContain("forwarding address");
+    expect(errors).toContain("Take the local posture");
+    expect(errors).toContain("--base-url");
+    // …and it refuses INSTEAD of reporting success over a dead door.
+    expect(await readdir(root)).not.toContain("lib");
+    expect(sink.logs.join("\n")).not.toContain("Wired");
   });
 
   it("offers the doctor check only when nothing is left to paste, and never changes the exit code", async () => {

--- a/packages/vendo/tests/cli/provider-deps.test.ts
+++ b/packages/vendo/tests/cli/provider-deps.test.ts
@@ -2,7 +2,7 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { aiBelowPeerFloor, defaultRunner, ensureProviderDeps, ensureVendoPackage, ensureZodFloor, installCommandFor, installStderrTail, providerModuleFor, VENDO_PACKAGE_SPEC, zodBelowAiSdkFloor, ZOD_FLOOR_SPEC } from "../../src/cli/provider-deps.js";
+import { aiBelowPeerFloor, defaultRunner, ensureGeneratedImports, ensureProviderDeps, ensureVendoPackage, ensureZodFloor, installCommandFor, installStderrTail, providerModuleFor, VENDO_PACKAGE_SPEC, zodBelowAiSdkFloor, ZOD_FLOOR_SPEC } from "../../src/cli/provider-deps.js";
 
 // Init installs the provider module the resolved credential loads at
 // runtime (0.4.1 E2E cert finding: nothing declares @ai-sdk/*, so a fresh
@@ -285,6 +285,44 @@ describe("ensureProviderDeps", () => {
  *  pnpm's strict node_modules that package sits inside the alias's own nested
  *  resolution and the host cannot resolve the `@vendoai/vendo/*` imports every
  *  scaffold writes — the wired route fails to compile and 500s. */
+describe("ensureGeneratedImports", () => {
+  /** A tsconfig path alias is bare by every other test — no leading dot, slash
+      or `node:` — so it reached the installer as if it were a package. `@/lib`
+      has an EMPTY scope, which no npm name may have, and `pnpm add @/lib` wrote
+      `"lib": "link:@/lib"` into the host's dependencies. A live proof found it
+      there; doctor reports green over it. */
+  it("never installs a tsconfig path alias, and still installs the real packages beside it", async () => {
+    const root = await tempRoot();
+    await installModule(root, "next");
+    await writeFile(join(root, "package.json"), JSON.stringify({ name: "host", dependencies: { next: "16.0.0" } }));
+    const calls: Array<{ args: string[] }> = [];
+    const messages = output();
+    await ensureGeneratedImports({
+      root,
+      sources: [
+        'import { vendo } from "@/lib/vendo";\n'
+        + 'import { streamText } from "ai";\n'
+        + 'import { anthropic } from "@ai-sdk/anthropic";\n'
+        + 'import { createVendo } from "@vendoai/vendo/server";\n',
+      ],
+      output: messages.sink,
+      run: async (_command, args) => {
+        calls.push({ args });
+        return 0;
+      },
+    });
+
+    const installed = calls.flatMap((call) => call.args);
+    // The alias never becomes a package specifier, under any spelling.
+    expect(installed.some((arg) => arg.includes("@/lib"))).toBe(false);
+    expect(installed).not.toContain("lib");
+    // …and the real imports beside it are still declared.
+    expect(installed).toContain("ai@^6");
+    expect(installed).toContain("@ai-sdk/anthropic@^3");
+    expect(installed).toContain(VENDO_PACKAGE_SPEC);
+  });
+});
+
 describe("ensureVendoPackage", () => {
   it("adds the package the wiring imports when only the alias resolves", async () => {
     const root = await tempRoot();


### PR DESCRIPTION
Cloud provisions the tenant on first use, so init has no `<secret>` placeholder
to print and no service-key question to ask on the broker path — `envLines` and
its closing block are deleted with them. The two MCP env vars survive as an
explicit override that always wins, and local/BYO is untouched.

The three outside-agents pages are rewritten as one golden path with a
checkpoint per step, zero-key posture first and Cloud as a one-line upsell.
Both warning boxes, the hand-rolled curl and the hand-rolled token helper are
gone — `vendo.tokenFor()` replaces all of them.

Net −63 lines. Stacked on #1503; review that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops printing placeholder broker secrets and rejects service keys on the broker posture; also refuses the Cloud broker on non-https origins. Docs consolidate the MCP path and switch all backend minting to `vendo.tokenFor()`.

- Init (MCP): writes the chosen sign‑in posture into the composition; with `VENDO_API_KEY` the runtime provisions the tenant and key on first use. `--service-key` with `--posture broker` exits 1 (both via flags and interactive). Broker posture on a non‑https `VENDO_BASE_URL` exits 1 with guidance. Drops the placeholder env block; `finishRun` prints only step lines.
- Provider deps: validates npm package names and skips tsconfig path aliases (e.g. `@/lib`), preventing entries like `"lib": "link:@/lib"` from landing in `dependencies`.
- Docs: one golden path with checkpoints. `/api/vendo/mcp/connect` is the entry for Claude/ChatGPT/Cursor. `vendo.tokenFor(request | userId)` is the only mint path; invalid/blank subjects fail fast. Checkpoints now match production: door answers `401` with `WWW-Authenticate`; Cloud problems return `400 validation` (with reason/link) or `503 unavailable`. Approvals are opt‑in (default policy asks only on `risk: destructive`). Clarifies who must reach the door, https requirement, question order, and adds `prebuild`. Audit attribution uses `svc:<hash8>`. Broker overrides remain `VENDO_MCP_BROKER_URL` and `VENDO_MCP_FEDERATION_SECRET`; the door URL always derives from `VENDO_BASE_URL`.

- Rollout/migration:
  - Cloud: no action; ignore previously printed `<secret>` placeholders.
  - Dev on Cloud broker: require an https origin for `VENDO_BASE_URL` (use a tunnel) or choose the local posture.
  - Replace custom token helpers with `vendo.tokenFor()`.
  - Drop `--service-key` with `--posture broker`. For local or BYO broker, set `VENDO_SERVICE_KEY` and list it in `mcp.serviceAuth.keys`; to BYO broker, set `VENDO_MCP_BROKER_URL` and `VENDO_MCP_FEDERATION_SECRET`.

<sup>Written for commit aa0bcf6a281611d8cd531d1e67c5c941415d27a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1524?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

