### PR TITLE
fix(vendo): a client that leaves at the last token no longer cancels the turn's own commit

### DIFF
--- a/packages/vendo/src/harness-turn.ts
+++ b/packages/vendo/src/harness-turn.ts
@@ -776,8 +776,10 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
             emitRun("ok", null);
             // The same moment, said to the wire: the thinker is done, so the
             // client-idle watchdog must not abort what is left (the workspace
-            // commit, the transcript, the audit row).
-            finishActiveTurn(published.threadId, published.ctx.principal.subject);
+            // commit, the transcript, the audit row). By turn, never by thread —
+            // a sibling turn on this thread is still streaming. The runtime
+            // always resolves one (`started.ctx.turnId ?? mintTurnId()`).
+            finishActiveTurn(published.ctx.turnId!);
           };
         },
         // The turn's closing writes as ONE call, where the store serves it: the

--- a/packages/vendo/src/harness-turn.ts
+++ b/packages/vendo/src/harness-turn.ts
@@ -75,6 +75,7 @@ import {
 import type { VendoToolSearchConfig } from "@vendoai/harnesses/vendo";
 import { createUIMessageStream, createUIMessageStreamResponse, type LanguageModel, type UIMessage } from "ai";
 import { discoveryRail } from "./prompt.js";
+import { finishActiveTurn } from "./turn-liveness.js";
 import { isUserFilePath, userFilePath } from "./user-files.js";
 import type { Limiter } from "./limits.js";
 
@@ -773,6 +774,10 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
           return () => {
             unpublish?.();
             emitRun("ok", null);
+            // The same moment, said to the wire: the thinker is done, so the
+            // client-idle watchdog must not abort what is left (the workspace
+            // commit, the transcript, the audit row).
+            finishActiveTurn(published.threadId, published.ctx.principal.subject);
           };
         },
         // The turn's closing writes as ONE call, where the store serves it: the

--- a/packages/vendo/src/turn-liveness.ts
+++ b/packages/vendo/src/turn-liveness.ts
@@ -16,15 +16,31 @@
  * beatable after it.
  */
 
+import { log } from "@vendoai/core";
 import { environment } from "./wire/shared.js";
 
 const IDLE_ABORT_MS = 15_000;
+
+/** What the client is told when the watchdog ends its turn: the ai-SDK stream's
+ *  own terminal chunks. A turn the SERVER ended has to ARRIVE as an ending —
+ *  without one the bytes simply stop, `useChat` stays in `streaming`, and the
+ *  panel polls a turn that is never coming back. */
+const IDLE_ABORT_FRAME = new TextEncoder().encode(
+  `data: ${JSON.stringify({ type: "error", errorText: "This turn was stopped because the page stopped responding." })}\n\n`
+  + "data: [DONE]\n\n",
+);
+
+/** The idle race's winner when the watchdog fired rather than a chunk arriving. */
+const IDLE = Symbol("idle-abort");
 
 interface ActiveTurn {
   threadId: string;
   subject: string;
   abort: () => void;
   idleTimer?: ReturnType<typeof setTimeout>;
+  /** The model has spoken and only the turn's own closing work is left, so the
+   *  watchdog has stood down ({@link finishActiveTurn}). */
+  finished?: boolean;
 }
 
 const ACTIVE_TURNS_KEY = Symbol.for("vendoai.vendo.active-turns@1");
