### PR TITLE
feat(apps,vendo,ui): the grant write path the ✦ toggle needs

### DIFF
--- a/.changeset/app-share-grants.md
+++ b/.changeset/app-share-grants.md
@@ -1,0 +1,12 @@
+---
+"@vendoai/apps": minor
+"@vendoai/vendo": minor
+"@vendoai/ui": minor
+---
+
+An app can be shared again. `AppsRuntime.access` regains `list`, `grant` and
+`revoke` (viewer-scoped read, owner-scoped writes, each write answering with the
+resulting list), the wire mounts `GET /apps/:id/grants` and
+`PUT|DELETE /apps/:id/grants/:principal`, and the client regains
+`apps.grants/.share/.unshare`. The person picker and `promote` are deliberately
+not back.

--- a/packages/apps/src/server/doors/access-surface.ts
+++ b/packages/apps/src/server/doors/access-surface.ts
@@ -1,25 +1,59 @@
 /**
- * Build contract §9.3 — `AppsRuntime.access`: what level the CALLER holds on
- * an app.
+ * Build contract §9.2–§9.3 — `AppsRuntime.access`: what level the CALLER holds
+ * on an app, and the grant writes the ✦ share toggle needs.
  *
- * A read, and only a read. The grant-writing doors that used to sit beside it
- * (`list`/`grant`/`revoke`/`holder`) existed for the Share dialog, which no
- * host ever mounted; they went with it. Grant ROWS are still written and read
- * through the `AppAccess` seam (`config.appAccess`) — this surface just never
- * had a caller for that half.
+ * The LEVEL lives here, not on the wire, so the MCP door inherits the same
+ * rules without a second copy: `list` needs viewer, grant/revoke need owner.
+ * `config.appAccess` is set unconditionally from the composed store, so the
+ * seam is always present under `createVendo`.
  */
+import { VendoError } from "@vendoai/core";
 import type { AppsRuntimeContext } from "../runtime/runtime-context.js";
 import type { AppsRuntime } from "../runtime/types.js";
 
 export type AccessSurfaceDeps = Pick<AppsRuntimeContext, "config" | "holds">;
 
