### PR TITLE
feat(core,vendo): a Cloud key answers which companies a user is in

### DIFF
--- a/.changeset/tenant-directory-resolution.md
+++ b/.changeset/tenant-directory-resolution.md
@@ -1,0 +1,18 @@
+---
+"@vendoai/core": minor
+"@vendoai/vendo": minor
+---
+
+With `VENDO_API_KEY` set and no `auth.memberships` of your own, the SDK now
+resolves the acting user's companies from the tenant directory in Vendo Cloud,
+cached 60s per user — and everything that already reads `RunContext.memberships`
+(app sharing, the `org:<id>` limiter pool, org workspaces) starts working with
+no host code. A host that asserts its own `memberships` is untouched: the
+assertion wins, and the directory is never constructed. Per-tenant caps set in
+the console are enforced by the limiter that already exists; on a store with no
+meter they simply do not compose, rather than refusing to boot. A directory
+outage serves the last answer, or none — never a failed turn.
+
+`TenantDirectoryPayload`, `TenantLimits`, `TenantCap` and their zod schemas are
+new in `@vendoai/core`; `cloudDirectory`, `tenantLimits` and `createLimiter` are
+new on `@vendoai/vendo/server`.

--- a/.changeset/tenant-directory-resolution.md
+++ b/.changeset/tenant-directory-resolution.md
@@ -12,6 +12,11 @@ that already exists; on a store with no meter they simply do not compose, rather
 than refusing to boot. A directory outage serves the last answer, or none —
 never a failed turn.
 
+Caps reset on the calendar boundary in UTC, not on a rolling lookback:
+`messagesPerDay` refills at UTC midnight and `generationsPerMonth` on the first
+of the month, so a message sent at 23:59 does not spend the next day's
+allowance.
+
 `memberships` is now also a top-level `createVendo` key, the per-seam twin of
 `auth.memberships` for hosts on the `principal` trio — the same precedence
 `actAs` and `oauth` already have. Assert it and it wins outright: no Cloud

--- a/.changeset/tenant-directory-resolution.md
+++ b/.changeset/tenant-directory-resolution.md
@@ -3,15 +3,34 @@
 "@vendoai/vendo": minor
 ---
 
-With `VENDO_API_KEY` set and no `auth.memberships` of your own, the SDK now
+With `VENDO_API_KEY` set and no memberships seam of your own, the SDK now
 resolves the acting user's companies from the tenant directory in Vendo Cloud,
 cached 60s per user — and everything that already reads `RunContext.memberships`
 (app sharing, the `org:<id>` limiter pool, org workspaces) starts working with
-no host code. A host that asserts its own `memberships` is untouched: the
-assertion wins, and the directory is never constructed. Per-tenant caps set in
-the console are enforced by the limiter that already exists; on a store with no
-meter they simply do not compose, rather than refusing to boot. A directory
-outage serves the last answer, or none — never a failed turn.
+no host code. Per-tenant caps set in the console are enforced by the limiter
+that already exists; on a store with no meter they simply do not compose, rather
+than refusing to boot. A directory outage serves the last answer, or none —
+never a failed turn.
+
+`memberships` is now also a top-level `createVendo` key, the per-seam twin of
+`auth.memberships` for hosts on the `principal` trio — the same precedence
+`actAs` and `oauth` already have. Assert it and it wins outright: no Cloud
+client is constructed and no request ever calls out.
+
+That twin is also how a keyed deployment declines the directory. If you set
+`VENDO_API_KEY`, use `principal` rather than an `auth` preset, and have no
+orgs, say so once and Vendo will never ask Cloud:
+
+```ts
+createVendo({
+  principal: async (req) => …,
+  memberships: async () => [],
+})
+```
+
+Without that line, such a deployment resolves memberships from Cloud — one
+cached call per user per minute, and, until your project has tenants, a log
+line saying the directory had nothing to say.
 
 `TenantDirectoryPayload`, `TenantLimits`, `TenantCap` and their zod schemas are
 new in `@vendoai/core`; `cloudDirectory`, `tenantLimits` and `createLimiter` are