@@ -63,10 +79,18 @@ export function touchActiveTurn(threadId: string, subject: string): boolean {
     if (turn.threadId !== threadId || turn.subject !== subject) continue;
     active = true;
     if (turn.idleTimer !== undefined) clearTimeout(turn.idleTimer);
+    // Still in flight — its closing work is running — but past the point where
+    // a vanished client may end it. The beat is answered; nothing is re-armed.
+    if (turn.finished === true) continue;
     turn.idleTimer = setTimeout(() => {
-      console.warn(
-        `[vendo] turn on thread ${turn.threadId} lost its client heartbeat for ${idleAbortMs()}ms — aborting the abandoned turn.`,
-      );
+      // Through the log seam, not a bare console call: an idle abort is the one
+      // way a turn ends with a 200 and no trace, so the host's own
+      // observability has to be able to see it.
+      log({
+        code: "vendo.turn-idle-abort",
+        level: "warn",
+        message: `[vendo] turn on thread ${turn.threadId} lost its client heartbeat for ${idleAbortMs()}ms — aborting the abandoned turn.`,
+      });
       // Drop the entry now (idempotent with the stream-settled unregister):
       // an idle-aborted turn is over, and a late beat must see it inactive
       // even before the runtime drains the closing stream.
@@ -76,6 +100,36 @@ export function touchActiveTurn(threadId: string, subject: string): boolean {
     turn.idleTimer.unref?.();
   }
   return active;
+}
+
+/**
+ * The turn's thinker is done: from here it is only the turn's own closing work —
+ * the workspace commit that collects and syncs back what the agent built, then
+ * the transcript, the harness state and the audit row. The watchdog stands down
+ * at exactly this line.
+ *
+ * It exists because those two phases have opposite answers to "the client
+ * vanished". A client that leaves MID-STREAM is what the watchdog is for: nobody
+ * is waiting for the tokens still being generated. A client that leaves after
+ * the last token is not — the work is already done and paid for, and aborting it
+ * loses what the turn just made. That is the shipped failure: an abort landed
+ * during sync-back, the turn's app never reached the store, and the response was
+ * still a 200.
+ *
+ * Published from INSIDE the turn (`liveTurn`'s disposer, `harness-turn.ts`) for
+ * the same reason the steer sink is: the boundary is a moment in the runtime's
+ * loop, and the wire cannot see it — the response body stays open through the
+ * whole commit, so the bytes running out is far too late to mean this.
+ *
+ * The registration STAYS: the turn really is still in flight, and a beat should
+ * keep saying so until its stream ends.
+ */
+export function finishActiveTurn(threadId: string, subject: string): void {
+  for (const turn of activeTurns()) {
+    if (turn.threadId !== threadId || turn.subject !== subject) continue;
+    if (turn.idleTimer !== undefined) clearTimeout(turn.idleTimer);
+    turn.finished = true;
+  }
 }
 
 /**
@@ -130,8 +184,15 @@ export async function steerActiveTurn(
 
 /** Wrap a turn response so `onSettled` runs exactly once when its stream
  *  finishes, errors, or is cancelled — the turn's registry entry must not
- *  outlive the stream. Mirrors the wire's inflight-bracket wrapper. */
-export function trackTurnResponse(response: Response, onSettled: () => void): Response {
+ *  outlive the stream. Mirrors the wire's inflight-bracket wrapper.
+ *
+ *  `idle` is the watchdog's own abort (the wire holds one per turn, separate
+ *  from the client-disconnect fast path): when it fires, this client's stream
+ *  ENDS — terminal chunks, then close — because a turn the server ended must
+ *  read as an ending on the wire. Only this branch is ended; the recording
+ *  branch underneath keeps following the real turn, so a client that rejoins
+ *  through `GET /threads/:id/stream` still replays what actually happened. */
+export function trackTurnResponse(response: Response, onSettled: () => void, idle: AbortSignal): Response {
   if (response.body === null) {
     onSettled();
     return response;
@@ -143,10 +204,21 @@ export function trackTurnResponse(response: Response, onSettled: () => void): Re
     onSettled();
   };
   const reader = response.body.getReader();
+  const aborted = new Promise<typeof IDLE>((resolve) => {
+    idle.addEventListener("abort", () => resolve(IDLE), { once: true });
+  });
   const tracked = new ReadableStream<Uint8Array>({
     async pull(controller) {
       try {
-        const { done, value } = await reader.read();
+        const next = await Promise.race([reader.read(), aborted]);
+        if (next === IDLE) {
+          controller.enqueue(IDLE_ABORT_FRAME);
+          settle();
+          controller.close();
+          void reader.cancel();
+          return;
+        }
+        const { done, value } = next;
         if (done) {
           settle();
           controller.close();

--- a/packages/vendo/src/turn-liveness.ts
+++ b/packages/vendo/src/turn-liveness.ts
@@ -36,6 +36,12 @@ const IDLE = Symbol("idle-abort");
 interface ActiveTurn {
   threadId: string;
   subject: string;
+  /** THIS turn, not merely this thread. Two turns can be in flight on one thread
+   *  for one principal — nothing serializes them, which is why a beat refreshes
+   *  every match below — so the finish signal has to name one of them. Absent
+   *  for a caller that cannot name its turn; such a registration keeps exactly
+   *  the run-to-completion semantics it always had. */
+  turnId?: string;
   abort: () => void;
   idleTimer?: ReturnType<typeof setTimeout>;
   /** The model has spoken and only the turn's own closing work is left, so the
@@ -60,7 +66,12 @@ function idleAbortMs(): number {
 
 /** Track one streaming turn; returns its unregister. Registration alone never
  *  arms the watchdog — only a first heartbeat does. */
-export function registerActiveTurn(turn: { threadId: string; subject: string; abort: () => void }): () => void {
+export function registerActiveTurn(turn: {
+  threadId: string;
+  subject: string;
+  turnId?: string;
+  abort: () => void;
+}): () => void {
   const entry: ActiveTurn = { ...turn };
   activeTurns().add(entry);
   return () => {
@@ -121,12 +132,17 @@ export function touchActiveTurn(threadId: string, subject: string): boolean {
  * loop, and the wire cannot see it — the response body stays open through the
  * whole commit, so the bytes running out is far too late to mean this.
  *
+ * Addressed by TURN and not by thread, unlike the beat: nothing serializes two
+ * turns on one thread, and standing one turn's watchdog down must not stand its
+ * sibling's down with it — that sibling is still streaming, and reaping it if
+ * its client leaves is the whole point of the watchdog.
+ *
  * The registration STAYS: the turn really is still in flight, and a beat should
  * keep saying so until its stream ends.
  */
-export function finishActiveTurn(threadId: string, subject: string): void {
+export function finishActiveTurn(turnId: string): void {
   for (const turn of activeTurns()) {
-    if (turn.threadId !== threadId || turn.subject !== subject) continue;
+    if (turn.turnId !== turnId) continue;
     if (turn.idleTimer !== undefined) clearTimeout(turn.idleTimer);
     turn.finished = true;
   }

--- a/packages/vendo/src/wire/threads.ts
+++ b/packages/vendo/src/wire/threads.ts
@@ -124,10 +124,18 @@ export const threadRoutes: RouteEntry[] = [
     });
     const threadId = turn.headers.get(THREAD_ID_HEADER);
     if (threadId === null) return turn;
+    // The watchdog's abort gets its own channel beside the fast path's: an idle
+    // abort is the SERVER ending the turn, so this client is told on its stream
+    // instead of being left on bytes that stop, while a client that aborted its
+    // own fetch is told nothing (it is gone).
+    const idleAbort = new AbortController();
     const unregister = registerActiveTurn({
       threadId,
       subject: ctx.principal.subject,
-      abort: () => turnAbort.abort(),
+      abort: () => {
+        idleAbort.abort();
+        turnAbort.abort();
+      },
     });
     // Stream resume (blueprint §4.1 item 5): the turn's bytes are recorded so a
     // client whose connection died can rejoin through `GET /threads/:id/stream`.
@@ -142,6 +150,7 @@ export const threadRoutes: RouteEntry[] = [
     return trackTurnResponse(
       recordResumableTurn(turn, { threadId, subject: ctx.principal.subject }),
       unregister,
+      idleAbort.signal,
     );
   }),
   // Prompt-cache warming (sub-1s shipment): the client fires this once when

--- a/packages/vendo/src/wire/threads.ts
+++ b/packages/vendo/src/wire/threads.ts
@@ -1,4 +1,4 @@
-import { defineOwn, isPlainObject, THREAD_WINDOW_INITIAL, VendoError, vendoViewWirePartSchema, withSseKeepalive } from "@vendoai/core";
+import { defineOwn, isPlainObject, mintTurnId, THREAD_WINDOW_INITIAL, VendoError, vendoViewWirePartSchema, withSseKeepalive } from "@vendoai/core";
 import { UI_MESSAGE_STREAM_HEADERS } from "ai";
 import { registerActiveTurn, steerActiveTurn, touchActiveTurn, trackTurnResponse } from "../turn-liveness.js";
 import { recordResumableTurn, resumableTurnStream } from "../turn-resume.js";
@@ -113,13 +113,20 @@ export const threadRoutes: RouteEntry[] = [
     const turnAbort = new AbortController();
     if (request.signal.aborted) turnAbort.abort();
     else request.signal.addEventListener("abort", () => turnAbort.abort(), { once: true });
+    // Minted HERE, and handed to the door on the ctx: the runtime adopts a
+    // caller's `turnId` (that is how `agent.chat().turnId` stays joinable to the
+    // rows its turn writes), so the registration below and the finish signal
+    // that ends its watchdog name the SAME turn. Nothing serializes two turns on
+    // one thread, so naming only the thread would let either one stand the
+    // other's watchdog down.
+    const turnId = mintTurnId();
     // Architecture §3 — ONE thinker's door. `harness:` when the host named one,
     // `vendo()` when they did not; a store that can keep neither the transcript
     // nor the workspace refuses the turn inside the door, naming what it needs.
     const turn = await deps.harness.stream({
       ...(body["threadId"] === undefined ? {} : { threadId: string(body["threadId"], "threadId") }),
       message: body["message"] as never,
-      ctx: situation === undefined ? ctx : { ...ctx, context: situation },
+      ctx: { ...ctx, turnId, ...(situation === undefined ? {} : { context: situation }) },
       signal: turnAbort.signal,
     });
     const threadId = turn.headers.get(THREAD_ID_HEADER);
@@ -132,6 +139,7 @@ export const threadRoutes: RouteEntry[] = [
     const unregister = registerActiveTurn({
       threadId,
       subject: ctx.principal.subject,
+      turnId,
       abort: () => {
         idleAbort.abort();
         turnAbort.abort();

--- a/packages/vendo/tests/turn-liveness-finished-turns.test.ts
+++ b/packages/vendo/tests/turn-liveness-finished-turns.test.ts
@@ -1,0 +1,208 @@
+/**
+ * ENG-353 follow-up — the idle watchdog and the turn's own closing work.
+ *
+ * A turn has two phases and they answer "the client vanished" differently. While
+ * the thinker is STREAMING, a client that left is exactly what the watchdog is
+ * for: nobody is waiting for the tokens still being generated. Once the last
+ * token is out, the rest of the turn — the workspace commit that syncs back what
+ * the agent built, then the transcript, the state and the audit row — is work the
+ * person already paid for, and aborting it throws away what the turn just made.
+ * The shipped failure: an abort landed during sync-back, the turn's app never
+ * reached the store, the response was still a 200, and nothing was logged.
+ *
+ * The WHOLE chain, no stub on either side: the real wire routes, the real
+ * liveness registry, the real harness runtime and a real store. The only thing
+ * scripted is the thinker, because a unit test cannot run a model — and the
+ * blob seam under the workspace is held open so the test can STAND inside the
+ * closing phase instead of racing it.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { FilesAdapter, Principal, VendoLogEvent } from "@vendoai/core";
+import { createStore } from "@vendoai/store";
+import type { LanguageModel } from "ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createVendo, type Vendo } from "../src/server.js";
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  vi.unstubAllEnvs();
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+// Generous margins: CI runners under coverage load stall for hundreds of
+// milliseconds, and a spurious idle-abort here would flake the suite.
+const IDLE_MS = 1_000;
+
+const principal: Principal = { kind: "user", subject: "user_liveness" };
+const wait = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+const request = (method: string, path: string, body?: unknown): Request =>
+  new Request(`https://host.test/api/vendo${path}`, {
+    method,
+    headers: { "content-type": "application/json" },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  });
+
+const turnBody = { message: { id: "m_ask", role: "user", parts: [{ type: "text", text: "build me a dashboard" }] } };
+const beat = (vendo: Vendo, threadId: string): Promise<Response> =>
+  vendo.handler(request("POST", `/threads/${threadId}/heartbeat`, {}));
+
+/** What the scripted thinker leaves behind, and the reason it is BYTES: content
+ *  past the inline cap lands through the blob seam, which is a host-suppliable
+ *  adapter — so the test can hold the turn's sync-back open by holding it. */
+const OUTPUT = new Uint8Array([0, 159, 146, 150, 255]);
+
+interface Deployment {
+  vendo: Vendo;
+  /** Let the scripted thinker say its last word and end the turn. */
+  finishThinking: () => void;
+  /** The turn's own abort signal, as the harness received it. */
+  signal: () => AbortSignal;
+  /** Resolves once the turn's sync-back is landing the thinker's file: the
+   *  runtime commits only after its loop has ended, so being here IS being past
+   *  the last token, with the response still open. */
+  syncingBack: Promise<void>;
+  /** Let the sync-back finish. */
+  releaseSyncBack: () => void;
+  /** Everything the deployment's log seam was told. */
+  logged: VendoLogEvent[];
+}
+
+async function deployment(): Promise<Deployment> {
+  const dataDir = await mkdtemp(join(tmpdir(), "vendo-finished-turn-"));
+  const store = createStore({ dataDir });
+
+  let finishThinking!: () => void;
+  const thinking = new Promise<void>((resolve) => { finishThinking = resolve; });
+  let arriveSyncBack!: () => void;
+  const syncingBack = new Promise<void>((resolve) => { arriveSyncBack = resolve; });
+  let releaseSyncBack!: () => void;
+  const syncedBack = new Promise<void>((resolve) => { releaseSyncBack = resolve; });
+  cleanups.push(async () => {
+    // Nothing parked at teardown: a thinker still awaiting — or a commit still
+    // held — keeps the turn, and the suite, from ending.
+    finishThinking();
+    releaseSyncBack();
+    await store.close();
+    await rm(dataDir, { recursive: true, force: true });
+  });
+
+  const blobs = new Map<string, Uint8Array>();
+  const files: FilesAdapter = {
+    put: async (key, bytes) => {
+      // Only the thinker's own output is held; anything else the deployment
+      // stores must not be gated behind a turn that has not run yet.
+      if (bytes.length === OUTPUT.length && bytes.every((byte, at) => byte === OUTPUT[at])) {
+        arriveSyncBack();
+        await syncedBack;
+      }
+      blobs.set(key, bytes);
+    },
+    get: async (key) => {
+      const bytes = blobs.get(key);
+      return bytes === undefined ? undefined : { bytes };
+    },
+    delete: async (key) => { blobs.delete(key); },
+  };
+
+  let signal: AbortSignal | undefined;
+  const harness = {
+    name: "scripted-thinker",
+    async *run(turn: { signal: AbortSignal; workspace: { writeFile: (path: string, content: Uint8Array) => Promise<void> } }) {
+      signal = turn.signal;
+      yield { type: "text" as const, delta: "here it is" };
+      // Staged, not durable: the turn's own commit is what lands it.
+      await turn.workspace.writeFile("/user/report.bin", OUTPUT);
+      await thinking;
+      yield { type: "text" as const, delta: " — done." };
+    },
+  };
+
+  const logged: VendoLogEvent[] = [];
+  const vendo = createVendo({
+    models: { default: {} as LanguageModel },
+    principal: async () => principal,
+    store,
+    files,
+    logger: (event) => logged.push(event),
+    harness: harness as never,
+  });
+  return { vendo, finishThinking, signal: () => signal!, syncingBack, releaseSyncBack, logged };
+}
+
+describe("turn liveness — a finished turn's closing work is not the watchdog's to abort", () => {
+  it("a client that goes quiet after the last token does not abort the turn's commit", async () => {
+    vi.stubEnv("VENDO_TURN_IDLE_ABORT_MS", String(IDLE_MS));
+    const { vendo, finishThinking, signal, syncingBack, releaseSyncBack } = await deployment();
+
+    const turn = await vendo.handler(request("POST", "/threads", turnBody));
+    const threadId = turn.headers.get("x-vendo-thread-id")!;
+    // One beat arms the watchdog — and then the tab goes away for good.
+    expect(await (await beat(vendo, threadId)).json()).toEqual({ active: true });
+
+    finishThinking();
+    await syncingBack;
+    // Where we are, said by the wire itself: the turn in flight no longer takes
+    // words, because its thinker is done.
+    const steered = await vendo.handler(request("POST", `/threads/${threadId}/steer`, {
+      text: "one more thing",
+      messageId: "m_late",
+    }));
+    expect(await steered.json()).toEqual({ landed: false });
+
+    // Far past the idle window with no beat since. Mid-stream this is exactly an
+    // abandoned turn; here it is a turn that already answered.
+    await wait(IDLE_MS * 3);
+    expect(signal().aborted).toBe(false);
+
+    releaseSyncBack();
+    await turn.text();
+
+    // Read back through the REAL read path: the turn's answer landed.
+    const thread = await (await vendo.handler(request("GET", `/threads/${threadId}`))).json() as {
+      messages: Array<{ role: string; parts: unknown }>;
+    };
+    expect(thread.messages.map((message) => message.role)).toEqual(["user", "assistant"]);
+    expect(JSON.stringify(thread.messages.at(-1)!.parts)).toContain("here it is");
+  });
+
+  it("still aborts a turn whose client goes quiet mid-stream", async () => {
+    vi.stubEnv("VENDO_TURN_IDLE_ABORT_MS", String(IDLE_MS));
+    const { vendo, signal } = await deployment();
+
+    // The thinker is never released: this turn is mid-stream throughout.
+    const turn = await vendo.handler(request("POST", "/threads", turnBody));
+    const threadId = turn.headers.get("x-vendo-thread-id")!;
+    expect(await (await beat(vendo, threadId)).json()).toEqual({ active: true });
+    expect(signal().aborted).toBe(false);
+
+    await wait(IDLE_MS * 3);
+    expect(signal().aborted).toBe(true);
+  });
+
+  it("an idle abort says so: one log line, and a stream that ends instead of stopping", async () => {
+    vi.stubEnv("VENDO_TURN_IDLE_ABORT_MS", String(IDLE_MS));
+    const { vendo, signal, logged } = await deployment();
+
+    const turn = await vendo.handler(request("POST", "/threads", turnBody));
+    const threadId = turn.headers.get("x-vendo-thread-id")!;
+    // This client is still READING — only its beats stopped (a throttled tab).
+    // It is the one that would otherwise spin on bytes that simply stop.
+    const sending = turn.text();
+    expect(await (await beat(vendo, threadId)).json()).toEqual({ active: true });
+
+    await wait(IDLE_MS * 3);
+    expect(signal().aborted).toBe(true);
+
+    const sent = await sending;
+    expect(sent).toContain("\"type\":\"error\"");
+    expect(sent.trimEnd().endsWith("data: [DONE]")).toBe(true);
+
+    const idle = logged.find((event) => event.code === "vendo.turn-idle-abort");
+    expect(idle?.level).toBe("warn");
+    expect(idle?.message).toContain(threadId);
+    expect(idle?.message).toContain(`${IDLE_MS}ms`);
+  });
+});

--- a/packages/vendo/tests/turn-liveness-finished-turns.test.ts
+++ b/packages/vendo/tests/turn-liveness-finished-turns.test.ts
@@ -56,10 +56,10 @@ const OUTPUT = new Uint8Array([0, 159, 146, 150, 255]);
 
 interface Deployment {
   vendo: Vendo;
-  /** Let the scripted thinker say its last word and end the turn. */
-  finishThinking: () => void;
-  /** The turn's own abort signal, as the harness received it. */
-  signal: () => AbortSignal;
+  /** Let the nth scripted thinker say its last word and end its turn. */
+  finishThinking: (at?: number) => void;
+  /** The nth turn's own abort signal, as the harness received it. */
+  signal: (at?: number) => AbortSignal;
   /** Resolves once the turn's sync-back is landing the thinker's file: the
    *  runtime commits only after its loop has ended, so being here IS being past
    *  the last token, with the response still open. */
@@ -74,8 +74,13 @@ async function deployment(): Promise<Deployment> {
   const dataDir = await mkdtemp(join(tmpdir(), "vendo-finished-turn-"));
   const store = createStore({ dataDir });
 
-  let finishThinking!: () => void;
-  const thinking = new Promise<void>((resolve) => { finishThinking = resolve; });
+  // One gate per turn a test starts, minted UP FRONT so a test can release a
+  // turn before its thinker has reached the park.
+  const gates = [0, 1].map(() => {
+    let open!: () => void;
+    const opened = new Promise<void>((resolve) => { open = resolve; });
+    return { opened, open: () => open() };
+  });
   let arriveSyncBack!: () => void;
   const syncingBack = new Promise<void>((resolve) => { arriveSyncBack = resolve; });
   let releaseSyncBack!: () => void;
@@ -83,7 +88,7 @@ async function deployment(): Promise<Deployment> {
   cleanups.push(async () => {
     // Nothing parked at teardown: a thinker still awaiting — or a commit still
     // held — keeps the turn, and the suite, from ending.
-    finishThinking();
+    for (const gate of gates) gate.open();
     releaseSyncBack();
     await store.close();
     await rm(dataDir, { recursive: true, force: true });
@@ -107,15 +112,17 @@ async function deployment(): Promise<Deployment> {
     delete: async (key) => { blobs.delete(key); },
   };
 
-  let signal: AbortSignal | undefined;
+  const signals: AbortSignal[] = [];
+  let started = 0;
   const harness = {
     name: "scripted-thinker",
     async *run(turn: { signal: AbortSignal; workspace: { writeFile: (path: string, content: Uint8Array) => Promise<void> } }) {
-      signal = turn.signal;
+      const gate = gates[started++]!;
+      signals.push(turn.signal);
       yield { type: "text" as const, delta: "here it is" };
       // Staged, not durable: the turn's own commit is what lands it.
       await turn.workspace.writeFile("/user/report.bin", OUTPUT);
-      await thinking;
+      await gate.opened;
       yield { type: "text" as const, delta: " — done." };
     },
   };
@@ -129,7 +136,14 @@ async function deployment(): Promise<Deployment> {
     logger: (event) => logged.push(event),
     harness: harness as never,
   });
-  return { vendo, finishThinking, signal: () => signal!, syncingBack, releaseSyncBack, logged };
+  return {
+    vendo,
+    finishThinking: (at = 0) => gates[at]!.open(),
+    signal: (at = 0) => signals[at]!,
+    syncingBack,
+    releaseSyncBack,
+    logged,
+  };
 }
 
 describe("turn liveness — a finished turn's closing work is not the watchdog's to abort", () => {
@@ -180,6 +194,35 @@ describe("turn liveness — a finished turn's closing work is not the watchdog's
 
     await wait(IDLE_MS * 3);
     expect(signal().aborted).toBe(true);
+  });
+
+  it("standing one turn down leaves its sibling on the same thread still watched", async () => {
+    vi.stubEnv("VENDO_TURN_IDLE_ABORT_MS", String(IDLE_MS));
+    const { vendo, finishThinking, signal, releaseSyncBack } = await deployment();
+    // This test is about the sibling, not the commit: let the first turn close.
+    releaseSyncBack();
+
+    // Two turns in flight on ONE thread for one principal. Nothing serializes
+    // them, which is exactly why the finish signal has to name a turn.
+    const first = await vendo.handler(request("POST", "/threads", turnBody));
+    const threadId = first.headers.get("x-vendo-thread-id")!;
+    const second = await vendo.handler(request("POST", "/threads", {
+      threadId,
+      message: { id: "m_ask_again", role: "user", parts: [{ type: "text", text: "and a chart" }] },
+    }));
+    expect(second.headers.get("x-vendo-thread-id")).toBe(threadId);
+
+    // The first turn finishes — thinker done, commit done, stream closed.
+    finishThinking(0);
+    await first.text();
+
+    // The second is still streaming, and the beat still reaches it. Arming it
+    // here rather than earlier keeps the test off the clock: what is being
+    // checked is that this beat can still arm, not how fast the first turn was.
+    expect(await (await beat(vendo, threadId)).json()).toEqual({ active: true });
+
+    await wait(IDLE_MS * 3);
+    expect(signal(1).aborted).toBe(true);
   });
 
   it("an idle abort says so: one log line, and a stream that ends instead of stopping", async () => {


### PR DESCRIPTION
## The bug

ENG-353's idle watchdog reaps a turn whose **client** vanished mid-stream: the panel beats `POST /threads/:id/heartbeat` while it reads, and 15s of silence aborts the turn.

It was still armed after the thinker had finished. On a real turn the model emitted its last token, the tab stopped beating, and the abort landed **inside the turn's closing work** — the workspace commit that collects and syncs back what the agent built, then the transcript, the harness state and the audit row. The turn's app never reached the store, the HTTP response was still a `200`, nothing was logged, and the client saw a stream that simply stopped, so the UI polled forever.

## The fix

**1. The watchdog stands down at the stream-complete boundary.**

The runtime already names that moment: `liveTurn`'s disposer runs the instant the harness loop ends and *before* `commit()` (`harnesses/src/runtime.ts` — `unpublish?.()` then `await commit()`). It now also tells the wire, via `finishActiveTurn` (`packages/vendo/src/harness-turn.ts`). The wire cannot see this boundary itself: the response body stays open through the whole commit, so bytes running out is far too late to mean it.

- The 15s window **during streaming** is unchanged.
- A beat during the closing phase still answers `active: true` — the turn really is in flight — it just never re-arms.
- The separate hard ceilings are untouched.

**2. An idle abort is observable.**

- It goes through the log seam with a `vendo.turn-idle-abort` code and the same sentence (thread id + how long idle). It was a bare `console.warn`, which never reached a host's own observability — which is why the incident had no trace.
- The client's stream is **ended** with the ai-SDK terminal chunks (`{"type":"error",…}` then `[DONE]`) instead of just stopping. Only this client's branch ends; the recording branch keeps following the real turn, so a client rejoining through `GET /threads/:id/stream` still replays what actually happened.

## Tests

New file `packages/vendo/tests/turn-liveness-finished-turns.test.ts` — the whole chain, no stub on either side: real wire routes, real liveness registry, real harness runtime, real store. Only the thinker is scripted, and the blob seam under the workspace is held open so the test **stands inside** the closing phase instead of racing it (the wire's own `/steer` route answering `landed: false` is the in-test proof that the boundary was crossed).

| test | red against unfixed code |
|---|---|
| a client that goes quiet after the last token does not abort the turn's commit | yes — `expected true to be false` (the abort fired during sync-back) |
| still aborts a turn whose client goes quiet mid-stream | green before and after (the window is unchanged) |
| an idle abort says so: one log line, and a stream that ends instead of stopping | yes — `expected ': heartbeat\n\ndata: {"type":"text-st…' to contain '"type":"error"'` |

Both red→green proofs were run by reverting each half in turn.

## Gate

`pnpm build`, `pnpm typecheck`, `pnpm lint` green. `pnpm test:affected` green except `fixtures/redteam` `away-authority.e2e.test.ts`, which **also fails on the base commit** (verified on `4b29796a3`, with a different assertion failing each run — it is flaky there, not caused by this change).

The touched slice — `turn-liveness`, `server`, `stream-resume`, `sse-keepalive` and the new file — is 134/134 green, including the existing ENG-353 and steer suites.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the idle watchdog from aborting a finished turn’s closing commit when a client stops heartbeats after the last token. The watchdog now disarms at stream-complete; mid‑stream behavior and hard ceilings are unchanged. Idle aborts are logged and the client stream ends with terminal frames instead of silently stopping.

- Finish is per turn, not per thread: the wire mints a `turnId` (`mintTurnId`), passes it on `ctx`, and registers it; `finishActiveTurn(turnId)` stands down only that turn so a sibling on the same thread remains watched. Beats during closing still return `active: true` but do not re‑arm the timer. Implemented in `packages/vendo/src/harness-turn.ts` and `packages/vendo/src/wire/threads.ts`.
- Idle aborts are observable: `packages/vendo/src/turn-liveness.ts` logs via `log` from `@vendoai/core` with code `vendo.turn-idle-abort`, and `trackTurnResponse(response, onSettled, idleSignal)` injects `{"type":"error",…}` and `[DONE]` to end only this client’s branch; the recording/resume path remains intact.
- Tests: `packages/vendo/tests/turn-liveness-finished-turns.test.ts` covers no abort after last token during commit, mid‑stream abort, sibling watchdog isolation, and observable idle abort behavior.

<sup>Written for commit df6f91d979b140db4a2c19d7ea0e0f2ad878ef26. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1528?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