-export const createAccessSurface = ({ config, holds }: AccessSurfaceDeps): AppsRuntime["access"] => ({
-  async levelFor(appId, ctx) {
-    if (config.appAccess === undefined) {
-      // No seam ⇒ no grant row can exist, so ownership is the only level —
-      // which is exactly what `holds` degenerates to, at one store read.
-      return await holds(appId, ctx, "owner") ? "owner" : null;
+export const createAccessSurface = ({ config, holds }: AccessSurfaceDeps): AppsRuntime["access"] => {
+  /** §9.4's posture in one place: what the caller cannot VIEW stays not-found;
+      a proven viewer denied a stronger action gets forbidden. */
+  const require = async (appId: Parameters<AppsRuntime["access"]["list"]>[0], ctx: Parameters<AppsRuntime["access"]["list"]>[1], level: "viewer" | "owner") => {
+    if (await holds(appId, ctx, level)) return;
+    if (level !== "viewer" && await holds(appId, ctx, "viewer")) {
+      throw new VendoError("forbidden", `owner access is required for ${appId}`);
     }
-    return await config.appAccess.levelFor(ctx, appId);
-  },
-});
+    throw new VendoError("not-found", `app not found: ${appId}`);
+  };
+  const access: AppsRuntime["access"] = {
+    async levelFor(appId, ctx) {
+      if (config.appAccess === undefined) {
+        // No seam ⇒ no grant row can exist, so ownership is the only level —
+        // which is exactly what `holds` degenerates to, at one store read.
+        return await holds(appId, ctx, "owner") ? "owner" : null;
+      }
+      return await config.appAccess.levelFor(ctx, appId);
+    },
+    async list(appId, ctx) {
+      await require(appId, ctx, "viewer");
+      // No seam ⇒ no grant row can exist, so the empty list is the honest
+      // answer, not a refusal telling a keyless deployment to go buy something.
+      return config.appAccess === undefined ? [] : await config.appAccess.list(ctx, appId);
+    },
+    async grant(appId, principal, level, ctx) {
+      await require(appId, ctx, "owner");
+      await config.appAccess!.grant(ctx, appId, principal, level);
+      return await access.list(appId, ctx);
+    },
+    async revoke(appId, principal, ctx) {
+      await require(appId, ctx, "owner");
+      await config.appAccess!.revoke(ctx, appId, principal);
+      // The revoke LANDED. A caller who just removed their own last grant may
+      // no longer read it — that is §9.4 answering a different question, not a
+      // failed removal, so answer with what they can still legitimately see.
+      return await access.list(appId, ctx).catch((reason: unknown) => {
+        if (reason instanceof VendoError && (reason.code === "not-found" || reason.code === "forbidden")) return [];
+        throw reason;
+      });
+    },
+  };
+  return access;
+};

--- a/packages/apps/src/server/runtime/types.ts
+++ b/packages/apps/src/server/runtime/types.ts
@@ -10,6 +10,7 @@
 import type {
   AccessLevel,
   AppAccess,
+  AppGrantRecord,
   AppId,
   ApprovalId,
   ApprovalRequest,
@@ -636,11 +637,18 @@ export interface AppsRuntime {
    * host's own component, invisible to the server until it renders.
    */
   slots: SlotRegistry;
-  /** Build contract §9.3 — what level the CALLER holds. */
+  /** Build contract §9.2–§9.3 — what level the CALLER holds, and the grant
+   *  writes the ✦ share toggle needs. `list` is viewer-scoped (reading who
+   *  else can reach an app you can see); grant/revoke are owner-scoped. Every
+   *  write answers with the resulting list, so a surface never makes a second
+   *  round trip to learn what it just did. */
   access: {
     /** The caller's own level, or null when they cannot see the app at all —
      *  what the surface reads to decide between "Edit" and the fork offer. */
     levelFor(appId: AppId, ctx: RunContext): Promise<AccessLevel | null>;
+    list(appId: AppId, ctx: RunContext): Promise<AppGrantRecord[]>;
+    grant(appId: AppId, principal: string, level: AccessLevel, ctx: RunContext): Promise<AppGrantRecord[]>;
+    revoke(appId: AppId, principal: string, ctx: RunContext): Promise<AppGrantRecord[]>;
   };
   edit(appId: AppId, instruction: string, ctx: RunContext): Promise<EditResult>;
   /**

--- a/packages/apps/tests/access.test.ts
+++ b/packages/apps/tests/access.test.ts
@@ -10,7 +10,7 @@ import {
   type AppDocument,
 } from "../src/contract/index.js";
 import { appAccessConformance } from "@vendoai/core/conformance";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createApps, type AppsConfig, type AppsRuntime } from "../src/server/index.js";
 import { scriptedAssembler } from "../src/server/testing/screen-assembler.js";
 import { guardFixture } from "../src/server/testing/guard-fixture.js";
@@ -404,3 +404,62 @@ describe("§9.3 — the permission check costs what it claims to cost", () => {
  *  the ONE unattended firing path is the automations engine, whose own
  *  `memberships` seam is proven in
  *  `packages/automations/src/sponsorship.test.ts`. */
+
+/** Build contract §9.2 — the grant write half, back for the ✦ toggle and
+    nothing else. `list` is viewer-gated; grant/revoke are owner-gated, and the
+    RUNTIME owns the level so the wire never re-derives it. */
+describe("§9.2 — the grant write surface", () => {
+  /** The app is held by the ORG, because sharing implies the org workspace —
+      core's app-access conformance kit refuses an org grant on a still-personal
+      app, and `promote` is not part of this restore. Alice administers acme, so
+      she is its owner without a grant row of her own. */
+  const shared = async (): Promise<{ runtime: AppsRuntime; access: AppAccess; alice: RunContext }> => {
+    const { runtime, store, access } = setup();
+    await seedAppRow(engineOverAdapter(store), doc("app_share"), "acme");
+    return { runtime, access, alice: { ...ctx("alice"), memberships: [{ org: "acme", admin: true }] } };
+  };
+  const bob: RunContext = { ...ctx("bob"), memberships: [{ org: "acme" }] };
+
+  it("an owner grants an org at viewer level and reads it back", async () => {
+    const { runtime, alice } = await shared();
+    const granted = await runtime.access.grant("app_share", "org:acme", "viewer", alice);
+    expect(granted).toEqual([expect.objectContaining({ principal: "org:acme", level: "viewer" })]);
+    expect(await runtime.access.list("app_share", alice)).toHaveLength(1);
+  });
+
+  it("a member of that org can now see the app, and can list its grants", async () => {
+    const { runtime, alice } = await shared();
+    await runtime.access.grant("app_share", "org:acme", "viewer", alice);
+    expect(await runtime.access.levelFor("app_share", bob)).toBe("viewer");
+    expect(await runtime.access.list("app_share", bob)).toHaveLength(1);
+  });
+
+  it("revoking leaves the grant list empty and the member outside", async () => {
+    const { runtime, alice } = await shared();
+    await runtime.access.grant("app_share", "org:acme", "viewer", alice);
+    expect(await runtime.access.revoke("app_share", "org:acme", alice)).toEqual([]);
+    expect(await runtime.access.levelFor("app_share", bob)).toBeNull();
+  });
+
+  it("a viewer may NOT grant — proven viewer, denied action, forbidden", async () => {
+    const { runtime, access, alice } = await shared();
+    await runtime.access.grant("app_share", "org:acme", "viewer", alice);
+    // The seam gates too, so the refusal alone cannot tell whose gate answered.
+    // The RUNTIME's is the one the MCP door inherits, and it is proven by the
+    // seam never being reached — mutate this gate to `viewer` and this is the
+    // assertion that goes red.
+    const seam = vi.spyOn(access, "grant");
+    await expect(runtime.access.grant("app_share", "user:kim", "viewer", bob))
+      .rejects.toMatchObject({ code: "forbidden" });
+    expect(seam).not.toHaveBeenCalled();
+  });
+
+  it("a stranger is told nothing at all — existence stays masked", async () => {
+    const { runtime, access } = await shared();
+    const seam = vi.spyOn(access, "grant");
+    await expect(runtime.access.list("app_share", ctx("kim"))).rejects.toMatchObject({ code: "not-found" });
+    await expect(runtime.access.grant("app_share", "org:acme", "viewer", ctx("kim")))
+      .rejects.toMatchObject({ code: "not-found" });
+    expect(seam).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/client-impl.ts
+++ b/packages/ui/src/client-impl.ts
@@ -159,7 +159,7 @@ export function createVendoClient(config: VendoClientConfig): VendoClient {
     return (await response.json()) as T;
   }
 
-  async function json<T>(path: string, method: "POST" | "PATCH" | "DELETE", body: unknown = {}): Promise<T> {
+  async function json<T>(path: string, method: "POST" | "PUT" | "PATCH" | "DELETE", body: unknown = {}): Promise<T> {
     return readJson<T>(path, {
       method,
       headers: { "Content-Type": "application/json" },
@@ -246,6 +246,12 @@ export function createVendoClient(config: VendoClientConfig): VendoClient {
           body: bytes as BodyInit,
         }),
       fork: id => json(`/apps/${idPath(id)}/fork`, "POST"),
+      // The principal rides the PATH, percent-encoded — `org:acme` contains a
+      // ":" and, for a team, a "/".
+      grants: id => readJson(`/apps/${idPath(id)}/grants`),
+      share: (id, principal, level) =>
+        json(`/apps/${idPath(id)}/grants/${idPath(principal)}`, "PUT", { level }),
+      unshare: (id, principal) => json(`/apps/${idPath(id)}/grants/${idPath(principal)}`, "DELETE"),
       shipDiff: id => readJson(`/apps/${idPath(id)}/ship-diff`),
       reseed: id => json(`/apps/${idPath(id)}/reseed`, "POST"),
       seedFrom: body => json("/apps/seed", "POST", body),

--- a/packages/ui/src/client.ts
+++ b/packages/ui/src/client.ts
@@ -6,7 +6,9 @@
  * implementation lives in client-impl.ts (lane A).
  */
 import {
+  type AccessLevel,
   type AppDocument,
+  type AppGrantRecord,
   type AppId,
   type ApprovalDecision,
   type ApprovalId,
@@ -123,6 +125,19 @@ export interface VendoClient {
     exportApp(id: AppId): Promise<Uint8Array>;
     importApp(bytes: Uint8Array): Promise<AppDocument>;
     fork(id: AppId): Promise<AppDocument>;
+    /**
+     * Build contract §9.2 — the ✦ share toggle's transport. `grants` reads the
+     * app's grant list, the caller's own level, AND the caller's memberships
+     * (projected off the ctx), so ONE round trip tells the menu which tenant to
+     * name and whether the share is already on.
+     */
+    grants(id: AppId): Promise<{
+      level: AccessLevel | null;
+      grants: AppGrantRecord[];
+      orgs: { org: string; display?: string }[];
+    }>;
+    share(id: AppId, principal: string, level: AccessLevel): Promise<{ grants: AppGrantRecord[] }>;
+    unshare(id: AppId, principal: string): Promise<{ grants: AppGrantRecord[] }>;
     /** GET /apps/:id/ship-diff — the reviewable diff vs the captured host baselines (06 §8–§9). */
     shipDiff(id: AppId): Promise<ShipDiff>;
     /** POST /apps/:id/reseed — rebuild the remix against the host's current

--- a/packages/vendo/src/wire/apps.ts
+++ b/packages/vendo/src/wire/apps.ts
@@ -1,4 +1,4 @@
-import { isVendoError, VendoError, type Json, type RunContext, type StoreOps } from "@vendoai/core";
+import { isVendoError, VendoError, type AccessLevel, type Json, type RunContext, type StoreOps } from "@vendoai/core";
 import { json, requestJson, route, string, type RouteEntry, type WireContext } from "./shared.js";
 
 /** What the ?pending=1 disambiguation learned about a record open() refused
@@ -177,6 +177,16 @@ async function handleHistory(wire: WireContext, appId: string, ctx: RunContext):
     repetitions of the triple. */
 const op = (wire: WireContext, method: string, operation: string, length = 3): boolean =>
   wire.request.method === method && wire.segments[2] === operation && wire.segments.length === length;
+
+/** Build contract §9.3 — the level vocabulary is CLOSED, so the wire refuses
+    anything outside it instead of letting a typo reach the store. */
+function accessLevel(value: unknown): AccessLevel {
+  const level = string(value, "level");
+  if (level !== "viewer" && level !== "editor" && level !== "owner") {
+    throw new VendoError("validation", "level must be viewer, editor, or owner");
+  }
+  return level;
+}
 
 /** 06-apps / 09 §3 — the /apps wire area: CRUD, open/call/edit, history,
     ship-diff, seed drift/re-seed, the ✦ gesture (seed), export/import,
@@ -365,6 +375,29 @@ export const appRoutes: RouteEntry[] = [
     }
     if (op(wire, "POST", "fork")) {
       return json(await deps.apps.fork(appId, ctx));
+    }
+    // Build contract §9.2 — the ✦ share toggle's door. The LEVEL lives in the
+    // runtime, so the MCP door inherits the same rules. `orgs` is projected off
+    // the ctx the wire already resolved, so ONE round trip tells the menu which
+    // tenant to name and whether the share is on.
+    if (op(wire, "GET", "grants")) {
+      return json({
+        level: await deps.apps.access.levelFor(appId, ctx),
+        grants: await deps.apps.access.list(appId, ctx),
+        orgs: (ctx.memberships ?? []).map(({ org, display }) => ({
+          org,
+          ...(display === undefined ? {} : { display }),
+        })),
+      });
+    }
+    if (op(wire, "PUT", "grants", 4)) {
+      const body = await requestJson(request);
+      const principal = string(segments[3], "principal");
+      return json({ grants: await deps.apps.access.grant(appId, principal, accessLevel(body["level"]), ctx) });
+    }
+    if (op(wire, "DELETE", "grants", 4)) {
+      const principal = string(segments[3], "principal");
+      return json({ grants: await deps.apps.access.revoke(appId, principal, ctx) });
     }
     return undefined;
   }),

--- a/packages/vendo/tests/wire/apps.grants.test.ts
+++ b/packages/vendo/tests/wire/apps.grants.test.ts
@@ -1,0 +1,101 @@
+import type { AccessLevel, AppGrantRecord, Membership, RunContext } from "@vendoai/core";
+import { describe, expect, it, vi } from "vitest";
+import { appRoutes } from "../../src/wire/apps.js";
+import { dispatchRoutes, routeSegments, type WireDeps } from "../../src/wire/shared.js";
+
+/** Build contract §9.2 — the ✦ toggle's door. ONE round trip tells the menu
+    which tenant to name and whether the share is on. */
+
+const ctx = (memberships: Membership[] = []): RunContext => ({
+  principal: { kind: "user", subject: "alice" },
+  venue: "app",
+  presence: "present",
+  sessionId: "s_alice",
+  ...(memberships.length === 0 ? {} : { memberships }),
+});
+
+const grantRow = (principal: string): AppGrantRecord => ({
+  id: "g_1", appId: "app_1" as never, orgId: "acme", principal, level: "viewer",
+  createdBy: "alice", createdAt: "2026-08-01T00:00:00.000Z",
+});
+
+const wireFor = (over: {
+  level?: AccessLevel | null;
+  grants?: AppGrantRecord[];
+  memberships?: Membership[];
+  grant?: WireDeps["apps"]["access"]["grant"];
+  revoke?: WireDeps["apps"]["access"]["revoke"];
+}) => {
+  const deps = {
+    apps: {
+      access: {
+        levelFor: async () => over.level ?? "owner",
+        list: async () => over.grants ?? [],
+        grant: over.grant ?? (async () => over.grants ?? []),
+        revoke: over.revoke ?? (async () => []),
+      },
+    },
+  } as unknown as WireDeps;
+  return async (method: string, path: string, body?: unknown): Promise<Response | undefined> => {
+    const url = new URL(`https://maple.test/api/vendo${path}`);
+    return dispatchRoutes(appRoutes, {
+      request: new Request(url, {
+        method,
+        ...(body === undefined ? {} : { body: JSON.stringify(body), headers: { "content-type": "application/json" } }),
+      }),
+      url,
+      path,
+      segments: routeSegments(path),
+      params: {},
+      context: async () => ctx(over.memberships ?? []),
+      sweep: async () => {},
+      deps,
+    } as never);
+  };
+};
+
+describe("§9.2 — /apps/:id/grants", () => {
+  it("answers the level, the grants, and the caller's own orgs in one GET", async () => {
+    const send = wireFor({
+      level: "owner",
+      grants: [grantRow("org:acme")],
+      memberships: [{ org: "acme", display: "Acme Corp" }],
+    });
+    const response = await send("GET", "/apps/app_1/grants");
+    await expect(response!.json()).resolves.toEqual({
+      level: "owner",
+      grants: [grantRow("org:acme")],
+      orgs: [{ org: "acme", display: "Acme Corp" }],
+    });
+  });
+
+  it("omits display for an org the host named no display for", async () => {
+    const send = wireFor({ memberships: [{ org: "acme" }] });
+    const body = await (await send("GET", "/apps/app_1/grants"))!.json();
+    expect(body.orgs).toEqual([{ org: "acme" }]);
+  });
+
+  it("writes a grant and answers with the resulting list", async () => {
+    const grant = vi.fn(async () => [grantRow("org:acme")]);
+    const send = wireFor({ grant: grant as never });
+    const response = await send("PUT", "/apps/app_1/grants/org%3Aacme", { level: "viewer" });
+    expect(grant).toHaveBeenCalledWith("app_1", "org:acme", "viewer", expect.anything());
+    await expect(response!.json()).resolves.toEqual({ grants: [grantRow("org:acme")] });
+  });
+
+  it("refuses a level outside the closed vocabulary before the store sees it", async () => {
+    const grant = vi.fn();
+    const send = wireFor({ grant: grant as never });
+    await expect(send("PUT", "/apps/app_1/grants/org%3Aacme", { level: "admin" }))
+      .rejects.toMatchObject({ code: "validation" });
+    expect(grant).not.toHaveBeenCalled();
+  });
+
+  it("revokes and answers with what is left", async () => {
+    const revoke = vi.fn(async () => []);
+    const send = wireFor({ revoke: revoke as never });
+    const response = await send("DELETE", "/apps/app_1/grants/org%3Aacme");
+    expect(revoke).toHaveBeenCalledWith("app_1", "org:acme", expect.anything());
+    await expect(response!.json()).resolves.toEqual({ grants: [] });
+  });
+});


### PR DESCRIPTION
Slice 4.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores app sharing for the ✦ toggle and makes Update outcomes visible. The runtime, wire, and client now support listing and changing app grants with clear gating, and `open()` reports any wishes the last Update could not replay.

- Runtime: `AppsRuntime.access` adds `list`, `grant`, and `revoke`. `list` requires viewer; `grant`/`revoke` require owner. Writes return the resulting list. Non-viewers get not-found; proven viewers without owner get forbidden. If a revoke removes the caller’s last grant, the response is an empty list. The runtime owns the caller’s level; the wire does not re-derive it.
- Wire: mounts `GET /apps/:id/grants` returning `{ level, grants, orgs }`; `PUT /apps/:id/grants/:principal` and `DELETE /apps/:id/grants/:principal` perform writes and answer `{ grants }`. Validates `level` against the closed set (viewer|editor|owner). `principal` is percent-encoded in the path.
- UI: the client regains `apps.grants`, `.share`, and `.unshare`; `PUT` is supported in the request helper. Person picker and `promote` remain out.
- Update visibility: `open()` now includes `seedUnapplied`, the last Update’s unapplied wishes, rendered beside `seedDrift` so a no-op or partial replay is visible without a chat.
- Tests: coverage for gating, validation, list/write responses, the one-round-trip read, and the new Update verdict.

<sup>Written for commit 9ec5b0d44a674f602e36a436723cf2d602ce5b55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1529?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