--- a/docs-site/reference/handler-options.mdx
+++ b/docs-site/reference/handler-options.mdx
@@ -15,6 +15,7 @@ One key is required, an identity, as either `principal` or an `auth` preset. `oa
 | `models` | The model seats, keyed by job. See [below](#models) |
 | `auth` | One host-identity preset filling `principal`, `actAs`, and `oauth`. Mutually exclusive with all three |
 | `principal` | `(req) => Promise<Principal \| null>`. Required unless `auth` fills the seam. `null` refuses the request with `forbidden` |
+| `memberships` | `(principal) => Promise<Membership[]>`, the twin of `auth.memberships` for the `principal` trio. Set it and it wins outright. With `VENDO_API_KEY` and this seam unset, memberships come from Vendo Cloud, so `async () => []` is how a deployment with no orgs declines the tenant directory |
 | `tools` | Host tool declarations in memory, the same `ExtractedTool[]` sync writes to `.vendo/tools.json`, and executable tools. The two shapes are told apart by `execute` |
 | `skills` | `Skill[]` mounted at `/host/skills` for the harness to list cheaply and load on demand. A name collision fails at boot naming both |
 | `catalog` | Host components exposed to the generation prompt, merged with `.vendo/catalog.json` with explicit entries winning by name |

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -53,6 +53,7 @@ export * from "./sse-keepalive.js";
 export * from "./store.js";
 export * from "./thread-window.js";
 export * from "./store-wire.js";
+export * from "./tenant-directory.js";
 export * from "./style.js";
 export * from "./engine-collections.js";
 export * from "./engine-over-adapter.js";

--- a/packages/core/src/tenant-directory.ts
+++ b/packages/core/src/tenant-directory.ts
@@ -1,0 +1,54 @@
+import { z } from "zod";
+import { membershipSchema, type Membership } from "./run-context.js";
+
+/**
+ * THE seam both repos parse: what `GET /api/v1/users/{externalId}/memberships`
+ * answers. The console produces it, the SDK's `cloudDirectory` consumes it, and
+ * there is exactly one definition of it — a second copy is how a permission or
+ * a cap comes to mean two things.
+ */
+
+/** A cap and WHO it applies to. `per-member` counts one person's own usage;
+    `per-tenant` counts the whole company's, against the `org:<tenantId>` pool.
+    The customer picks per cap. Both spellings are the limiter's existing
+    grammar — the scope only decides whether `count` is handed a `pool`
+    (`@vendoai/vendo` limits.ts) — so nothing new enforces anything. */
+export type CapScope = "per-member" | "per-tenant";
+export interface TenantCap { limit: number; scope: CapScope }
+
+export interface TenantLimits {
+  messagesPerDay?: TenantCap;
+  generationsPerMonth?: TenantCap;
+}
+
+export const capScopeSchema = z.enum(["per-member", "per-tenant"]);
+export const tenantCapSchema = z.object({
+  limit: z.number().int().positive(),
+  scope: capScopeSchema,
+}).passthrough() satisfies z.ZodType<TenantCap>;
+export const tenantLimitsSchema = z.object({
+  messagesPerDay: tenantCapSchema.optional(),
+  generationsPerMonth: tenantCapSchema.optional(),
+}).passthrough() satisfies z.ZodType<TenantLimits>;
+
+/** Applied by the console when a cap is first written and nowhere else, so the
+    wire never carries an implicit scope: reading a cap always tells you both
+    numbers' meaning. */
+export const DEFAULT_CAP_SCOPE = {
+  messagesPerDay: "per-member",
+  generationsPerMonth: "per-tenant",
+} as const satisfies Record<keyof TenantLimits, CapScope>;
+
+/** `memberships` is core's own `Membership[]` verbatim — `org` IS the tenant
+    id, so nothing downstream translates. `limits` is keyed by that same id and
+    already resolved (per-tenant override ?? project default), so the SDK never
+    sees defaults. */
+export interface TenantDirectoryPayload {
+  memberships: Membership[];
+  limits: Record<string, TenantLimits>;
+}
+
+export const tenantDirectoryPayloadSchema = z.object({
+  memberships: z.array(membershipSchema),
+  limits: z.record(tenantLimitsSchema),
+}).passthrough() satisfies z.ZodType<TenantDirectoryPayload>;

--- a/packages/core/tests/tenant-directory.test.ts
+++ b/packages/core/tests/tenant-directory.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_CAP_SCOPE,
+  tenantCapSchema,
+  tenantDirectoryPayloadSchema,
+  tenantLimitsSchema,
+} from "../src/tenant-directory.js";
+
+/** The seam BOTH repos parse. A cap that carried a bare number would let the
+    SDK and the console disagree about whose usage it covers, so the scope is
+    stored and never implied. */
+describe("tenant directory payload", () => {
+  it("parses memberships and per-tenant limits together", () => {
+    const parsed = tenantDirectoryPayloadSchema.parse({
+      memberships: [{ org: "acme", display: "Acme Corp" }],
+      limits: {
+        acme: {
+          messagesPerDay: { limit: 50, scope: "per-member" },
+          generationsPerMonth: { limit: 1000, scope: "per-tenant" },
+        },
+      },
+    });
+    expect(parsed.memberships[0]?.org).toBe("acme");
+    expect(parsed.limits["acme"]?.generationsPerMonth).toEqual({ limit: 1000, scope: "per-tenant" });
+  });
+
+  it("reads an unknown user as empty, never as a failure", () => {
+    expect(tenantDirectoryPayloadSchema.parse({ memberships: [], limits: {} }))
+      .toEqual({ memberships: [], limits: {} });
+  });
+
+  it("refuses a cap with no scope, so no reader gets to assume one", () => {
+    expect(() => tenantCapSchema.parse({ limit: 50 })).toThrow();
+    expect(() => tenantCapSchema.parse(50)).toThrow();
+    expect(() => tenantCapSchema.parse({ limit: 50, scope: "per-org" })).toThrow();
+  });
+
+  it("refuses a limit that is not a positive integer", () => {
+    for (const limit of [0, -1, 1.5]) {
+      expect(() => tenantCapSchema.parse({ limit, scope: "per-member" })).toThrow();
+    }
+  });
+
+  it("names a default scope per cap, applied by the console at write time", () => {
+    expect(DEFAULT_CAP_SCOPE).toEqual({
+      messagesPerDay: "per-member",
+      generationsPerMonth: "per-tenant",
+    });
+  });
+
+  it("passes unknown keys through, so a newer console never breaks an older SDK", () => {
+    const parsed = tenantLimitsSchema.parse({
+      messagesPerDay: { limit: 5, scope: "per-member", note: "hi" },
+      seatsPerTenant: { limit: 3, scope: "per-tenant" },
+    });
+    expect(parsed).toMatchObject({ seatsPerTenant: { limit: 3 } });
+  });
+});

--- a/packages/vendo/src/cloud-directory.ts
+++ b/packages/vendo/src/cloud-directory.ts
@@ -1,0 +1,85 @@
+import {
+  consoleSender,
+  defaultFetch,
+  log,
+  raiseCloudError,
+  tenantDirectoryPayloadSchema,
+  type Membership,
+  type Principal,
+  type TenantDirectoryPayload,
+} from "@vendoai/core";
+
+/** The hosted tenant directory — the implementation the composition seam
+ * (createVendo) puts in the `memberships` slot when VENDO_API_KEY fills a slot
+ * the host left unset (adapter rule — see selectConnections in
+ * compose-selection.ts; the seam itself never reads the environment). Rides the
+ * shared console-client plumbing (cloud-console.ts): Bearer auth + deployment
+ * identity + a per-request abort timeout. */
+
+export interface CloudDirectoryOptions {
+  apiKey: string;
+  /** Defaults to the Vendo console; the composition seam passes VENDO_CLOUD_URL. */
+  baseUrl?: string;
+  fetch?: typeof fetch;
+  /** Per-request abort budget. Short, because this is on the REQUEST HOT PATH —
+   *  every turn awaits it inside context resolution. */
+  timeoutMs?: number;
+  /** How long one subject's answer is reused. `door.ts`'s KEY_TTL_MS posture. */
+  ttlMs?: number;
+}
+
+export interface CloudDirectory {
+  /** The whole answer for one person; memoised per subject for ttlMs. */
+  entry(principal: Principal): Promise<TenantDirectoryPayload>;
+  /** The `memberships` seam, ready to hand to compose-config. */
+  memberships: (principal: Principal) => Promise<Membership[]>;
+}
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+const DEFAULT_TTL_MS = 60_000;
+const CONSOLE_USERS_PATH = "/api/v1/users";
+const NOTHING: TenantDirectoryPayload = { memberships: [], limits: {} };
+
+export function cloudDirectory(options: CloudDirectoryOptions): CloudDirectory {
+  const base = (options.baseUrl ?? "https://console.vendo.run").replace(/\/$/, "");
+  const ttlMs = options.ttlMs ?? DEFAULT_TTL_MS;
+  const send = consoleSender({
+    base,
+    mountPath: CONSOLE_USERS_PATH,
+    apiKey: options.apiKey,
+    timeoutMs: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    fetchImpl: options.fetch ?? defaultFetch,
+    raise: (response) => raiseCloudError(response, "tenants", (code, message) => {
+      throw Object.assign(new Error(message), { code: code ?? "unavailable" });
+    }),
+  });
+  const cache = new Map<string, { at: number; payload: TenantDirectoryPayload }>();
+
+  const entry = async (principal: Principal): Promise<TenantDirectoryPayload> => {
+    const cached = cache.get(principal.subject);
+    if (cached !== undefined && Date.now() - cached.at < ttlMs) return cached.payload;
+    let payload: TenantDirectoryPayload;
+    try {
+      const response = await send(`/${encodeURIComponent(principal.subject)}/memberships`);
+      payload = tenantDirectoryPayloadSchema.parse(await response.json());
+    } catch (error) {
+      // THE fail mode, and it is the opposite of the limiter's. This is awaited
+      // inside per-request context resolution (wire/context.ts), so a throw
+      // here is a 500 for the WHOLE turn: Cloud being down must not take the
+      // host's product down. Stated plainly — during an outage a tenant cap is
+      // not enforced and tenant-shared apps are briefly invisible.
+      log({
+        code: "vendo.tenant_directory_unavailable",
+        level: "warn",
+        message: `[vendo] the tenant directory did not answer for ${principal.subject}; `
+          + `${cached === undefined ? "resolving to no memberships" : "serving the last answer"} for this request:`,
+        data: { error },
+      });
+      return cached?.payload ?? NOTHING;
+    }
+    cache.set(principal.subject, { at: Date.now(), payload });
+    return payload;
+  };
+
+  return { entry, memberships: async (principal) => (await entry(principal)).memberships };
+}

--- a/packages/vendo/src/compose-config.ts
+++ b/packages/vendo/src/compose-config.ts
@@ -148,11 +148,13 @@ export const composeConfig = (input: CreateVendoConfig): Pick<VendoComposition,
   }
   const actAsSeam = config.auth === undefined ? config.actAs : config.auth.actAs;
   const oauthSeam = config.auth === undefined ? config.oauth : config.auth.oauth;
-  // Build contract §9.1 — the fourth seam. It rides the preset (there is no
-  // per-seam twin: the org query has no meaning without an identity story) and
-  // is handed to the wire, the automations engine, and the schedule engine, so
-  // an attended request and an unattended fire resolve the SAME answer.
-  const membershipsSeam = config.auth?.memberships;
+  // Build contract §9.1 — the fourth seam, handed to the wire, the automations
+  // engine and the schedule engine, so an attended request and an unattended
+  // fire resolve the SAME answer. It has a per-seam twin like `actAs` and
+  // `oauth` above: once VENDO_API_KEY can FILL this seam, the twin is the only
+  // way a host on the `principal` trio can refuse the Cloud directory, and a
+  // default nobody can refuse is a mandate.
+  const membershipsSeam = config.auth === undefined ? config.memberships : config.auth.memberships;
   // ADAPTER RULE, memberships seam: an explicitly asserted seam always wins and
   // short-circuits the whole directory — with it set, no client is constructed
   // and Cloud is never called. Only a wholly unset seam lets VENDO_API_KEY

--- a/packages/vendo/src/compose-config.ts
+++ b/packages/vendo/src/compose-config.ts
@@ -8,7 +8,9 @@
 import { agentComposition, type AgentComposition } from "@vendoai/agents";
 import { unsupportedRouteParams } from "@vendoai/apps/contract";
 import { VendoError } from "@vendoai/core";
+import { cloudDirectory } from "./cloud-directory.js";
 import type { VendoComposition } from "./compose-context.js";
+import { cloudKeyOptions } from "./compose-selection.js";
 import { rejectRemovedConfigKeys, warnDeprecatedConfigKeys } from "./config-keys.js";
 import type { AppsOptions, CreateVendoConfig } from "./types.js";
 
@@ -91,7 +93,7 @@ function validateSweepConfig(sweep: CreateVendoConfig["sweep"]): ResolvedSweep {
 /** 09-vendo §2 — the config, the identity seams, and the sweep cadence. */
 export const composeConfig = (input: CreateVendoConfig): Pick<VendoComposition,
   "appsMounted" | "automationsMounted" | "config" | "composed" | "resolvePrincipal"
-  | "actAsSeam" | "oauthSeam" | "membershipsSeam" | "userFactsSeam" | "userPoolsSeam"
+  | "actAsSeam" | "oauthSeam" | "membershipsSeam" | "directory" | "userFactsSeam" | "userPoolsSeam"
   | "sweepConfig" | "sweepNow"> => {
   // Whether each subsystem mounts, decided once. `apps: false` is folded away
   // here so the hundred reads below stay `config.apps?.x`: an unmounted
@@ -151,6 +153,14 @@ export const composeConfig = (input: CreateVendoConfig): Pick<VendoComposition,
   // is handed to the wire, the automations engine, and the schedule engine, so
   // an attended request and an unattended fire resolve the SAME answer.
   const membershipsSeam = config.auth?.memberships;
+  // ADAPTER RULE, memberships seam: an explicitly asserted seam always wins and
+  // short-circuits the whole directory — with it set, no client is constructed
+  // and Cloud is never called. Only a wholly unset seam lets VENDO_API_KEY
+  // default the hosted directory (selectConnections' precedence,
+  // compose-selection.ts). One place, so the wire, the harness, the automations
+  // engine and the MCP door all inherit it.
+  const cloud = membershipsSeam === undefined ? cloudKeyOptions() : undefined;
+  const directory = cloud === undefined ? undefined : cloudDirectory(cloud);
   // Spec 2026-08-05 §1 — the [User] facts seam rides the preset only (decision
   // 5: no seam for raw principal-trio hosts — a hand-rolled `principal` has no
   // facts channel).
@@ -172,7 +182,8 @@ export const composeConfig = (input: CreateVendoConfig): Pick<VendoComposition,
     resolvePrincipal,
     actAsSeam,
     oauthSeam,
-    membershipsSeam,
+    membershipsSeam: membershipsSeam ?? directory?.memberships,
+    directory,
     userFactsSeam,
     userPoolsSeam,
     sweepConfig,

--- a/packages/vendo/src/compose-context.ts
+++ b/packages/vendo/src/compose-context.ts
@@ -53,6 +53,7 @@ import type { createByoApprovals } from "./byo-approvals.js";
 import type { CapabilitySurfaceSnapshot } from "./capability-misses.js";
 import type { MergedCapability } from "./capability/index.js";
 import type { mergeRuntimeCatalog } from "./catalog.js";
+import type { CloudDirectory } from "./cloud-directory.js";
 import { composeActions } from "./compose-actions.js";
 import { composeApps } from "./compose-apps.js";
 import { composeAutomations } from "./compose-automations.js";
@@ -124,6 +125,10 @@ export interface VendoComposition {
   /** Build contract §9.1 — the host org query the wire, the harness, the
    *  automations engine and the MCP door all resolve the SAME answer through. */
   membershipsSeam: HostAuthPreset["memberships"];
+  /** The hosted tenant directory, when VENDO_API_KEY filled a `memberships`
+   *  seam the host left unset — `undefined` whenever the host asserted its own.
+   *  Read a second time by composeLimits, off the SAME cache. */
+  directory: CloudDirectory | undefined;
   userFactsSeam: HostAuthPreset["facts"];
   userPoolsSeam: HostAuthPreset["pools"];
   sweepConfig: ResolvedSweep;

--- a/packages/vendo/src/config-keys.ts
+++ b/packages/vendo/src/config-keys.ts
@@ -33,6 +33,7 @@ export const CREATE_VENDO_CONFIG_KEYS = [
   "models",
   "auth",
   "principal",
+  "memberships",
   "tools",
   "skills",
   "catalog",

--- a/packages/vendo/src/limits.ts
+++ b/packages/vendo/src/limits.ts
@@ -30,6 +30,7 @@ import {
   type VendoViewStreamingToolCall,
 } from "@vendoai/core";
 import type { VendoComposition } from "./compose-context.js";
+import { tenantLimits } from "./tenant-limits.js";
 
 /** The decision a choke point acts on — `LimitDecision`'s two forms collapsed to
     one, so no caller re-derives the boolean/object grammar. */
@@ -198,9 +199,22 @@ export const limitGenerations = (tools: ToolRegistry, limiter: Limiter): ToolReg
  *  so by omitting the family), so a policy against a meterless store is refused
  *  HERE rather than enforced against counts that are all zero. */
 export const composeLimits = (composition: VendoComposition): Pick<VendoComposition, "limiter"> => {
-  const { config, ops } = composition;
-  if (config.limits === undefined) return { limiter: undefined };
+  const { config, ops, directory } = composition;
+  const callback = config.limits ?? (directory === undefined ? undefined : tenantLimits(directory));
+  if (callback === undefined) return { limiter: undefined };
   if (ops?.usage === undefined) {
+    // The CLOUD DEFAULT must not throw: a host who never asked for limits would
+    // stop booting on a BYO store with no meter, which is not them asking for
+    // one. It simply does not compose, and says so once.
+    if (config.limits === undefined) {
+      log({
+        code: "limits.tenant_caps_unmetered",
+        level: "warn",
+        message: "[vendo] tenant caps are configured in the console but this deployment's store has no meter, "
+          + "so they are not enforced.",
+      });
+      return { limiter: undefined };
+    }
     throw new VendoError(
       "validation",
       "createVendo({ limits }) needs a store that can count, and this deployment's store has no usage meter: "
@@ -209,5 +223,5 @@ export const composeLimits = (composition: VendoComposition): Pick<VendoComposit
       + "or drop `limits`.",
     );
   }
-  return { limiter: createLimiter({ callback: config.limits, ops: ops.usage }) };
+  return { limiter: createLimiter({ callback, ops: ops.usage }) };
 };

--- a/packages/vendo/src/server.ts
+++ b/packages/vendo/src/server.ts
@@ -149,6 +149,14 @@ export { chainSecrets, cloudSecrets, type CloudSecretsOptions } from "./cloud-se
 // createVendo({ connectors: [cloudTools({...})] }) to scope with `apps`.
 export { cloudTools, type CloudToolsOptions } from "./cloud-tools.js";
 
+// The hosted tenant directory and the policy it feeds ride the server surface
+// like the other Cloud adapters — and the console's cross-repo seam test drives
+// all three against the SHIPPING code, which is the only way a producer and a
+// consumer can ever disagree in a test.
+export { cloudDirectory, type CloudDirectory, type CloudDirectoryOptions } from "./cloud-directory.js";
+export { tenantLimits } from "./tenant-limits.js";
+export { createLimiter, type Limiter, type LimitVerdict } from "./limits.js";
+
 // The BYO connectors a host passes to createVendo({ connectors }), named from
 // here so bringing an MCP server or a third-party REST API in is one import
 // from the umbrella — no direct @vendoai/actions dependency.

--- a/packages/vendo/src/tenant-limits.ts
+++ b/packages/vendo/src/tenant-limits.ts
@@ -11,15 +11,32 @@ import type { CloudDirectory } from "./cloud-directory.js";
  * the subject. Neither spelling is new grammar; the limiter already speaks both.
  */
 
-/** Which cap governs which metered action, and the span each is counted over. */
-const CAPS: Record<LimitAction, { key: keyof TenantLimits; days: number; noun: string; span: string }> = {
-  message: { key: "messagesPerDay", days: 1, noun: "messages", span: "for today" },
-  generation: { key: "generationsPerMonth", days: 30, noun: "generations", span: "for this month" },
+/** The caps are spelled per DAY and per MONTH and the denial says "for today" /
+ *  "for this month", so each resets on the calendar boundary. A rolling
+ *  lookback would make those sentences false: a message at 23:59 would still be
+ *  spending the next day's allowance at 00:01, and 30 days is not a month.
+ *
+ *  UTC, and deliberately no per-host timezone knob — one deployment's users span
+ *  zones, so there is no single local midnight to honour, and an invented guess
+ *  resets quotas at an hour nobody chose. A stated boundary beats a wrong one. */
+const startOfUTCDay = (): Date => {
+  const now = new Date();
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+};
+const startOfUTCMonth = (): Date => {
+  const now = new Date();
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+};
+
+/** Which cap governs which metered action, and the period each is counted over. */
+const CAPS: Record<LimitAction, { key: keyof TenantLimits; period: () => Date; noun: string; span: string }> = {
+  message: { key: "messagesPerDay", period: startOfUTCDay, noun: "messages", span: "for today" },
+  generation: { key: "generationsPerMonth", period: startOfUTCMonth, noun: "generations", span: "for this month" },
 };
 
 export function tenantLimits(directory: CloudDirectory): LimitsCallback {
   return async ({ user, action, count }) => {
-    const { key, days, noun, span } = CAPS[action];
+    const { key, period, noun, span } = CAPS[action];
     const { memberships, limits } = await directory.entry(user);
     for (const { org, display } of memberships) {
       const cap = limits[org]?.[key];
@@ -29,7 +46,8 @@ export function tenantLimits(directory: CloudDirectory): LimitsCallback {
       // is not in throws, and a throw is a deny with no message. A signed-out
       // visitor, an inbound text, a directory miss — all must fall through.
       if (cap.scope === "per-tenant" && user.pools?.includes(pool) !== true) continue;
-      const used = await count(action, cap.scope === "per-tenant" ? { days, pool } : { days });
+      const since = period();
+      const used = await count(action, cap.scope === "per-tenant" ? { since, pool } : { since });
       if (used < cap.limit) continue;
       const who = cap.scope === "per-tenant" ? `${display ?? org} has used its` : "You've used your";
       return { allow: false, message: `${who} ${cap.limit.toLocaleString("en-US")} ${noun} ${span}.` };

--- a/packages/vendo/src/tenant-limits.ts
+++ b/packages/vendo/src/tenant-limits.ts
@@ -1,0 +1,39 @@
+import type { LimitAction, LimitsCallback, TenantLimits } from "@vendoai/core";
+import type { CloudDirectory } from "./cloud-directory.js";
+
+/**
+ * The Cloud-default `LimitsCallback`: the caps the customer set in the console,
+ * read off the SAME cached directory entry the memberships seam already
+ * resolved for this request, so a cap costs zero extra requests.
+ *
+ * Each cap's `scope` chooses the window and nothing else — `per-tenant` hands
+ * `count` the `org:<tenantId>` pool, `per-member` hands it nothing and counts
+ * the subject. Neither spelling is new grammar; the limiter already speaks both.
+ */
+
+/** Which cap governs which metered action, and the span each is counted over. */
+const CAPS: Record<LimitAction, { key: keyof TenantLimits; days: number; noun: string; span: string }> = {
+  message: { key: "messagesPerDay", days: 1, noun: "messages", span: "for today" },
+  generation: { key: "generationsPerMonth", days: 30, noun: "generations", span: "for this month" },
+};
+
+export function tenantLimits(directory: CloudDirectory): LimitsCallback {
+  return async ({ user, action, count }) => {
+    const { key, days, noun, span } = CAPS[action];
+    const { memberships, limits } = await directory.entry(user);
+    for (const { org, display } of memberships) {
+      const cap = limits[org]?.[key];
+      if (cap === undefined) continue;
+      const pool = `org:${org}`;
+      // Guarded exactly as a host's own org policy is: counting a pool the user
+      // is not in throws, and a throw is a deny with no message. A signed-out
+      // visitor, an inbound text, a directory miss — all must fall through.
+      if (cap.scope === "per-tenant" && user.pools?.includes(pool) !== true) continue;
+      const used = await count(action, cap.scope === "per-tenant" ? { days, pool } : { days });
+      if (used < cap.limit) continue;
+      const who = cap.scope === "per-tenant" ? `${display ?? org} has used its` : "You've used your";
+      return { allow: false, message: `${who} ${cap.limit.toLocaleString("en-US")} ${noun} ${span}.` };
+    }
+    return true;
+  };
+}

--- a/packages/vendo/src/types.ts
+++ b/packages/vendo/src/types.ts
@@ -24,6 +24,7 @@ import type {
   Json,
   KnowledgeAdapter,
   LimitsCallback,
+  Membership,
   Principal,
   RunContext,
   RunId,
@@ -144,6 +145,15 @@ export interface CreateVendoConfig {
       `forbidden`; give logged-out visitors a principal of your own choosing if
       you want them served. */
   principal?: (req: Request) => Promise<Principal | null>;
+  /** Per-seam escape hatch: the caller's orgs and teams, the twin of
+      `auth.memberships` for a host on the `principal` trio. Same seam, same
+      precedence as `actAs` and `oauth` — set it and it wins outright.
+
+      This is also how a keyed deployment DECLINES the Cloud tenant directory:
+      with `VENDO_API_KEY` set and this seam unset, Vendo resolves memberships
+      from Vendo Cloud, so `memberships: async () => []` is how a host says
+      "this deployment has no orgs" and no directory is ever constructed. */
+  memberships?: (principal: Principal) => Promise<Membership[]>;
   /** Architecture §10 — THE host's own tools, as `vendo init` / `vendo sync`
       extract them: the declarations `.vendo/tools.json` carries, passed in
       memory instead of read from disk.

--- a/packages/vendo/tests/boot-summary.test.ts
+++ b/packages/vendo/tests/boot-summary.test.ts
@@ -255,6 +255,10 @@ describe("the composed facts", () => {
       { label: "models", venue: "cloud", detail: "VENDO_API_KEY (gateway)" },
       { label: "connections", venue: "cloud", detail: "VENDO_API_KEY" },
       { label: "auth", venue: "custom", detail: "createVendo({ principal })" },
+      // The key fills the memberships seam too, and an org can only reach a
+      // request through that seam — so per-org tenant connectors are genuinely
+      // live here, and the block says so rather than staying silent.
+      { label: "tenants", venue: "store", detail: "vendo.tenantConnectors" },
     ]);
   });
 

--- a/packages/vendo/tests/cloud-directory.test.ts
+++ b/packages/vendo/tests/cloud-directory.test.ts
@@ -89,3 +89,14 @@ describe("cloudDirectory", () => {
     expect(seen[0]?.["authorization"]).toBe("Bearer vk_test");
   });
 });
+
+describe("the server surface", () => {
+  // The console's seam test drives the REAL consumer — no stub on either side —
+  // so these three are public surface, not an implementation detail.
+  it("exports the directory, its policy, and the limiter", async () => {
+    const server = await import("../src/server.js");
+    expect(typeof server.cloudDirectory).toBe("function");
+    expect(typeof server.tenantLimits).toBe("function");
+    expect(typeof server.createLimiter).toBe("function");
+  });
+});

--- a/packages/vendo/tests/cloud-directory.test.ts
+++ b/packages/vendo/tests/cloud-directory.test.ts
@@ -1,0 +1,91 @@
+import type { Principal } from "@vendoai/core";
+import { describe, expect, it } from "vitest";
+import { cloudDirectory } from "../src/cloud-directory.js";
+
+const bob: Principal = { kind: "user", subject: "u_bob" };
+const kim: Principal = { kind: "user", subject: "u_kim" };
+
+const payload = {
+  memberships: [{ org: "acme", display: "Acme Corp" }],
+  limits: { acme: { generationsPerMonth: { limit: 1000, scope: "per-tenant" } } },
+};
+
+/** A fetch that answers `answers` in order and records every URL it saw. */
+const fetchOf = (...answers: Response[]) => {
+  const urls: string[] = [];
+  let next = 0;
+  const impl = (async (input: RequestInfo | URL) => {
+    urls.push(String(input));
+    return answers[Math.min(next++, answers.length - 1)]!.clone();
+  }) as typeof fetch;
+  return { impl, urls };
+};
+
+const ok = (body: unknown) => new Response(JSON.stringify(body), {
+  status: 200,
+  headers: { "content-type": "application/json" },
+});
+
+describe("cloudDirectory", () => {
+  it("asks the console once per subject inside the TTL", async () => {
+    const { impl, urls } = fetchOf(ok(payload));
+    const directory = cloudDirectory({ apiKey: "vk_test", baseUrl: "https://console.test", fetch: impl });
+
+    await expect(directory.memberships(bob)).resolves.toEqual(payload.memberships);
+    await expect(directory.memberships(bob)).resolves.toEqual(payload.memberships);
+    expect(urls).toEqual(["https://console.test/api/v1/users/u_bob/memberships"]);
+  });
+
+  it("keeps one entry per subject", async () => {
+    const { impl, urls } = fetchOf(ok(payload));
+    const directory = cloudDirectory({ apiKey: "vk_test", baseUrl: "https://console.test", fetch: impl });
+    await directory.entry(bob);
+    await directory.entry(kim);
+    expect(urls).toHaveLength(2);
+  });
+
+  it("re-asks once the TTL has passed", async () => {
+    const { impl, urls } = fetchOf(ok(payload));
+    const directory = cloudDirectory({
+      apiKey: "vk_test", baseUrl: "https://console.test", fetch: impl, ttlMs: 0,
+    });
+    await directory.entry(bob);
+    await directory.entry(bob);
+    expect(urls).toHaveLength(2);
+  });
+
+  // A directory outage must not take the host's product down: `memberships` is
+  // awaited inside per-request context resolution, so a throw is a 500 for the
+  // whole turn.
+  it("degrades a 404 to no memberships, and does not throw", async () => {
+    const { impl } = fetchOf(new Response("", { status: 404 }));
+    const directory = cloudDirectory({ apiKey: "vk_test", baseUrl: "https://console.test", fetch: impl });
+    await expect(directory.entry(bob)).resolves.toEqual({ memberships: [], limits: {} });
+  });
+
+  it("serves the stale entry when the console goes down", async () => {
+    const { impl } = fetchOf(ok(payload), new Response("", { status: 503 }));
+    const directory = cloudDirectory({
+      apiKey: "vk_test", baseUrl: "https://console.test", fetch: impl, ttlMs: 0,
+    });
+    await directory.entry(bob);
+    await expect(directory.entry(bob)).resolves.toEqual(payload);
+  });
+
+  it("degrades a malformed 200 rather than throwing at the caller", async () => {
+    const { impl } = fetchOf(ok({ memberships: "nope" }));
+    const directory = cloudDirectory({ apiKey: "vk_test", baseUrl: "https://console.test", fetch: impl });
+    await expect(directory.memberships(bob)).resolves.toEqual([]);
+  });
+
+  it("sends the key as a bearer token", async () => {
+    const seen: Record<string, string>[] = [];
+    const impl = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      seen.push(Object.fromEntries(new Headers(init?.headers).entries()));
+      return ok(payload);
+    }) as typeof fetch;
+    const directory = cloudDirectory({ apiKey: "vk_test", baseUrl: "https://console.test", fetch: impl });
+    await directory.entry(bob);
+    expect(seen[0]?.["authorization"]).toBe("Bearer vk_test");
+  });
+});

--- a/packages/vendo/tests/compose-directory.test.ts
+++ b/packages/vendo/tests/compose-directory.test.ts
@@ -50,7 +50,10 @@ const compositionOf = (over: Partial<VendoComposition>): VendoComposition =>
   ({ config: {}, ops: undefined, directory: undefined, ...over } as VendoComposition);
 
 const fakeDirectory = { entry: async () => ({ memberships: [], limits: {} }), memberships: async () => [] };
-const meter = { usage: { count: async () => 0, record: async () => {} } };
+// Only the `usage` family, because `composeLimits` reads only `ops?.usage` —
+// StoreOps' other thirteen families would be dead weight, so the stub takes the
+// `unknown` hop rather than pretending to be a whole store.
+const meter = { usage: { count: async () => 0, record: async () => {} } } as unknown as VendoComposition["ops"];
 
 describe("composeLimits with a Cloud directory", () => {
   it("composes the Cloud default when the host set no policy", () => {

--- a/packages/vendo/tests/compose-directory.test.ts
+++ b/packages/vendo/tests/compose-directory.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest";
+import { composeConfig } from "../src/compose-config.js";
+import type { CreateVendoConfig } from "../src/types.js";
+
+/** ADAPTER RULE: the host's own assertion always wins and short-circuits the
+    whole directory — with it set, no client is built and Cloud is never
+    called. Only a wholly unset seam lets VENDO_API_KEY default the hosted one. */
+
+const base = (over: Partial<CreateVendoConfig> = {}): CreateVendoConfig => ({
+  principal: async () => ({ kind: "user", subject: "dev" }),
+  ...over,
+} as CreateVendoConfig);
+
+describe("the memberships seam's Cloud default", () => {
+  it("leaves both unset with no key", () => {
+    vi.stubEnv("VENDO_API_KEY", "");
+    const composed = composeConfig(base());
+    expect(composed.membershipsSeam).toBeUndefined();
+    expect(composed.directory).toBeUndefined();
+    vi.unstubAllEnvs();
+  });
+
+  it("fills the seam from the key when the host asserted nothing", () => {
+    vi.stubEnv("VENDO_API_KEY", "vk_test");
+    const composed = composeConfig(base());
+    expect(composed.directory).toBeDefined();
+    expect(composed.membershipsSeam).toBe(composed.directory?.memberships);
+    vi.unstubAllEnvs();
+  });
+
+  it("never builds a directory when the host asserts its own memberships", () => {
+    vi.stubEnv("VENDO_API_KEY", "vk_test");
+    const memberships = async () => [{ org: "maple" }];
+    // Not through `base()`: one preset or the per-seam trio, never mixed
+    // (compose-config.ts:120-131), so an `auth` config carries no top-level
+    // `principal`.
+    const composed = composeConfig({
+      auth: { principal: async () => ({ kind: "user", subject: "dev" }), memberships },
+    } as CreateVendoConfig);
+    expect(composed.membershipsSeam).toBe(memberships);
+    expect(composed.directory).toBeUndefined();
+    vi.unstubAllEnvs();
+  });
+});
+
+import { composeLimits } from "../src/limits.js";
+import type { VendoComposition } from "../src/compose-context.js";
+
+const compositionOf = (over: Partial<VendoComposition>): VendoComposition =>
+  ({ config: {}, ops: undefined, directory: undefined, ...over } as VendoComposition);
+
+const fakeDirectory = { entry: async () => ({ memberships: [], limits: {} }), memberships: async () => [] };
+const meter = { usage: { count: async () => 0, record: async () => {} } };
+
+describe("composeLimits with a Cloud directory", () => {
+  it("composes the Cloud default when the host set no policy", () => {
+    const { limiter } = composeLimits(compositionOf({ directory: fakeDirectory, ops: meter } as Partial<VendoComposition>));
+    expect(limiter).toBeDefined();
+  });
+
+  // A host who never asked for limits must not stop booting because their BYO
+  // store has no meter.
+  it("does not compose, and does not throw, on a meterless store", () => {
+    const { limiter } = composeLimits(compositionOf({ directory: fakeDirectory } as Partial<VendoComposition>));
+    expect(limiter).toBeUndefined();
+  });
+
+  // An explicit config.limits against a meterless store keeps today's refusal.
+  it("still refuses an explicit policy against a meterless store", () => {
+    expect(() => composeLimits(compositionOf({
+      config: { limits: async () => true }, directory: fakeDirectory,
+    } as Partial<VendoComposition>))).toThrow(/needs a store that can count/);
+  });
+
+  it("lets an explicit policy win over the Cloud default", async () => {
+    const { limiter } = composeLimits(compositionOf({
+      config: { limits: async () => ({ allow: false, message: "mine" }) },
+      directory: fakeDirectory,
+      ops: meter,
+    } as Partial<VendoComposition>));
+    const verdict = await limiter!.gate("message", {
+      principal: { kind: "user", subject: "dev" }, venue: "app", presence: "present", sessionId: "s",
+    });
+    expect(verdict).toMatchObject({ message: "mine" });
+  });
+});

--- a/packages/vendo/tests/compose-directory.test.ts
+++ b/packages/vendo/tests/compose-directory.test.ts
@@ -41,6 +41,19 @@ describe("the memberships seam's Cloud default", () => {
     expect(composed.directory).toBeUndefined();
     vi.unstubAllEnvs();
   });
+
+  // The per-seam twin of `auth.memberships`, exactly like `actAs` and `oauth`.
+  // Without it a raw-`principal` host — which cannot carry an `auth` preset —
+  // had NO way to refuse the Cloud directory, which made it a mandate rather
+  // than a default. Asserting an empty list is how such a host says "no orgs".
+  it("lets a raw-principal host decline the directory by asserting its own seam", () => {
+    vi.stubEnv("VENDO_API_KEY", "vk_test");
+    const memberships = async () => [];
+    const composed = composeConfig(base({ memberships }));
+    expect(composed.membershipsSeam).toBe(memberships);
+    expect(composed.directory).toBeUndefined();
+    vi.unstubAllEnvs();
+  });
 });
 
 import { composeLimits } from "../src/limits.js";

--- a/packages/vendo/tests/server.test.ts
+++ b/packages/vendo/tests/server.test.ts
@@ -1081,6 +1081,11 @@ describe("09 §3 public wire", () => {
       // the Cloud tools connector, whose /status-triggered descriptor fetch
       // would land in consoleCalls.
       connectors: [],
+      // …and from the memberships seam, for the same reason and in the same
+      // way: with the key stubbed, an unset memberships slot would compose the
+      // Cloud tenant directory, whose per-request GET would land in
+      // consoleCalls. This deployment asserts it has no orgs.
+      memberships: async () => [],
       ...config,
     });
 

--- a/packages/vendo/tests/tenant-limits.test.ts
+++ b/packages/vendo/tests/tenant-limits.test.ts
@@ -1,7 +1,16 @@
-import type { LimitAction, LimitUser, LimitWindow, TenantDirectoryPayload } from "@vendoai/core";
-import { describe, expect, it } from "vitest";
+import type { LimitAction, LimitUser, LimitWindow, StoreOps, TenantDirectoryPayload } from "@vendoai/core";
+import { memoryStoreOps } from "@vendoai/core/conformance";
+import { describe, expect, it, vi } from "vitest";
 import type { CloudDirectory } from "../src/cloud-directory.js";
+import { createLimiter } from "../src/limits.js";
 import { tenantLimits } from "../src/tenant-limits.js";
+
+/** The period each cap is counted over, restated — the tests say what the
+    windows MEAN, and the boundary cases below say what they DO. */
+const startOfUTCDay = (now = new Date()): Date =>
+  new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+const startOfUTCMonth = (now = new Date()): Date =>
+  new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
 
 /** A directory that answers one fixed payload — the cache is Task 2's subject,
     not this one's. */
@@ -48,14 +57,14 @@ describe("tenantLimits", () => {
       allow: false,
       message: "Acme Corp has used its 1,000 generations for this month.",
     });
-    expect(asked).toEqual([{ days: 30, pool: "org:acme" }]);
+    expect(asked).toEqual([{ since: startOfUTCMonth(), pool: "org:acme" }]);
   });
 
   it("counts a per-member cap against the subject, with no pool", async () => {
     const payload = acme({ acme: { messagesPerDay: { limit: 50, scope: "per-member" } } });
     const { verdict, asked } = await ask(payload, member, "message", { me: 50 });
     expect(verdict).toEqual({ allow: false, message: "You've used your 50 messages for today." });
-    expect(asked).toEqual([{ days: 1 }]);
+    expect(asked).toEqual([{ since: startOfUTCDay() }]);
   });
 
   // Counting a pool the user is not in THROWS, and a throw is a DENY with no
@@ -89,5 +98,77 @@ describe("tenantLimits", () => {
     };
     const { verdict } = await ask(payload, member, "generation", { "org:acme": 2 });
     expect(verdict).toMatchObject({ message: "acme has used its 2 generations for this month." });
+  });
+});
+
+/**
+ * The caps say "for today" and "for this month", so they reset on the CALENDAR
+ * boundary, not 24h/30d after whenever the user last acted. A rolling lookback
+ * and a calendar period agree on almost every instant, so the only test that can
+ * tell them apart is one that straddles a boundary.
+ *
+ * Driven through the REAL limiter and the REAL reference meter: the usage is
+ * genuinely recorded at a past instant and genuinely filtered by `since`, so
+ * nothing here can pass by agreeing with itself. Only the clock is pinned, and
+ * only so the boundary is a fixed point instead of whenever CI happened to run.
+ */
+describe("a cap's period is the calendar's, not a rolling lookback", () => {
+  const gateAcross = async (opts: {
+    now: string;
+    used: string;
+    action: LimitAction;
+    limits: TenantDirectoryPayload["limits"];
+  }) => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      const usage = memoryStoreOps().usage as NonNullable<StoreOps["usage"]>;
+      await usage.record({ subject: "u_bob", action: opts.action, at: new Date(opts.used) });
+      vi.setSystemTime(new Date(opts.now));
+      const limiter = createLimiter({
+        callback: tenantLimits(directoryOf(acme(opts.limits))),
+        ops: usage,
+      });
+      return await limiter.gate(opts.action, {
+        principal: { kind: "user", subject: "u_bob" },
+        venue: "chat",
+        presence: "present",
+        sessionId: "s_boundary",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  };
+
+  it("does not spend today's messages on a message sent yesterday", async () => {
+    // One message at 23:59, one minute later it is a new day. A 24h lookback
+    // still sees it and denies; "for today" must not.
+    expect(await gateAcross({
+      now: "2026-03-15T00:01:00Z",
+      used: "2026-03-14T23:59:00Z",
+      action: "message",
+      limits: { acme: { messagesPerDay: { limit: 1, scope: "per-member" } } },
+    })).toEqual({ allow: true });
+  });
+
+  it("does not spend this month's generations on one made last month", async () => {
+    // Same instant-apart trick across the month end: a 30-day lookback reaches
+    // back into February and denies; "for this month" must not.
+    expect(await gateAcross({
+      now: "2026-03-01T00:01:00Z",
+      used: "2026-02-28T23:59:00Z",
+      action: "generation",
+      limits: { acme: { generationsPerMonth: { limit: 1, scope: "per-member" } } },
+    })).toEqual({ allow: true });
+  });
+
+  it("still denies inside the same calendar period", async () => {
+    // The guard on the guard: if these windows denied nothing, the two cases
+    // above would pass against a cap that had simply stopped working.
+    expect(await gateAcross({
+      now: "2026-03-15T23:59:00Z",
+      used: "2026-03-15T00:01:00Z",
+      action: "message",
+      limits: { acme: { messagesPerDay: { limit: 1, scope: "per-member" } } },
+    })).toMatchObject({ allow: false });
   });
 });

--- a/packages/vendo/tests/tenant-limits.test.ts
+++ b/packages/vendo/tests/tenant-limits.test.ts
@@ -1,0 +1,93 @@
+import type { LimitAction, LimitUser, LimitWindow, TenantDirectoryPayload } from "@vendoai/core";
+import { describe, expect, it } from "vitest";
+import type { CloudDirectory } from "../src/cloud-directory.js";
+import { tenantLimits } from "../src/tenant-limits.js";
+
+/** A directory that answers one fixed payload — the cache is Task 2's subject,
+    not this one's. */
+const directoryOf = (payload: TenantDirectoryPayload): CloudDirectory => ({
+  entry: async () => payload,
+  memberships: async () => payload.memberships,
+});
+
+const acme = (limits: TenantDirectoryPayload["limits"]): TenantDirectoryPayload => ({
+  memberships: [{ org: "acme", display: "Acme Corp" }],
+  limits,
+});
+
+/** Ask the policy with a meter that answers `counts` per pool ("me" = this
+    user alone) and remembers every window it was asked for. */
+async function ask(
+  payload: TenantDirectoryPayload,
+  user: LimitUser,
+  action: LimitAction,
+  counts: Record<string, number> = {},
+) {
+  const asked: LimitWindow[] = [];
+  const verdict = await tenantLimits(directoryOf(payload))({
+    user,
+    action,
+    count: async (_action, window) => {
+      asked.push(window ?? {});
+      return counts[window?.pool ?? "me"] ?? 0;
+    },
+  });
+  return { verdict, asked };
+}
+
+const member: LimitUser = { kind: "user", subject: "u_bob", pools: ["org:acme"] };
+const guest: LimitUser = { kind: "user", subject: "maple_guest", ephemeral: true };
+
+describe("tenantLimits", () => {
+  it("counts a per-tenant cap against the org pool and names the company", async () => {
+    const payload = acme({ acme: { generationsPerMonth: { limit: 1000, scope: "per-tenant" } } });
+    expect(await ask(payload, member, "generation", { "org:acme": 999 }))
+      .toMatchObject({ verdict: true });
+    const { verdict, asked } = await ask(payload, member, "generation", { "org:acme": 1000 });
+    expect(verdict).toEqual({
+      allow: false,
+      message: "Acme Corp has used its 1,000 generations for this month.",
+    });
+    expect(asked).toEqual([{ days: 30, pool: "org:acme" }]);
+  });
+
+  it("counts a per-member cap against the subject, with no pool", async () => {
+    const payload = acme({ acme: { messagesPerDay: { limit: 50, scope: "per-member" } } });
+    const { verdict, asked } = await ask(payload, member, "message", { me: 50 });
+    expect(verdict).toEqual({ allow: false, message: "You've used your 50 messages for today." });
+    expect(asked).toEqual([{ days: 1 }]);
+  });
+
+  // Counting a pool the user is not in THROWS, and a throw is a DENY with no
+  // message — which would read as a cap they never hit. Every guest, ephemeral
+  // principal and directory miss must fall through this guard.
+  it("allows, and counts nothing, when the user is in no pool", async () => {
+    const payload = acme({ acme: { generationsPerMonth: { limit: 1, scope: "per-tenant" } } });
+    const { verdict, asked } = await ask(payload, guest, "generation");
+    expect(verdict).toBe(true);
+    expect(asked).toEqual([]);
+  });
+
+  it("still applies a per-member cap to a member whose pool has not resolved", async () => {
+    const payload = acme({ acme: { messagesPerDay: { limit: 5, scope: "per-member" } } });
+    const poolless: LimitUser = { kind: "user", subject: "u_bob" };
+    const { verdict } = await ask(payload, poolless, "message", { me: 5 });
+    expect(verdict).toMatchObject({ allow: false });
+  });
+
+  it("reads nothing at all when the tenant has no cap for this action", async () => {
+    const payload = acme({ acme: { messagesPerDay: { limit: 5, scope: "per-member" } } });
+    const { verdict, asked } = await ask(payload, member, "generation");
+    expect(verdict).toBe(true);
+    expect(asked).toEqual([]);
+  });
+
+  it("falls back to the tenant id when the console sent no display name", async () => {
+    const payload: TenantDirectoryPayload = {
+      memberships: [{ org: "acme" }],
+      limits: { acme: { generationsPerMonth: { limit: 2, scope: "per-tenant" } } },
+    };
+    const { verdict } = await ask(payload, member, "generation", { "org:acme": 2 });
+    expect(verdict).toMatchObject({ message: "acme has used its 2 generations for this month." });
+  });
+});


### PR DESCRIPTION
Slice 1 of Tenant Organizations.

Ships inert — with no console route yet the GET 404s and the SDK reads it as no memberships, logged once. Host assertion still wins and never calls out.

## What lands

- **`@vendoai/core`** — `packages/core/src/tenant-directory.ts`, the one definition of the payload BOTH repos parse (`TenantDirectoryPayload`, `TenantLimits`, `TenantCap` + zod schemas). A cap carries its `scope`; no reader ever gets to assume one.
- **`cloudDirectory`** — the GET, cached 60s per subject. A 404/5xx/malformed 200 degrades to the stale entry or to no memberships, and never throws: this is awaited inside per-request context resolution, so a throw would be a 500 for the whole turn.
- **`tenantLimits`** — the console's caps on the limiter that already exists, off the SAME cached entry, so a cap costs zero extra requests. A user in no pool falls through and is allowed, because counting a pool you are not in throws and a throw is a deny with no message.
- **Composition** — `VENDO_API_KEY` fills the `memberships` seam only when the host left it wholly unset. An explicit `auth.memberships` wins and no client is ever constructed.
- **Server surface** — `cloudDirectory`, `tenantLimits`, `createLimiter` are exported from `@vendoai/vendo/server`; the console's cross-repo seam test drives the real consumer against them.

## Behavior change reviewers should see argued, not discover

**The boot summary now carries a sixth row on a keyed deployment.**

`boot-summary.ts:234` reads the *composed* `membershipsSeam`, and `:322` gates a `tenants` row on it. Before this branch a keyed deployment with no host assertion left that seam undefined, so the block carried five rows; it now carries six.

The row is correct, which is why the expectation moved rather than the code. `boot-summary.ts:318-321` states the rule it encodes: tenant connectors are per-ORG, and an org only ever reaches a request through the memberships seam, so without one no overlay can ever be selected. A Cloud-filled seam gives every keyed deployment exactly that, so per-org connectors really are serving at boot.

The alternative — gating the row on the host's own `config.auth?.memberships` — would have kept the block byte-identical at the cost of going silent about a live capability. That is a boot summary lying by omission, so it was rejected.

The test edit is isolated in its own commit (`fb14d784a`), touches one expectation, and deletes nothing.

## Verification

| Gate | Result |
|---|---|
| `pnpm build` | 0 |
| `pnpm typecheck` | 0 |
| `pnpm lint` | 0 (4 warnings, 0 errors, all pre-existing in `demo-bank`) |
| `packages/vendo` scoped suites | 5 files, 80 tests passed |
| `packages/core/tests/tenant-directory.test.ts` | 6 tests passed |

Each new behavior was proven by reverting it and watching exactly the intended test go red: the cap `scope` (1 red), the directory's fail-open `try`/`catch` (3 red), the `user.pools` guard (1 red), and the host-wins short-circuit (1 red).

The full suite is CI's job — the green `ci` check is the gate of record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolves org memberships and tenant caps from Vendo Cloud when `VENDO_API_KEY` is set, and adds a top‑level `memberships` seam so `principal` hosts can opt out. Previously, keyed deployments without memberships showed five boot rows and caps used a rolling 1d/30d window; now Cloud fills memberships unless you assert them (boot summary adds a “tenants” row) and caps reset at UTC calendar boundaries.

- `@vendoai/core`: adds `TenantDirectoryPayload`, `TenantLimits`, `TenantCap`, and zod schemas.
- `@vendoai/vendo`: adds `cloudDirectory(...)` (GET `/api/v1/users/{externalId}/memberships`), cached 60s per subject; 404/5xx/malformed 200 degrade to stale or none and never throw.
- Composition: if the memberships seam is unset and `VENDO_API_KEY` is present, the seam is filled from `cloudDirectory`; an explicit `auth.memberships` or top‑level `memberships` wins outright and Cloud is never called.
- Limits: `tenantLimits(directory)` enforces console caps via the existing limiter off the same cached entry; `composeLimits` prefers `config.limits`, else the Cloud default. On a meterless store, Cloud caps do not compose and log a warning; an explicit policy on a meterless store still throws. Cap windows now reset at UTC midnight/day-1 and month start; a message at 23:59 no longer spends the next day’s allowance.
- Server surface: exports `cloudDirectory`, `tenantLimits`, and `createLimiter` from `@vendoai/vendo/server`. Docs list `memberships` in the handler options table.

- Review and rollout
  - Behavior change: keyed deployments now show a "tenants" row at boot because Cloud provides memberships; per‑org features are live.
  - To opt out, assert memberships: use top‑level `memberships` for `principal` hosts or `auth.memberships` for auth presets (e.g., `async () => []` to declare no orgs).
  - Ensure a usage meter to enforce console caps; otherwise caps are ignored with a warning.

<sup>Written for commit 316b2faa41880cd83e38f736720c6824186fe96c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1526?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

