### PR TITLE
feat(vendo): init prints facts and a link — instructions live in the docs

### DIFF
--- a/.changeset/gentle-pandas-listen.md
+++ b/.changeset/gentle-pandas-listen.md
@@ -1,0 +1,33 @@
+---
+"@vendoai/vendo": minor
+---
+
+`vendo init` states facts and links out. Every instruction it used to print —
+the `<VendoProvider>` mount paste, the AI SDK and Mastra loop snippets, the MCP
+client steps, the doctor gate, the agent tail — was a second copy of something
+the docs already carry, and a terminal cannot keep a copy correct. The run now
+ends on four computed lines: what it wired, what it detected, the guard posture
+it left, and one URL for the use case you picked. `--agent` receives the same
+facts as structured JSON (`wrote`, `detected`, `guardPosture`, `continueUrl`)
+instead of `pasteEdits`.
+
+A backend agent is a real answer to the first question now (`--use-case
+backend`), so `vendo doctor` stops demanding a mounted UI from a server-side
+install and the run points at the backend quickstart.
+
+The models question decides the wiring. Choosing Vendo Cloud no longer writes
+`anthropic("claude-sonnet-4-6")` into your composition because an
+`ANTHROPIC_API_KEY` happened to be in your shell — the runtime resolves the
+model from `VENDO_API_KEY`, so nothing is written. Choosing your own key writes
+the provider line as before. Init records the key its wiring actually reads, and
+`vendo doctor`'s E-MODEL-001 now names that one variable instead of listing
+three provider keys the resolver never consults.
+
+Nothing prompts after the up-front questions. "Where does this app run in dev?"
+moved ahead of the AI pass, the uncertain-theme-slot review is gone (uncertain
+slots keep what was extracted and the run says which), and the zod-floor bump
+prints its command rather than asking. Every stage spinner carries elapsed time,
+and the AI pass says up front that it can take several minutes.
+
+`vendo init --check` / `--no-check` are removed: doctor is a standalone command,
+and init succeeds or fails on its own work.

--- a/docs-site/production/troubleshooting/e-model-001.mdx
+++ b/docs-site/production/troubleshooting/e-model-001.mdx
@@ -1,7 +1,7 @@
 ---
 title: "E-MODEL-001"
 sidebarTitle: "E-MODEL-001"
-description: "No model credential resolves, so the agent cannot answer a turn."
+description: "The key this install's models wiring reads is not set, so the agent cannot answer a turn."
 ---
 
 # E-MODEL-001
@@ -9,37 +9,44 @@ description: "No model credential resolves, so the agent cannot answer a turn."
 <Warning>
 **what doctor prints** (warning)
 
-model credential: none found — set a model key (ANTHROPIC_API_KEY /
-OPENAI_API_KEY / GOOGLE_GENERATIVE_AI_API_KEY) or VENDO_API_KEY and select it
-in your composition's `models`, or the agent cannot answer
+model credential: ANTHROPIC\_API\_KEY is not set, and it is the only key this
+install's `models` wiring reads — the wire is wired, but the agent cannot answer
+a single turn
 </Warning>
 
-Every wiring check can pass and the agent can still answer nothing: no model
-credential resolves on this machine.
+Every wiring check can pass and the agent can still answer nothing: the one key
+this install reads is not set.
 
 `check model/credential` · `error_code E-MODEL-001` · `doctor exits 0` (warning only)
 
 ## What you're seeing
 
-Doctor resolves the credential through the same ladder the runtime rides, over
-the environment plus `.env` and `.env.local`. Nothing on that ladder won.
+Doctor names exactly one variable, and it is the one **your** wiring consults —
+never a list. It finds that variable from the answer `vendo init` recorded in
+`.vendo/install.json` (`modelKey`), or, failing that, from the provider your
+composition's own `models` line names:
+
+- `models: { default: anthropic("claude-sonnet-4-6") }` → `ANTHROPIC_API_KEY`
+- `models: { default: openai("gpt-5") }` → `OPENAI_API_KEY`
+- no `models` line at all → `VENDO_API_KEY`, which is the only variable the
+  runtime ladder reads on its own
+
+Doctor looks for that variable in the environment plus `.env` and `.env.local`.
 
 ## Why
 
 A provider key on its own is a **credential**, not a selection — since the
-selection law, nothing picks a model off the environment. A host with
-`ANTHROPIC_API_KEY` set and no `models` line in its composition lands here, and
-so does a host with no key at all.
+selection law, nothing picks a model off the environment. So setting a key the
+composition does not name changes nothing, which is why this warning names one
+variable instead of three.
 
 This is a warning and never a failure: production keys legitimately live in a
 deploy platform's secret store, which doctor cannot read.
 
 ## The fix
 
-Pick either rung.
-
-Your own provider key — put it in `.env.local` and **select the model in your
-composition** (`lib/vendo.ts`):
+Set the variable doctor named. If that is a provider key, put it in `.env.local`
+— it is already **selected in your composition** (`lib/vendo.ts`):
 
 ```ts
 import { anthropic } from "@ai-sdk/anthropic";

--- a/fixtures/install-seam/src/stranger.ts
+++ b/fixtures/install-seam/src/stranger.ts
@@ -255,7 +255,6 @@ export async function bootStranger(artifactsDir: string): Promise<{ stranger: St
         scaffoldDir,
         "--yes",
         "--no-ai",
-        "--no-check",
         "--framework", "next",
         "--auth", "none",
         "--use-case", "agent-loop",

--- a/packages/vendo/skills/vendo-setup/SKILL.md
+++ b/packages/vendo/skills/vendo-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vendo-setup
-description: Install and configure Vendo (the embedded product agent) in a host repo. Use when asked to add Vendo to an app, run vendo init/doctor/sync, wire the Vendo handler or VendoProvider, or debug a Vendo install until doctor exits 0.
+description: Install and configure Vendo (the embedded product agent) in a host repo. Use when asked to add Vendo to an app, run vendo init/doctor/sync, wire the Vendo handler or VendoProvider, or debug a Vendo install.
 ---
 
 # Vendo setup
@@ -38,23 +38,33 @@ fetch it when you need more detail than this skill carries.
    ```
 
    That run writes, narrates itself, and ends on the receipt, the LAST JSON
-   object it prints: `{"status": "written", …}` with `wrote` (the files
-   it created), `pasteEdits` (the changes only you can make), `tools`,
-   `riskRecommendations`, and `judgment`, which is always `delegated` with a
-   checklist that is yours to work through. Both runs exit 0, so branch on
-   `status`, never on the exit code. All answers on the first call and it
-   writes in one pass.
+   object it prints: `{"status": "written", …}` with `wrote` (the files it
+   created), `detected` (framework, auth, package manager, port),
+   `guardPosture`, `continueUrl` (the ONE page carrying the instructions for
+   the use case you picked), `keptUncertain`, `pendingLoosenings`, and
+   `judgment`. `judgment` is `graded` with the file it wrote when a judgment
+   engine resolved on this machine, and `delegated` with a checklist that is
+   yours to work through when none did — read it, do not assume either. Both
+   runs exit 0, so branch on `status`, never on the exit code. All answers on
+   the first call and it writes in one pass.
 
-   Never relay a mechanical question. The deploy URL, the zod floor, the
-   theme slots and the live check are never asked: they take their defaults
-   and show up in the diff.
+   Never relay a mechanical question. The zod floor and the theme slots are
+   never asked: they take their defaults and show up in the diff. The one
+   question about SPENDING — may a coding agent read this codebase — is asked
+   up front with the others, never mid-run, so a run that has started writing
+   will not stop to ask you anything.
 
-   **Init never edits a file a human wrote.** Every file it writes is new and
-   Vendo-owned, plus its own `package.json` hooks. Mounting the visible
-   surface is a paste YOU must apply: the receipt carries it in `pasteEdits`
-   as `{ file, lines, why }` and the run prints it in a framed "ONE STEP
-   LEFT" block. Apply it before calling the install done; `vendo doctor`
-   fails with `E-WIRE-004` until it lands.
+   `pendingLoosenings` is a count, not a task: a loosening (waking a disabled
+   tool, lowering a risk grade) is never applied without a human, so the pass
+   holds them as `pending` and nothing blocks. `vendo sync --review` is where
+   a person answers them.
+
+   **Init never edits a file a human wrote, and it prints no code.** Every file
+   it writes is new and Vendo-owned, plus its own `package.json` hooks. The
+   work it cannot do — mounting the visible surface, wiring your own agent
+   loop, pointing an MCP client at the door — is at `continueUrl`. Fetch that
+   page and follow it before calling the install done; `vendo doctor` grades
+   what is still missing (`E-WIRE-004` for the mount).
 
 3. What init does (framework detected from `package.json`, `next` beats
    `express`; with neither present it refuses to guess and asks for
@@ -65,13 +75,10 @@ fetch it when you need more detail than this skill carries.
      gitignored `.vendo/data/` for the PGlite store. Commit `.vendo/`,
      never `.vendo/data/`.
    - Next.js: writes `app/api/vendo/[...vendo]/route.ts` (or under
-     `src/app`). It writes no client file: mounting
-     `<VendoProvider baseUrl="/api/vendo">` around `{children}` is your paste
-     (see the `mount` step above).
-   - Express: proposes `vendo/server.ts` (`.mjs` without a tsconfig) plus a
-     starter `vendo/ai.ts`; you must still mount
-     `app.use("/api/vendo", mountVendo())` and wrap the client in
-     `<VendoProvider>` yourself.
+     `src/app`) and the `lib/vendo.ts` composition over it. It writes no client
+     file: mounting the provider is yours, at `continueUrl`.
+   - Express: proposes `vendo/server.ts` (`.mjs` without a tsconfig); mounting
+     it and wrapping the client are yours, at `continueUrl`.
    - Adds `predev`/`prebuild` sync hooks to `package.json` (consent-gated).
 
 4. Model credential: the starter model module uses
@@ -97,8 +104,8 @@ fetch it when you need more detail than this skill carries.
    the model credential in your environment. It needs no running app.
    Exit 0 = green; exit 1 prints each `broken:` line. Fix and re-run until 0.
    Common fixes: missing `.vendo/*` file (re-run `npx vendo init`), layout not
-   wrapped (`E-WIRE-004` — paste the exact import + wrap lines doctor prints
-   into the named file; init will never make that edit for you).
+   wrapped (`E-WIRE-004` — its troubleshooting page carries the exact lines;
+   init will never make that edit for you).
 
 ## Stage 2 — review and keep extraction fresh
 
@@ -145,4 +152,8 @@ fetch it when you need more detail than this skill carries.
   explicitly asked for unattended setup.
 - Do not hand-edit generated files (`.vendo/tools.json`, theme regeneration);
   use `overrides.json` and re-run sync.
-- Done means `npx vendo doctor` exits 0, not merely that files exist.
+- Done means the work at `continueUrl` is applied — init writes no client file
+  and prints no code, so the mount (and any loop or MCP wiring) is yours, and
+  that page carries the exact lines. `npx vendo doctor` is the separate,
+  orthogonal check on what is on disk; init's own exit code is about init's own
+  work and never about doctor.

--- a/packages/vendo/src/cli.ts
+++ b/packages/vendo/src/cli.ts
@@ -43,7 +43,6 @@ Options:
   --base-url <url>           Init only: where the app runs in dev — written to .env.local as VENDO_BASE_URL (production is set where you deploy)
   --posture <name>           Init only, --use-case mcp: how outside agents sign in (local, broker)
   --service-key              Init only, --use-case mcp: set up a machine-to-machine service key
-  --check / --no-check       Init only: run vendo doctor at the end (offered only when no paste is outstanding)
   --ai                       Init/sync: run the AI judgment pass without asking (works non-interactively)
   --engine <name>            Init/sync: pin the AI engine (claude, codex, npx) instead of first-available
   --theme <slot=value>       Init only: override a theme slot value directly (repeatable)
@@ -83,7 +82,7 @@ function options(args: string[], name: string): string[] {
     spellings and stay accepted so pinned scripts and hooks keep working. */
 const INIT_FLAGS = new Set([
   "--agent", "--yes", "--force", "--byo", "--ai", "--ai-polish", "--no-ai",
-  "--service-key", "--check", "--no-check",
+  "--service-key",
 ]);
 const INIT_VALUE_OPTIONS = ["--auth", "--framework", "--cloud-key", "--theme", "--engine", "--use-case", "--base-url", "--posture"];
 /** Agent-install-dx: every init wizard question has a value-flag answer; a
@@ -216,9 +215,6 @@ async function initCommand(args: string[]): Promise<number> {
   if (serviceKey && posture === "broker") {
     problems.push(`--service-key does not apply to --posture broker: ${SERVICE_KEY_ON_BROKER}`);
   }
-  if (args.includes("--check") && args.includes("--no-check")) {
-    problems.push("--check and --no-check answer the same question — pass one or the other");
-  }
   if (problems.length > 0) {
     console.error(`vendo init: ${problems.join("; ")}\n\n${HELP}`);
     return 1;
@@ -238,7 +234,6 @@ async function initCommand(args: string[]): Promise<number> {
     ...(baseUrl === undefined ? {} : { baseUrl }),
     ...(posture === undefined ? {} : { posture: posture as InitOptions["posture"] }),
     ...(serviceKey ? { serviceKey: true } : {}),
-    ...(args.includes("--check") ? { check: true } : args.includes("--no-check") ? { check: false } : {}),
     ...(themePairs.length === 0 ? {} : {
       themeAnswers: Object.fromEntries(themePairs.map((pair) => {
         const at = pair.indexOf("=");

--- a/packages/vendo/src/cli/doctor-codes.ts
+++ b/packages/vendo/src/cli/doctor-codes.ts
@@ -80,7 +80,7 @@ export const DOCTOR_ERROR_CODES = {
   "E-TURN-001": "RETIRED — doctor no longer runs a model turn",
   "E-TURN-002": "RETIRED — doctor no longer runs a model turn",
   "E-CLOUD-001": "VENDO_API_KEY is set but not usable",
-  "E-MODEL-001": "no model credential resolves (the wire is wired, but the agent cannot answer a single turn)",
+  "E-MODEL-001": "the key this install's `models` wiring reads is not set (the wire is wired, but the agent cannot answer a single turn)",
   "E-TOOLS-001": "every extracted host tool is disabled or excluded (zero live host tools)",
   "E-TOOLS-002": "the extracted tool surface is empty (zero host tools)",
   "E-TOOLS-003": "part of the tool catalog is ungraded (nobody has graded it, so it asks on every call)",

--- a/packages/vendo/src/cli/doctor-config-checks.ts
+++ b/packages/vendo/src/cli/doctor-config-checks.ts
@@ -6,13 +6,15 @@ import { firstOpenApiSpec, openApiMountPath } from "@vendoai/actions/sync";
 import { publicBase, type RiskLabel } from "@vendoai/core";
 import { CONFIG_SURFACES, OVERRIDES_ENABLEMENT_NOTE } from "../config-surface.js";
 import { UPLOAD_MAX_BYTES } from "../wire/files.js";
-import { describeDevCredential, resolveDevCredential } from "../dev-creds/resolve.js";
+import { ENV_KEY_VARS, describeDevCredential, resolveDevCredential } from "../dev-creds/resolve.js";
 // Relative (not the #dev-creds condition): the CLI is Node-only and the edge
 // build deliberately does not export the pin map.
 import { SLOT_PIN_ENV } from "../dev-creds/model.js";
 import type { DoctorRun } from "./doctor-report.js";
 import { EJECT_MANIFEST_FILE, type EjectedManifest } from "./eject.js";
 import { NEXT_SERVER_EXTERNALS, NEXT_SERVER_EXTERNALS_LINE, detectFramework, missingServerExternals, nextConfigPath, transpileConflictNote, transpiledServerExternals } from "./framework.js";
+import { compositionModulePath } from "./init-scaffolds.js";
+import { readModelKey } from "./install-record.js";
 import { walk } from "./theme/walk.js";
 import { exists, readOptional } from "./shared.js";
 
@@ -168,26 +170,63 @@ export async function checkSurfaceOwnership(run: DoctorRun): Promise<void> {
   run.pass("config/ownership", `surface ownership (file = local source of truth; unset = passed in code or not set at all): ${surfaceOwners.join(", ")}. ${OVERRIDES_ENABLEMENT_NOTE}`);
 }
 
-/** Models spec 2026-07-22 — exactly two honest model facts, resolver-based
- *  (the same resolver the runtime rides, no network): which credential rung
- *  wins, and any active VENDO_MODEL_* pins. Deliberately NO role/alias
- *  table: on the Cloud rung the family names map to concrete models
- *  SERVER-SIDE, so the client would only be guessing. */
+/** The env var THIS install's `models` wiring reads: the provider its
+ *  composition's own `models` line names, else the key `vendo init` recorded.
+ *  Null when neither exists — a pre-record install, or a composition that passes
+ *  its models in code doctor cannot read.
+ *
+ *  The COMPOSITION is the authority, and the order matters: it is the file the
+ *  runtime loads, and a host may rewrite its `models` line long after init
+ *  recorded an answer. Reading the record first meant a project initialised
+ *  against Anthropic and later moved to `openai("gpt-5")` was still graded on
+ *  ANTHROPIC_API_KEY — doctor green, first turn dead. The record is the fallback
+ *  for what the file cannot show: a Vendo Cloud install names no provider at
+ *  all, and the Express/custom scaffolds have no `models` line to read.
+ *
+ *  Either way it is ONE key: since the selection law an ambient provider key
+ *  selects nothing, so a composition wired to `openai("gpt-5")` lives or dies on
+ *  OPENAI_API_KEY and on nothing else. */
+async function wiredModelKey(root: string): Promise<string | null> {
+  const source = await readOptional(await compositionModulePath(root));
+  const provider = source === null ? null : /\bmodels\s*:\s*\{\s*default\s*:\s*(\w+)\(/.exec(source)?.[1];
+  const composed = ENV_KEY_VARS.find((entry) => entry.provider === provider)?.envVar;
+  return composed ?? await readModelKey(root) ?? null;
+}
+
+/** Models spec 2026-07-22 — exactly two honest model facts, no network: whether
+ *  the key this install's own wiring reads is set, and any active VENDO_MODEL_*
+ *  pins. Deliberately NO role/alias table: on the Cloud rung the family names
+ *  map to concrete models SERVER-SIDE, so the client would only be guessing. */
 export async function checkModelResolution(run: DoctorRun): Promise<void> {
   const { env } = run;
-  const modelCredential = await resolveDevCredential({ env });
-  if (modelCredential.rung !== "none") {
-    run.pass("model/credential", `model credential: ${describeDevCredential(modelCredential)}`);
+  const wired = await wiredModelKey(run.root);
+  if (wired !== null) {
+    // Naming any OTHER key is what sent hosts to set a variable that changes
+    // nothing: the warning used to list three provider keys the runtime ladder
+    // never consults, on a host whose composition read exactly one of them.
+    if ((env[wired] ?? "").trim() !== "") {
+      run.pass("model/credential", `model credential: ${wired} — the key this install's \`models\` wiring reads`);
+    } else {
+      run.warn("model/credential", "E-MODEL-001",
+        `model credential: ${wired} is not set, and it is the only key this install's \`models\` wiring reads `
+        + "— the wire is wired, but the agent cannot answer a single turn");
+    }
   } else {
-    // A WARNING, not a note: an install with no model answers nothing, and an
-    // invisible line (notes are suppressed under --json) is how an agent
-    // reported a green doctor on a host that could not take a single turn.
-    // Not a failure either — production keys legitimately live outside the
-    // files doctor reads — so doctor still exits 0.
-    run.warn("model/credential", "E-MODEL-001",
-      "model credential: none found — set a model key (ANTHROPIC_API_KEY / OPENAI_API_KEY / "
-      + "GOOGLE_GENERATIVE_AI_API_KEY) or VENDO_API_KEY and select it in your composition's `models`, "
-      + "or the agent cannot answer");
+    // No recorded answer and no readable `models` line: fall back to the runtime
+    // ladder, which since the selection law reads VENDO_API_KEY and nothing else.
+    const modelCredential = await resolveDevCredential({ env });
+    if (modelCredential.rung !== "none") {
+      run.pass("model/credential", `model credential: ${describeDevCredential(modelCredential)}`);
+    } else {
+      // A WARNING, not a note: an install with no model answers nothing, and an
+      // invisible line (notes are suppressed under --json) is how an agent
+      // reported a green doctor on a host that could not take a single turn.
+      // Not a failure either — production keys legitimately live outside the
+      // files doctor reads — so doctor still exits 0.
+      run.warn("model/credential", "E-MODEL-001",
+        "model credential: VENDO_API_KEY is not set and this install's composition selects no model "
+        + "— run `vendo login`, or add a `models` line naming a provider whose key you hold");
+    }
   }
   const activePins = Object.values(SLOT_PIN_ENV)
     .map((name) => ({ name, value: env[name]?.trim() }))

--- a/packages/vendo/src/cli/init-mcp.ts
+++ b/packages/vendo/src/cli/init-mcp.ts
@@ -6,9 +6,10 @@
  * the moment the user picks this path: init CREATES the composition, so writing
  * `mcp: true` into it is not editing anyone's code, and the origin-root
  * discovery route is a new file at a fixed path with a fixed two-line body.
- * Exactly two things stay the user's, and they are the two init genuinely
- * cannot do — set the base URL where they deploy, and point a client at the
- * door. They are `steps`, named rather than buried.
+ * What is left for the user — the deployed base URL, pointing a client at the
+ * door, the broker's environment overrides — is the docs page's, not the
+ * terminal's: init states what it wired and links to
+ * https://docs.vendo.run/outside-agents/quickstart.
  *
  * PURE: no fs, no network, no clock. Every file body, step line and environment
  * line is decided from the answers alone, so the whole plan is assertable
@@ -17,7 +18,6 @@
  */
 import { randomBytes } from "node:crypto";
 import { join, relative, sep } from "node:path";
-import { MCP_MOUNT } from "../door-paths.js";
 import type { AuthMatch } from "./init-auth.js";
 import { compositionModuleSource, type ScaffoldModel } from "./init-scaffolds.js";
 
@@ -63,10 +63,6 @@ export interface McpPlanInput {
       caller's to plan: an EXISTING one is compared by the keys it registers,
       which a pure planner cannot read. */
   serverActions: boolean;
-  /** Is a Vendo Cloud key in hand this run? Gates the posture select: a keyless
-      run never sees it — local is the default and the broker keeps today's
-      one-line pointer. */
-  cloudKey: boolean;
   posture: McpPosture;
   /** Did the user say yes to "will your own backend call these tools
       machine-to-machine?" */
@@ -77,10 +73,6 @@ export interface McpPlanInput {
       exchanging the old key started failing — the same reuse-don't-remint rule
       `VENDO_API_KEY` follows. Read by the caller; this module stays fs-free. */
   existingServiceKey?: string;
-  /** The origin captured earlier this run — the DEV one, which is what a client
-      config and doctor both want while the developer is still local. Null when
-      the run could not ask. */
-  baseUrl: string | null;
   /** The provider key init found in the environment. This path's composition
       module is the ONLY place it may land: the thin route composes nothing, so
       writing it there too would be a second, dead selection. */
@@ -116,10 +108,6 @@ export interface McpPlan {
    * against the posture the user just chose (compose-mcp.ts:98-113).
    */
   serviceKeyValue?: string;
-  /** The lines the run ends on. The FIRST is ALWAYS the base URL: a door whose
-      discovery points at the wrong origin surfaces hours later as "Claude can't
-      find my server". */
-  steps: string[];
   /** The provider and file of the `models` line this plan wrote — the
       composition module, never the route it replaced. The caller's closing
       summary names this file, so it can never point a reader at a route that
@@ -128,22 +116,6 @@ export interface McpPlan {
   modelWritten: { provider: ScaffoldModel["provider"]; path: string } | null;
   /** Why nothing was written. Set means the other fields are empty. */
   blocked?: string;
-}
-
-/** The plan's closing block, as a pretty run reads it: each step numbered by
-    its headline and its detail indented under it. A flat list of
-    `headline\ndetail` strings reads as a wall — the numbers and the indent are
-    what make it read as steps. (Plain runs print the same strings unnumbered:
-    the newline becomes an indent and nothing else, since a plain transcript is
-    parsed as often as it is read.) */
-export function mcpStepLines(plan: Pick<McpPlan, "steps">): string[] {
-  const lines: string[] = [];
-  plan.steps.forEach((step, index) => {
-    const [headline, ...detail] = step.split("\n");
-    lines.push(`${index + 1}. ${headline}`);
-    for (const rest of detail) lines.push(`   ${rest}`);
-  });
-  return lines;
 }
 
 /** Why a service key cannot ride the broker posture, in the ONE voice both
@@ -200,28 +172,10 @@ export function wellKnownRouteSource(specifier: string): string {
     `export const { GET, POST } = wellKnownVendoHandler(vendo);\n`;
 }
 
-/** The keyless sign-in pointer — today's two lines of prose, kept exactly where
-    they are useful. A run with no Cloud key is never shown the posture select,
-    so this is the whole story it gets. */
-const KEYLESS_SIGN_IN =
-  "Sign-in: your app serves its own OAuth — nothing to configure. Set VENDO_MCP_BROKER_URL "
-  + "to front it with an external authorization server (e.g. Vendo Cloud's broker) — "
-  + "same client URL either way.";
-
-/** The Cloud sign-in pointer, and the reason this path prints no environment
-    values at all: the runtime reads the broker URL and the federation secret
-    from Cloud and provisions the tenant on first use, so there is nothing for
-    the operator to copy. The two variables survive as an explicit override,
-    which — adapter rule — always wins over the Cloud default. */
-const CLOUD_SIGN_IN =
-  "Sign-in: Vendo Cloud fronts the door — your VENDO_API_KEY provisions the tenant on first use, "
-  + "so there is nothing to copy. Set VENDO_MCP_BROKER_URL and VENDO_MCP_FEDERATION_SECRET to point "
-  + "at a broker of your own instead — same client URL either way.";
-
 export function planMcp(input: McpPlanInput): McpPlan {
-  const { root, appDir, composition, framework, authWired, serverActions, cloudKey, posture, serviceKey, baseUrl } = input;
+  const { root, appDir, composition, framework, authWired, serverActions, posture, serviceKey } = input;
   const models = input.models ?? null;
-  const refuse = (why: string): McpPlan => ({ changes: [], compositionSource: null, steps: [], modelWritten: null, blocked: why });
+  const refuse = (why: string): McpPlan => ({ changes: [], compositionSource: null, modelWritten: null, blocked: why });
 
   if (framework !== "next") {
     return refuse(
@@ -250,27 +204,6 @@ export function planMcp(input: McpPlanInput): McpPlan {
   const serviceAuth = posture === "local" && serviceKey;
   const changes: McpChange[] = [change(join(wellKnownDir, "route.ts"), wellKnownRouteSource(input.compositionSpecifier))];
 
-  // The client-facing URL is derived from the base URL and NEVER from the broker
-  // URL, so it is the same in both postures — switching posture later invalidates
-  // nothing a user already configured in Claude, ChatGPT or Cursor.
-  const clientBase = baseUrl ?? "https://<your deployment>";
-  // Each step is "headline\ndetail…" — the caller numbers the headlines and
-  // indents the detail lines, so a step never wraps mid-phrase into a wall.
-  const steps = [
-    baseUrl === null
-      ? "Set `VENDO_BASE_URL` to the origin this app answers on — .env.local in dev, your deploy platform in production\nwithout it, discovery points at the wrong origin and clients cannot find your server"
-      : `When you deploy, set \`VENDO_BASE_URL\` in your platform to the public origin\ndev is answered — \`${baseUrl}\` is in .env.local, and every discovery URL hangs off it`,
-    `Point any MCP client at \`${clientBase}${MCP_MOUNT}\`\nyour users' setup page ships free at \`${MCP_MOUNT}/connect\` — copy for Claude · ChatGPT · Cursor included`,
-    "Claude Code: `/plugin marketplace add runvendo/vendo` then `/plugin install vendo@vendo`",
-  ];
-  if (posture === "broker") steps.push(CLOUD_SIGN_IN);
-  else if (!cloudKey) steps.push(KEYLESS_SIGN_IN);
-  // Only the local door has a step here: Cloud provisions the service key
-  // itself, and the console is where it is listed, rotated and revoked.
-  if (serviceAuth) {
-    steps.push(`Your backend exchanges \`VENDO_SERVICE_KEY\` at \`${clientBase}${MCP_MOUNT}/token\`\nfor a 10-minute token acting as a named user — svc: attribution in the audit`);
-  }
-
   return {
     changes,
     compositionSource: compositionModuleSource({ serverActions, auth: authWired, models, mcp: { serviceAuth } }),
@@ -278,6 +211,5 @@ export function planMcp(input: McpPlanInput): McpPlan {
       ? { serviceKeyValue: wellFormedServiceKey(input.existingServiceKey) ? input.existingServiceKey!.trim() : generateServiceKey() }
       : {}),
     modelWritten: models === null ? null : { provider: models.provider, path: relative(root, composition).split(sep).join("/") },
-    steps,
   };
 }

--- a/packages/vendo/src/cli/init-questions.ts
+++ b/packages/vendo/src/cli/init-questions.ts
@@ -7,9 +7,9 @@
  * as flags on a re-run, and that run writes. No new flags exist for any of it:
  * every option below names one of the six init already validates.
  *
- * Only what a PERSON must decide appears here. The zod floor, the theme slots
- * and the live check are mechanical, so they default exactly as `--yes` leaves
- * them and show up in the diff instead of in someone's chat.
+ * Only what a PERSON must decide appears here. The zod floor and the theme
+ * slots are mechanical, so they default exactly as `--yes` leaves them and show
+ * up in the diff instead of in someone's chat.
  *
  * PURE apart from reading the host's dependencies for auth: every prompt is
  * decided from the answers already on the command line, so the whole set is

--- a/packages/vendo/src/cli/init-scaffolds.ts
+++ b/packages/vendo/src/cli/init-scaffolds.ts
@@ -298,31 +298,6 @@ function registrationSpecifier(root: string, wiringDir: string, registration: Se
   return target.startsWith(".") ? target : `./${target}`;
 }
 
-/** The paste that adds missing registrations to an existing map — only the
-    missing ones, never the whole file. Aliases continue the file's own
-    `actionN` convention above the highest one already in it, so a paste can
-    never shadow a binding the developer already has. */
-export function missingRegistrationLines(
-  root: string,
-  wiringDir: string,
-  map: string,
-  missing: readonly ServerActionRegistration[],
-): string[] {
-  const used = [...map.matchAll(/\baction(\d+)\b/g)].map((match) => Number(match[1]));
-  let next = used.length === 0 ? 0 : Math.max(...used) + 1;
-  const imports: string[] = [];
-  const entries: string[] = [];
-  for (const registration of missing) {
-    const alias = `action${next++}`;
-    const specifier = registrationSpecifier(root, wiringDir, registration);
-    imports.push(registration.exportName === "default"
-      ? `import ${alias} from ${JSON.stringify(specifier)};`
-      : `import { ${registration.exportName} as ${alias} } from ${JSON.stringify(specifier)};`);
-    entries.push(`  ${JSON.stringify(registrationKey(registration))}: ${alias},`);
-  }
-  return [...imports, "… then add inside the serverActions map:", ...entries];
-}
-
 /**
  * The generated server-action registration map (04-actions §1, ENG-248): the
  * wiring file imports each detected `"use server"` action module and passes

--- a/packages/vendo/src/cli/init.ts
+++ b/packages/vendo/src/cli/init.ts
@@ -1,23 +1,19 @@
-import { mkdir, readdir, readFile } from "node:fs/promises";
-import { dirname, join, relative, resolve, sep } from "node:path";
-import type { ExtractedTool } from "@vendoai/actions";
+import { mkdir, readFile } from "node:fs/promises";
+import { dirname, join, relative, resolve } from "node:path";
 import { isVendoError, VendoError } from "@vendoai/core";
-import { createInterface } from "node:readline/promises";
 import { stdin, stdout } from "node:process";
 import { scrubErrorDetail, type Telemetry } from "@vendoai/telemetry";
 import { detectDepVersions, installedAiVersion } from "./dep-versions.js";
-import { AUTH_MD_URL, ensureEnvLocalIgnored, runCloudStep, upsertEnvLocal, type CloudStepOptions } from "./cloud-init.js";
-import { runDoctor } from "./doctor.js";
+import { ensureEnvLocalIgnored, runCloudStep, upsertEnvLocal, type CloudStepOptions } from "./cloud-init.js";
 import type { InitPolishSeam } from "./init-judgment.js";
-import { BROKER_NEEDS_HTTPS, mcpStepLines, planMcp, SERVICE_KEY_ON_BROKER, wellFormedServiceKey, type McpPosture } from "./init-mcp.js";
+import { BROKER_NEEDS_HTTPS, planMcp, SERVICE_KEY_ON_BROKER, wellFormedServiceKey, type McpPosture } from "./init-mcp.js";
 import { initQuestions } from "./init-questions.js";
-import { rendererFlowOptions, runSyncFlow, writeFonts, type SyncFlowResult } from "./sync-flow.js";
+import { readEnvFiles, rendererFlowOptions, resolveJudgmentConsent, runSyncFlow, writeFonts, type SyncFlowResult } from "./sync-flow.js";
 import { BRIEF_TEMPLATE } from "./extract/stages.js";
 import { ENV_KEY_VARS, resolveDevCredential, describeDevCredential, type DevCredential } from "../dev-creds/resolve.js";
-import { NEXT_SERVER_EXTERNALS, NEXT_SERVER_EXTERNALS_LINE, SERVER_EXTERNALS_ARRAY, blankComments, detectAgentLoopRoute, detectFramework, detectVendoWiring, missingServerExternals, nextConfigPath, transpileConflictNote, transpiledServerExternals, workspaceHostCandidates, type HostFramework } from "./framework.js";
+import { NEXT_SERVER_EXTERNALS, NEXT_SERVER_EXTERNALS_LINE, SERVER_EXTERNALS_ARRAY, blankComments, detectAgentLoopRoute, detectFramework, detectVendoWiring, missingServerExternals, nextConfigPath, transpiledServerExternals, workspaceHostCandidates, type HostFramework } from "./framework.js";
 import {
   AUTH_FAMILY_INFO,
-  AUTH_PRESET_SPECIFIER,
   composedAuthPreset,
   detectAuthPreset,
   resolveScaffoldAuth,
@@ -34,11 +30,8 @@ import {
   customServerSource,
   devBaseUrl,
   devPort,
-  disabledTools,
   expressServerSource,
   importsGeneratedMap,
-  missingRegistrationLines,
-  missingRegistrations,
   requiredServerActions,
   routeSource,
   serverActionsModuleSource,
@@ -46,7 +39,7 @@ import {
   vendoEnvExample,
   type ScaffoldModel,
 } from "./init-scaffolds.js";
-import { INIT_USE_CASES, readUseCase, writeUseCase, type InitUseCase } from "./install-record.js";
+import { INIT_USE_CASES, readModelKey, readUseCase, writeInstallRecord, type InitUseCase } from "./install-record.js";
 import { createPrettyOutput, plainSecret, plainSelect, plainText, usePrettyOutput, type PrettyOutput, type SelectOption } from "./pretty.js";
 import { contrastingText } from "./theme/color.js";
 import { themeFontFamilies } from "./theme/embed-fonts.js";
@@ -61,7 +54,6 @@ import {
 import {
   appDirectory,
   askYesNo,
-  clientRoot,
   cloudProjectProps,
   consoleOutput,
   detectPackageManager,
@@ -76,84 +68,80 @@ import {
 } from "./shared.js";
 
 /**
- * `vendo init` (install-dx v1, re-derived 2026-07-18): one command, zero
- * questions on the happy path, no ceremony.
+ * `vendo init` (install-dx v1, re-derived 2026-07-18): one command, the
+ * up-front questions, no ceremony.
  *
- *   scan → wire (the server surface — the composition module `lib/vendo.ts`
- *   and the catch-all handler over it; init never writes a client file;
- *   a detected auth preset gets one consent-style confirm in interactive runs,
- *   --yes/non-interactive accept it silently — plus package.json hooks)
- *   → key (env stated, else the cloud starter offer) → done summary (files
- *   changed, the mount paste, next steps).
+ *   scan → ask → wire (the server surface — the composition module
+ *   `lib/vendo.ts` and the catch-all handler over it; init never writes a
+ *   client file; plus package.json hooks) → key (env stated, else the cloud
+ *   starter offer) → facts.
  *
  * INIT ONLY EVER CREATES FILES IN YOUR SOURCE TREE (locked DX law). Everything
  * above is a NEW Vendo-owned file, or Vendo-owned config: `package.json`'s two
  * sync hooks, and one idempotent append of `VENDO_BASE_URL` to `.env.example`
  * (the only pre-existing host-authored file init still writes, and it appends
  * — it never rewrites a line). A source file that already exists is never
- * written at all, however stale: mounting the visible
- * surface in the host's own layout, wiring `serverActions` into a route that
- * predates the host's actions, refreshing a stale registration map — each one
- * is the developer's paste, so the run ends with one unmissable block naming
- * the file and the exact lines (the `ManualEdit`s below), and `vendo doctor`
- * fails until they land (E-WIRE-004, E-WIRE-009).
+ * written at all, however stale: mounting the visible surface in the host's own
+ * layout, wiring `serverActions` into a route that predates the host's actions,
+ * refreshing a stale registration map. `vendo doctor` grades every one of them
+ * (E-WIRE-004, E-WIRE-009) and each code's page carries the fix.
+ *
+ * IT PRINTS NO CODE AND NO STEPS. Every snippet it used to print — the mount
+ * paste, the loop wiring, the MCP steps — was a second copy of something the
+ * docs already carry, and a terminal cannot keep a copy correct. The run ends
+ * on facts and ONE URL (`printFacts`); `--agent` gets the same as JSON.
  *
  * Removed by design: the interview, per-diff y/N approvals, the lib/ai.ts
  * scaffold (createVendo's `model` is optional now), remix offers, the
  * encryption-key step, the refine offer (the `vendo refine` command itself is
- * gone — format v3 replaces it with the enrichment pass), and the finale
- * ceremony (doctor owns verification and the live turn).
+ * gone — format v3 replaces it with the enrichment pass), the finale ceremony,
+ * and the doctor check (doctor is a standalone command, and init's exit code is
+ * about init's own work).
  */
 
 const BRIEF_PLACEHOLDER = `${BRIEF_TEMPLATE}\n`;
 
-export interface RiskRecommendation {
-  tool: string;
-  risk: ExtractedTool["risk"];
-  recommendation: string;
-}
-
-/** A step init cannot take for you. Init only ever CREATES files in your source
-    tree, so every change to a file that already exists — the visible-surface
-    mount, the server-action wiring — is the developer's paste, structured so
-    the terminal block, the `manualSteps` lines and the receipt's `pasteEdits`
-    all carry the SAME file and lines. */
-export interface ManualEdit {
-  /** The file the paste goes in, relative to the init root. */
-  file: string;
-  /** The exact lines to paste (or the diff to apply), in order. */
-  lines: string[];
-  /** What skipping it costs. */
-  why: string;
-}
-
 export { INIT_USE_CASES, type InitUseCase };
 
 /** What the run settled before it writes anything. Everything else buildPlan
-    resolves — the changes, the pastes, the auth facts — rides beside it on that
-    function's return, where each has exactly one reader. */
+    resolves — the changes, the auth facts — rides beside it on that function's
+    return, where each has exactly one reader. */
 interface InitPlan {
   framework: Exclude<HostFramework, "unknown"> | "custom";
   /** The `.vendo` artifacts every path lays down. */
   writes: string[];
 }
 
-/** How an agent-mode run ENDS: the same facts the prose tail carries, as data.
-    Its twin is `InitQuestions` — one status field tells them apart, and both
-    exit 0, so the coding agent branches on the shape and never on a code. */
-export interface InitReceipt {
-  status: "written";
-  root: string;
-  useCase: InitUseCase;
+/** How the run ENDS, in every mode: what it wired, what it detected, the guard
+    posture it left behind, and the ONE page that carries the instructions. */
+interface InitFacts {
   /** The install's files, root-relative: what init wrote, plus what an earlier
       init already put there (it is idempotent, so a re-run leaves the same set
       in place). Every entry exists on disk. */
   wrote: string[];
-  /** What init could not write for you: the mount, the wiring it found stale,
-      the loop snippet. Verbatim `ManualEdit`s (see `handSteps`). */
-  pasteEdits: ManualEdit[];
-  tools: number;
-  riskRecommendations: RiskRecommendation[];
+  detected: { framework: string; auth: string; packageManager: string; port: number };
+  guardPosture: string;
+  continueUrl: string;
+  /** Slots the extraction was unsure of and KEPT as extracted. Nothing blocks
+      on them: init asks nothing once the question phase is over. */
+  keptUncertain: string[];
+  /** Loosening proposals the judgment pass held as PENDING. Never applied — a
+      loosening needs a human — and never asked about mid-run, so the count is
+      a fact the run reports and `vendo sync --review` is where it is answered. */
+  pendingLoosenings: number;
+}
+
+/** How an agent-mode run ENDS: the same facts, as data. Its twin is
+    `InitQuestions` — one status field tells them apart, and both exit 0, so the
+    coding agent branches on the shape and never on a code. */
+export interface InitReceipt extends InitFacts {
+  status: "written";
+  root: string;
+  useCase: InitUseCase;
+  /** MCP re-run only: the service key is in `.env.local`, but `serviceAuth` is
+      not in the composition — init never rewrites a file it did not author, so
+      that one line is the developer's, at the continue URL. */
+  serviceAuthUnwired?: true;
   /** Agent mode grades like every other run — `graded` means the pass ran here
       and the grades are on disk. `delegated` is the one fallback left: no
       judgment engine resolved on this machine, so the catalog is ungraded and
@@ -162,6 +150,21 @@ export interface InitReceipt {
     | { status: "graded"; file: string }
     | { status: "delegated"; checklist: string[] };
 }
+
+/** The one guard fact a fresh install owes its reader. TRUE by construction:
+    the policy init writes matches destructive→ask and read→run, and `write` hits
+    no rule, so the guard's own default posture runs it (packages/guard
+    guard.ts's `#defaultPosture`, which only withholds ungraded + destructive). */
+const GUARD_POSTURE = "writes run without approval — how to tighten: vendo.run/agents.md";
+
+/** Where each install continues. ONE page per answer — the terminal states what
+    it wired and the docs carry every instruction, because a snippet printed at a
+    terminal is a copy nobody can keep correct. */
+const CONTINUE_URLS: Record<InitUseCase, string> = {
+  embedded: "https://docs.vendo.run/product/quickstart",
+  "agent-loop": "https://docs.vendo.run/existing-agent/ai-sdk",
+  mcp: "https://docs.vendo.run/outside-agents/quickstart",
+};
 
 const JUDGMENT_CHECKLIST = [
   "task-quality descriptions per tool",
@@ -202,10 +205,6 @@ export interface InitOptions {
   posture?: McpPosture;
   /** --service-key: set up a machine-to-machine key (MCP use case only). */
   serviceKey?: boolean;
-  /** --check / --no-check: run `vendo doctor` at the end. Only OFFERED when
-      the run owes no paste — doctor grades the paste, and the paste happens
-      after init exits. Never changes init's exit code either way. */
-  check?: boolean;
   /** --ai / --no-ai (`--ai-polish` is the legacy spelling of `--ai`): `true`
       runs the judgment pass with no prompt, `false` forces it off, and
       `undefined` asks in an interactive run and skips otherwise. No answer is
@@ -229,9 +228,6 @@ export interface InitOptions {
   installProvider?: InstallRunner;
   /** Test seam: the `@vendoai/vendo` install subprocess (#1153). */
   installVendo?: InstallRunner;
-  /** Test seam: the zod-floor bump confirm (provider-deps.ts, FINDINGS F2),
-      asked only in interactive runs. Mirrors the auth confirm's shape. */
-  confirmZodBump?: (question: string, defaultYes: boolean) => Promise<boolean>;
   /** Test seam: the zod-floor bump install subprocess. */
   installZod?: InstallRunner;
   /** Test seam (ENG-339): cloud-in-init step overrides. */
@@ -257,12 +253,6 @@ export interface InitOptions {
       asked" — the prompt itself turns a bare Enter into the prefilled default,
       so a seam that answers "" stands for a run that never got to ask. */
   askText?: (question: string, hint?: string, defaultValue?: string) => Promise<string>;
-  /** Test seam: the doctor-check offer. Mirrors the auth confirm's shape. */
-  confirmCheck?: (question: string, defaultYes: boolean) => Promise<boolean>;
-  /** Test seam: the check itself (default: `vendo doctor`). */
-  runCheck?: (root: string) => Promise<boolean>;
-  /** Uncertain-slot review — asked ONLY when the model reports uncertainty. */
-  themeReview?: (summary: ThemeSummary) => Promise<Record<string, string>>;
 }
 
 const THEME_PALETTE_SLOTS = ["accent", "background", "surface", "text", "mutedText", "border", "danger"] as const;
@@ -288,51 +278,6 @@ function printThemeSummary(summary: ThemeSummary, output: Output): void {
   }
   for (const error of summary.errors) output.error(`warning: ${error}`);
   output.log("Theme lives in .vendo/theme.json — edit it anytime; it is the source of truth.");
-}
-
-/** The model writes these notes, at whatever length it likes, in its own first
-    person — one ran to ~450 characters. On the rail the whole thing is a dim
-    hint, so the FIRST sentence is the share that earns the space: it is the
-    reading it chose, and the rest is the alternative it rejected (#1165). */
-export function firstSentence(note: string): string {
-  const end = /[.;](?:\s|$)/.exec(note);
-  const head = (end === null ? note : note.slice(0, end.index)).trim();
-  return head.length > 160 ? `${head.slice(0, 159).trimEnd()}…` : head;
-}
-
-/** The same review on the rail: a `◇` question per slot, the model's reasoning
-    as a dim hint under it, and the `●` receipt — instead of a 450-character
-    unstyled line at column 0, the one place the rail used to die (#1165). */
-export function prettyThemeReview(pretty: Pick<PrettyOutput, "text">) {
-  return async (summary: ThemeSummary): Promise<Record<string, string>> => {
-    const overrides: Record<string, string> = {};
-    for (const { slot, note } of summary.uncertain) {
-      const answer = await pretty.text(
-        `Theme ${slot} is uncertain — extracted ${summary.slots[slot]}. Replacement value, or Enter to keep`,
-        firstSentence(note),
-      );
-      if (answer !== "") overrides[slot] = answer;
-    }
-    return overrides;
-  };
-}
-
-/** Interactive review of model-flagged uncertain slots (the ONLY theme question). */
-async function defaultThemeReview(summary: ThemeSummary): Promise<Record<string, string>> {
-  if (!stdin.isTTY || !stdout.isTTY) return {};
-  const prompt = createInterface({ input: stdin, output: stdout });
-  const overrides: Record<string, string> = {};
-  try {
-    for (const { slot, note } of summary.uncertain) {
-      const answer = (await prompt.question(
-        `Theme ${slot} is uncertain (${note}); extracted ${summary.slots[slot]}. Replacement value, or Enter to keep: `,
-      )).trim();
-      if (answer !== "") overrides[slot] = answer;
-    }
-  } finally {
-    prompt.close();
-  }
-  return overrides;
 }
 
 /** The framework the run scaffolds for. "unknown" detection lands on the
@@ -427,33 +372,6 @@ function pastePath(target: string): string {
 }
 
 
-/** Relative, posix-style import specifier from the layout's directory to the
-    project-root `.vendo/theme.json` — printed for the user's paste, never
-    written by init. Returns null when the project EXPLICITLY disables
-    resolveJsonModule, so the printed snippet compiles. */
-async function themeImportSpecifier(root: string, layoutDir: string): Promise<string | null> {
-  if (await resolveJsonModuleDisabled(root)) return null;
-  const themeJson = join(root, ".vendo", "theme.json");
-  return relative(layoutDir, themeJson).split(sep).join("/");
-}
-
-/** True only when tsconfig/jsconfig EXPLICITLY sets
-    `compilerOptions.resolveJsonModule === false` — the one case where importing
-    theme.json breaks the build. */
-async function resolveJsonModuleDisabled(root: string): Promise<boolean> {
-  for (const file of ["tsconfig.json", "jsconfig.json"]) {
-    const raw = await readOptional(join(root, file));
-    if (raw === null) continue;
-    try {
-      const config = JSON.parse(raw) as { compilerOptions?: { resolveJsonModule?: boolean } };
-      if (config.compilerOptions?.resolveJsonModule === false) return true;
-    } catch {
-      // Malformed config — assume the default (enabled).
-    }
-  }
-  return false;
-}
-
 function diff(path: string, before: string | null, after: string): string {
   const oldLines = before === null ? [] : before.trimEnd().split("\n");
   const newLines = after.trimEnd().split("\n");
@@ -463,29 +381,6 @@ function diff(path: string, before: string | null, after: string): string {
     ...oldLines.map((line) => `-${line}`),
     ...newLines.map((line) => `+${line}`),
   ].join("\n");
-}
-
-/**
- * The server-action wiring an EXISTING route is missing (ENG-248): a host that
- * adds `"use server"` actions AFTER the initial init gets vendo-actions.ts
- * generated, but its route.ts still calls `createVendo` without
- * `serverActions` — so every server-action call fails closed at runtime. Init
- * does not own a file it did not create, so this returns the developer's paste
- * rather than a rewrite. Null when there is nothing to say: the route already
- * passes a map (including one sourced from somewhere else — a local map, an
- * aliased import — which our import would only shadow), or the composition is
- * unrecognized and no honest two-line paste exists for it.
- */
-function routeServerActionsEdit(source: string, file: string): ManualEdit | null {
-  if (serverActionsWiring(source) !== "unwired") return null;
-  return {
-    file,
-    lines: [
-      ...(importsGeneratedMap(source) ? [] : [`import { serverActions } from "./vendo-actions";`]),
-      `… then add inside createVendo({ … }): serverActions,`,
-    ],
-    why: "createVendo dispatches server-action tools through that map — without it every one of them fails closed at execution time (no work performed).",
-  };
 }
 
 /** The auto-installed hooks carry `--no-ai` explicitly so they can never
@@ -599,32 +494,6 @@ function nextConfigWithExternals(raw: string, missing: readonly string[]): strin
 
 const NEXT_CONFIG_SCAFFOLD = `const nextConfig = {\n  ${NEXT_SERVER_EXTERNALS_LINE}\n};\n\nexport default nextConfig;\n`;
 
-const NEXT_EXTERNALS_WHY =
-  "@vendoai/apps is the entry that matters: its checker imports esbuild through a variable specifier the bundler cannot see, so an \"esbuild\" entry alone is inert. Bundled, that import resolves from your app root, where pnpm never hoists esbuild, and every generated screen fails its checks while the app looks fine. Doctor fails E-CFG-004 until the line is there.";
-
-/** 04-actions §1 risk ladder projected as advice: destructive asks first,
-    writes get reviewed, reads auto-run (no entry). */
-function riskRecommendations(tools: ExtractedTool[]): RiskRecommendation[] {
-  return tools.flatMap((tool) => {
-    if (tool.disabled === true) {
-      return [{ tool: tool.name, risk: tool.risk, recommendation: "extracted disabled (unclassifiable); enable it deliberately in .vendo/overrides.json after review" }];
-    }
-    if (tool.confirmEach === true) {
-      return [{ tool: tool.name, risk: tool.risk, recommendation: "already marked confirmEach in .vendo/overrides.json; policy asks before running it" }];
-    }
-    if (tool.risk === "ungraded") {
-      return [{ tool: tool.name, risk: tool.risk, recommendation: "nobody has graded this yet, so it asks on every call; run `vendo sync --ai` with a model key, or grade it in .vendo/overrides.json" }];
-    }
-    if (tool.risk === "destructive") {
-      return [{ tool: tool.name, risk: tool.risk, recommendation: "irreversible; mark it confirmEach in .vendo/overrides.json so policy asks first" }];
-    }
-    if (tool.risk === "write") {
-      return [{ tool: tool.name, risk: tool.risk, recommendation: "writes host data; review it and mark confirmEach in .vendo/overrides.json when irreversible" }];
-    }
-    return [];
-  });
-}
-
 /** The packaged vendo-setup skill (shipped in the npm tarball next to dist/).
     Resolved relative to this module so src (tests) and dist (published bin)
     agree; a missing file degrades to not offering the skill. */
@@ -634,136 +503,6 @@ async function setupSkillSource(): Promise<string | null> {
   } catch {
     return null;
   }
-}
-
-/** The mount paste for a Next host, as data — ONE paste: `<VendoProvider>`
-    around the app's client root WITH `<VendoOverlay />` inside it. The paste
-    used to omit the overlay (the bubble was "an optional documented line"),
-    but a verbatim install then rendered NOTHING — wired and invisible reads
-    as broken (field: expense.fyi, ENG-421 / #1370), and doctor E-WIRE-006
-    already hard-fails an overlay-less host, so the paste and the gate now
-    agree. The why-line names the escape: hosts rendering their own surface
-    delete the overlay line. A host that already mounts a surface needs
-    nothing. Null on Express and custom hosts: their wiring has no single
-    host file to name, so it stays in the printed lines below — and null for an
-    install that mounts no Vendo UI at all (see `mountsUi`). */
-async function mountStep(root: string, layout: LayoutWiring, mountedUi: boolean): Promise<ManualEdit | null> {
-  if (!mountedUi) return null;
-  if (layout.kind === "already" || layout.kind === "express" || layout.kind === "custom") return null;
-  const { file: entry, children } = await clientRoot(root);
-  const entryDir = dirname(entry);
-  const specifier = await themeImportSpecifier(root, entryDir);
-  const fontsPath = join(root, ".vendo", "fonts.css");
-  const fonts = await exists(fontsPath) ? relative(entryDir, fontsPath).split(sep).join("/") : null;
-  return {
-    file: relative(root, entry),
-    lines: [
-      ...(fonts === null ? [] : [`import ${JSON.stringify(fonts)};`]),
-      `import { VendoOverlay, VendoProvider } from "@vendoai/vendo/react";`,
-      ...(specifier === null
-        ? []
-        : [
-            `import theme from ${JSON.stringify(specifier)};`,
-            `import type { VendoTheme } from "@vendoai/vendo";`,
-          ]),
-      `… then wrap: <VendoProvider baseUrl="/api/vendo"${specifier === null ? "" : " theme={theme as VendoTheme}"}>${children}<VendoOverlay /></VendoProvider>`,
-    ],
-    why: "<VendoProvider> is what the @vendoai/ui hooks and embeds read; baseUrl is the wire mount, path prefix included. <VendoOverlay /> is the visible agent — delete that line if you render your own surface. Until this lands, Vendo is wired but nothing on the page can reach it."
-      + (fonts === null ? "" : " fonts.css carries your brand font as inlined @font-face rules, so generated screens render it wherever your own stylesheet doesn't reach."),
-  };
-}
-
-/** A manual edit as the compact printed/plan lines. */
-function editLines(step: ManualEdit): string[] {
-  return [`In ${step.file}:`, ...step.lines.map((line) => `  ${line}`), `  (${step.why})`];
-}
-
-/** Everything the run could not do itself: the mount paste plus, on Express
-    and custom runtimes, their own two wiring lines. */
-async function manualWiringLines(root: string, layout: LayoutWiring, mountedUi: boolean): Promise<string[]> {
-  // The client mount is dropped where no Vendo UI is mounted by design; the
-  // server-side line stays, because that is what serves apps and approvals.
-  const clientMount = mountedUi
-    ? [`<VendoProvider baseUrl="/api/vendo" theme={theme}>…</VendoProvider>  // around your client root`]
-    : [];
-  if (layout.kind === "express") {
-    return [
-      `app.use("/api/vendo", mountVendo());   // in your server`,
-      ...clientMount,
-    ];
-  }
-  if (layout.kind === "custom") {
-    return [
-      `Route your runtime's requests through the generated module — Cloudflare Workers: export default { fetch: (request, env) => handleVendoRequest(request, env) };`,
-      ...clientMount,
-      `Set VENDO_BASE_URL to the deployment's FULL public URL, path prefix included (credential forwarding fails closed without it).`,
-    ];
-  }
-  const step = await mountStep(root, layout, mountedUi);
-  return step === null ? [] : editLines(step);
-}
-
-/** The repo-specific agent tail (agent-install-dx): a non-interactive
-    scaffold run is agent-driven, so the run ends with plain deterministic
-    pointers — the wired auth preset and what is still stubbed about it, the
-    exact files left to hand-edit (derived from what THIS run wrote, never
-    canned prose), and the one doctor command that gates "done". A pointer to
-    work, not documentation: the playbook carries the teaching. */
-async function agentTailLines(args: {
-  root: string;
-  framework: Exclude<HostFramework, "unknown"> | "custom";
-  compositionPath: string | null;
-  authWired: AuthMatch | null;
-  /** How far the visible-surface wiring got this run. */
-  layout: LayoutWiring;
-  /** No model credential resolved this run — the tail points the agent at
-      the auth.md key flow (Agent Install DX, Layer 2). */
-  cloudKeyMissing: boolean;
-  /** Files that already existed, so init printed the change instead. */
-  edits: ManualEdit[];
-  /** Does this install mount a Vendo surface at all (see `mountsUi`)? */
-  mountedUi: boolean;
-}): Promise<string[]> {
-  const lines: string[] = [];
-  // Auth is a tail fact only when a composition was created this run — a
-  // re-run against an existing composition changed nothing about auth.
-  if (args.compositionPath !== null) {
-    if (args.authWired === null) {
-      lines.push("auth: none wired — sessions stay anonymous until a preset is added");
-    } else if (args.authWired.source === "picked") {
-      lines.push(`auth: ${args.authWired.preset}() wired — stubbed: ${args.authWired.dependency} is not in package.json; install it before the first authenticated run`);
-    } else {
-      lines.push(`auth: ${args.authWired.preset}() wired (detected ${args.authWired.dependency})`);
-    }
-  }
-  if (args.compositionPath !== null && args.authWired === null) {
-    lines.push(`edit ${args.compositionPath} — add the auth preset named in the advisory above when the host has auth`);
-  }
-  if (args.framework === "express") {
-    // No exact entry file exists to name on Express — point at the printed
-    // wiring lines instead of guessing a path.
-    lines.push(args.mountedUi
-      ? "edit your server and client entries — paste the mountVendo() and <VendoProvider> lines above (without a mounted provider, nothing on the page can reach Vendo)"
-      : "edit your server entry — paste the mountVendo() line above (this install mounts no Vendo UI, so there is no provider to wrap)");
-  } else if (args.layout.kind === "manual" && args.mountedUi) {
-    const entry = relative(args.root, (await clientRoot(args.root)).file);
-    lines.push(`edit ${entry} — wrap the app in the <VendoProvider> lines above (without it, nothing on the page can reach Vendo)`);
-  }
-  for (const edit of args.edits) {
-    lines.push(`edit ${edit.file} — apply the change printed above yourself (it already exists, so init did not write it)`);
-  }
-  const off = await disabledTools(args.root);
-  if (off.length > 0) {
-    lines.push(`tools off: ${off.join(", ")}. The assistant will never offer these. To turn one on, set "disabled": false under its name in ${join(".vendo", "overrides.json")}`);
-  }
-  if (await readOptional(join(args.root, ".vendo", "brief.md")) === BRIEF_PLACEHOLDER) {
-    lines.push(`edit ${join(".vendo", "brief.md")} — replace the placeholder with what this product does and for whom`);
-  }
-  if (args.cloudKeyMissing) {
-    lines.push(`cloud key: none — for Vendo Cloud, fetch ${AUTH_MD_URL} and run \`vendo login\` (your human approves a code in the browser; the key lands in .env.local), then re-run init or pass --cloud-key <key>; --byo with a provider key also works`);
-  }
-  lines.push("gate: run `vendo doctor --json` — done when every check reports green");
-  return lines;
 }
 
 const EMBEDDED_OPTION: SelectOption = { value: "embedded", label: "Embedded in my app — chat + generated UI" };
@@ -785,14 +524,6 @@ function useCaseOptions(agentLoopRoute: string | null): SelectOption[] {
         MCP_OPTION,
       ];
 }
-
-/** Does this install mount a visible Vendo surface? An agent-loop or MCP install
-    reaches the agent through the host's own loop or the MCP door and mounts no
-    Vendo UI by design, so the <VendoProvider>/<VendoOverlay> paste is not a step
-    it owes — printing it anyway ended those two runs with a paste nobody should
-    apply and a step count nobody could clear. The same rule doctor grades by
-    (doctor-wiring-checks.ts's `mountedUi`). */
-const mountsUi = (useCase: InitUseCase): boolean => useCase !== "agent-loop" && useCase !== "mcp";
 
 /** The run's FIRST question. Every path shares the same wired route, so a
     wrong pick costs nothing; the right one saves a docs round trip. --yes and
@@ -868,125 +599,36 @@ export async function captureDevBaseUrl(input: {
   return url;
 }
 
-/** The footer's stats. It never claims more than the run achieved: an
-    outstanding paste renders "1 paste left", never "agent live". */
-export function runStats(input: {
-  toolCount: number;
-  brandCaptured: boolean;
-  handSteps: number;
-  checkPassed: boolean;
-}): string {
+/** The footer's stats. It never claims more than the run achieved: the catalog
+    it read, the brand it captured, and that the wiring landed. */
+export function runStats(input: { toolCount: number; brandCaptured: boolean }): string {
   return [
     `${input.toolCount} tool${input.toolCount === 1 ? "" : "s"}`,
     ...(input.brandCaptured ? ["brand captured"] : []),
-    input.handSteps > 0
-      ? `${input.handSteps} paste${input.handSteps === 1 ? "" : "s"} left`
-      : input.checkPassed ? "agent live" : "wired",
+    "wired",
   ].join(" · ");
 }
 
-/** The `principal` the loop snippets hand the pack, as lines that COMPILE for
- *  the auth this composition wires. Both snippets used to name a bare
- *  `principal` that was declared nowhere, so a verbatim paste did not typecheck
- *  and the developer had to guess where a caller comes from.
- *
- *  A preset resolves it from the request — `principal` is not nullable and every
- *  preset's resolver returns `Principal | null`, so the refusal is part of the
- *  paste. Anonymous, it is the literal the scaffolded composition itself
- *  resolves, subject and all: the loop and the wire MUST resolve the same
- *  subject, or every app and approval made in chat is invisible to the embeds
- *  (0.4.1 E2E cert blocker B4). */
-function principalLines(preset: AuthPresetName | null): { imports: string[]; lines: string[] } {
-  if (preset === null) {
-    return {
-      imports: [],
-      lines: [`const principal = { kind: "user", subject: "demo-user" } as const; // the SAME subject your composition resolves`],
-    };
-  }
-  return {
-    imports: [`import { ${preset} } from ${JSON.stringify(AUTH_PRESET_SPECIFIER[preset])};`],
-    lines: [
-      `const principal = await ${preset}().principal(request);`,
-      `if (principal === null) return new Response("Unauthorized", { status: 401 });`,
-    ],
-  };
-}
-
-/** The agent file the Mastra snippet names. `<your-agent>.ts` was a placeholder
-    the reader had to translate; a host that already has agents under
-    src/mastra/agents can be told which file. First file wins (readdir is
-    sorted), and the placeholder stays when there is nothing to name. */
-async function mastraAgentFile(root: string, agents: string): Promise<string> {
-  const entries = await readdir(join(root, agents)).catch(() => [] as string[]);
-  return entries.filter((name) => /\.[cm]?[jt]sx?$/.test(name)).sort()[0] ?? "<your-agent>.ts";
-}
-
-/** Variant B — the user's own agent loop. Which snippet prints is read off
-    the same package.json init already parses (`ai` → AI SDK, `@mastra/core`
-    → Mastra); the generated route stays either way, because it is what
-    serves apps and approvals to the embeds. Mastra's principal step is a
-    step of its own, not a footnote: vendoMastraTools reads the principal off
-    the request context and a call without one fails closed. */
-async function agentLoopSteps(root: string, preset: AuthPresetName | null): Promise<ManualEdit[]> {
-  let dependencies: Record<string, unknown> = {};
+/** Does the host declare this package (either dependency block)? */
+async function dependsOn(root: string, name: string): Promise<boolean> {
   try {
     const manifest = JSON.parse((await readOptional(join(root, "package.json"))) ?? "{}") as {
       dependencies?: Record<string, string>;
       devDependencies?: Record<string, string>;
     };
-    dependencies = { ...manifest.dependencies, ...manifest.devDependencies };
+    return Object.hasOwn({ ...manifest.dependencies, ...manifest.devDependencies }, name);
   } catch {
-    // No readable manifest — neither snippet is honest, so print neither.
+    return false;
   }
-  // The `vendo` these snippets call is the SAME instance the wire route serves
-  // — the composition module init wrote. A second createVendo in the loop would
-  // share none of its state, so the import is part of the paste, not an
-  // exercise for the reader.
-  const agents = join("src", "mastra", "agents");
-  const caller = principalLines(preset);
-  // The chat route's own directory, off the SAME src-aware helper the scaffolds
-  // use: a host whose app router lives under src/ was told to edit app/api/chat,
-  // a path it does not have.
-  const chat = relative(root, join(await appDirectory(root), "api", "chat"));
-  if (Object.hasOwn(dependencies, "@mastra/core")) {
-    return [
-      {
-        file: join(agents, await mastraAgentFile(root, agents)),
-        lines: [
-          `import { vendoMastraTools } from "@vendoai/vendo/mastra";`,
-          `import { vendo } from ${JSON.stringify(await compositionSpecifier(root, join(root, agents)))};`,
-          `… then spread the pack: tools: async () => ({ ...yourTools, ...(await vendoMastraTools(vendo)) })`,
-        ],
-        why: "Your loop, your model — Vendo adds guarded vendo_* tools, vendo_make (inline micro-apps) and vendo_delegate. https://docs.vendo.run/existing-agent/mastra",
-      },
-      {
-        file: join(chat, "route.ts"),
-        lines: [
-          `import { VENDO_PRINCIPAL_KEY } from "@vendoai/vendo/mastra";`,
-          ...caller.imports,
-          `… then inside your POST handler, before the run:`,
-          ...caller.lines,
-          `requestContext.set(VENDO_PRINCIPAL_KEY, principal);`,
-        ],
-        why: "vendoMastraTools reads the principal off the request context — a call without one fails closed, so an install that skips this looks broken at the first tool call.",
-      },
-    ];
-  }
-  if (Object.hasOwn(dependencies, "ai")) {
-    return [{
-      file: join(chat, "route.ts"),
-      lines: [
-        `import { vendoTools } from "@vendoai/vendo/ai-sdk";`,
-        `import { vendo } from ${JSON.stringify(await compositionSpecifier(root, join(root, chat)))};`,
-        ...caller.imports,
-        `… then inside your POST handler:`,
-        ...caller.lines,
-        `… and inside streamText: tools: { ...yourTools, ...(await vendoTools(vendo, { principal })) }`,
-      ],
-      why: "Your loop, your model — Vendo adds guarded vendo_* tools, vendo_make (inline micro-apps) and vendo_delegate. https://docs.vendo.run/existing-agent/ai-sdk",
-    }];
-  }
-  return [];
+}
+
+/** The ONE page this install continues at. An agent-loop host is sent to the
+    page for the loop package it actually has — read off the same package.json
+    everything else here reads. */
+async function continueUrl(root: string, useCase: InitUseCase): Promise<string> {
+  return useCase === "agent-loop" && await dependsOn(root, "@mastra/core")
+    ? "https://docs.vendo.run/existing-agent/mastra"
+    : CONTINUE_URLS[useCase];
 }
 
 const POSTURE_OPTIONS: SelectOption[] = [
@@ -1001,8 +643,8 @@ const POSTURE_OPTIONS: SelectOption[] = [
 /** Variant C. Init asks two more questions here and then WRITES what it
  *  legitimately owns: it creates the composition file, so putting `mcp: true`
  *  and a serviceAuth key into a file it is authoring is not editing anyone's
- *  code. It never discovers posture and never reaches a broker — it prints
- *  environment lines for the operator, exactly as the console would.
+ *  code. It never discovers posture and never reaches a broker — the operator's
+ *  environment values live on the continue page.
  *
  *  The posture select only appears when the run holds a Cloud key: a keyless
  *  run cannot use a broker, so local is simply the default. */
@@ -1016,9 +658,13 @@ async function planMcpScaffold(input: {
   framework: Exclude<HostFramework, "unknown"> | "custom";
   authWired: AuthMatch | null;
   cloudKey: boolean;
+  models: ScaffoldModel | null;
+  /** The dev origin captured with the other up-front questions. The broker
+      refusal below is the only thing that still reads it: a Cloud-fronted door
+      cannot stand on an http origin. Null when the run could not ask. */
   baseUrl: string | null;
-}): Promise<ReturnType<typeof planMcp> | null> {
-  const { root, options, output, pretty, interactive, changes, framework, authWired, cloudKey, baseUrl } = input;
+}): Promise<{ modelWritten: ScaffoldPlan["modelWritten"]; serviceAuthUnwired: boolean } | null> {
+  const { root, options, output, pretty, interactive, changes, framework, authWired, cloudKey, models, baseUrl } = input;
   const ask = options.yes === true || !interactive;
 
   let posture: McpPosture = options.posture ?? "local";
@@ -1067,19 +713,10 @@ async function planMcpScaffold(input: {
     // — the file itself is the only remaining evidence.
     authAlreadyWired: authWired === null && await composedAuthPreset(composition) !== null,
     serverActions: (await requiredServerActions(root)).length > 0,
-    cloudKey,
     posture,
     serviceKey,
     ...(existingServiceKey === null ? {} : { existingServiceKey }),
-    // Resolved again here rather than reused: the `--byo` paste lands in
-    // .env.local during the cloud step, which runs after the plan was built.
-    models: scaffoldModel(root, options),
-    // Not optional: a null base URL is an ANSWER the plan reads, and it is
-    // what makes steps[] lead with the recoverable version of E-MCP-009's
-    // failure instead of assuming an origin. Set, it is the DEV origin — which
-    // is the right one for a client config and for doctor, both of which run
-    // against the app the developer is looking at.
-    baseUrl,
+    models,
   });
   if (mcp.blocked !== undefined) {
     // Nothing MCP was written and the reason says what to do about it. The
@@ -1120,96 +757,42 @@ async function planMcpScaffold(input: {
       await ensureEnvLocalIgnored(root, output);
     }
   }
-  // …and the models line only counts where the composition was actually
-  // written: a re-run against an existing one must not claim a line it left
-  // untouched, in a file it did not open.
-  return planned === undefined ? { ...mcp, modelWritten: null } : mcp;
+  return {
+    // The models line only counts where the composition was actually written: a
+    // re-run against an existing one must not claim a line it left untouched, in
+    // a file it did not open.
+    modelWritten: planned === undefined ? null : mcp.modelWritten,
+    // …and on that same re-run the key is in .env.local while `serviceAuth` is
+    // not in the composition. Init never rewrites a file it did not author, so
+    // that one line is the developer's — at the continue URL, not here.
+    serviceAuthUnwired: planned === undefined && mcp.serviceKeyValue !== undefined,
+  };
 }
-
-/** The install check — `vendo doctor`, reading what init just wrote. It only
- *  OFFERS itself when the run owes no hand step: doctor grades whether the
- *  <VendoProvider> paste landed, and the paste happens after init exits, so
- *  offering it on a run that still owes one would fail a run that did nothing
- *  wrong. Nothing here can change init's exit code. */
-async function offerDoctorCheck(input: {
-  root: string;
-  options: InitOptions;
-  output: Output;
-  pretty: PrettyOutput | null;
-  interactive: boolean;
-}): Promise<boolean> {
-  const { root, options, output, pretty, interactive } = input;
-  try {
-    if (options.check === false) return false;
-    if (options.check !== true) {
-      const confirm = options.confirmCheck
-        ?? (options.yes === true || !interactive || stdin.isTTY !== true
-          ? undefined
-          : (pretty === null ? askYesNo : pretty.confirm));
-      if (confirm === undefined) return false;
-      if (!(await confirm("Check the install now?", true))) return false;
-    }
-    pretty?.spin("vendo doctor — checking the install…");
-    const check = options.runCheck ?? (async (target: string) =>
-      (await runDoctor({ targetDir: target, output })) === 0);
-    const passed = await check(root);
-    pretty?.stopSpin();
-    output.log(passed
-      ? "Doctor passed — your install is wired"
-      : "Doctor did not pass — `npx vendo doctor` prints what is missing.");
-    return passed;
-  } catch {
-    // Best-effort by design: init already succeeded.
-    pretty?.stopSpin();
-    return false;
-  }
-}
-
-/** Whether the visible surface is already mounted in the host's own source —
-    drives the mount paste and the agent tail. Init never edits those files, so
-    there is no "wired by init" state: the only question is what is left for
-    the developer to paste. */
-type LayoutWiring =
-  /** A Vendo mount already exists — nothing to do or say. */
-  | { kind: "already" }
-  /** Nothing mounts Vendo yet — the printed paste is the step. */
-  | { kind: "manual" }
-  /** Express hosts keep their two printed wiring lines. */
-  | { kind: "express" }
-  /** Custom-runtime hosts (--framework custom): the generated module's two
-      printed wiring lines — route requests through it, mount the client. */
-  | { kind: "custom" };
 
 /** What one framework's composition branch contributes to the plan: the files
- *  init will create, the pastes it can only describe, and the auth facts the
- *  agent tail reports. */
+ *  init will create and the auth facts the run reports. */
 interface ScaffoldPlan {
   changes: PlannedChange[];
-  edits: ManualEdit[];
   authAdvice: string | null;
   authWired: AuthMatch | null;
   compositionPath: string | null;
-  layout: LayoutWiring;
   /** The provider and file of the `models` line this run wrote — the migration
       path off the removed ambient-key behaviour, and what the closing summary
-      reports. Null when no provider key resolved, or when the composition
-      already existed (init never edits a file it did not author). */
+      reports. Null when no provider line was written. */
   modelWritten: { provider: ScaffoldModel["provider"]; path: string } | null;
-  /** Re-render the composition this run authored with an explicit `models` line,
-      for a provider key that only arrives AFTER planning: the `--byo` paste lands
-      in .env.local during the cloud step, which runs after the plan is built but
-      before a single file is written. Returns the modelWritten to report. Null
-      when this run authored no composition. */
+  /** Write an explicit `models` line into the composition this run authored.
+      The models ANSWER is only settled by the cloud step, which runs after the
+      plan is built and before a single file is written, so the line can never be
+      resolved at plan time. Returns the modelWritten to report; null when this
+      run authored no composition. */
   rewriteModels: ((model: ScaffoldModel) => ScaffoldPlan["modelWritten"]) | null;
 }
 
-const emptyScaffold = (layout: LayoutWiring): ScaffoldPlan => ({
+const emptyScaffold = (): ScaffoldPlan => ({
   changes: [],
-  edits: [],
   authAdvice: null,
   authWired: null,
   compositionPath: null,
-  layout,
   modelWritten: null,
   rewriteModels: null,
 });
@@ -1220,7 +803,7 @@ async function planCustomComposition(
   confirmAuth?: ConfirmAuth,
   selectAuth?: SelectAuth,
 ): Promise<ScaffoldPlan> {
-  const scaffold = emptyScaffold({ kind: "custom" });
+  const scaffold = emptyScaffold();
   const wiring = await detectVendoWiring(root);
   if (!wiring.server || !wiring.client) {
     const typescript = await exists(join(root, "tsconfig.json"));
@@ -1248,7 +831,7 @@ async function planExpressComposition(
   confirmAuth?: ConfirmAuth,
   selectAuth?: SelectAuth,
 ): Promise<ScaffoldPlan> {
-  const scaffold = emptyScaffold({ kind: "express" });
+  const scaffold = emptyScaffold();
   const wiring = await detectVendoWiring(root);
   if (!wiring.server || !wiring.client) {
     const typescript = await exists(join(root, "tsconfig.json"));
@@ -1295,14 +878,8 @@ function planServerActionsMap(
     scaffold.changes.push({ absolute: actionsModule, path, before: null, after: actionsAfter, diff: diff(path, null, actionsAfter) });
     return;
   }
-  const missing = missingRegistrations(actionsBefore, registrations);
-  if (missing.length > 0) {
-    scaffold.edits.push({
-      file: path,
-      lines: missingRegistrationLines(root, dirname(actionsModule), actionsBefore, missing),
-      why: `${missing.length} action${missing.length === 1 ? "" : "s"} the host exposes ${missing.length === 1 ? "is" : "are"} not registered here — ${missing.length === 1 ? "it fails" : "each one fails"} closed at execution time (no work performed). The rest of the file is yours; nothing else needs to change.`,
-    });
-  }
+  // Missing entries are NOT init's to add: the map is the developer's file from
+  // creation on. Doctor grades the gap (E-WIRE-009) and its page carries the fix.
 }
 
 async function planNextComposition(
@@ -1311,7 +888,7 @@ async function planNextComposition(
   confirmAuth?: ConfirmAuth,
   selectAuth?: SelectAuth,
 ): Promise<ScaffoldPlan> {
-  const scaffold = emptyScaffold({ kind: "manual" });
+  const scaffold = emptyScaffold();
   const app = await appDirectory(root);
   const route = join(app, "api", "vendo", "[...vendo]", "route.ts");
   const libModule = await compositionModulePath(root);
@@ -1347,15 +924,13 @@ async function planNextComposition(
     const path = relative(root, composition);
     // Detect + confirm happens only on fresh composition creation.
     const auth = await resolveScaffoldAuth(root, path, options.auth, confirmAuth, selectAuth);
-    const models = scaffoldModel(root, options);
     const render = (model: ScaffoldModel | null): string =>
       compositionModuleSource({ serverActions: registrations.length > 0, auth: auth.wired, models: model });
-    const change = { absolute: composition, path, before: null, after: render(models), diff: diff(path, null, render(models)) };
+    const change = { absolute: composition, path, before: null, after: render(null), diff: diff(path, null, render(null)) };
     scaffold.changes.push(change);
     scaffold.authAdvice = auth.advice;
     scaffold.authWired = auth.wired;
     scaffold.compositionPath = path;
-    if (models !== null) scaffold.modelWritten = { provider: models.provider, path };
     // Same renderer, same arguments, one late model — never a second way to
     // write this line. The change object is still unwritten at this point.
     scaffold.rewriteModels = (model) => {
@@ -1363,41 +938,20 @@ async function planNextComposition(
       change.diff = diff(path, null, change.after);
       return { provider: model.provider, path };
     };
-  } else if (registrations.length > 0) {
-    // The composition already exists but server actions appeared since it was
-    // generated: name the wiring the existing createVendo is missing, so
-    // server-action execution stops failing closed (ENG-248).
-    const edit = routeServerActionsEdit(compositionBefore, relative(root, composition));
-    if (edit !== null) scaffold.edits.push(edit);
   }
-
-  // Init never writes a client file, so the only question is whether the host
-  // already mounts one. A host source that mounts the provider IS the mount.
-  const mounts = await detectVendoWiring(root);
-  if (mounts.client) scaffold.layout = { kind: "already" };
   return scaffold;
 }
 
-async function buildPlan(options: InitOptions, mountedUi: boolean, confirmAuth?: ConfirmAuth, selectAuth?: SelectAuth): Promise<{
+async function buildPlan(options: InitOptions, confirmAuth?: ConfirmAuth, selectAuth?: SelectAuth): Promise<{
   plan: InitPlan;
   changes: PlannedChange[];
-  manualSteps: string[];
-  /** The mount paste as data; null when a surface is already mounted or the
-      host is Express/custom (their lines ride `manualSteps`). */
-  mount: ManualEdit | null;
-  /** Changes to files that already exist, which init therefore leaves alone. */
-  edits: ManualEdit[];
   authAdvice: string | null;
-  /** What the fresh composition wired (agent-tail fact); null when no
-      composition was created this run OR it stayed anonymous. */
+  /** What the fresh composition wired; null when no composition was created
+      this run OR it stayed anonymous. */
   authWired: AuthMatch | null;
   /** Relative path of the composition created THIS run; null otherwise. */
   compositionPath: string | null;
-  /** How the visible surface reached (or didn't reach) the layout. */
-  layout: LayoutWiring;
-  /** The `models` line this run wrote, and where (ScaffoldPlan.modelWritten). */
-  modelWritten: ScaffoldPlan["modelWritten"];
-  /** See ScaffoldPlan.rewriteModels — the `--byo` paste arrives after this plan. */
+  /** See ScaffoldPlan.rewriteModels — the models answer arrives after this plan. */
   rewriteModels: ScaffoldPlan["rewriteModels"];
 }> {
   const root = resolve(options.targetDir);
@@ -1409,7 +963,7 @@ async function buildPlan(options: InitOptions, mountedUi: boolean, confirmAuth?:
     : framework === "express"
       ? await planExpressComposition(root, options, confirmAuth, selectAuth)
       : await planNextComposition(root, options, confirmAuth, selectAuth);
-  const { changes, edits, authAdvice, authWired, compositionPath, layout, modelWritten, rewriteModels } = scaffold;
+  const { changes, authAdvice, authWired, compositionPath, rewriteModels } = scaffold;
 
   const packageJson = join(root, "package.json");
   const packageBefore = await readOptional(packageJson);
@@ -1445,13 +999,9 @@ async function buildPlan(options: InitOptions, mountedUi: boolean, confirmAuth?:
         : before === null
           ? NEXT_CONFIG_SCAFFOLD
           : nextConfigWithExternals(before, missing);
-      if (after === null) {
-        edits.push({
-          file: path,
-          lines: [`… add inside the config object: ${NEXT_SERVER_EXTERNALS_LINE}`],
-          why: conflicting.length === 0 ? NEXT_EXTERNALS_WHY : `${transpileConflictNote(conflicting)} ${NEXT_EXTERNALS_WHY}`,
-        });
-      } else changes.push({ absolute, path, before, after, diff: diff(path, before, after) });
+      // A config init cannot safely edit is left alone and graded by doctor
+      // (E-CFG-004, whose page carries the line and the transpile caveat).
+      if (after !== null) changes.push({ absolute, path, before, after, diff: diff(path, before, after) });
     }
   }
   // Agent surface: a host that already uses skills (.claude/ exists) gets the
@@ -1480,24 +1030,7 @@ async function buildPlan(options: InitOptions, mountedUi: boolean, confirmAuth?:
     ".vendo/fonts.css",
     ".vendo/data/.gitignore",
   ];
-  const mount = await mountStep(root, layout, mountedUi);
-  const manualSteps = [
-    ...await manualWiringLines(root, layout, mountedUi),
-    ...edits.flatMap(editLines),
-  ];
-  return {
-    changes,
-    edits,
-    manualSteps,
-    mount,
-    authAdvice,
-    authWired,
-    compositionPath,
-    layout,
-    modelWritten,
-    rewriteModels,
-    plan: { framework, writes },
-  };
+  return { changes, authAdvice, authWired, compositionPath, rewriteModels, plan: { framework, writes } };
 }
 
 async function writeIfMissing(path: string, content: string, force: boolean): Promise<void> {
@@ -1566,10 +1099,14 @@ function applyThemeAnswers(
 }
 
 /** Theme finalization (Task 4): merge whatever the AI pass filled — if
- *  consent was declined or unavailable, `themeDraft` is simply null
- *  and the exact-only summary stands — then --theme answers (a human
- *  "(you)" wins over a model value), the one-glance palette print, and
- *  finally the uncertain-slot review. */
+ *  consent was declined or unavailable, `themeDraft` is simply null and the
+ *  exact-only summary stands — then --theme answers (a human "(you)" wins over
+ *  a model value), and the one-glance palette print.
+ *
+ *  It asks NOTHING. This ran after the long AI pass, which is exactly when the
+ *  person who started the install has walked away, so a slot the model was
+ *  unsure of keeps what was extracted and the run REPORTS the slot instead
+ *  (`InitFacts.keptUncertain`). Returns those slot names. */
 async function finalizeTheme(input: {
   root: string;
   themeSummary: ThemeSummary;
@@ -1577,25 +1114,13 @@ async function finalizeTheme(input: {
   themePath: string;
   options: InitOptions;
   output: Output;
-  pretty: PrettyOutput | null;
-}): Promise<void> {
-  const { root, themeSummary, themeDraft, themePath, options, pretty, output } = input;
+}): Promise<string[]> {
+  const { root, themeSummary, themeDraft, themePath, options, output } = input;
   const summary = themeDraft === null ? themeSummary : applyThemeDraft(themeSummary, themeDraft);
-  // --theme answers land first; the review prompt then covers only the
-  // uncertain slots the flags left unanswered (non-interactive runs keep
-  // the extracted/merged values for those, exactly as before).
   const answers: Record<string, string> = { ...(options.themeAnswers ?? {}) };
-  const unanswered = summary.uncertain.filter((entry) => !Object.hasOwn(answers, entry.slot));
-  if (unanswered.length > 0 && options.yes !== true) {
-    const review = options.themeReview
-      ?? (pretty === null ? defaultThemeReview : prettyThemeReview(pretty));
-    const reviewed = await review(
-      unanswered.length === summary.uncertain.length ? summary : { ...summary, uncertain: unanswered },
-    );
-    for (const [slot, raw] of Object.entries(reviewed)) {
-      if (!Object.hasOwn(answers, slot)) answers[slot] = raw;
-    }
-  }
+  const kept = summary.uncertain
+    .filter((entry) => !Object.hasOwn(answers, entry.slot))
+    .map((entry) => entry.slot);
   if (Object.keys(answers).length > 0) applyThemeAnswers(summary, answers, output);
   const document = toVendoTheme(summary.slots);
   // A model fill or a --theme answer can replace the family AFTER the flow
@@ -1612,68 +1137,7 @@ async function finalizeTheme(input: {
   applyThemeFonts(document, fonts);
   await writeText(themePath, `${JSON.stringify(document, null, 2)}\n`);
   printThemeSummary(summary, output);
-}
-
-/** Done — the pastes init cannot take (it only ever CREATES files in your
- *  source tree), then their own dev server. They get their own framed block
- *  because skipping them is the whole failure mode: a green install nobody
- *  can see, or server-action tools that silently fail closed. */
-function printClosingSteps(input: {
-  output: Output;
-  handSteps: ManualEdit[];
-  manualSteps: string[];
-  credential: DevCredential;
-  cloud: { keyValid: boolean };
-  compositionPath: string | null;
-}): void {
-  const { output, handSteps, manualSteps, credential, cloud, compositionPath } = input;
-  if (handSteps.length > 0) {
-    const rule = "─".repeat(64);
-    output.log(`\n${rule}`);
-    output.log(handSteps.length === 1
-      ? "ONE STEP LEFT — paste this yourself (init never edits your files)"
-      : `${handSteps.length} STEPS LEFT — paste these yourself (init never edits your files)`);
-    for (const step of handSteps) {
-      output.log(`\n  File: ${step.file}`);
-      for (const line of step.lines) output.log(`    ${line}`);
-      output.log(`\n  ${step.why}`);
-    }
-    // No `Then confirm it landed: npx vendo doctor` here: the ending below
-    // already names doctor, six lines down, and saying it twice is the
-    // duplication the redesign set out to remove (#1164).
-    output.log(rule);
-  }
-  // Express and custom hosts have no single host file to name, so their
-  // wiring keeps the compact list; the block above already said everything
-  // a Next host needs, and nothing is printed twice.
-  if (handSteps.length === 0 && manualSteps.length > 0) {
-    output.log("\nLast steps are yours:");
-    for (const line of manualSteps) output.log(`  ${line}`);
-  }
-  // A run without a USABLE model credential is wired but not answering, so
-  // the closing line must not claim otherwise. The rung alone is not that
-  // answer: resolveDevCredential only checks that VENDO_API_KEY is non-blank
-  // (and VENDO_DEV_CREDENTIAL=vendo-cloud pins the rung with no key at all),
-  // so a malformed key resolves "vendo-cloud" while the cloud step — the one
-  // thing that inspected the key — already said it is not usable. Keyless,
-  // the composition decides: one written THIS run passes no model, so "no
-  // key" is the whole story, while one init did not write may pass its own
-  // `model` to createVendo — nothing here can see that, so state the
-  // condition rather than guess either way.
-  // …and it only gets to speak at all once nothing is outstanding: a paste
-  // still pending means the frame above just said Vendo is invisible until
-  // it lands, so "the agent is live in your app" would contradict it in the
-  // same breath (self-serve audit F5).
-  const modelReady = credential.rung === "env-key"
-    || (credential.rung === "vendo-cloud" && cloud.keyValid);
-  if (handSteps.length === 0) {
-    output.log(`\nThen start your dev server — ${modelReady
-      ? "the agent is live in your app."
-      : compositionPath !== null
-        ? "the agent is live once you add a model key."
-        : "no model key resolved here, so the agent is live only if your composition passes its own model."}`);
-  }
-  output.log(`${handSteps.length === 0 ? "" : "\n"}Verify everything: \`npx vendo doctor\`.`);
+  return kept;
 }
 
 /** An undetectable framework has NO safe default: a non-interactive run
@@ -1774,7 +1238,7 @@ async function guardNonInteractive(input: {
     root,
     options,
     framework: await resolveFramework(root, options),
-    modelKey: cloudKey || scaffoldModel(root, options) !== null,
+    modelKey: cloudKey || providerKey(root, options) !== null,
     cloudKey,
     devPort: await devPort(root),
   });
@@ -1860,28 +1324,34 @@ function credentialEnv(root: string, env: Record<string, string | undefined>): R
   return effective;
 }
 
-/** The provider key a scaffold written THIS run should name in `models`, or
- *  null when the host has no provider key at all. A Cloud key is not one: its
- *  models resolve through the gateway's own family names, so nothing is written.
- *
- *  This sweeps ENV_KEY_VARS directly instead of asking `resolveDevCredential`.
- *  "Which provider key is lying around for me to write an explicit selection
- *  for?" is a DIFFERENT question from "what selects the model at runtime?", and
- *  since the selection law a bare provider key answers the second one with
- *  nothing — so routing this through the runtime ladder silently returned null
- *  for every real host and wrote no line at all. That is backwards: the ambient
- *  key is exactly the signal that this host needs the explicit selection, since
- *  it is the host whose boot the law just broke. The ladder's own env-key rung
- *  is reachable only through the internal VENDO_DEV_CREDENTIAL pin, which no
- *  host running `vendo init` sets.
- *
- *  Resolved here, at scaffold time, because the file is authored before the
- *  interactive credential step runs — detection is pure and read-only, so
- *  asking twice costs nothing. */
-function scaffoldModel(root: string, options: InitOptions): ScaffoldModel | null {
+/** Is a provider key in this host's environment? The models QUESTION reads this
+    to know whether it still has to be asked; the wiring below does not. */
+function providerKey(root: string, options: InitOptions): ScaffoldModel | null {
   const env = credentialEnv(root, options.env ?? process.env);
   const found = ENV_KEY_VARS.find((entry) => (env[entry.envVar] ?? "").trim() !== "");
   return found === undefined ? null : { provider: found.provider, envVar: found.envVar };
+}
+
+/**
+ * What the composition's `models` line should say — decided by the models
+ * ANSWER, never by what happens to be in the environment.
+ *
+ * Vendo Cloud (a usable key in hand) → null. The runtime ladder resolves the
+ * model from `VENDO_API_KEY` on its own (harnesses/src/inference/resolve.ts),
+ * so writing `anthropic("claude-sonnet-4-6")` here would override the answer the
+ * user just gave with whatever key was lying around in their shell — and the
+ * comment beside it would name a key the wiring does not read.
+ *
+ * Own key → the provider key it found, written as the explicit selection. Since
+ * the selection law an ambient key selects nothing by itself, so that line is
+ * exactly what this host needs.
+ *
+ * Called AFTER the cloud step, which is when the answer exists at all — and by
+ * then a key pasted during it is already in .env.local, which `credentialEnv`
+ * reads.
+ */
+function wiredModel(root: string, options: InitOptions, cloudKeyValid: boolean): ScaffoldModel | null {
+  return cloudKeyValid ? null : providerKey(root, options);
 }
 
 /** Key first (product order fix): the model-credential story — env keys,
@@ -1973,8 +1443,10 @@ async function wireAndScaffold(input: {
   changes: PlannedChange[];
   force: boolean;
   useCase: InitUseCase;
+  /** The env var the composition's `models` wiring reads (see `wiredModel`). */
+  modelKey: string | null;
 }): Promise<number> {
-  const { root, changes, force, useCase } = input;
+  const { root, changes, force, useCase, modelKey } = input;
   const wiringStarted = Date.now();
   for (const change of changes) {
     await writeText(change.absolute, change.after);
@@ -1982,9 +1454,10 @@ async function wireAndScaffold(input: {
 
   await ensureVendoEnvExample(root);
   await mkdir(join(root, ".vendo"), { recursive: true });
-  // Not writeIfMissing: this is THE answer this run resolved, and doctor reads
-  // it to know which checks a mounted-UI-less install can never pass.
-  await writeUseCase(root, useCase);
+  // Not writeIfMissing: these are THE answers this run resolved, and doctor
+  // reads them to know which checks a mounted-UI-less install can never pass and
+  // which model key this host's own wiring consults.
+  await writeInstallRecord(root, { useCase, modelKey });
   await writeIfMissing(
     join(root, ".vendo", "overrides.json"),
     `${JSON.stringify({
@@ -2027,13 +1500,16 @@ async function runInstallSyncFlow(input: {
   output: Output;
   options: InitOptions;
   pretty: PrettyOutput | null;
+  /** The judgment answer init settled during its question phase (null when
+      there was nothing to ask). Passing it is what keeps the flow silent. */
+  consent: { ai: boolean; engine?: string } | null;
 }): Promise<SyncFlowResult> {
-  const { root, output, options, pretty } = input;
+  const { root, output, options, pretty, consent } = input;
   // `--extract` is the test seam onto the flow's judgment step, in init's own
   // flat spelling; where it overlaps a real flag, the seam wins.
   const extract = options.extract ?? {};
-  const ai = extract.ai ?? options.ai;
-  const engine = extract.engine ?? options.engine;
+  const ai = extract.ai ?? options.ai ?? consent?.ai;
+  const engine = extract.engine ?? options.engine ?? consent?.engine;
   return runSyncFlow({
     root,
     output,
@@ -2054,8 +1530,13 @@ async function runInstallSyncFlow(input: {
     // receipt's checklist (runInit's judgment line says so out loud).
     ...(options.agent === true && ai === undefined ? { ai: true } : {}),
     // --ai IS the consent (no prompt, non-interactive runs stop skipping);
-    // --no-ai is the refusal. No flag = ask, every interactive run.
+    // --no-ai is the refusal. With no flag, `consent` above carries the answer
+    // init already collected up front, so the flow never asks either way.
     ...(ai === undefined ? {} : { ai }),
+    // A loosening is never applied without a human, and init stopped asking
+    // once its questions were done — so they queue as pending and the closing
+    // facts report the count.
+    queueLoosenings: true,
     ...(options.force === true ? { force: true } : {}),
     ...(engine === undefined ? {} : { engine }),
     // The questions AND the spinner, in the one spelling sync uses: passing
@@ -2077,8 +1558,6 @@ async function ensureHostDeps(input: {
   root: string;
   output: Output;
   options: InitOptions;
-  pretty: PrettyOutput | null;
-  interactive: boolean;
   credential: DevCredential;
   /** The provider whose import this run wrote into the composition, if any. */
   wrote: ScaffoldModel["provider"] | undefined;
@@ -2086,7 +1565,7 @@ async function ensureHostDeps(input: {
       of the host's package.json (see ensureGeneratedImports). */
   generated: readonly string[];
 }): Promise<void> {
-  const { root, output, options, pretty, interactive, credential, wrote, generated } = input;
+  const { root, output, options, credential, wrote, generated } = input;
   // Every package those generated files import has to be a declared dependency
   // of the host, or the app cannot compile what init just wrote. First, so the
   // declaration is in place before the resolvability repair below asks about it.
@@ -2125,134 +1604,153 @@ async function ensureHostDeps(input: {
   // FINDINGS F2 (skateshop): a host pinning zod < 3.25 builds red once the
   // wiring pulls ai@6 into the bundle (ai imports the zod/v3 + zod/v4
   // subpaths that arrive in 3.25, and the host's own pin wins the installed
-  // tree). Ask-and-bump with the auth confirm's interactivity posture:
-  // --yes performs the announced bump, non-interactive prints the command.
+  // tree). It does not ASK — this runs minutes past the question phase, where
+  // the person who started the install has walked away — so `--yes` performs
+  // the announced bump and every other run states the problem and the command
+  // (doctor grades the gap as E-DEP-003).
   await ensureZodFloor({
     root,
     output,
     ...(options.yes === true ? { yes: true } : {}),
-    ...(options.yes === true || !interactive
-      ? {}
-      : { confirm: options.confirmZodBump ?? (pretty === null ? askYesNo : pretty.confirm) }),
     ...(options.installZod === undefined ? {} : { run: options.installZod }),
   });
 }
 
-/** The run's ending, as its own phase — the same reason wireAndScaffold and
- *  resolveModelCredential are their own functions. The last question, then
- *  everything still the user's to paste, then the doctor check on the runs that
- *  owe nothing, and finally the stats the footer carries. Returns those stats;
- *  it never decides the exit code. */
-async function finishRun(input: {
+/** The LAST of the up-front questions: may a coding agent read this codebase,
+ *  and where several could, which one. It used to be asked INSIDE the flow, at
+ *  the top of the pass that then runs for minutes — well past the point the
+ *  person who started the install had walked away. It is knowable before any of
+ *  that (the engine ladder is a read-only probe of this machine), so init asks
+ *  it here and hands the flow a settled answer.
+ *
+ *  Null means there is nothing to ask, and the flow keeps its own silent
+ *  handling: `--ai`/`--no-ai` and agent mode already answered, `--yes` takes the
+ *  defaults, a run that cannot ask cannot ask, and a machine with no engine at
+ *  all has no question to put.
+ *
+ *  The posture is the JUDGMENT step's own — a real TTY that no package script
+ *  drives — and deliberately not init's run-wide `interactive`: spending money
+ *  on a model is not a question a programmatic caller may be assumed to have
+ *  answered, and this is also the gate that keeps the engine ladder (a
+ *  subprocess probe of this machine) off every run that would never ask. */
+async function askJudgmentUpFront(input: {
+  root: string;
+  env: Record<string, string | undefined>;
+  options: InitOptions;
+  pretty: PrettyOutput | null;
+}): Promise<{ ai: boolean; engine?: string } | null> {
+  const { root, options, pretty } = input;
+  const seam = options.extract ?? {};
+  const attended = seam.interactive
+    ?? (!invokedByPackageScript() && Boolean(stdin.isTTY) && Boolean(stdout.isTTY));
+  if (!attended || options.agent === true || options.yes === true) return null;
+  if ((seam.ai ?? options.ai) !== undefined) return null;
+  return await resolveJudgmentConsent({
+    root,
+    env: await readEnvFiles(root, input.env),
+    ...(options.engine === undefined ? {} : { engine: options.engine }),
+    ...(seam.harnesses === undefined ? {} : { harnesses: seam.harnesses }),
+    // Renderer first, seams last: a stubbed prompt always wins.
+    ...(pretty === null ? {} : { choose: pretty.select, confirm: pretty.confirm }),
+    ...(seam.choose === undefined ? {} : { choose: seam.choose }),
+    ...(seam.confirm === undefined ? {} : { confirm: seam.confirm }),
+  });
+}
+
+/** The key the install RECORDS as the one its wiring reads — only ever what
+ *  THIS run wired. A composition init did not author is the authority on
+ *  itself, and doctor reads that file's own `models` line, so a run that wired
+ *  nothing new keeps whatever answer an earlier one established. */
+async function recordedModelKey(input: {
+  root: string;
+  models: ScaffoldModel | null;
+  landed: ScaffoldPlan["modelWritten"];
+  cloudKeyValid: boolean;
+  authoredComposition: boolean;
+}): Promise<string | null> {
+  if (input.landed !== null && input.models !== null) return input.models.envVar;
+  if (input.cloudKeyValid && input.authoredComposition) return "VENDO_API_KEY";
+  return await readModelKey(input.root) ?? null;
+}
+
+/** The run's LAST words, in both modes: what it wired, what it detected, the
+ *  guard posture it left, and the ONE page that carries the instructions —
+ *  as prose, or as the `--agent` receipt over the same object. No run prints
+ *  both, and neither shape carries a step, a snippet or a command. */
+async function emitEnding(input: {
   root: string;
   options: InitOptions;
   output: Output;
-  pretty: PrettyOutput | null;
-  interactive: boolean;
   useCase: InitUseCase;
-  mcp: ReturnType<typeof planMcp> | null;
-  mount: ManualEdit | null;
-  edits: ManualEdit[];
-  manualSteps: string[];
-  credential: DevCredential;
-  cloud: { keyValid: boolean };
-  compositionPath: string | null;
   framework: Exclude<HostFramework, "unknown"> | "custom";
-  authWired: AuthMatch | null;
-  layout: LayoutWiring;
-  toolCount: number;
-  brandCaptured: boolean;
-  /** Receipt-only (--agent): the install's files, and the risk ladder read off
-      the catalog this run synced. Empty on every other run. */
   wrote: string[];
-  risks: RiskRecommendation[];
-  /** Did the judgment pass actually run this run? The receipt reports `graded`
-      when it did, and hands back the REQUIRED checklist when it did not. */
+  keptUncertain: string[];
+  pendingLoosenings: number;
+  serviceAuthUnwired: boolean;
   judged: boolean;
-}): Promise<string> {
-  const {
-    root, options, output, pretty, interactive, useCase, mcp, mount, edits, manualSteps,
-    credential, cloud, compositionPath, framework, authWired, layout, toolCount, brandCaptured,
-    wrote, risks, judged,
-  } = input;
-
-  // Where does this app run in dev? — every path but MCP, which needed the
-  // answer before it wrote. The answer lands in .env.local inside, so there is
-  // nothing to read back here.
-  if (useCase !== "mcp") await captureDevBaseUrl({ root, options, output, pretty });
-
-  // Variant B: the wired route stays (it serves apps and approvals to the
-  // embeds) — what is added is the one snippet for their own loop, written for
-  // the auth this composition wires. A re-run over an existing composition never
-  // re-decides auth, so the file itself is the only evidence left (the same read
-  // the MCP arm makes).
-  const loopPreset = authWired?.preset
-    ?? (useCase === "agent-loop" ? await composedAuthPreset(await compositionModulePath(root)) : null);
-  const handSteps = [
-    ...(mount === null ? [] : [mount]),
-    ...edits,
-    ...(useCase === "agent-loop" ? await agentLoopSteps(root, loopPreset) : []),
-  ];
-  printClosingSteps({ output, handSteps, manualSteps, credential, cloud, compositionPath });
-  if (mcp !== null) {
-    // A step is `headline\ndetail`: the pretty block numbers and indents it,
-    // and a plain transcript keeps the detail on its own indented line.
-    if (pretty === null) {
-      for (const line of mcp.steps) output.log(`  ${line.replace(/\n/g, "\n    ")}`);
-    } else pretty.block("Steps that are yours", mcpStepLines(mcp), "◇");
-  }
-
-  // The check offers itself ONLY when nothing is left to paste: doctor
-  // grades the paste, and the paste happens after init exits.
-  const checkPassed = handSteps.length === 0
-    && await offerDoctorCheck({ root, options, output, pretty, interactive });
-
-  // The receipt: agent mode's LAST line, and the whole of its ending. Same
-  // facts as the prose tail below, shaped so the caller can act on them without
-  // parsing sentences.
+}): Promise<void> {
+  const { root, options, output, useCase, framework, wrote, keptUncertain, pendingLoosenings } = input;
+  const auth = await detectAuthPreset(root);
+  const facts: InitFacts = {
+    wrote,
+    detected: {
+      framework: FRAMEWORK_NAMES[framework],
+      auth: auth.matches.length === 0
+        ? "no auth detected"
+        : auth.matches.map((match) => AUTH_FAMILY_INFO[match.preset].name).join(" / "),
+      packageManager: await detectPackageManager(root),
+      port: await devPort(root),
+    },
+    guardPosture: GUARD_POSTURE,
+    continueUrl: await continueUrl(root, useCase),
+    keptUncertain,
+    pendingLoosenings,
+  };
   if (options.agent === true) {
     output.log(JSON.stringify({
       status: "written",
       root,
       useCase,
-      wrote,
-      pasteEdits: handSteps,
-      tools: toolCount,
-      riskRecommendations: risks,
-      judgment: judged
+      ...facts,
+      ...(input.serviceAuthUnwired ? { serviceAuthUnwired: true } : {}),
+      judgment: input.judged
         ? { status: "graded", file: join(".vendo", "judgments.json") }
         : { status: "delegated", checklist: JUDGMENT_CHECKLIST },
     } satisfies InitReceipt, null, 2));
-    return runStats({ toolCount, brandCaptured, handSteps: handSteps.length, checkPassed });
+    return;
   }
+  const { framework: name, auth: family, packageManager, port } = facts.detected;
+  output.log(`\nWired: ${facts.wrote.join(", ")}`);
+  output.log(`Detected: ${name} · ${family} · ${packageManager} · port ${port}`);
+  output.log(`Guard: ${facts.guardPosture}`);
+  if (facts.keptUncertain.length > 0) {
+    output.log(`Kept as extracted (uncertain): ${facts.keptUncertain.join(", ")}`);
+  }
+  if (facts.pendingLoosenings > 0) {
+    output.log(`Pending review: ${facts.pendingLoosenings} loosening proposal${facts.pendingLoosenings === 1 ? "" : "s"} held, none applied — \`vendo sync --review\``);
+  }
+  output.log(`Continue: ${facts.continueUrl}`);
+}
 
-  // Agent tail (agent-install-dx): the --yes-or-non-TTY path is agent-driven
-  // — the run's FINAL block is the repo-specific pointers an agent parses.
-  // Interactive human runs keep the clack-style output untouched.
-  if (options.yes === true || !interactive) {
-    output.log("\nAgent tail:");
-    const tail = await agentTailLines({ root, framework, compositionPath, authWired, layout, edits, mountedUi: mountsUi(useCase), cloudKeyMissing: credential.rung === "none" });
-    for (const line of tail) output.log(`  ${line}`);
+/** #478 + FINDINGS F3 — the end-of-run summary warns on an `ai` outside the
+ *  peer contract instead of waiting for doctor's E-DEP-001. The contract admits
+ *  both live majors (6 and 7), so only the two edges warn: npm installs a peer
+ *  conflict without failing, and the re-read only sees a pre-v6 copy when
+ *  ensureProviderDeps could not install over the hoisted one. */
+async function warnOffContractAi(root: string, output: Output): Promise<void> {
+  const aiVersion = await installedAiVersion(root);
+  if (aiVersion !== null && Number.parseInt(aiVersion, 10) >= 8) {
+    output.error(`warning: installed ai@${aiVersion} is a major Vendo has never been run against — Vendo speaks ai@6 and ai@7; pin one (npm install ai@^7 @ai-sdk/anthropic@^4 @ai-sdk/react@^4) or track github.com/runvendo/vendo/issues/478`);
+  } else if (aiVersion !== null && aiBelowPeerFloor(aiVersion)) {
+    output.error(`warning: installed ai@${aiVersion} predates the ai@6 peer contract — every turn fails at runtime until the app resolves its own ai@6 (E-DEP-001).`);
   }
-  // The run's LAST word is the outstanding paste (self-serve audit F5: the
-  // one step that matters used to scroll off-screen). The frame itself stays
-  // up-screen — the agent tail's "the lines above" pointers depend on that
-  // order — so the closer is a one-line echo of it, not a second copy. A human
-  // terminal has the paste block six lines up and legible, and gets the count
-  // in the footer instead.
-  if (handSteps.length > 0 && pretty === null) {
-    output.log(handSteps.length === 1
-      ? `\n→ Don't forget the paste in ${handSteps[0]!.file} (frame above)`
-      : `\n→ Don't forget the ${handSteps.length} pastes above (frame above)`);
-  }
-  return runStats({ toolCount, brandCaptured, handSteps: handSteps.length, checkPassed });
 }
 
 export async function runInit(input: InitOptions): Promise<number> {
   // Agent mode answers every MECHANICAL question the way `--yes` does — the
-  // base URL, the zod floor, the theme slots, the live check — so they land in
-  // the diff instead of in someone's chat. Only what a person must decide is
-  // relayed, and that happens before anything here writes.
+  // base URL, the zod floor, the theme slots — so they land in the diff instead
+  // of in someone's chat. Only what a person must decide is relayed, and that
+  // happens before anything here writes.
   const options: InitOptions = input.agent === true ? { ...input, yes: true } : input;
   // The clack-style renderer rides the SAME Output seam: it restyles the
   // exact plain messages below, and is selected only for a human terminal
@@ -2269,21 +1767,7 @@ export async function runInit(input: InitOptions): Promise<number> {
 
   /** A plan failure the HOST must fix (a manifest npm itself would refuse)
       exits with the CLI's normal one-line error instead of a raw stack. */
-  /** #478 + FINDINGS F3 — the end-of-run summary warns on an `ai` outside the
- *  peer contract instead of waiting for doctor's E-DEP-001. The contract admits
- *  both live majors (6 and 7), so only the two edges warn: npm installs a peer
- *  conflict without failing, and the re-read only sees a pre-v6 copy when
- *  ensureProviderDeps could not install over the hoisted one. */
-async function warnOffContractAi(root: string, output: Output): Promise<void> {
-  const aiVersion = await installedAiVersion(root);
-  if (aiVersion !== null && Number.parseInt(aiVersion, 10) >= 8) {
-    output.error(`warning: installed ai@${aiVersion} is a major Vendo has never been run against — Vendo speaks ai@6 and ai@7; pin one (npm install ai@^7 @ai-sdk/anthropic@^4 @ai-sdk/react@^4) or track github.com/runvendo/vendo/issues/478`);
-  } else if (aiVersion !== null && aiBelowPeerFloor(aiVersion)) {
-    output.error(`warning: installed ai@${aiVersion} predates the ai@6 peer contract — every turn fails at runtime until the app resolves its own ai@6 (E-DEP-001).`);
-  }
-}
-
-const explainedPlanFailure = (error: unknown): boolean => {
+  const explainedPlanFailure = (error: unknown): boolean => {
     if (isVendoError(error) && error.code === "validation") {
       output.error(`vendo init: ${error.message}`);
       return true;
@@ -2324,7 +1808,7 @@ const explainedPlanFailure = (error: unknown): boolean => {
       root,
       options,
       framework: await resolveFramework(root, options),
-      modelKey: cloudKey || scaffoldModel(root, options) !== null,
+      modelKey: cloudKey || providerKey(root, options) !== null,
       cloudKey,
       devPort: await devPort(root),
       // Only when the use case is still open — the scan costs a source walk, and
@@ -2350,9 +1834,9 @@ const explainedPlanFailure = (error: unknown): boolean => {
     ? undefined
     : (options.selectAuth ?? (pretty === null ? plainSelect : pretty.select));
   const detectStarted = Date.now();
-  const built = await buildPlanOrExplained(options, mountsUi(useCase), confirmAuth, selectAuth);
+  const built = await buildPlanOrExplained(options, confirmAuth, selectAuth);
   if (built === null) return 1;
-  const { plan, changes, edits, manualSteps, mount, authAdvice, authWired, compositionPath, layout, modelWritten, rewriteModels } = built;
+  const { plan, changes, authAdvice, authWired, compositionPath, rewriteModels } = built;
   const detectMs = Date.now() - detectStarted;
   let telemetry = telemetryFor(options, output, root);
   await telemetry.track("init_started", { framework: plan.framework });
@@ -2375,36 +1859,45 @@ const explainedPlanFailure = (error: unknown): boolean => {
       telemetry = telemetryFor(options, output, root);
     }
 
-    // The MCP door derives every discovery URL from VENDO_BASE_URL and both
-    // extra answers change the composition's own source, so that path needs
-    // all three BEFORE it writes. Every other path asks the URL at the end,
-    // where it is one Enter.
-    let mcp: ReturnType<typeof planMcp> | null = null;
+    // "Where does this app run in dev?" — asked HERE on every path, with the
+    // rest of the questions. The MCP arm reads the answer back (a broker door
+    // refuses a non-https origin). It used to be asked at the very end, minutes past
+    // the AI pass, by which point the person who started the install had walked
+    // away; the MCP arm always needed it up here anyway, since the door derives
+    // every discovery URL from it. The MCP arm's own two questions follow, and
+    // then nothing in this run prompts again.
+    const baseUrl = await captureDevBaseUrl({ root, options, output, pretty });
+
+    const consent = await askJudgmentUpFront({ root, env, options, pretty });
+
+    // The models ANSWER, now that the cloud step has settled it: a usable Cloud
+    // key resolves the model at runtime and writes no line; otherwise the
+    // provider key found here is written as the explicit selection. Both the
+    // composition and the install record read this one value.
+    const models = wiredModel(root, options, cloud.keyValid);
+
+    let mcp: Awaited<ReturnType<typeof planMcpScaffold>> = null;
     if (useCase === "mcp") {
-      const baseUrl = await captureDevBaseUrl({ root, options, output, pretty });
       mcp = await planMcpScaffold({
-        root, options, output, pretty, interactive, changes, baseUrl,
+        root, options, output, pretty, interactive, changes, models, baseUrl,
         framework: plan.framework, authWired, cloudKey: cloud.keyValid,
       });
     }
+    // The MCP arm re-renders the same composition, so it owns the line where it
+    // has one; everywhere else the plan's own renderer writes it. The change
+    // objects are still unwritten at this point.
+    const modelLanded = useCase === "mcp"
+      ? mcp?.modelWritten ?? null
+      : models === null ? null : rewriteModels?.(models) ?? null;
 
-    // A provider key pasted THIS run (`vendo init --byo`) lands in .env.local
-    // during the cloud step — after the plan was built, before anything is
-    // written. Re-render the composition so the key the user just handed over
-    // selects a model instead of sitting dead in a file the run also told them
-    // was wired. Written exactly ONCE: the MCP arm plans after the cloud step,
-    // so its own scaffold already saw the key (hence the mcp === null gate), and
-    // a run whose plan already carries a line never reaches this.
-    let pastedModel: ScaffoldPlan["modelWritten"] = null;
-    if (mcp === null && modelWritten === null && rewriteModels !== null) {
-      const pasted = ENV_KEY_VARS.find((entry) => entry.envVar === cloud.wroteKeyVar);
-      if (pasted !== undefined) {
-        pastedModel = rewriteModels({ provider: pasted.provider, envVar: pasted.envVar });
-      }
-    }
+    const modelKey = await recordedModelKey({
+      root, models, landed: modelLanded,
+      cloudKeyValid: cloud.keyValid,
+      authoredComposition: compositionPath !== null,
+    });
 
     pretty?.spin("Wiring your app…");
-    const wiringMs = await wireAndScaffold({ root, changes, force: options.force === true, useCase });
+    const wiringMs = await wireAndScaffold({ root, changes, force: options.force === true, useCase, modelKey });
     pretty?.stopSpin();
 
     // Summary — what changed. What was LEARNED is the shared flow's report,
@@ -2429,19 +1922,19 @@ const explainedPlanFailure = (error: unknown): boolean => {
     // stays fail-LOUD: the catch at the bottom still exits 1.
     const themePath = join(root, ".vendo", "theme.json");
     const engineStarted = Date.now();
-    const flow = await runInstallSyncFlow({ root, output, options, pretty });
+    const flow = await runInstallSyncFlow({ root, output, options, pretty, consent });
     const engineMs = Date.now() - engineStarted;
     const { themeSummary, counts: { tools: toolCount, routes: routeCount } } = flow;
 
     // Theme finalization (Task 4): merge whatever the AI pass filled — if
     // consent was declined or unavailable, `flow.themeDraft` is simply null
     // and the exact-only summary stands — then --theme answers (a human
-    // "(you)" wins over a model value), the one-glance palette print, and
-    // finally the uncertain-slot review. Skipped entirely when theme.json
-    // pre-existed this run (the flow reconciles that one instead).
-    if (themeSummary !== null) {
-      await finalizeTheme({ root, themeSummary, themeDraft: flow.themeDraft, themePath, options, output, pretty });
-    }
+    // "(you)" wins over a model value) and the one-glance palette print.
+    // Skipped entirely when theme.json pre-existed this run (the flow
+    // reconciles that one instead).
+    const keptUncertain = themeSummary === null
+      ? []
+      : await finalizeTheme({ root, themeSummary, themeDraft: flow.themeDraft, themePath, options, output });
 
     // Judgment state, one line: a pass that ran already narrated itself (it
     // owns the judged/queued/rejected counts); otherwise say so honestly.
@@ -2473,17 +1966,8 @@ const explainedPlanFailure = (error: unknown): boolean => {
       ...(await cloudProjectProps(root)),
     });
 
-    // What the run actually WROTE, resolved before the install step because the
-    // install has to cover the import this run authored — not only what the
-    // runtime credential would load.
-    //
-    // It only ever names the file that actually holds the line — the same
-    // composition module on every path; the MCP arm only re-renders it, and
-    // does so after the cloud step, so its answer wins where it has one.
-    const modelLanded = mcp === null ? (modelWritten ?? pastedModel) : mcp.modelWritten;
-
     await ensureHostDeps({
-      root, output, options, pretty, interactive, credential,
+      root, output, options, credential,
       wrote: modelLanded?.provider,
       generated: generatedSources(changes),
     });
@@ -2510,26 +1994,24 @@ const explainedPlanFailure = (error: unknown): boolean => {
 
     // `wrote` names files the caller may open, so the plan's static list is
     // filtered to what is actually on disk: fonts.css exists only when a font
-    // was embedded, and naming it would send an agent to a file that is not
+    // was embedded, and naming it would send a reader to a file that is not
     // there.
-    const planned = options.agent !== true ? [] : (await Promise.all(
+    const planned = (await Promise.all(
       plan.writes.map(async (path) => await exists(join(root, path)) ? path : null),
     )).filter((path): path is string => path !== null);
+
+    await emitEnding({
+      root, options, output, useCase, framework: plan.framework, keptUncertain,
+      wrote: [...planned, ...changes.map((change) => change.path)],
+      pendingLoosenings: flow.judged.queued,
+      serviceAuthUnwired: mcp?.serviceAuthUnwired === true,
+      judged: flow.judged.ran,
+    });
 
     // Called on its OWN line, never inside `pretty?.done(…)`: optional
     // chaining short-circuits its arguments, so a null `pretty` — every
     // non-TTY run — would skip the entire ending without a trace.
-    const stats = await finishRun({
-      root, options, output, pretty, interactive, useCase, mcp, mount, edits, manualSteps,
-      credential, cloud, compositionPath, framework: plan.framework, authWired, layout,
-      toolCount, brandCaptured: themeSummary !== null,
-      wrote: [...planned, ...changes.map((change) => change.path)],
-      // The SAME projection the plan used to make from a throwaway extraction,
-      // over the catalog the flow already read this run.
-      risks: riskRecommendations(flow.catalog),
-      judged: flow.judged.ran,
-    });
-    pretty?.done(Date.now() - started, true, stats);
+    pretty?.done(Date.now() - started, true, runStats({ toolCount, brandCaptured: themeSummary !== null }));
     return 0;
   } catch (error) {
     await telemetry.track("init_failed", {

--- a/packages/vendo/src/cli/install-record.ts
+++ b/packages/vendo/src/cli/install-record.ts
@@ -2,8 +2,8 @@ import { join } from "node:path";
 import { readOptional, writeText } from "./shared.js";
 
 /** How the host's people will reach the agent — `vendo init`'s FIRST question.
-    It decides what gets scaffolded and how the run ends; the wired route is the
-    same in all three, so picking wrong costs nothing. */
+    It decides what gets scaffolded and where the run says to continue; the
+    wired route is the same in all three, so picking wrong costs nothing. */
 export type InitUseCase = "embedded" | "agent-loop" | "mcp";
 
 export const INIT_USE_CASES: readonly InitUseCase[] = ["embedded", "agent-loop", "mcp"];
@@ -32,9 +32,35 @@ export async function readUseCase(root: string): Promise<InitUseCase | undefined
   }
 }
 
-export async function writeUseCase(root: string, useCase: InitUseCase): Promise<void> {
+/**
+ * The env var this install's model wiring actually reads: `VENDO_API_KEY` when
+ * the models answer was Vendo Cloud (the runtime ladder resolves it and the
+ * composition names no provider), else the provider key its `models` line
+ * names. Recording the KEY rather than the answer is what lets `vendo doctor`
+ * grade the one variable that changes anything — it used to name three provider
+ * keys the resolver never reads. Absent when no key resolved at all.
+ */
+export async function readModelKey(root: string): Promise<string | undefined> {
+  const raw = await readOptional(join(root, ".vendo", INSTALL_FILE));
+  if (raw === null) return undefined;
+  try {
+    const value = (JSON.parse(raw) as { modelKey?: unknown }).modelKey;
+    return typeof value === "string" && value !== "" ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function writeInstallRecord(
+  root: string,
+  record: { useCase: InitUseCase; modelKey: string | null },
+): Promise<void> {
   await writeText(
     join(root, ".vendo", INSTALL_FILE),
-    `${JSON.stringify({ format: "vendo/install@1", useCase }, null, 2)}\n`,
+    `${JSON.stringify({
+      format: "vendo/install@1",
+      useCase: record.useCase,
+      ...(record.modelKey === null ? {} : { modelKey: record.modelKey }),
+    }, null, 2)}\n`,
   );
 }

--- a/packages/vendo/src/cli/pretty.ts
+++ b/packages/vendo/src/cli/pretty.ts
@@ -19,9 +19,8 @@ import type { Output } from "./shared.js";
  * because runInit's emissions are unchanged: this is a renderer over the
  * existing Output seam, not a second copy of the copy. The collapse rules
  * below are pure string rules over those exact plain strings; the renderer
- * restyles and groups. The copy it owns is the block TITLES and the one docs
- * pointer (MOUNT_DOCS) that cannot live in the caller without changing the
- * receipt's pinned `pasteEdits`; every fact on screen is still the caller's.
+ * restyles and groups. The only copy it owns is the block TITLES; every fact on
+ * screen is still the caller's.
  */
 
 const ESC = "\u001b";
@@ -113,6 +112,13 @@ export interface PrettyOutput extends Output {
 }
 
 const FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+/** A stage's elapsed time, read the way a clock is: seconds under a minute,
+    `m ss` above it. Every spinner carries one, because the slow stages run for
+    MINUTES and a spinning frame with no clock reads as a hang. */
+const elapsed = (ms: number): string => {
+  const total = Math.floor(ms / 1000);
+  return total < 60 ? `${total}s` : `${Math.floor(total / 60)}m${String(total % 60).padStart(2, "0")}s`;
+};
 const BAR = dim("│");
 const CLEAR_LINE = `\r${ESC}[2K`;
 /** Splits a chunk into text, CSI sequences (none of which costs a cell) and the
@@ -167,24 +173,6 @@ function judgmentTally(text: string): string | null {
   const count = /^ \((\d+)\)(?::|$)/.exec(text.slice(label.length));
   return count === null ? null : `${label} (${count[1]!})`;
 }
-/** The paste block's ASCII frame — dropped; the block rides the rail instead. */
-const PASTE_RULE = "─".repeat(64);
-const PASTE_HEAD = /^(ONE|\d+) STEPS? LEFT — paste th(?:is|ese) yourself \((.+)\)$/;
-const PASTE_FILE = /^ {2}File: (.+)$/;
-/** The caller's one-line wrap instruction — `… then wrap: <VendoProvider …>
-    {children}</VendoProvider>` — destructured so the block can print the real
-    JSX instead of the prose: the open tag, a dim `…` for the app tree that is
-    already there, the close tag. The children capture is deliberately dropped;
-    the child expression genuinely differs by router (`{children}` in an
-    app-router layout, `<Component {...pageProps} />` in a pages `_app`), so one
-    literal in the terminal would be wrong for half of hosts and the docs
-    pointer below carries the exact per-router wording instead. */
-const MOUNT_WRAP = /^… then wrap: (<VendoProvider\b[^>]*>).*<\/VendoProvider>$/;
-/** This pointer is the renderer's and not the caller's: the mount's `lines` are
-    pinned byte-for-byte by the receipt's `pasteEdits`, and a line added there
-    would change that JSON. Emitted here, the --agent path never sees it (the
-    rail is off in agent mode). */
-const MOUNT_DOCS = "docs.vendo.run/product/mount-the-surface#the-provider — exact wording for layout.tsx and _app.tsx";
 const WIRED = /^(Wired \(\d+ files?\)):$/;
 const DIFF_MARKER = /^ {2}([+~]) (.+)$/;
 const THEME = /^Theme: (.*)$/;
@@ -475,7 +463,6 @@ interface RenderState {
   catalog: string[];
   impact: string[];
   judgment: { summary: string; details: string[] } | null;
-  paste: { count: number; why: string; titled: boolean } | null;
 }
 
 function flushCatalog(state: RenderState, rail: Rail): void {
@@ -620,57 +607,12 @@ function renderIndented(raw: string, state: RenderState, rail: Rail): void {
   rail.body(`${keep}${rest}`);
 }
 
-/** The 64-dash paste frame becomes a ◇ section on the rail. */
-function renderPaste(raw: string, state: RenderState, rail: Rail): void {
-  const open = state.paste;
-  if (raw === PASTE_RULE) {
-    if (open === null) state.paste = { count: 0, why: "", titled: false };
-    else {
-      if (open.why !== "") rail.body(dim(open.why));
-      state.paste = null;
-    }
-    return;
-  }
-  const head = PASTE_HEAD.exec(raw);
-  if (head !== null) {
-    state.paste = { count: head[1] === "ONE" ? 1 : Number(head[1]), why: head[2]!, titled: false };
-    return;
-  }
-  const file = open === null ? null : PASTE_FILE.exec(raw);
-  if (file !== null && open !== null) {
-    if (open.titled) rail.bar();
-    else {
-      open.titled = true;
-      rail.section(rail.accent("◇"), bold(open.count === 1 ? `One paste left — ${file[1]}` : `${open.count} pastes left`));
-      if (open.count === 1) return;
-    }
-    rail.body(bold(file[1]!));
-    return;
-  }
-  const wrap = MOUNT_WRAP.exec(raw.trimStart());
-  if (wrap !== null) {
-    // The snippet's own indent, with the docs pointer under the JSX it explains.
-    const keep = " ".repeat(Math.max(0, raw.length - raw.trimStart().length - state.absorb));
-    rail.bar();
-    rail.body(`${keep}${wrap[1]!}`);
-    rail.body(`${keep}  ${dim("…")}`);
-    rail.body(`${keep}</VendoProvider>`);
-    rail.body(`${keep}${dim(MOUNT_DOCS)}`);
-    return;
-  }
-  renderIndented(raw, state, rail);
-}
-
 function renderRaw(raw: string, state: RenderState, rail: Rail): void {
   if (raw === "") {
     flushCatalog(state, rail);
     flushJudgment(state, rail);
     flushImpact(state, rail);
     rail.bar();
-    return;
-  }
-  if (state.paste !== null || raw === PASTE_RULE) {
-    renderPaste(raw, state, rail);
     return;
   }
   if (raw.startsWith(IMPACT_LINE)) {
@@ -732,7 +674,7 @@ export function createPrettyOutput(options: PrettyOptions = {}): PrettyOutput {
   let lastWasBar = false;
   let timer: ReturnType<typeof setInterval> | null = null;
   let frame = 0;
-  const state: RenderState = { absorb: 0, catalog: [], impact: [], judgment: null, paste: null };
+  const state: RenderState = { absorb: 0, catalog: [], impact: [], judgment: null };
   /** Same capability probe the banner uses, so the rail and the mark above it
       are the same purple on the same terminal. */
   const lilac = accentFor(env);
@@ -924,9 +866,10 @@ export function createPrettyOutput(options: PrettyOptions = {}): PrettyOutput {
       stopSpin();
       ensureHeader();
       flush();
+      const started = Date.now();
       const draw = (): void => {
         frame = (frame + 1) % FRAMES.length;
-        write(`${CLEAR_LINE}${lilac(FRAMES[frame]!)}  ${dim(label)}`);
+        write(`${CLEAR_LINE}${lilac(FRAMES[frame]!)}  ${dim(`${label} ${elapsed(Date.now() - started)}`)}`);
       };
       timer = setInterval(draw, 80);
       timer.unref?.();

--- a/packages/vendo/src/cli/sync-flow.ts
+++ b/packages/vendo/src/cli/sync-flow.ts
@@ -81,6 +81,12 @@ export interface SyncFlowOptions {
    *  minutes: extraction and the judgment pass. Absent (plain runs, CI, pipes)
    *  → nothing spins and the printed lines stay exactly what they are today. */
   spinner?: { spin: (label: string) => void; stopSpin: () => void };
+  /** Never block on the loosening review: proposals QUEUE as pending instead
+      of being reviewed inline. init sets it, because init asks nothing once its
+      up-front questions are done — a loosening is never applied without a
+      human, so queueing is the only other honest answer. `vendo sync --review`
+      is the deliberate ask and is unaffected. */
+  queueLoosenings?: boolean;
   /** Test seam: the wall-clock budget for each Cloud reconcile. */
   baselineBudgetMs?: number;
 }
@@ -116,7 +122,13 @@ async function withSpin<T>(
 
 export interface SyncFlowResult {
   report: SyncReportWithWarnings;
-  judged: { ran: boolean; engine?: "claude" | "codex" | "npx-engine" };
+  judged: {
+    ran: boolean;
+    engine?: "claude" | "codex" | "npx-engine";
+    /** Loosening proposals held as PENDING — never applied, waiting for a human
+        (`vendo sync --review`). init reports the count in its closing facts. */
+    queued: number;
+  };
   /** The theme re-scan: which slots this run took from the host, and which the
    *  host disagrees with but a human owns. null = nothing to reconcile (the
    *  file was just created, or there is none). */
@@ -366,6 +378,78 @@ function printImpact(output: Output, impact: ToolImpact[]): void {
  * `--ai` run never probes a single harness; the pass resolves its own engine
  * behind its credential gate instead.
  */
+const JUDGMENT_SKIPPED = "Skipped — extractor defaults stand; re-run `vendo init` any time to add the AI polish.";
+
+/** THE one question the judgment pass owes a person: may a coding agent read
+ *  this codebase, and — where several could — which one. ONE question either
+ *  way, and it never prints: the caller owns what a decline says, because init
+ *  asks this UP FRONT (nothing may prompt once the long pass starts) while sync
+ *  still asks it inline. Null is "no". */
+async function askJudgmentConsent(input: {
+  available: readonly AvailableEngine[];
+  chosen: AvailableEngine;
+  /** `--engine` already named the family, so there is nothing left to pick. */
+  pinned: boolean;
+  choose?: SyncFlowOptions["choose"];
+  confirm?: SyncFlowOptions["confirm"];
+}): Promise<AvailableEngine | null> {
+  const { available, chosen, pinned } = input;
+  if (!pinned && available.length > 1) {
+    // Several engines: the SAME single consent question, as a pick-with-
+    // default instead of yes/no — never a second question.
+    const picked = await (input.choose ?? plainSelect)(
+      "Let a coding agent read this codebase to draft tool descriptions, review risk, write the product brief, and fill unresolved theme slots? Source goes to the chosen provider under your account.",
+      [
+        ...available.map((entry) => ({ value: entry.family, label: entry.credential, hint: `--engine ${entry.family}` })),
+        { value: "skip", label: "Skip — keep extractor defaults" },
+      ],
+      0,
+    );
+    return available.find((entry) => entry.family === picked) ?? null;
+  }
+  const consented = await (input.confirm ?? askYesNo)(
+    `Let ${chosen.credential} read this codebase to draft tool descriptions, review risk, write the product brief, and fill unresolved theme slots? Source goes to your model provider under your account.`,
+    true,
+  );
+  return consented ? chosen : null;
+}
+
+/**
+ * init's UP-FRONT form of that question. It is knowable before the long pass —
+ * the ladder is a read-only probe of this machine — so init asks it with the
+ * rest of its questions and hands the flow a settled `--ai`/`--engine` pair,
+ * leaving nothing to prompt once the writing starts.
+ *
+ * Null means there was no question to ask: no engine resolves here, so the flow
+ * takes its own (silent, non-prompting) unavailable path and says so there.
+ */
+export async function resolveJudgmentConsent(input: {
+  root: string;
+  env: Record<string, string | undefined>;
+  engine?: string;
+  harnesses?: Parameters<typeof selectJudgmentEngines>[0]["harnesses"];
+  choose?: SyncFlowOptions["choose"];
+  confirm?: SyncFlowOptions["confirm"];
+}): Promise<{ ai: boolean; engine?: string } | null> {
+  const available = await selectJudgmentEngines({
+    root: input.root,
+    env: input.env,
+    ...(input.harnesses === undefined ? {} : { harnesses: input.harnesses }),
+  });
+  if (available.length === 0) return null;
+  // An unavailable `--engine` pin is the flow's own loud line, not a question.
+  const pinned = input.engine === undefined ? undefined : available.find((entry) => entry.family === input.engine);
+  if (input.engine !== undefined && pinned === undefined) return null;
+  const chosen = await askJudgmentConsent({
+    available,
+    chosen: pinned ?? available[0]!,
+    pinned: input.engine !== undefined,
+    ...(input.choose === undefined ? {} : { choose: input.choose }),
+    ...(input.confirm === undefined ? {} : { confirm: input.confirm }),
+  });
+  return chosen === null ? { ai: false } : { ai: true, engine: chosen.family };
+}
+
 async function chooseEngine(
   options: SyncFlowOptions,
   env: Record<string, string | undefined>,
@@ -416,36 +500,20 @@ async function chooseEngine(
   // `--ai` IS the answer: the ladder was walked only to report what is here.
   if (options.ai === true) return { skip: false, engine: chosen };
 
-  if (options.engine === undefined && available.length > 1) {
-    // Several engines: the SAME single consent question, as a pick-with-
-    // default instead of yes/no — never a second question.
-    const choose = options.choose ?? plainSelect;
-    const picked = await choose(
-      "Let a coding agent read this codebase to draft tool descriptions, review risk, write the product brief, and fill unresolved theme slots? Source goes to the chosen provider under your account.",
-      [
-        ...available.map((entry) => ({ value: entry.family, label: entry.credential, hint: `--engine ${entry.family}` })),
-        { value: "skip", label: "Skip — keep extractor defaults" },
-      ],
-      0,
-    );
-    const selected = available.find((entry) => entry.family === picked);
-    if (selected === undefined) {
-      output.log("Skipped — extractor defaults stand; re-run `vendo init` any time to add the AI polish.");
-      return { skip: true };
-    }
-    chosen = selected;
-  } else {
-    const confirm = options.judge?.confirm ?? options.confirm ?? askYesNo;
-    const consented = await confirm(
-      `Let ${chosen.credential} read this codebase to draft tool descriptions, review risk, write the product brief, and fill unresolved theme slots? Source goes to your model provider under your account.`,
-      true,
-    );
-    if (!consented) {
-      output.log("Skipped — extractor defaults stand; re-run `vendo init` any time to add the AI polish.");
-      return { skip: true };
-    }
+  const consented = await askJudgmentConsent({
+    available,
+    chosen,
+    pinned: options.engine !== undefined,
+    ...(options.choose === undefined ? {} : { choose: options.choose }),
+    ...(options.judge?.confirm ?? options.confirm) === undefined
+      ? {}
+      : { confirm: options.judge?.confirm ?? options.confirm },
+  });
+  if (consented === null) {
+    output.log(JUDGMENT_SKIPPED);
+    return { skip: true };
   }
-  return { skip: false, engine: chosen };
+  return { skip: false, engine: consented };
 }
 
 /** The two CLI-level event sinks every stage writes through — printed AND
@@ -539,7 +607,7 @@ async function runGradingStages(input: {
 }): Promise<{ judged: SyncFlowResult["judged"]; themeDraft: SyncFlowResult["themeDraft"] }> {
   const { root, vendoDir, mode, env, options, output, themeSummary } = input;
   const { note, noteError } = input.notes;
-  const judged: SyncFlowResult["judged"] = { ran: false };
+  const judged: SyncFlowResult["judged"] = { ran: false, queued: 0 };
   let themeDraft: SyncFlowResult["themeDraft"] = null;
   const selection = await chooseEngine(options, env, note);
   if (selection.skip) return { judged, themeDraft };
@@ -548,8 +616,11 @@ async function runGradingStages(input: {
   // incremental sync stays as quiet as it is today. With a renderer attached
   // that same narration becomes the spinner's label instead of a printed line.
   const credential = selection.engine === undefined ? null : selection.engine.credential;
+  // It says how long this takes because it TAKES that long: the pass reads the
+  // whole API and then drafts prose over it, and a silent spinner on a
+  // many-minute stage is what a person reads as a hang.
   const narration = mode === "full" && credential !== null
-    ? `Reading your product (${credential})…`
+    ? `Reading your product (${credential}) — this can take several minutes…`
     : null;
   if (narration !== null && options.spinner === undefined) output.log(`\n${narration}`);
   const spinLabel = narration
@@ -561,7 +632,9 @@ async function runGradingStages(input: {
     // loosenings queue instead — and no `confirm` is handed down at all, so
     // nothing downstream can acquire a way to block.
     const attended = options.interactive && !options.yes;
-    const loosenings = attended || options.review === true ? "review" : "queue";
+    const loosenings = options.queueLoosenings !== true && (attended || options.review === true)
+      ? "review"
+      : "queue";
     const pass = await withSpin(options.spinner, spinLabel, () => runJudgmentPass({
       root,
       out: vendoDir,
@@ -581,7 +654,8 @@ async function runGradingStages(input: {
     // The pass already printed the count and `vendo sync --review`; say WHY
     // they were held, so an unattended caller doesn't read it as a refusal.
     if (loosenings === "queue" && pass.status === "judged" && pass.queued > 0) {
-      note("  (held, not applied: this run had no one to ask — re-run `vendo init` in a terminal to review them inline)");
+      judged.queued = pass.queued;
+      note("  (held, not applied: a loosening needs a human — review them with `vendo sync --review`)");
     }
     judged.ran = true;
     const engine = selection.engine === undefined ? undefined : ENGINE_BY_HARNESS_ID[selection.engine.harness.id];

--- a/packages/vendo/tests/cli.test.ts
+++ b/packages/vendo/tests/cli.test.ts
@@ -35,7 +35,8 @@ describe("vendo CLI commands", () => {
     expect(help).toContain("--base-url <url>");
     expect(help).toContain("--posture <name>");
     expect(help).toContain("--service-key");
-    expect(help).toContain("--check / --no-check");
+    // Doctor is a standalone command: init neither offers it nor runs it.
+    expect(help).not.toContain("--check");
     // The interview flags are gone with the interview.
     expect(help).not.toContain("--brief <text>");
     expect(help).not.toContain("Init/refine: module exporting");
@@ -103,7 +104,7 @@ describe("vendo CLI commands", () => {
     expect(await main(["init", root, "--agent", "--yes", "--force",
       "--auth", "clerk", "--framework", "next", "--theme", "accent=#7c3bed",
       "--use-case", "mcp", "--base-url", "https://app.acme.com", "--posture", "local",
-      "--service-key", "--no-check"])).toBe(0);
+      "--service-key"])).toBe(0);
 
     expect(await readdir(root)).toEqual([]); // the ask pass wrote nothing
     // Value-flag values are never mistaken for the target dir: --framework
@@ -172,8 +173,10 @@ describe("vendo CLI commands", () => {
     expect(error.mock.calls.flat().join("\n")).toContain("provisioned with the tenant on first use");
     expect(error.mock.calls.flat().join("\n")).toContain("https://docs.vendo.run/outside-agents/service-keys-and-broker");
 
-    expect(await main(["init", root, "--check", "--no-check"])).toBe(1);
-    expect(error.mock.calls.flat().join("\n")).toContain("--check and --no-check answer the same question");
+    // Init no longer runs doctor, so its flags are gone — and an unknown flag
+    // fails loudly rather than being dropped (ENG-335).
+    expect(await main(["init", root, "--check"])).toBe(1);
+    expect(error.mock.calls.flat().join("\n")).toContain("unknown option: --check");
 
     expect(await readdir(root)).toEqual([]); // nothing ever ran
     error.mockRestore();

--- a/packages/vendo/tests/cli/docs-links.test.ts
+++ b/packages/vendo/tests/cli/docs-links.test.ts
@@ -90,12 +90,13 @@ describe("every docs.vendo.run URL the CLI prints reaches a page that exists", (
   it("found the URLs at all — an empty sweep would pass the check above vacuously", async () => {
     const paths = await printedDocsPaths();
     expect(paths.size).toBeGreaterThan(5);
-    // The five the audit caught, in their FIXED spellings.
+    // The audit's own spellings, plus the four continue URLs — which are now the
+    // ONLY instructions init hands anyone, so a stale one is the whole install.
     const all = [...paths.keys()];
+    expect(all).toContain("/product/quickstart");
     expect(all).toContain("/existing-agent/ai-sdk");
     expect(all).toContain("/existing-agent/mastra");
     expect(all).toContain("/outside-agents/quickstart");
-    expect(all).toContain("/product/mount-the-surface#the-provider");
     expect(all).toContain("/production/troubleshooting/e-wire-001");
   });
 });

--- a/packages/vendo/tests/cli/doctor-codes.test.ts
+++ b/packages/vendo/tests/cli/doctor-codes.test.ts
@@ -57,7 +57,7 @@ describe("doctor error-code registry", () => {
         "E-MCP-007": "the local MCP registry auth challenge is malformed",
         "E-MCP-008": "RETIRED — doctor no longer fetches the live registry auth challenge",
         "E-MCP-009": "the MCP door is wired but VENDO_BASE_URL is not set (discovery advertises the wrong origin)",
-        "E-MODEL-001": "no model credential resolves (the wire is wired, but the agent cannot answer a single turn)",
+        "E-MODEL-001": "the key this install's \`models\` wiring reads is not set (the wire is wired, but the agent cannot answer a single turn)",
         "E-SCHED-001": "RETIRED — doctor no longer reads machines and schedules off a running app",
         "E-STORE-001": "the store's data directory is on ephemeral disk (it will be wiped on redeploy)",
         "E-TENANT-001": "tenant connectors are wired but the store has no encryption key, so a tenant's pasted token has nowhere safe to live",

--- a/packages/vendo/tests/cli/doctor.test.ts
+++ b/packages/vendo/tests/cli/doctor.test.ts
@@ -473,7 +473,10 @@ describe("vendo doctor (model credentials + --json + cloud)", () => {
       output: messages.sink,
       telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
     })).toBe(0);
-    expect(messages.errors.join("\n")).toContain("warning: model credential: none found");
+    expect(messages.errors.join("\n")).toContain("warning: model credential: VENDO_API_KEY is not set");
+    // …and it names ONLY the variable the runtime ladder reads. Listing the
+    // provider keys sent hosts to set one that changes nothing.
+    expect(messages.errors.join("\n")).not.toContain("ANTHROPIC_API_KEY");
     expect(messages.logs.some((line) => line.startsWith("ok: model credential:"))).toBe(false);
 
     // …and the machine surface carries the code and its fix_ref.
@@ -490,6 +493,97 @@ describe("vendo doctor (model credentials + --json + cloud)", () => {
     expect(credential).toMatchObject({ status: "warning", error_code: "E-MODEL-001", fix_ref: doctorFixRef("E-MODEL-001") });
     expect(report.wired).toBe(true);
     expect(report.exit).toBe(0);
+  });
+
+  /** The warning used to name three provider keys the resolver never reads, so
+      a host set ANTHROPIC_API_KEY, changed nothing, and came back. Doctor now
+      grades the ONE key this install's own wiring consults: the answer init
+      recorded, else the provider its composition's `models` line names. */
+  it("grades the key the install's own models wiring reads, and names only that key", async () => {
+    const recorded = await healthy();
+    await writeFile(join(recorded, ".vendo", "install.json"),
+      JSON.stringify({ format: "vendo/install@1", useCase: "embedded", modelKey: "ANTHROPIC_API_KEY" }));
+
+    const missing = output();
+    expect(await runDoctor({
+      targetDir: recorded,
+      // A Cloud key set here proves the point: it is NOT what this composition
+      // reads, so greening on it is the dishonesty being fixed.
+      env: { VENDO_API_KEY: `vnd_${"a".repeat(40)}` },
+      output: missing.sink,
+      telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
+    })).toBe(0);
+    const warning = missing.errors.find((line) => line.includes("model credential"))!;
+    expect(warning).toContain("ANTHROPIC_API_KEY");
+    expect(warning).not.toContain("OPENAI_API_KEY");
+    expect(warning).not.toContain("VENDO_API_KEY");
+
+    const set = output();
+    expect(await runDoctor({
+      targetDir: recorded,
+      env: { ANTHROPIC_API_KEY: "sk-test" },
+      output: set.sink,
+      telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
+    })).toBe(0);
+    expect(set.logs.some((line) => line.startsWith("ok: model credential:") && line.includes("ANTHROPIC_API_KEY"))).toBe(true);
+  });
+
+  /** Greptile P1 on #1530: the record is a snapshot of init time, the
+      composition is what the runtime LOADS. A project initialised against
+      Anthropic and later moved to openai must be graded on OPENAI_API_KEY, or
+      doctor greens a host whose first turn is dead. */
+  it("prefers the composition's CURRENT models line over a stale recorded key", async () => {
+    const root = await healthy();
+    await writeFile(join(root, ".vendo", "install.json"),
+      JSON.stringify({ format: "vendo/install@1", useCase: "embedded", modelKey: "ANTHROPIC_API_KEY" }));
+    await mkdir(join(root, "lib"), { recursive: true });
+    await writeFile(join(root, "lib", "vendo.ts"),
+      'import { openai } from "@ai-sdk/openai";\n'
+      + "export const vendo = createVendo({\n"
+      + '  models: { default: openai("gpt-5") }, // OPENAI_API_KEY supplies the key\n'
+      + "});\n");
+
+    // The stale key being SET must not green it — the runtime reads the other one.
+    const stale = output();
+    expect(await runDoctor({
+      targetDir: root,
+      env: { ANTHROPIC_API_KEY: "sk-test" },
+      output: stale.sink,
+      telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
+    })).toBe(0);
+    const warning = stale.errors.find((line) => line.includes("model credential"))!;
+    expect(warning).toContain("OPENAI_API_KEY");
+    expect(stale.logs.some((line) => line.startsWith("ok: model credential:"))).toBe(false);
+
+    // …and the key the composition actually names is what passes it.
+    const live = output();
+    expect(await runDoctor({
+      targetDir: root,
+      env: { OPENAI_API_KEY: "sk-test" },
+      output: live.sink,
+      telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
+    })).toBe(0);
+    expect(live.logs.some((line) => line.startsWith("ok: model credential:") && line.includes("OPENAI_API_KEY"))).toBe(true);
+  });
+
+  it("falls back to the recorded key when the composition names no model", async () => {
+    const root = await healthy();
+    await mkdir(join(root, "lib"), { recursive: true });
+    await writeFile(join(root, "lib", "vendo.ts"),
+      'import { openai } from "@ai-sdk/openai";\n'
+      + "export const vendo = createVendo({\n"
+      + '  models: { default: openai("gpt-5") }, // OPENAI_API_KEY supplies the key\n'
+      + "});\n");
+    const messages = output();
+    expect(await runDoctor({
+      targetDir: root,
+      env: {},
+      output: messages.sink,
+      telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
+    })).toBe(0);
+    const warning = messages.errors.find((line) => line.includes("model credential"))!;
+    expect(warning).toContain("OPENAI_API_KEY");
+    expect(warning).not.toContain("ANTHROPIC_API_KEY");
   });
 
   it("emits one machine-readable JSON object a script can consume", async () => {

--- a/packages/vendo/tests/cli/init-install-dx.test.ts
+++ b/packages/vendo/tests/cli/init-install-dx.test.ts
@@ -169,8 +169,6 @@ describe("the use-case recommendation reads the loop detection", () => {
         return "agent-loop";
       },
       askText: async (_question, _hint, prefill) => prefill ?? "",
-      confirmCheck: async () => false,
-      confirmZodBump: async () => false,
     })).toBe(0);
     // Recommended means FIRST: index 0 is what the select defaults to.
     expect(asked[0]?.value).toBe("agent-loop");
@@ -189,8 +187,6 @@ describe("the use-case recommendation reads the loop detection", () => {
         return "embedded";
       },
       askText: async (_question, _hint, prefill) => prefill ?? "",
-      confirmCheck: async () => false,
-      confirmZodBump: async () => false,
     })).toBe(0);
     expect(asked[0]).toEqual({ value: "embedded", hint: "recommended" });
   });
@@ -255,7 +251,7 @@ describe("the MCP re-run false alarm", () => {
     const again = output();
     expect(await run(root, again, { useCase: "mcp", yes: true, baseUrl: "http://localhost:3000" })).toBe(0);
     expect(again.errors.join("\n")).not.toContain("nothing MCP was written");
-    expect(again.logs.join("\n")).toContain("Point any MCP client at");
+    expect(again.logs.join("\n")).toContain("Continue: https://docs.vendo.run/outside-agents/quickstart");
   });
 
   it("still refuses an anonymous composition — the door genuinely cannot open", async () => {
@@ -287,6 +283,36 @@ describe("VENDO_SERVICE_KEY", () => {
     expect(keyIn(await readFile(join(root, ".env.local"), "utf8"))).toBe(minted);
     expect(again.logs.join("\n")).toContain("VENDO_SERVICE_KEY already set — reused");
     expect(again.logs.join("\n")).not.toContain("Generated VENDO_SERVICE_KEY");
+  });
+
+  /** The `--service-key --force` field report: the env key landed and the
+      composition still said `mcp: true`. Init never rewrites a file it did not
+      author, so the key is honest and the WIRING is the developer's — a fact
+      the receipt has to carry, because nothing else on the run can say it. */
+  it("says so in the receipt when the composition it did not author holds no serviceAuth", async () => {
+    const root = await mcpFixture();
+    const answers = { useCase: "mcp" as const, auth: "clerk" as const, posture: "local" as const, baseUrl: "http://localhost:3000" };
+    expect(await run(root, output(), { ...answers, yes: true })).toBe(0);
+    const composition = await readFile(join(root, "lib", "vendo.ts"), "utf8");
+    expect(composition).toContain("mcp: true,");
+
+    const again = output();
+    expect(await run(root, again, { ...answers, agent: true, byo: true, serviceKey: true, force: true })).toBe(0);
+    // The file is untouched and the key is real…
+    expect(await readFile(join(root, "lib", "vendo.ts"), "utf8")).toBe(composition);
+    expect(keyIn(await readFile(join(root, ".env.local"), "utf8"))).toMatch(/^[0-9a-f]{64}$/);
+    // …so the receipt names the one line still missing, and the page that has it.
+    const receipt = JSON.parse(again.logs.at(-1)!) as InitReceipt;
+    expect(receipt.serviceAuthUnwired).toBe(true);
+    expect(receipt.continueUrl).toBe("https://docs.vendo.run/outside-agents/quickstart");
+
+    // A run that authored the composition itself wires it, and says nothing.
+    const fresh = await mcpFixture();
+    const freshSink = output();
+    expect(await run(fresh, freshSink, { ...answers, agent: true, byo: true, serviceKey: true })).toBe(0);
+    expect(await readFile(join(fresh, "lib", "vendo.ts"), "utf8"))
+      .toContain('mcp: serviceKey === "" ? true : { serviceAuth: { keys: [serviceKey] } },');
+    expect((JSON.parse(freshSink.logs.at(-1)!) as InitReceipt).serviceAuthUnwired).toBeUndefined();
   });
 
   it("replaces a value that is not a key this door could exchange", async () => {
@@ -369,77 +395,15 @@ describe("what the generated files import becomes a host dependency", () => {
   });
 });
 
-describe("the agent-loop paste compiles as printed", () => {
-  it("declares the principal from the preset the composition wires", async () => {
-    const root = await fixture({ dependencies: { next: "16.0.0", ai: "6.0.0", "@clerk/nextjs": "7.0.0" } });
-    const sink = output();
-    expect(await run(root, sink, { useCase: "agent-loop", auth: "clerk", yes: true })).toBe(0);
-    const logs = sink.logs.join("\n");
-    expect(logs).toContain('import { clerk } from "@vendoai/vendo/auth/clerk";');
-    expect(logs).toContain("const principal = await clerk().principal(request);");
-    expect(logs).toContain('if (principal === null) return new Response("Unauthorized", { status: 401 });');
-    // …and never the bare `principal` that was declared nowhere.
-    expect(logs).not.toContain("{ ...yourTools, ...(await vendoTools(vendo, { principal })) }\n  (Your loop");
-  });
-
-  it("declares the SAME anonymous principal the composition resolves", async () => {
-    const root = await fixture({ dependencies: { next: "16.0.0", ai: "6.0.0" } });
-    const sink = output();
-    expect(await run(root, sink, { useCase: "agent-loop", auth: "none", yes: true })).toBe(0);
-    expect(sink.logs.join("\n")).toContain('const principal = { kind: "user", subject: "demo-user" } as const;');
-    expect(await readFile(join(root, "lib", "vendo.ts"), "utf8")).toContain('subject: "demo-user"');
-  });
-
-  it("names the host's own chat route under src/, never a path it does not have", async () => {
-    const root = await mkdtemp(join(tmpdir(), "vendo-install-dx-src-"));
-    cleanup.push(root);
-    await mkdir(join(root, "src", "app"), { recursive: true });
-    await writeFile(join(root, "package.json"), JSON.stringify({
-      name: "host",
-      dependencies: { next: "16.0.0", ai: "6.0.0", "@vendoai/vendo": "0.3.0" },
-    }));
-    await writeFile(join(root, "src", "app", "layout.tsx"),
-      "export default function Layout({ children }) { return <html><body>{children}</body></html>; }\n");
-    const sink = output();
-    expect(await run(root, sink, { useCase: "agent-loop", auth: "none", yes: true })).toBe(0);
-    expect(sink.logs.join("\n")).toContain(`File: ${join("src", "app", "api", "chat", "route.ts")}`);
-    expect(sink.logs.join("\n")).not.toContain(`File: ${join("app", "api", "chat", "route.ts")}`);
-  });
-
-  it("resolves <your-agent> to the Mastra agent the host actually has", async () => {
-    const root = await fixture({ dependencies: { next: "16.0.0", "@mastra/core": "1.0.0" } });
-    await mkdir(join(root, "src", "mastra", "agents"), { recursive: true });
-    await writeFile(join(root, "src", "mastra", "agents", "support.ts"), "export const support = {};\n");
-    const sink = output();
-    expect(await run(root, sink, { useCase: "agent-loop", auth: "none", yes: true })).toBe(0);
-    const logs = sink.logs.join("\n");
-    expect(logs).toContain(`File: ${join("src", "mastra", "agents", "support.ts")}`);
-    expect(logs).not.toContain("<your-agent>");
-  });
-
-  it("keeps the placeholder when there is no agent file to name", async () => {
-    const root = await fixture({ dependencies: { next: "16.0.0", "@mastra/core": "1.0.0" } });
-    const sink = output();
-    expect(await run(root, sink, { useCase: "agent-loop", auth: "none", yes: true })).toBe(0);
-    expect(sink.logs.join("\n")).toContain("<your-agent>.ts");
-  });
-});
-
-describe("the mount paste is gated on the use case", () => {
-  it.each(["agent-loop", "mcp"] as const)("owes no <VendoProvider> paste for %s", async (useCase) => {
+describe("the mount is doctor's to grade, and only for an embedded install", () => {
+  it.each(["agent-loop", "mcp"] as const)("records %s, so doctor skips the mounted-UI checks", async (useCase) => {
     const root = await fixture({ dependencies: { next: "16.0.0", "@clerk/nextjs": "7.0.0" } });
     const sink = output();
     expect(await run(root, sink, { useCase, auth: "clerk", yes: true, baseUrl: "http://localhost:3000" })).toBe(0);
-    const logs = sink.logs.join("\n");
-    expect(logs).not.toContain("VendoProvider");
-    expect(logs).not.toContain("VendoOverlay");
-  });
-
-  it("still owes it for an embedded install", async () => {
-    const root = await fixture();
-    const sink = output();
-    expect(await run(root, sink, { useCase: "embedded", auth: "none", yes: true })).toBe(0);
-    expect(sink.logs.join("\n")).toContain("VendoOverlay");
+    // The terminal never prints the mount either way — that is the docs' —
+    // but the RECORD is what tells doctor this install owes no surface.
+    expect(sink.logs.join("\n")).not.toContain("VendoProvider");
+    expect(JSON.parse(await readFile(join(root, ".vendo", "install.json"), "utf8"))).toMatchObject({ useCase });
   });
 });
 
@@ -462,8 +426,6 @@ describe("VENDO_BASE_URL reaches .env.local from an attended terminal", () => {
         ai: false,
         cloud: { ...NO_CLOUD, models: "later" },
         askText: async (_question, _hint, prefill) => prefill ?? "",
-        confirmCheck: async () => false,
-        confirmZodBump: async () => false,
       })).toBe(0);
     } finally {
       process.stdin.isTTY = tty.in;

--- a/packages/vendo/tests/cli/init-mcp.test.ts
+++ b/packages/vendo/tests/cli/init-mcp.test.ts
@@ -4,7 +4,7 @@ import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { doorWellKnownPaths } from "../../src/door-paths.js";
 import { compositionSpecifier, routeSource } from "../../src/cli/init-scaffolds.js";
-import { generateServiceKey, mcpStepLines, planMcp, wellKnownRouteSource, type McpPlan, type McpPlanInput } from "../../src/cli/init-mcp.js";
+import { generateServiceKey, planMcp, wellKnownRouteSource, type McpPlan, type McpPlanInput } from "../../src/cli/init-mcp.js";
 
 const cleanup: string[] = [];
 afterEach(async () => {
@@ -28,10 +28,8 @@ function plan(overrides: Partial<McpPlanInput> = {}): McpPlan {
     framework: "next",
     authWired: clerk,
     serverActions: true,
-    cloudKey: true,
     posture: "local",
     serviceKey: false,
-    baseUrl: "https://app.acme.com",
     ...overrides,
   });
 }
@@ -71,7 +69,6 @@ describe("planMcp — what it refuses to write", () => {
     expect(blocked.blocked).toMatch(/cannot open without one/);
     expect(blocked.changes).toEqual([]);
     expect(blocked.compositionSource).toBeNull();
-    expect(blocked.steps).toEqual([]);
   });
 
   it("writes nothing off the Next.js app router — the discovery paths are origin-root", () => {
@@ -89,7 +86,6 @@ describe("planMcp — the service key", () => {
     expect(local.serviceKeyValue).toMatch(/^[0-9a-f]{64}$/);
     expect(local.compositionSource).toContain("const serviceKey = process.env.VENDO_SERVICE_KEY");
     expect(local.compositionSource).toContain(`mcp: serviceKey === "" ? true : { serviceAuth: { keys: [serviceKey] } },`);
-    expect(local.steps.at(-1)).toContain("/api/vendo/mcp/token");
   });
 
   // serviceAuth is local-door mechanics: the RFC 8693 exchange lives at the
@@ -103,84 +99,15 @@ describe("planMcp — the service key", () => {
     expect(broker.serviceKeyValue).toBeUndefined();
     expect(broker.compositionSource).toContain("mcp: true,");
     expect(broker.compositionSource).not.toContain("serviceAuth");
-    expect(broker.steps.join("\n")).not.toContain("VENDO_SERVICE_KEY");
   });
 
-  it("says nothing about service keys when the answer was no", () => {
-    const none = plan();
-    expect(none.serviceKeyValue).toBeUndefined();
-    expect(none.steps.join("\n")).not.toContain("VENDO_SERVICE_KEY");
+  it("mints nothing when the answer was no", () => {
+    expect(plan().serviceKeyValue).toBeUndefined();
   });
 
   it("mints 32 hex bytes", () => {
     expect(generateServiceKey()).toMatch(/^[0-9a-f]{64}$/);
     expect(generateServiceKey()).not.toBe(generateServiceKey());
-  });
-});
-
-describe("planMcp — the two steps that stay the user's", () => {
-  it("puts the base URL FIRST, always", () => {
-    expect(plan().steps[0]).toContain("`VENDO_BASE_URL`");
-    expect(plan({ baseUrl: null }).steps[0]).toContain("Set `VENDO_BASE_URL`");
-    expect(plan({ posture: "broker", serviceKey: true }).steps[0]).toContain("`VENDO_BASE_URL`");
-  });
-
-  /** The captured origin is the DEV one now (init writes it to .env.local), so
-      the step points at deploy time for production instead of claiming the
-      answer already covers it. */
-  it("names the captured origin as dev-and-done, and the risk when there is none", () => {
-    expect(plan().steps[0]).toContain("When you deploy, set `VENDO_BASE_URL` in your platform to the public origin");
-    expect(plan().steps[0]).toContain("`https://app.acme.com` is in .env.local");
-    expect(plan().steps[0]).not.toContain(".env.example");
-    expect(plan({ baseUrl: null }).steps[0]).toContain("points at the wrong origin");
-    expect(plan({ baseUrl: null }).steps[0]).toContain(".env.local in dev, your deploy platform in production");
-  });
-
-  it("points clients at the same URL in BOTH postures — it derives from the base URL, never the broker", () => {
-    const client = "Point any MCP client at `https://app.acme.com/api/vendo/mcp`";
-    expect(plan().steps.map((step) => step.split("\n")[0])).toContain(client);
-    expect(plan({ posture: "broker" }).steps.map((step) => step.split("\n")[0])).toContain(client);
-  });
-});
-
-describe("planMcp — the sign-in posture", () => {
-  // The broker posture used to close on two placeholder environment values the
-  // operator had to go and look up. Cloud reads both itself and provisions the
-  // tenant on first use, so a placeholder printed here is a step that no longer
-  // exists — and a `<secret>` on screen is what made this path feel like setup.
-  it("prints no placeholder environment values under broker posture — Cloud provisions the tenant", () => {
-    const broker = plan({ posture: "broker" }).steps.join("\n");
-    expect(broker).not.toContain("<secret>");
-    expect(broker).not.toMatch(/VENDO_MCP_(BROKER_URL|FEDERATION_SECRET)=/);
-    expect(broker).toContain("provisions the tenant on first use");
-  });
-
-  // The posture select only appears when a Cloud key is in hand; a keyless run
-  // gets local as the default and today's one-line pointer.
-  it("adds the keyless pointer only when no Cloud key is in hand", () => {
-    expect(plan({ cloudKey: false }).steps.join("\n")).toContain("Sign-in: your app serves its own OAuth");
-    expect(plan().steps.join("\n")).not.toContain("Sign-in: your app serves its own OAuth");
-  });
-});
-
-describe("mcpStepLines — the closing block reads as steps, not a wall", () => {
-  it("numbers every headline and indents its detail under it", () => {
-    const broker = plan({ posture: "broker", serviceKey: true });
-    const lines = mcpStepLines(broker);
-    // Every step's headline is numbered in order...
-    const numbered = lines.filter((line) => /^\d+\. /.test(line));
-    expect(numbered).toHaveLength(broker.steps.length);
-    expect(numbered.map((line) => line.split(". ")[0])).toEqual(
-      broker.steps.map((_step, index) => String(index + 1)),
-    );
-    // ...and every detail line is indented under the headline it belongs to,
-    // never left at the margin where it would read as another step.
-    for (const [index, step] of broker.steps.entries()) {
-      const [headline, ...detail] = step.split("\n");
-      const at = lines.indexOf(`${index + 1}. ${headline!}`);
-      expect(at).toBeGreaterThanOrEqual(0);
-      expect(lines.slice(at + 1, at + 1 + detail.length)).toEqual(detail.map((rest) => `   ${rest}`));
-    }
   });
 });
 
@@ -231,10 +158,8 @@ describe("the generated MCP door answers every well-known path (seam)", () => {
       framework: "next",
       authWired: clerk,
       serverActions: false,
-      cloudKey: true,
       posture: "local",
       serviceKey: true,
-      baseUrl: BASE_URL,
     });
     const files = [
       { absolute: routePath, after: routeSource(await compositionSpecifier(root, dirname(routePath))) },

--- a/packages/vendo/tests/cli/init.test.ts
+++ b/packages/vendo/tests/cli/init.test.ts
@@ -9,7 +9,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { runDoctor } from "../../src/cli/doctor.js";
 import type { ExtractionHarness } from "../../src/cli/extract/harness.js";
 import { NEXT_SERVER_EXTERNALS, NEXT_SERVER_EXTERNALS_LINE } from "../../src/cli/framework.js";
-import { firstSentence, prettyThemeReview, runInit, type InitReceipt } from "../../src/cli/init.js";
+import { runInit, type InitReceipt } from "../../src/cli/init.js";
 import type { InitQuestions } from "../../src/cli/init-questions.js";
 import { CLI_VERSION, type Output } from "../../src/cli/shared.js";
 
@@ -163,7 +163,7 @@ describe("vendo init (zero-question)", () => {
     expect(questionsOf(sink.logs).detected).toMatchObject({ framework: expected });
   });
 
-  it("wires a fresh Next host with no prompts: route + hooks + .vendo, and one paste", async () => {
+  it("wires a fresh Next host with no prompts: route + hooks + .vendo", async () => {
     const root = await fixture();
     const sink = output();
     expect(await run(root, sink)).toBe(0);
@@ -226,42 +226,9 @@ describe("vendo init (zero-question)", () => {
     expect(logs).toContain("~ package.json");
     // No auth dependency in the fixture: one calm advisory, nothing guessed.
     expect(logs).toContain("Auth: no provider detected");
-    expect(logs).toContain("ONE STEP LEFT — paste this yourself (init never edits your files)");
-    // The mount block replaces the compact list; nothing is printed twice.
-    expect(logs).not.toContain("Last steps are yours:");
-    expect(logs).toContain("npx vendo doctor");
     // No interview, no per-diff consent, no refine offer, no finale.
     expect(logs).not.toContain("[y/N]");
     expect(logs).not.toContain("vendo refine");
-  });
-
-  // A plain transcript is parsed as often as it is read, so the MCP steps keep
-  // their exact strings there — the newline inside a step becomes an indent and
-  // nothing else. (The pretty run numbers the same strings; mcpStepLines owns
-  // that half.)
-  it("mcp: the plain transcript indents each step's detail under its headline", async () => {
-    const root = await mkdtemp(join(tmpdir(), "vendo-init-mcp-plain-"));
-    cleanup.push(root);
-    await mkdir(join(root, "app"), { recursive: true });
-    await writeFile(join(root, "package.json"), JSON.stringify({
-      name: "mcp-host",
-      dependencies: { next: "16.0.0", "@clerk/nextjs": "7.0.0" },
-    }));
-    await writeFile(join(root, "tsconfig.json"), "{}\n");
-    await writeFile(join(root, "app", "layout.tsx"),
-      "export default function Layout({ children }) { return <html><body>{children}</body></html>; }\n");
-    const sink = output();
-    expect(await run(root, sink, {
-      useCase: "mcp", yes: true, auth: "clerk", baseUrl: "http://localhost:3000",
-    })).toBe(0);
-    const logs = sink.logs.join("\n");
-    expect(logs).toContain(
-      "  When you deploy, set `VENDO_BASE_URL` in your platform to the public origin\n"
-      + "    dev is answered — `http://localhost:3000` is in .env.local, and every discovery URL hangs off it",
-    );
-    // The headline of a step is never indented past two spaces, so a reader
-    // (and a grep) can still tell a step from its detail.
-    expect(logs).toContain("  Point any MCP client at `http://localhost:3000/api/vendo/mcp`\n    your users' setup page");
   });
 
   it("is idempotent: a re-run changes nothing and says so", async () => {
@@ -272,15 +239,9 @@ describe("vendo init (zero-question)", () => {
     expect(await run(root, again)).toBe(0);
     expect(await tree(root)).toEqual(first);
     expect(again.logs.join("\n")).toContain("Already wired — nothing to change.");
-    // The second run's agent tail reflects what THIS run did: no composition
-    // was created (no auth line), the layout is already mounted (no layout
-    // line) — only the doctor gate remains.
-    const tail = again.logs.join("\n").split("Agent tail:")[1]!;
-    expect(tail).not.toContain("auth:");
-    expect(tail).toContain("vendo doctor --json");
   });
 
-  it("computes the paste's theme specifier from a src/app layout (../../ to project root)", async () => {
+  it("scaffolds into a src/app layout and never touches the host's own layout file", async () => {
     const root = await mkdtemp(join(tmpdir(), "vendo-init-srcapp-"));
     cleanup.push(root);
     await mkdir(join(root, "src", "app"), { recursive: true });
@@ -290,11 +251,8 @@ describe("vendo init (zero-question)", () => {
     const sink = output();
     expect(await run(root, sink)).toBe(0);
     await expect(readFile(join(root, "src", "app", "api", "vendo", "[...vendo]", "route.ts"), "utf8")).resolves.toContain("nextVendoHandler");
-    // The layout is untouched; the specifier rides the printed paste instead.
     expect(await readFile(join(root, "src", "app", "layout.tsx"), "utf8")).not.toContain("VendoProvider");
-    const logs = sink.logs.join("\n");
-    expect(logs).toContain('import theme from "../../.vendo/theme.json";');
-    expect(logs).toContain('import { VendoOverlay, VendoProvider } from "@vendoai/vendo/react";');
+    expect(sink.logs.join("\n")).toContain(`+ ${join("src", "app", "api", "vendo", "[...vendo]", "route.ts")}`);
   });
 
   it("scaffolds app/ under src/ when the host's pages router lives there (teable: pages+app must share one base)", async () => {
@@ -315,16 +273,6 @@ describe("vendo init (zero-question)", () => {
     // rule, so the two can never land on different bases.
     await expect(readFile(join(root, "src", "lib", "vendo.ts"), "utf8")).resolves.toContain("createVendo({");
     expect(await readdir(root)).not.toContain("app");
-  });
-
-  it("prints a theme-less paste when the project disables resolveJsonModule", async () => {
-    const root = await fixture();
-    await writeFile(join(root, "tsconfig.json"), JSON.stringify({ compilerOptions: { resolveJsonModule: false } }));
-    const sink = output();
-    expect(await run(root, sink)).toBe(0);
-    const logs = sink.logs.join("\n");
-    expect(logs).toContain('<VendoProvider baseUrl="/api/vendo">');
-    expect(logs).not.toContain("import theme from");
   });
 
   it.each([
@@ -639,33 +587,6 @@ describe("vendo init (zero-question)", () => {
   // run ENDS with the repo-specific agent tail (the wired auth preset and
   // what's still stubbed, the exact files to hand-edit, the doctor gate),
   // every line derived from what this run actually wrote.
-  it("non-interactive runs end with the agent tail: wired preset, hand-edit files, doctor gate", async () => {
-    const root = await fixture();
-    await writeFile(join(root, "package.json"), JSON.stringify({
-      name: "host",
-      dependencies: { next: "16.0.0", "next-auth": "5.0.0" },
-    }));
-    const sink = output();
-    expect(await run(root, sink)).toBe(0);
-    const logs = sink.logs.join("\n");
-    const tailAt = logs.indexOf("Agent tail:");
-    expect(tailAt).toBeGreaterThan(-1);
-    const tail = logs.slice(tailAt);
-    // The wired preset with its provenance — real run facts, not prose…
-    expect(tail).toContain("auth: authJs() wired (detected next-auth)");
-    // …the exact files the agent must now hand-edit, including the mount
-    // paste init will never make for it…
-    expect(tail).toContain(`edit ${join("app", "layout.tsx")} — wrap the app in the <VendoProvider> lines above`);
-    expect(tail).toContain(`edit ${join(".vendo", "brief.md")} — `);
-    // …and the machine gate, closing the tail block.
-    expect(tail).toContain("vendo doctor --json");
-    expect(sink.logs[sink.logs.length - 2]).toContain("vendo doctor --json");
-    expect(sink.logs[sink.logs.length - 2]).toContain("green");
-    // The one line after it is the outstanding-paste echo: with a mount still
-    // pending, the run's LAST word is the step the human owns (audit F5).
-    expect(sink.logs[sink.logs.length - 1]).toBe(`\n→ Don't forget the paste in ${join("app", "layout.tsx")} (frame above)`);
-  });
-
   /** Every fix-it text that reaches a NON-INTERACTIVE audience has to name the
       command that actually works there: a bare `vendo sync` skips the judgment
       pass unless a human answers the consent prompt, so an agent or a CI job
@@ -681,110 +602,9 @@ describe("vendo init (zero-question)", () => {
     // The keyless run's judgment line…
     const logs = sink.logs.join("\n");
     expect(logs).toContain("run `vendo sync --ai` to grade the catalog");
-    // …and the per-tool risk advice the receipt hands back.
-    const ungraded = receiptOf(sink.logs).riskRecommendations.filter((entry) => entry.risk === "ungraded");
-    expect(ungraded.length).toBeGreaterThan(0);
-    for (const entry of ungraded) expect(entry.recommendation).toContain("run `vendo sync --ai` with a model key");
     // The bare form never appears as advice (the sync hooks still use it with
     // their own explicit --no-ai, so scope the check to the advice lines).
     expect(logs).not.toContain("run `vendo sync` ");
-  });
-
-  // A tool the run extracted and then left off WITHOUT being asked to is the one
-  // fact the tail used to drop: the developer met it later, as an assistant that
-  // could not answer and would not say why. The human's own overrides.json
-  // disable stays unmentioned — that is the nag the test above forbids.
-  it("the tail names a tool the machine turned off, with the layer that did it and the way back on", async () => {
-    const root = await fixture();
-    await mkdir(join(root, "app", "api", "customers"), { recursive: true });
-    await writeFile(join(root, "app", "api", "customers", "route.ts"),
-      "export async function GET() { return Response.json({ customers: [] }); }\n");
-    await mkdir(join(root, ".vendo"), { recursive: true });
-    await writeFile(join(root, ".vendo", "judgments.json"), JSON.stringify({
-      format: "vendo/judgments@1",
-      tools: {
-        host_customers_list: {
-          binding: "GET /api/customers",
-          fields: { disabled: true },
-          evidence: "the handler returns the whole customer book",
-        },
-      },
-    }));
-    const sink = output();
-    expect(await run(root, sink)).toBe(0);
-    const tail = sink.logs.join("\n").split("Agent tail:")[1]!;
-    expect(tail).toContain("tools off: host_customers_list (turned off in .vendo/judgments.json)");
-    expect(tail).toContain('set "disabled": false');
-  });
-
-  // Agent-install-dx Layer 2 (key-mint integration): a keyless run's tail
-  // carries the complete in-band key story — the auth.md discovery URL, the
-  // `vendo login` ceremony, and both flag fallbacks — so the agent never
-  // detours to a browser signup it can't drive.
-  it("a keyless run's tail points at the auth.md key flow; a run with a key stays silent about it", async () => {
-    const keyless = await fixture();
-    const keylessSink = output();
-    expect(await run(keyless, keylessSink)).toBe(0);
-    const keylessTail = keylessSink.logs.join("\n").split("Agent tail:")[1]!;
-    expect(keylessTail).toContain("cloud key: none");
-    expect(keylessTail).toContain("https://vendo.run/auth.md");
-    expect(keylessTail).toContain("vendo login");
-    expect(keylessTail).toContain("--cloud-key");
-    expect(keylessTail).toContain("--byo");
-
-    const keyed = await fixture();
-    const keyedSink = output();
-    expect(await run(keyed, keyedSink, {
-      // A resolving credential, which a bare provider key no longer is.
-      env: { VENDO_DEV_CREDENTIAL: "env-key:anthropic", ANTHROPIC_API_KEY: "sk-ant-test" },
-    })).toBe(0);
-    const keyedTail = keyedSink.logs.join("\n").split("Agent tail:")[1]!;
-    expect(keyedTail).not.toContain("cloud key: none");
-  });
-
-  it("the tail states auth stubs honestly: anonymous scaffolds point at the composition, a picked preset names its missing SDK", async () => {
-    // No auth dependency: the tail says so and points the hand-edit at the
-    // generated composition file.
-    const anonymous = await fixture();
-    const anonymousSink = output();
-    expect(await run(anonymous, anonymousSink)).toBe(0);
-    const anonymousTail = anonymousSink.logs.join("\n").split("Agent tail:")[1]!;
-    expect(anonymousTail).toContain("auth: none wired");
-    expect(anonymousTail).toContain(`edit ${join("lib", "vendo.ts")} — `);
-    // The advisory count stays exact: the tail never repeats the "Auth:" line.
-    expect(anonymousSink.logs.filter((line) => line.includes("Auth:"))).toHaveLength(1);
-
-    // --auth clerk without the SDK: the stub is the missing runtime package.
-    const picked = await fixture();
-    const pickedSink = output();
-    expect(await run(picked, pickedSink, { yes: true, auth: "clerk" })).toBe(0);
-    const pickedTail = pickedSink.logs.join("\n").split("Agent tail:")[1]!;
-    expect(pickedTail).toContain("auth: clerk() wired");
-    expect(pickedTail).toContain("@clerk/backend");
-  });
-
-  it("interactive runs keep the clack-style summary — no agent tail; --yes brings it back even on a TTY", async () => {
-    const interactive = await fixture();
-    const interactiveSink = output();
-    expect(await run(interactive, interactiveSink, { interactive: true })).toBe(0);
-    expect(interactiveSink.logs.join("\n")).not.toContain("Agent tail");
-
-    // --yes IS the non-interactive path, TTY or not.
-    const flagged = await fixture();
-    const flaggedSink = output();
-    expect(await run(flagged, flaggedSink, { yes: true, interactive: true })).toBe(0);
-    expect(flaggedSink.logs.join("\n")).toContain("Agent tail:");
-  });
-
-  it("the Express tail points at the printed wiring lines (no exact entry file exists to name)", async () => {
-    const root = await expressFixture(false);
-    const sink = output();
-    expect(await run(root, sink)).toBe(0);
-    const tail = sink.logs.join("\n").split("Agent tail:")[1]!;
-    expect(tail).toContain("auth: none wired");
-    expect(tail).toContain(`edit ${join("vendo", "server.ts")} — `);
-    expect(tail).toContain("mountVendo()");
-    expect(tail).toContain("vendo doctor --json");
   });
 
   // Agent-install-dx: an undetectable framework has NO safe default — a
@@ -911,9 +731,8 @@ describe("vendo init (zero-question)", () => {
     expect(skippedSink.logs.join("\n")).toContain("this run cannot ask");
   });
 
-  it("--theme answers uncertain slots; the review prompt covers only what the flags left open", async () => {
+  it("--theme answers an uncertain slot; the rest are kept as extracted and reported", async () => {
     const root = await fixture();
-    const reviewed: string[] = [];
     const sink = output();
     expect(await run(root, sink, {
       ai: true,
@@ -927,33 +746,14 @@ describe("vendo init (zero-question)", () => {
           ],
         })],
       },
-      themeReview: async (summary) => {
-        reviewed.push(...summary.uncertain.map((entry) => entry.slot));
-        return {};
-      },
     })).toBe(0);
-    expect(reviewed).toEqual(["border"]); // accent was answered by flag
     const theme = JSON.parse(await readFile(join(root, ".vendo", "theme.json"), "utf8"));
     expect(theme.colors.accent).toBe("#facc15");
     // The contrast-derived accentText follows the flag-replaced accent.
     expect(theme.colors.accentText).toBe("#000000");
-
-    // With --yes the flag still applies — no prompt existed to answer.
-    const quiet = await fixture();
-    expect(await run(quiet, output(), {
-      yes: true,
-      ai: true,
-      themeAnswers: { accent: "#facc15" },
-      extract: {
-        harnesses: [themeHarness({
-          slots: { accent: "#196b46" },
-          uncertain: [{ slot: "accent", note: "green may be data-only" }],
-        })],
-      },
-      themeReview: async () => { throw new Error("prompted"); },
-    })).toBe(0);
-    const quietTheme = JSON.parse(await readFile(join(quiet, ".vendo", "theme.json"), "utf8"));
-    expect(quietTheme.colors.accent).toBe("#facc15");
+    // The slot the flags left open is a FACT, not a question: it keeps what was
+    // extracted and the run names it.
+    expect(sink.logs.join("\n")).toContain("Kept as extracted (uncertain): border");
   });
 
   // Task 3(c): a --theme answer beats a model value for the same slot, even
@@ -975,16 +775,6 @@ describe("vendo init (zero-question)", () => {
   // verbatim install rendered nothing — wired and invisible reads as broken,
   // while doctor E-WIRE-006 hard-fails exactly that state. One paste now
   // yields a visible agent; hosts with their own surface delete the line.
-  it("prints ONE paste — provider AND overlay, still never a generated file", async () => {
-    const root = await fixture();
-    const sink = output();
-    expect(await run(root, sink)).toBe(0);
-    const printed = sink.logs.join("\n");
-    expect(printed).toContain("<VendoProvider");
-    expect(printed).toContain("<VendoOverlay />");
-    expect(printed).not.toContain("vendo-root");
-  });
-
   it("states an env key in one line and skips the cloud offer", async () => {
     const root = await fixture();
     const sink = output();
@@ -1297,7 +1087,7 @@ describe("vendo init (zero-question)", () => {
     expect(composition).toContain("serverActions,");
   });
 
-  it("never regenerates an existing composition or vendo-actions.ts — it prints the paste instead", async () => {
+  it("never regenerates an existing composition or vendo-actions.ts, and says nothing about either", async () => {
     const libDir = "lib";
     const root = await fixture();
     expect(await run(root, output())).toBe(0);
@@ -1312,10 +1102,9 @@ describe("vendo init (zero-question)", () => {
     const second = output();
     expect(await run(root, second)).toBe(0);
     expect(await readFile(routePath, "utf8")).toBe(routeBefore);
-    const secondLogs = second.logs.join("\n");
-    expect(secondLogs).toContain(`File: ${join(libDir, "vendo.ts")}`);
-    expect(secondLogs).toContain('import { serverActions } from "./vendo-actions";');
-    expect(secondLogs).toContain("… then add inside createVendo({ … }): serverActions,");
+    // Init states facts and links out: the wiring gap is doctor's to grade
+    // (E-WIRE-009), so no snippet is printed here.
+    expect(second.logs.join("\n")).not.toContain("serverActions,");
 
     // The map that run CREATED now exists, so a surface change afterwards is a
     // printed paste of ONLY the missing entries — the file stays byte-identical,
@@ -1330,16 +1119,10 @@ describe("vendo init (zero-question)", () => {
     expect(await readFile(mapPath, "utf8")).toBe(mapBefore);
     expect(await readFile(routePath, "utf8")).toBe(routeBefore);
     const thirdLogs = third.logs.join("\n");
-    // The outstanding layout mount, the route wiring, and the unregistered action.
-    expect(thirdLogs).toContain("3 STEPS LEFT — paste these yourself (init never edits your files)");
-    expect(thirdLogs).toContain(`File: ${join(libDir, "vendo-actions.ts")}`);
-    expect(thirdLogs).toContain(`import { renamed as action1 } from ${JSON.stringify(ACTION_SPECIFIER)};`);
-    expect(thirdLogs).toContain("… then add inside the serverActions map:");
-    expect(thirdLogs).toContain('"app/actions/later.ts#renamed": action1,');
-    // Only the missing entry — never the whole file, and never the entry the
-    // map already carries.
+    // Nothing is printed for either file: they are the developer's, and doctor
+    // is what grades the missing registration.
+    expect(thirdLogs).not.toContain("action1");
     expect(thirdLogs).not.toContain("--- a/");
-    expect(thirdLogs).not.toContain("app/actions/later.ts#later");
   });
 
   // Regression (review B2): the map is compared by the KEYS it registers, never
@@ -1419,21 +1202,6 @@ describe("vendo init (zero-question)", () => {
     expect(logs).not.toContain("internal");
   });
 
-  it("carries the pastes it will not write into the receipt", async () => {
-    const routeDir = "lib";
-    const root = await fixture();
-    expect(await run(root, output())).toBe(0);
-    await mkdir(join(root, "app", "actions"), { recursive: true });
-    await writeFile(join(root, "app", "actions", "later.ts"),
-      '"use server";\n\nexport async function later() {\n  return 1;\n}\n');
-    const sink = output();
-    expect(await agentRun(root, sink)).toBe(0);
-    const edit = receiptOf(sink.logs).pasteEdits.find((paste) => paste.file === join(routeDir, "vendo.ts"));
-    expect(edit?.lines).toContain('import { serverActions } from "./vendo-actions";');
-    expect(edit?.why).toContain("fails closed");
-    expect(sink.logs.join("\n")).toContain(`File: ${join(routeDir, "vendo.ts")}`);
-  });
-
   it("leaves a hand-customized route that passes its own serverActions untouched (no conflicting import)", async () => {
     const root = await fixture();
     const routeDir = join(root, "app", "api", "vendo", "[...vendo]");
@@ -1472,8 +1240,8 @@ describe("vendo init (zero-question)", () => {
     expect(server).not.toContain("model");
     await expect(readFile(join(unwired, "vendo", "registry.tsx"))).rejects.toMatchObject({ code: "ENOENT" });
     await expect(readFile(join(unwired, "vendo", "ai.ts"))).rejects.toMatchObject({ code: "ENOENT" });
-    expect(sink.logs.join("\n")).toContain('app.use("/api/vendo", mountVendo());');
-    expect(sink.logs.join("\n")).toContain('<VendoProvider baseUrl="/api/vendo"');
+    // The mount lines live on the continue page, never in the terminal.
+    expect(sink.logs.join("\n")).not.toContain("mountVendo()");
     // Fresh composition creation with no auth dependency: one calm advisory.
     expect(sink.logs.join("\n")).toContain("Auth: no provider detected");
 
@@ -1701,17 +1469,18 @@ describe("vendo init (zero-question)", () => {
     expect(questions[0]).toContain("theme");
   });
 
-  // Task 4(d): the uncertain review is asked ONLY about slots the model
-  // actually flagged — a clean model reply never reaches the review prompt.
-  it("never opens the uncertain review when the model reports no uncertainty", async () => {
+  // A clean model reply names no uncertain slot, so the facts carry no
+  // kept-as-extracted line at all.
+  it("says nothing about uncertainty when the model reports none", async () => {
     const root = await fixture();
-    expect(await run(root, output(), {
+    const sink = output();
+    expect(await run(root, sink, {
       ai: true,
       extract: { harnesses: [themeHarness({ slots: { accent: "#2b7fff" } })] },
-      themeReview: async () => { throw new Error("must never be asked"); },
     })).toBe(0);
     const theme = JSON.parse(await readFile(join(root, ".vendo", "theme.json"), "utf8"));
     expect(theme.colors.accent).toBe("#2b7fff");
+    expect(sink.logs.join("\n")).not.toContain("Kept as extracted");
   });
 
   it("derives an applied next/font family deterministically — the model's fontFamily proposal never overrides it — and prints the one-glance summary", async () => {
@@ -1751,14 +1520,13 @@ describe("vendo init (zero-question)", () => {
     expect(logs).toContain(".vendo/theme.json");
   });
 
-  it("asks about the theme ONLY when the model reports uncertainty, and applies the answer", async () => {
+  it("keeps an uncertain slot as extracted, reports it, and still honours a --theme answer", async () => {
     const root = await fixture();
     await writeFile(join(root, "app", "layout.tsx"),
       'import "./globals.css";\nexport default function Layout({ children }) { return <html><body>{children}</body></html>; }\n');
     await writeFile(join(root, "app", "globals.css"),
       ":root { --color-ink: #111111; --color-evergreen-600: #196b46; }\n");
 
-    const reviewed: string[] = [];
     const sink = output();
     expect(await run(root, sink, {
       ai: true,
@@ -1768,13 +1536,9 @@ describe("vendo init (zero-question)", () => {
           uncertain: [{ slot: "accent", note: "green may be data-only" }],
         })],
       },
-      themeReview: async (summary) => {
-        reviewed.push(...summary.uncertain.map((entry) => entry.slot));
-        return { accent: "#facc15", border: "#ecebe8", danger: "chartreuse-ish", sparkle: "#123456" };
-      },
+      themeAnswers: { accent: "#facc15", border: "#ecebe8", danger: "chartreuse-ish", sparkle: "#123456" },
     })).toBe(0);
 
-    expect(reviewed).toEqual(["accent"]);
     const theme = JSON.parse(await readFile(join(root, ".vendo", "theme.json"), "utf8"));
     // The human answer wins; invalid values and unknown slots are ignored.
     expect(theme.colors.accent).toBe("#facc15");
@@ -1947,7 +1711,6 @@ describe("vendo init --agent (ask first, then write)", () => {
       status: "written",
       root,
       useCase: "embedded",
-      tools: expect.any(Number),
       judgment: {
         status: "delegated",
         checklist: [
@@ -1965,10 +1728,8 @@ describe("vendo init --agent (ask first, then write)", () => {
     // Every named path is one the caller can open: this rejects the plan's
     // static list, which promises a fonts.css only an embedded font creates.
     await Promise.all(receipt.wrote.map((path) => readFile(join(root, path), "utf8")));
-    // Init writes no client file, so the layout is a paste and never a write.
+    // Init writes no client file, so the host's layout is never a write.
     expect(receipt.wrote).not.toContain(join("app", "layout.tsx"));
-    expect(receipt.pasteEdits[0]?.file).toBe(join("app", "layout.tsx"));
-    expect(Array.isArray(receipt.riskRecommendations)).toBe(true);
     // The retired plan dump's fields are gone with it.
     expect(sink.logs.join("\n")).not.toContain("codeChanges");
     // Agent mode asks for the judgment pass now; no engine resolves in a test
@@ -2087,8 +1848,7 @@ describe("vendo init --agent (ask first, then write)", () => {
     expect(await agentRun(loop, loopSink, { useCase: "agent-loop" })).toBe(0);
     const loopReceipt = receiptOf(loopSink.logs);
     expect(loopReceipt.useCase).toBe("agent-loop");
-    expect(loopReceipt.pasteEdits.map((paste) => paste.lines.join("\n")).join("\n"))
-      .toContain('import { vendoTools } from "@vendoai/vendo/ai-sdk";');
+    expect(loopReceipt.continueUrl).toBe("https://docs.vendo.run/existing-agent/ai-sdk");
 
     const mcp = await fixture();
     const mcpSink = output();
@@ -2300,16 +2060,17 @@ describe("the next.config repair (Next hosts)", () => {
       serverExternalPackages (our own demo-bank hit it). A source-linked host
       that transpiles @vendoai/apps must therefore get the paste, never the
       write: init following its own advice would brick their dev server. */
-  it("keeps the paste when the host transpiles a package we would externalize", async () => {
+  // Next hard-fatals on a package named in both lists, so writing the property
+  // for a host that transpiles one would brick the dev server this run just
+  // wired. Doctor grades the gap (E-CFG-004) and its page carries the caveat.
+  it("leaves a config alone when the host transpiles a package we would externalize", async () => {
     const root = await fixture();
     const source = 'const nextConfig = {\n  transpilePackages: ["@vendoai/apps"],\n};\n\nexport default nextConfig;\n';
     await writeFile(join(root, "next.config.ts"), source);
     const sink = output();
     expect(await agentRun(root, sink)).toBe(0);
     expect(await readFile(join(root, "next.config.ts"), "utf8"), "init must not brick the host").toBe(source);
-    const paste = receiptOf(sink.logs).pasteEdits.find((edit) => edit.file === "next.config.ts");
-    expect(paste?.lines.join("\n")).toContain(NEXT_SERVER_EXTERNALS_LINE);
-    expect(paste?.why).toContain("Remove @vendoai/apps from transpilePackages first");
+    expect(sink.logs.join("\n")).not.toContain(NEXT_SERVER_EXTERNALS_LINE);
   });
 
   it("still edits when the transpilePackages entry is only a comment", async () => {
@@ -2320,165 +2081,20 @@ describe("the next.config repair (Next hosts)", () => {
     expect(await readFile(join(root, "next.config.ts"), "utf8")).toContain(NEXT_SERVER_EXTERNALS_LINE);
   });
 
-  it("hands back the paste instead of rewriting a config it cannot read", async () => {
+  it("leaves a config it cannot read as an object literal untouched", async () => {
     const root = await fixture();
     const dynamic = "export default (phase) => ({ reactStrictMode: true });\n";
     await writeFile(join(root, "next.config.mjs"), dynamic);
     const sink = output();
     expect(await agentRun(root, sink)).toBe(0);
     expect(await readFile(join(root, "next.config.mjs"), "utf8")).toBe(dynamic);
-    const paste = receiptOf(sink.logs).pasteEdits.find((edit) => edit.file === "next.config.mjs");
-    expect(paste?.lines.join("\n")).toContain('serverExternalPackages: ["@vendoai/apps", "esbuild", "@electric-sql/pglite", "@vendoai/store"],');
-    expect(sink.logs.join("\n")).toContain("next.config.mjs");
+    expect(receiptOf(sink.logs).wrote).not.toContain("next.config.mjs");
   });
 
   it("leaves an Express host's tree alone", async () => {
     const root = await expressFixture(true);
     expect(await run(root, output())).toBe(0);
     expect(Object.keys(await tree(root)).filter((path) => path.startsWith("next.config"))).toEqual([]);
-  });
-});
-
-describe("the mount paste (init never edits user-authored source)", () => {
-  /** The whole point of decision 1: a host layout that init COULD have
-      rewritten unambiguously is left byte-identical, and the paste is
-      printed instead. */
-  it("leaves an existing layout.tsx byte-identical and prints the mount block", async () => {
-    const root = await fixture();
-    const before = await readFile(join(root, "app", "layout.tsx"), "utf8");
-    const sink = output();
-    expect(await run(root, sink)).toBe(0);
-    expect(await readFile(join(root, "app", "layout.tsx"), "utf8")).toBe(before);
-    const logs = sink.logs.join("\n");
-    expect(logs).toContain("ONE STEP LEFT — paste this yourself (init never edits your files)");
-    expect(logs).toContain(`File: ${join("app", "layout.tsx")}`);
-    expect(logs).toContain('import { VendoOverlay, VendoProvider } from "@vendoai/vendo/react";');
-    expect(logs).toContain('<VendoProvider baseUrl="/api/vendo" theme={theme as VendoTheme}>{children}<VendoOverlay /></VendoProvider>');
-    // Doctor is named ONCE, at the ending — never a second time inside the
-    // paste frame (#1164).
-    expect(logs).not.toContain("Then confirm it landed: npx vendo doctor");
-    expect(logs.match(/npx vendo doctor/g)).toHaveLength(1);
-    // No layout diff is even proposed.
-    expect(logs).not.toContain("~ " + join("app", "layout.tsx"));
-  });
-
-  it("an ambiguous layout gets the same paste — nothing about the file changes", async () => {
-    const root = await fixture();
-    const twoSites = "export default function Layout({ children }) {\n" +
-      "  return <html><body><main>{children}</main><aside>{children}</aside></body></html>;\n}\n";
-    await writeFile(join(root, "app", "layout.tsx"), twoSites);
-    const sink = output();
-    expect(await run(root, sink)).toBe(0);
-    expect(await readFile(join(root, "app", "layout.tsx"), "utf8")).toBe(twoSites);
-    const logs = sink.logs.join("\n");
-    expect(logs).toContain("ONE STEP LEFT");
-    expect(logs).toContain('import { VendoOverlay, VendoProvider } from "@vendoai/vendo/react";');
-    expect(logs).toContain("<VendoProvider baseUrl=");
-    // The paste must yield a VISIBLE agent: a verbatim install that renders
-    // nothing reads as broken (field: expense.fyi, ENG-421 / #1370), and
-    // doctor E-WIRE-006 already hard-fails an overlay-less host.
-    expect(logs).toContain("<VendoOverlay />");
-  });
-
-  it("carries the same file and lines in the receipt's `pasteEdits`", async () => {
-    const root = await fixture();
-    const sink = output();
-    expect(await agentRun(root, sink)).toBe(0);
-    const receipt = receiptOf(sink.logs);
-    expect(receipt.pasteEdits[0]?.file).toBe(join("app", "layout.tsx"));
-    expect(receipt.pasteEdits[0]?.lines).toEqual([
-      'import { VendoOverlay, VendoProvider } from "@vendoai/vendo/react";',
-      'import theme from "../.vendo/theme.json";',
-      'import type { VendoTheme } from "@vendoai/vendo";',
-      '… then wrap: <VendoProvider baseUrl="/api/vendo" theme={theme as VendoTheme}>{children}<VendoOverlay /></VendoProvider>',
-    ]);
-    expect(receipt.pasteEdits[0]?.why).toContain("nothing on the page can reach it");
-    // The why-text names the escape hatch for hosts with their own surface
-    // (the overlay line is deletable, ENG-421 / #1370).
-    expect(receipt.pasteEdits[0]?.why).toContain("your own surface");
-    // The same lines are printed, and the layout itself is never written.
-    expect(sink.logs.join("\n")).toContain('<VendoProvider baseUrl="/api/vendo"');
-    expect(receipt.wrote).not.toContain(join("app", "layout.tsx"));
-  });
-
-  /** A host that already mounts the provider IS mounted — init has nothing
-      left to print, whatever surface it renders inside. */
-  it("a layout that already mounts <VendoProvider> gets no paste", async () => {
-    const root = await fixture();
-    await writeFile(join(root, "app", "layout.tsx"),
-      'import { VendoProvider } from "@vendoai/vendo/react";\n' +
-      "export default function Layout({ children }) { return <html><body><VendoProvider>{children}</VendoProvider></body></html>; }\n");
-    const sink = output();
-    expect(await run(root, sink)).toBe(0);
-    const logs = sink.logs.join("\n");
-    expect(logs).not.toContain("ONE STEP LEFT");
-  });
-
-  it("a host with its own surface (BYO embeds) is left entirely alone", async () => {
-    const root = await fixture();
-    await writeFile(join(root, "app", "layout.tsx"),
-      "export default function Layout({ children }) { return <html><body><VendoProvider>{children}</VendoProvider></body></html>; }\n");
-    await mkdir(join(root, "app", "chat"), { recursive: true });
-    await writeFile(join(root, "app", "chat", "page.tsx"),
-      "export default () => <VendoToolResult output={null} />;\n");
-    const sink = output();
-    expect(await run(root, sink)).toBe(0);
-    await expect(readFile(join(root, "vendo", "vendo-root.tsx"))).rejects.toMatchObject({ code: "ENOENT" });
-    expect(sink.logs.join("\n")).not.toContain("Last steps are yours:");
-  });
-
-  /** The nextcrm shape (corpus, pinned 5b6a555): every route lives under
-      app/[locale]/, so the app router's ROOT layout is app/[locale]/layout.tsx
-      and app/layout.tsx does not exist. Naming the phantom told the user to
-      create a second root layout — the one edit that breaks such a host. */
-  it("names the shallowest nested layout when the host has no app/layout.tsx", async () => {
-    const root = await fixture();
-    await rm(join(root, "app", "layout.tsx"));
-    await mkdir(join(root, "app", "[locale]", "(auth)"), { recursive: true });
-    await writeFile(join(root, "app", "[locale]", "layout.tsx"),
-      "export default function Layout({ children }) { return <html><body>{children}</body></html>; }\n");
-    await writeFile(join(root, "app", "[locale]", "(auth)", "layout.tsx"),
-      "export default function AuthLayout({ children }) { return <main>{children}</main>; }\n");
-    const sink = output();
-    expect(await agentRun(root, sink)).toBe(0);
-    const mount = receiptOf(sink.logs).pasteEdits[0];
-    expect(mount?.file).toBe(join("app", "[locale]", "layout.tsx"));
-    // The paste still wraps {children}, and the theme import walks out of the
-    // deeper directory.
-    expect(mount?.lines.at(-1)).toContain("{children}<VendoOverlay /></VendoProvider>");
-    expect(mount?.lines).toContain('import theme from "../../.vendo/theme.json";');
-  });
-
-  it("keeps naming app/layout.tsx when a root layout sits beside nested ones", async () => {
-    const root = await fixture();
-    await mkdir(join(root, "app", "(shop)"), { recursive: true });
-    await writeFile(join(root, "app", "(shop)", "layout.tsx"),
-      "export default function ShopLayout({ children }) { return <main>{children}</main>; }\n");
-    const sink = output();
-    expect(await agentRun(root, sink)).toBe(0);
-    expect(receiptOf(sink.logs).pasteEdits[0]?.file).toBe(join("app", "layout.tsx"));
-  });
-
-  it("still names pages/_app.tsx on a Pages-Router host with no layouts at all", async () => {
-    const root = await fixture();
-    await rm(join(root, "app", "layout.tsx"));
-    await mkdir(join(root, "pages"), { recursive: true });
-    await writeFile(join(root, "pages", "index.tsx"), "export default () => <main />;\n");
-    const sink = output();
-    expect(await agentRun(root, sink)).toBe(0);
-    const mount = receiptOf(sink.logs).pasteEdits[0];
-    expect(mount?.file).toBe(join("pages", "_app.tsx"));
-    expect(mount?.lines.at(-1)).toContain("<Component {...pageProps} /><VendoOverlay /></VendoProvider>");
-  });
-
-  /** No layout and no pages/ means the host has no client root yet — the
-      conventional app/layout.tsx is the address of the one it must create. */
-  it("falls back to app/layout.tsx only when the host has no client root at all", async () => {
-    const root = await fixture();
-    await rm(join(root, "app", "layout.tsx"));
-    const sink = output();
-    expect(await agentRun(root, sink)).toBe(0);
-    expect(receiptOf(sink.logs).pasteEdits[0]?.file).toBe(join("app", "layout.tsx"));
   });
 });
 
@@ -2615,9 +2231,10 @@ describe("vendo init (custom runtime)", () => {
     // No framework file-layout assumptions, and no client file.
     await expect(readFile(join(root, "vendo", "registry.tsx"))).rejects.toMatchObject({ code: "ENOENT" });
 
-    const log = sink.logs.join("\n");
-    expect(log).toContain("handleVendoRequest(request, env)");
-    expect(log).toContain("VENDO_BASE_URL");
+    // The routing lines the host still owes live in the generated module's own
+    // header comment and on the continue page — never printed at the terminal.
+    expect(server).toContain("handleVendoRequest(request, env)");
+    expect(sink.logs.join("\n")).not.toContain("handleVendoRequest(request, env)");
   });
 
   it("an undetectable host falls through to the custom scaffold interactively, never the Next layout", async () => {
@@ -2681,8 +2298,6 @@ describe("the five questions", () => {
       confirmAuth: async () => false,
       selectAuth: async () => "none",
       askText: async () => "",
-      confirmCheck: async () => false,
-      confirmZodBump: async () => false,
     }).finally(() => {
       process.stdin.isTTY = tty.in;
       process.stdout.isTTY = tty.out;
@@ -2709,39 +2324,6 @@ describe("the five questions", () => {
     // An explicit answer still wins over the record.
     expect(await run(root, output(), { yes: true, useCase: "embedded" })).toBe(0);
     expect(JSON.parse(await readFile(recorded, "utf8"))).toMatchObject({ useCase: "embedded" });
-  });
-
-  it("--use-case agent-loop adds the snippet for the loop package.json already names", async () => {
-    const aiSdk = await fixture();
-    await writeFile(join(aiSdk, "package.json"), JSON.stringify({
-      name: "host",
-      dependencies: { next: "16.0.0", ai: "6.0.0" },
-    }));
-    const aiSink = output();
-    expect(await run(aiSdk, aiSink, { useCase: "agent-loop" })).toBe(0);
-    const aiLogs = aiSink.logs.join("\n");
-    // ONE step, not two: an agent-loop install mounts no Vendo UI by design, so
-    // the <VendoProvider> paste is not a step it owes (the rule doctor grades by).
-    expect(aiLogs).toContain("ONE STEP LEFT");
-    expect(aiLogs).not.toContain("VendoOverlay");
-    expect(aiLogs).toContain('import { vendoTools } from "@vendoai/vendo/ai-sdk";');
-    // The `vendo` the snippet calls has to COME from somewhere: a second
-    // createVendo in the loop shares no state with the wire the embeds call.
-    expect(aiLogs).toContain(`import { vendo } from ${JSON.stringify(LIB_VENDO(3))};`);
-
-    // Mastra's principal step is a step of its own — a call without one fails
-    // closed, so an install that skips it looks broken at the first tool call.
-    const mastra = await fixture();
-    await writeFile(join(mastra, "package.json"), JSON.stringify({
-      name: "host",
-      dependencies: { next: "16.0.0", "@mastra/core": "1.0.0" },
-    }));
-    const mastraSink = output();
-    expect(await run(mastra, mastraSink, { useCase: "agent-loop" })).toBe(0);
-    const mastraLogs = mastraSink.logs.join("\n");
-    expect(mastraLogs).toContain("2 STEPS LEFT");
-    expect(mastraLogs).toContain("vendoMastraTools");
-    expect(mastraLogs).toContain("VENDO_PRINCIPAL_KEY");
   });
 
   /** The dev URL is a QUESTION now, and its answer is WRITTEN. An agent loop, a
@@ -2823,13 +2405,12 @@ describe("the five questions", () => {
       askText: async (_question, _hint, prefill) => prefill ?? "",
       confirmAuth: async () => false,
       selectUseCase: async () => "local",
-      confirmCheck: async () => false,
-      confirmZodBump: async () => false,
     })).toBe(0);
 
     expect(await readFile(join(root, ".env.local"), "utf8")).toContain("VENDO_BASE_URL=http://localhost:4300");
-    // The client URL a user pastes into Claude is the dev origin, not a guess.
-    expect(sink.logs.join("\n")).toContain("Point any MCP client at `http://localhost:4300/api/vendo/mcp`");
+    // The client URL, the deploy variable and the broker values all live on the
+    // page the run points at — the terminal states what it wired and links out.
+    expect(sink.logs.join("\n")).toContain("Continue: https://docs.vendo.run/outside-agents/quickstart");
 
     // The read-back: doctor over the repo init just wrote. No env override, so
     // it loads .env.local itself — the file this run produced. (Only this check
@@ -2863,8 +2444,6 @@ describe("the five questions", () => {
       selectUseCase: async () => "broker",
       askText: async (_question, _hint, prefill) => prefill ?? "",
       confirmAuth: async () => false,
-      confirmCheck: async () => false,
-      confirmZodBump: async () => false,
     })).toBe(1);
 
     const errors = sink.errors.join("\n");
@@ -2888,8 +2467,6 @@ describe("the five questions", () => {
       selectUseCase: async () => "broker",
       askText: async (_question, _hint, prefill) => prefill ?? "",
       confirmAuth: async () => false,
-      confirmCheck: async () => false,
-      confirmZodBump: async () => false,
     })).toBe(0);
     expect(await readdir(cloudOnly)).toContain("lib");
   });
@@ -2912,8 +2489,6 @@ describe("the five questions", () => {
       selectUseCase: async () => "broker",
       askText: async (_question, _hint, prefill) => prefill ?? "",
       confirmAuth: async () => false,
-      confirmCheck: async () => false,
-      confirmZodBump: async () => false,
     })).toBe(1);
 
     const errors = sink.errors.join("\n");
@@ -2926,75 +2501,255 @@ describe("the five questions", () => {
     expect(await readdir(root)).not.toContain("lib");
     expect(sink.logs.join("\n")).not.toContain("Wired");
   });
-
-  it("offers the doctor check only when nothing is left to paste, and never changes the exit code", async () => {
-    // A run that still owes the mount paste: doctor would grade that paste,
-    // so offering the check would fail a run that did nothing wrong.
-    const owing = await fixture();
-    expect(await run(owing, output(), {
-      interactive: true,
-      confirmCheck: async () => { throw new Error("prompted"); },
-      runCheck: async () => { throw new Error("ran"); },
-    })).toBe(0);
-
-    // Already mounted: the ask fires, and a check that blows up is still 0.
-    const mounted = await fixture();
-    await writeFile(join(mounted, "app", "layout.tsx"),
-      'import { VendoProvider } from "@vendoai/vendo/react";\n'
-      + "export default function Layout({ children }) { return <VendoProvider>{children}</VendoProvider>; }\n");
-    const asked: string[] = [];
-    expect(await run(mounted, output(), {
-      interactive: true,
-      confirmCheck: async (question) => { asked.push(question); return true; },
-      runCheck: async () => { throw new Error("doctor exploded"); },
-    })).toBe(0);
-    expect(asked).toEqual(["Check the install now?"]);
-  });
 });
 
 /**
- * #1165 — the uncertain-slot review used to hand a raw readline prompt a
- * ~450-character string, so it landed at column 0 with no rail, no wrapping and
- * the model's first person intact: the only place in the run where the rail
- * died. On the rail it is a `◇` question with the reasoning as a dim hint.
+ * The redesign: init states FACTS and links out. Every instruction it used to
+ * print — the mount paste, the loop snippet, the MCP steps, the doctor gate —
+ * was a second copy of something the docs already carry, and a terminal cannot
+ * keep a copy correct. Four lines, computed per run, and one URL.
  */
-describe("the uncertain-theme-slot review", () => {
-  const NOTE = "app/page.module.css defines two neutrals: `--background: #fafafa` on the "
-    + "full-height `.page` wrapper and `--foreground: #fff` painting the `.main` content "
-    + "panel. I picked #fafafa because it is the only neutral distinct from the "
-    + "already-fixed background (#ffffff); a literal cards/panels reading of `.main` would "
-    + "instead give #ffffff, identical to background.";
-  const summary = {
-    slots: { surface: "#fafafa" },
-    uncertain: [{ slot: "surface", note: NOTE }],
-  } as unknown as Parameters<ReturnType<typeof prettyThemeReview>>[0];
+describe("the closing output is facts, never code or steps", () => {
+  it("ends on Wired / Detected / Guard / Continue and prints no snippet at all", async () => {
+    const root = await fixture();
+    const sink = output();
+    expect(await run(root, sink)).toBe(0);
+    const logs = sink.logs.join("\n");
 
-  it("asks through the renderer, with the model's reasoning trimmed to the reading it chose", async () => {
-    const asked: { question: string; hint?: string }[] = [];
-    const review = prettyThemeReview({
-      text: async (question: string, hint?: string) => { asked.push({ question, hint }); return ""; },
+    expect(logs).toContain("Wired: ");
+    expect(logs).toContain(join("lib", "vendo.ts"));
+    expect(logs).toContain("Detected: Next.js · no auth detected · npm · port 3000");
+    expect(logs).toContain("Guard: writes run without approval — how to tighten: vendo.run/agents.md");
+    expect(logs).toContain("Continue: https://docs.vendo.run/product/quickstart");
+
+    // Nothing that reads as code or as homework.
+    expect(logs).not.toContain("STEP LEFT");
+    expect(logs).not.toContain("STEPS LEFT");
+    expect(logs).not.toContain("VendoProvider");
+    expect(logs).not.toContain("VendoOverlay");
+    expect(logs).not.toContain("Last steps are yours");
+    expect(logs).not.toContain("Agent tail:");
+    // Doctor is a standalone command; init never sends anyone there.
+    expect(logs).not.toContain("vendo doctor");
+  });
+
+  it.each([
+    ["embedded", {}, "https://docs.vendo.run/product/quickstart"],
+    ["agent-loop", { ai: "6.0.0" }, "https://docs.vendo.run/existing-agent/ai-sdk"],
+    ["agent-loop", { "@mastra/core": "1.0.0" }, "https://docs.vendo.run/existing-agent/mastra"],
+  ] as const)("continues at the page for %s", async (useCase, extraDeps, url) => {
+    const root = await fixture();
+    await writeFile(join(root, "package.json"), JSON.stringify({
+      name: "host",
+      dependencies: { next: "16.0.0", ...extraDeps },
+    }));
+    const sink = output();
+    expect(await run(root, sink, { useCase })).toBe(0);
+    expect(sink.logs.join("\n")).toContain(`Continue: ${url}`);
+  });
+
+  it("sends an MCP install to the door's own page", async () => {
+    const root = await fixture();
+    await writeFile(join(root, "package.json"), JSON.stringify({
+      name: "host",
+      dependencies: { next: "16.0.0", "@clerk/nextjs": "7.0.0" },
+    }));
+    const sink = output();
+    expect(await run(root, sink, {
+      useCase: "mcp", yes: true, auth: "clerk", baseUrl: "http://localhost:3000",
+    })).toBe(0);
+    const logs = sink.logs.join("\n");
+    expect(logs).toContain("Continue: https://docs.vendo.run/outside-agents/quickstart");
+    // The steps the docs page owns are no longer echoed at the terminal.
+    expect(logs).not.toContain("Point any MCP client at");
+    expect(logs).not.toContain("Set where you deploy");
+  });
+
+  it("carries the same facts in the --agent receipt, and no pastes", async () => {
+    const root = await fixture();
+    const sink = output();
+    expect(await agentRun(root, sink)).toBe(0);
+    const receipt = receiptOf(sink.logs) as unknown as Record<string, unknown>;
+    expect(receipt).toMatchObject({
+      status: "written",
+      root,
+      useCase: "embedded",
+      detected: { framework: "Next.js", auth: "no auth detected", packageManager: "npm", port: 3000 },
+      guardPosture: "writes run without approval — how to tighten: vendo.run/agents.md",
+      continueUrl: "https://docs.vendo.run/product/quickstart",
+      judgment: { status: "delegated" },
     });
-    await expect(review(summary)).resolves.toEqual({});
-    expect(asked).toHaveLength(1);
-    expect(asked[0]!.question).toBe(
-      "Theme surface is uncertain — extracted #fafafa. Replacement value, or Enter to keep",
-    );
-    // The hint is the reading it CHOSE. The rejected alternative and the "I
-    // picked…" first person behind it are what made the line a wall.
-    expect(asked[0]!.hint!.length).toBeLessThan(NOTE.length / 2);
-    expect(asked[0]!.hint).not.toContain("I picked");
-    expect(asked[0]!.hint).toContain("app/page.module.css defines two neutrals");
+    expect(receipt["wrote"]).toContain(join("lib", "vendo.ts"));
+    expect(receipt["pasteEdits"]).toBeUndefined();
+  });
+});
+
+describe("the judgment question is asked up front, and loosenings never block", () => {
+  /** It used to be asked at the TOP of the pass that then runs for minutes —
+      past the point the person who started the install has walked away. It is
+      knowable before that (the engine ladder is a read-only probe), so it is
+      asked with the other questions and the flow is handed the answer.
+
+      The discriminator is init's own WRITE step: the question phase ends when
+      init starts writing (`Wired (N files):`), and the pass runs after that. A
+      consent asked before the write is up front; one asked after it is the old
+      mid-run prompt. Asserting only "before the pass" would pass either way. */
+  it("asks for AI consent before init writes a single file, not at the top of the pass", async () => {
+    const events: string[] = [];
+    const root = await fixture();
+    const harness = themeHarness({ slots: { accent: "#2b7fff" } });
+    const sink = {
+      output: {
+        log: (message: string) => { if (message.startsWith("\nWired (")) events.push("wrote-files"); },
+        error: () => {},
+      },
+    };
+    expect(await run(root, sink, {
+      interactive: true,
+      askText: async (_q, _h, prefill) => { events.push("dev-url"); return prefill ?? ""; },
+      extract: {
+        interactive: true,
+        harnesses: [{
+          ...harness,
+          run: async (input) => { events.push("ai-pass"); return harness.run(input); },
+        }],
+        confirm: async () => { events.push("ai-consent"); return true; },
+      },
+    })).toBe(0);
+
+    expect(events).toContain("ai-consent");
+    expect(events).toContain("wrote-files");
+    expect(events).toContain("ai-pass");
+    // Asked ONCE, and before anything was written.
+    expect(events.filter((event) => event === "ai-consent")).toHaveLength(1);
+    expect(events.indexOf("ai-consent")).toBeLessThan(events.indexOf("wrote-files"));
+    // …which is the same side of the write as the other up-front questions.
+    expect(events.indexOf("dev-url")).toBeLessThan(events.indexOf("wrote-files"));
   });
 
-  it("keeps a typed replacement and treats Enter as keep", async () => {
-    await expect(prettyThemeReview({ text: async () => "#ffffff" })(summary))
-      .resolves.toEqual({ surface: "#ffffff" });
-    await expect(prettyThemeReview({ text: async () => "" })(summary)).resolves.toEqual({});
+  it("declining up front skips the pass, and never asks a second time", async () => {
+    const events: string[] = [];
+    const root = await fixture();
+    const logs: string[] = [];
+    const sink = {
+      output: {
+        log: (message: string) => {
+          logs.push(message);
+          if (message.startsWith("\nWired (")) events.push("wrote-files");
+        },
+        error: () => {},
+      },
+    };
+    expect(await run(root, sink, {
+      interactive: true,
+      extract: {
+        interactive: true,
+        harnesses: [{
+          ...themeHarness({}),
+          run: async () => { events.push("ai-pass"); return "```json\n{}\n```"; },
+        }],
+        confirm: async () => { events.push("ai-consent"); return false; },
+      },
+    })).toBe(0);
+    expect(events.filter((event) => event === "ai-consent")).toHaveLength(1);
+    expect(events.indexOf("ai-consent")).toBeLessThan(events.indexOf("wrote-files"));
+    expect(events).not.toContain("ai-pass");
+    expect(logs.join("\n")).toContain("judgment: structural-only");
   });
 
-  it("firstSentence caps a note that never ends a sentence", () => {
-    expect(firstSentence("x".repeat(400))).toHaveLength(160);
-    expect(firstSentence("Short and done. And more.")).toBe("Short and done");
+  /** A loosening is never applied without a human, and init stopped asking once
+      its questions were done — so they QUEUE (init passes `queueLoosenings`)
+      and the count becomes a fact the run reports, never a prompt it blocks on.
+      The queueing itself is proven against the real pass in judge/pass.test.ts;
+      this is init's half: no review prompt, and no line when none are pending. */
+  it("never opens the loosening review, and says nothing when none are pending", async () => {
+    const root = await fixture();
+    const sink = output();
+    expect(await run(root, sink, { yes: true, ai: true, extract: { harnesses: [themeHarness({})] } })).toBe(0);
+    expect(sink.logs.join("\n")).not.toContain("Pending review:");
+  });
+});
+
+describe("the models answer decides the wiring", () => {
+  it("writes NO models line for a Vendo Cloud key, however many provider keys are lying around", async () => {
+    const root = await fixture();
+    const sink = output();
+    expect(await runInit({
+      targetDir: root,
+      output: sink.output,
+      env: { VENDO_API_KEY: `vnd_${"a".repeat(40)}`, ANTHROPIC_API_KEY: "sk-ant-test" },
+      telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
+    })).toBe(0);
+    const composition = await readFile(join(root, "lib", "vendo.ts"), "utf8");
+    expect(composition).not.toContain("models:");
+    expect(composition).not.toContain("@ai-sdk/anthropic");
+    // …and the install records the key its wiring actually reads.
+    expect(JSON.parse(await readFile(join(root, ".vendo", "install.json"), "utf8")))
+      .toMatchObject({ modelKey: "VENDO_API_KEY" });
+  });
+
+  it("writes the provider line — and records that key — when the answer is bring-your-own", async () => {
+    const root = await fixture();
+    expect(await run(root, output(), {
+      byo: true,
+      env: { ANTHROPIC_API_KEY: "sk-ant-test" },
+    })).toBe(0);
+    const composition = await readFile(join(root, "lib", "vendo.ts"), "utf8");
+    expect(composition).toContain('models: { default: anthropic("claude-sonnet-4-6") }, // ANTHROPIC_API_KEY supplies the key');
+    expect(JSON.parse(await readFile(join(root, ".vendo", "install.json"), "utf8")))
+      .toMatchObject({ modelKey: "ANTHROPIC_API_KEY" });
+
+    // A re-run wires nothing new — init never rewrites a composition it did not
+    // author — so the record must not start claiming a key that file does not
+    // read, however the second run's answer came out.
+    expect(await runInit({
+      targetDir: root,
+      output: output().output,
+      env: { VENDO_API_KEY: `vnd_${"c".repeat(40)}` },
+      telemetry: { env: { VENDO_TELEMETRY_DISABLED: "1" } },
+    })).toBe(0);
+    expect(await readFile(join(root, "lib", "vendo.ts"), "utf8")).toBe(composition);
+    expect(JSON.parse(await readFile(join(root, ".vendo", "install.json"), "utf8")))
+      .toMatchObject({ modelKey: "ANTHROPIC_API_KEY" });
+  });
+});
+
+describe("nothing blocks after the up-front questions", () => {
+  it("asks the dev URL BEFORE the long AI pass, and never reviews theme slots after it", async () => {
+    const events: string[] = [];
+    const root = await fixture();
+    await writeFile(join(root, "app", "layout.tsx"),
+      'import "./globals.css";\nexport default function Layout({ children }) { return <html><body>{children}</body></html>; }\n');
+    await writeFile(join(root, "app", "globals.css"),
+      ":root { --color-ink: #111111; --color-evergreen-600: #196b46; }\n");
+    const harness = themeHarness({
+      slots: { accent: "#196b46", text: "#111111" },
+      uncertain: [{ slot: "accent", note: "green may be data-only" }],
+    });
+    const sink = output();
+    expect(await run(root, sink, {
+      interactive: true,
+      ai: true,
+      extract: {
+        harnesses: [{
+          ...harness,
+          run: async (input) => {
+            events.push("ai-pass");
+            return harness.run(input);
+          },
+        }],
+      },
+      askText: async (_question, _hint, prefill) => {
+        events.push("dev-url");
+        return prefill ?? "";
+      },
+    })).toBe(0);
+
+    expect(events[0]).toBe("dev-url");
+    expect(events).toContain("ai-pass");
+    // The uncertain slot keeps what was extracted, and the run SAYS so.
+    expect(JSON.parse(await readFile(join(root, ".vendo", "theme.json"), "utf8")).colors.accent).toBe("#196b46");
+    expect(sink.logs.join("\n")).toContain("Kept as extracted (uncertain): accent");
   });
 });
 

--- a/packages/vendo/tests/cli/onboarding-safety.test.ts
+++ b/packages/vendo/tests/cli/onboarding-safety.test.ts
@@ -45,17 +45,6 @@ async function pagesHost(): Promise<string> {
   return root;
 }
 
-/** The same host with the surface ALREADY mounted — nothing left to paste, so
-    the closing line about the model key is the run's own last word. */
-async function mountedPagesHost(): Promise<string> {
-  const root = await pagesHost();
-  await writeFile(join(root, "pages", "_app.tsx"),
-    'import { VendoRoot } from "@vendoai/vendo/react";\n' +
-    "export default function App({ Component, pageProps }) {\n" +
-    "  return <VendoRoot><Component {...pageProps} /><VendoOverlay /></VendoRoot>;\n}\n");
-  return root;
-}
-
 function run(root: string, sink: { output: Output }, extra: Partial<Parameters<typeof runInit>[0]> = {}): Promise<number> {
   return runInit({
     targetDir: root,
@@ -189,97 +178,6 @@ describe("exactly one askYesNo", () => {
     // A second, unguarded copy is how non-TTY callers used to hang.
     expect(definers).toEqual(["shared.ts"]);
     expect(await readFile(join(cli, "shared.ts"), "utf8")).toContain("if (!stdin.isTTY || !stdout.isTTY) return false;");
-  });
-});
-
-describe("the closing line tells the truth about the model key", () => {
-  const LIVE = "Then start your dev server — the agent is live in your app.";
-  const PENDING = "Then start your dev server — the agent is live once you add a model key.";
-
-  it("no usable key — however the rung resolved — is live only once one is added", async () => {
-    // A resolved rung is not a usable key: resolveDevCredential only checks
-    // that VENDO_API_KEY is non-blank, and VENDO_DEV_CREDENTIAL=vendo-cloud
-    // pins the rung with no key at all — so both used to print "the agent is
-    // live in your app", the malformed one right beside "not usable".
-    const keyless: Partial<Parameters<typeof runInit>[0]>[] = [
-      {},
-      {
-        env: { VENDO_API_KEY: "not-a-vendo-key" },
-        cloud: { cloudProbe: async () => ({ present: true, ok: false, error: "malformed", unlocks: ["x"] as readonly string[] }) },
-      },
-      { env: { VENDO_DEV_CREDENTIAL: "vendo-cloud" } },
-    ];
-    for (const extra of keyless) {
-      const sink = output();
-      expect(await run(await mountedPagesHost(), sink, extra)).toBe(0);
-      expect(sink.logs.join("\n")).toContain(PENDING);
-      expect(sink.logs.join("\n")).not.toContain(LIVE);
-    }
-  });
-
-  it("keyed: live in your app", async () => {
-    const sink = output();
-    // A RESOLVING credential — which a bare provider key stopped being under the
-    // selection law, so the env-key rung is named through the internal pin.
-    expect(await run(await mountedPagesHost(), sink, {
-      env: { VENDO_DEV_CREDENTIAL: "env-key:anthropic", ANTHROPIC_API_KEY: "sk-a" },
-    })).toBe(0);
-    expect(sink.logs.join("\n")).toContain(LIVE);
-  });
-
-  it("a re-run over an existing composition states the condition — it may pass its own model", async () => {
-    // createVendo({ models }) needs no env key, so a keyless re-run over a
-    // composition init did not write must claim neither "live" nor "not live".
-    const root = await mountedPagesHost();
-    expect(await run(root, output())).toBe(0);
-    const sink = output();
-    expect(await run(root, sink)).toBe(0);
-    const logs = sink.logs.join("\n");
-    expect(logs).toContain("no model key resolved here, so the agent is live only if your composition passes its own model.");
-    expect(logs).not.toContain(LIVE);
-    expect(logs).not.toContain(PENDING);
-  });
-
-  it("a key minted mid-run IS live", async () => {
-    const root = await mountedPagesHost();
-    const sink = output();
-    expect(await run(root, sink, {
-      cloud: {
-        cloudProbe: async () => ({ present: false, ok: false, unlocks: ["x"] as readonly string[] }),
-        confirm: async () => true,
-        deviceLogin: async () => {
-          await writeFile(join(root, ".env.local"), `VENDO_API_KEY=vnd_${"a".repeat(40)}\n`);
-          return 0;
-        },
-      },
-    })).toBe(0);
-    expect(sink.logs.join("\n")).toContain(LIVE);
-  });
-
-  // Self-serve audit F5: with a paste still outstanding, "the agent is live in
-  // your app" contradicted the frame two lines above it, which had just said
-  // Vendo stays invisible until that paste lands.
-  it("says nothing about being live while a paste is still pending", async () => {
-    const sink = output();
-    expect(await run(await pagesHost(), sink, { env: { ANTHROPIC_API_KEY: "sk-a" } })).toBe(0);
-    const logs = sink.logs.join("\n");
-    expect(logs).toContain("ONE STEP LEFT");
-    expect(logs).not.toContain("Then start your dev server");
-    // …and the outstanding paste is the run's very last word.
-    expect(sink.logs[sink.logs.length - 1]).toBe(`\n→ Don't forget the paste in ${join("pages", "_app.tsx")} (frame above)`);
-  });
-});
-
-describe("a pages-only host is told to wire the file it actually has", () => {
-  it("names pages/_app.tsx and never app/layout.tsx", async () => {
-    const sink = output();
-    expect(await run(await pagesHost(), sink)).toBe(0);
-    const logs = sink.logs.join("\n");
-    expect(logs).toContain("ONE STEP LEFT");
-    expect(logs).toContain(`File: ${join("pages", "_app.tsx")}`);
-    // The wrapped child is the pages-router one, not app-router's {children}.
-    expect(logs).toContain("<Component {...pageProps} /><VendoOverlay /></VendoProvider>");
-    expect(logs).not.toContain(join("app", "layout.tsx"));
   });
 });
 

--- a/packages/vendo/tests/cli/pretty.test.ts
+++ b/packages/vendo/tests/cli/pretty.test.ts
@@ -440,97 +440,6 @@ describe("createPrettyOutput (visual system)", () => {
     expect(out.raw()).toBe(`${message}\n`);
   });
 
-  it("turns the 64-dash paste frame into a ◇ section with an indented code block", () => {
-    const out = sink();
-    const rule = "─".repeat(64);
-    const pretty = createPrettyOutput({ write: out.write, banner: false });
-    pretty.log(`\n${rule}`);
-    pretty.log("ONE STEP LEFT — paste this yourself (init never edits your files)");
-    pretty.log("\n  File: app/layout.tsx");
-    pretty.log("    import { VendoProvider } from \"@vendoai/vendo/react\";");
-    pretty.log("\n  Without it, nothing on the page can reach Vendo.");
-    pretty.log("  Then confirm it landed: npx vendo doctor");
-    pretty.log(rule);
-    const plain = out.plain();
-    expect(plain).toContain("◇  One paste left — app/layout.tsx");
-    expect(plain).toContain("│    import { VendoProvider } from \"@vendoai/vendo/react\";");
-    expect(plain).toContain("│  init never edits your files");
-    expect(plain).not.toContain(rule);
-    expect(plain).not.toContain("ONE STEP LEFT");
-  });
-
-  it("points the mount paste at the docs for the child expression it elides", () => {
-    const out = sink();
-    const rule = "─".repeat(64);
-    const pretty = createPrettyOutput({ write: out.write, banner: false });
-    pretty.log(`\n${rule}`);
-    pretty.log("ONE STEP LEFT — paste this yourself (init never edits your files)");
-    pretty.log("\n  File: app/layout.tsx");
-    pretty.log("    import { VendoProvider } from \"@vendoai/vendo/react\";");
-    pretty.log("    … then wrap: <VendoProvider baseUrl=\"/api/vendo\" theme={theme as VendoTheme}>{children}</VendoProvider>");
-    pretty.log("\n  Without it, nothing on the page can reach Vendo.");
-    pretty.log(rule);
-    const plain = out.plain();
-    expect(plain).toContain("docs.vendo.run/product/mount-the-surface#the-provider — exact wording for layout.tsx and _app.tsx");
-    // Right under the wrap line it explains, and dim.
-    expect(plain.indexOf("</VendoProvider>")).toBeLessThan(plain.indexOf("docs.vendo.run/product/mount-the-surface"));
-    expect(out.raw()).toContain(`${ESC}[2mdocs.vendo.run/product/mount-the-surface#the-provider`);
-  });
-
-  it("prints the mount paste as real JSX, with a dim … for the app tree already there", () => {
-    const out = sink();
-    const rule = "─".repeat(64);
-    const pretty = createPrettyOutput({ write: out.write, banner: false });
-    pretty.log(`\n${rule}`);
-    pretty.log("ONE STEP LEFT — paste this yourself (init never edits your files)");
-    pretty.log("\n  File: app/layout.tsx");
-    pretty.log("    import { VendoProvider } from \"@vendoai/vendo/react\";");
-    pretty.log("    import theme from \"../.vendo/theme.json\";");
-    pretty.log("    import type { VendoTheme } from \"@vendoai/vendo\";");
-    pretty.log("    … then wrap: <VendoProvider baseUrl=\"/api/vendo\" theme={theme as VendoTheme}>{children}</VendoProvider>");
-    pretty.log(rule);
-    const plain = out.plain();
-    // The prose instruction is gone; what is left reads as the code it is.
-    expect(plain).not.toContain("… then wrap:");
-    expect(plain).not.toContain("{children}");
-    expect(plain).toContain("│    <VendoProvider baseUrl=\"/api/vendo\" theme={theme as VendoTheme}>");
-    expect(plain).toContain("│      …");
-    expect(plain).toContain("│    </VendoProvider>");
-    // A blank rail line sets the wrap apart from the imports above it.
-    expect(plain).toContain("│    import type { VendoTheme } from \"@vendoai/vendo\";\n│\n│    <VendoProvider");
-    // The app tree is a dim PLACEHOLDER, not code to paste…
-    expect(out.raw()).toContain(`${ESC}[2m…${ESC}[22m`);
-    // …which is exactly what the docs pointer under it exists to resolve.
-    expect(plain.indexOf("│    </VendoProvider>")).toBeLessThan(plain.indexOf("docs.vendo.run/product/mount-the-surface"));
-  });
-
-  it("keeps the real JSX when the host is a pages `_app` — the child expression differs, the shape does not", () => {
-    const out = sink();
-    const rule = "─".repeat(64);
-    const pretty = createPrettyOutput({ write: out.write, banner: false });
-    pretty.log(`\n${rule}`);
-    pretty.log("ONE STEP LEFT — paste this yourself (init never edits your files)");
-    pretty.log("\n  File: pages/_app.tsx");
-    pretty.log("    … then wrap: <VendoProvider baseUrl=\"/api/vendo\"><Component {...pageProps} /></VendoProvider>");
-    pretty.log(rule);
-    const plain = out.plain();
-    expect(plain).toContain("│    <VendoProvider baseUrl=\"/api/vendo\">");
-    expect(plain).toContain("│      …");
-    expect(plain).not.toContain("pageProps");
-  });
-
-  it("leaves a paste block with no mount snippet without the docs pointer", () => {
-    const out = sink();
-    const rule = "─".repeat(64);
-    const pretty = createPrettyOutput({ write: out.write, banner: false });
-    pretty.log(`\n${rule}`);
-    pretty.log("ONE STEP LEFT — paste this yourself (init never edits your files)");
-    pretty.log("\n  File: app/actions.ts");
-    pretty.log("    export const runtime = \"nodejs\";");
-    pretty.log(rule);
-    expect(out.plain()).not.toContain("docs.vendo.run/quickstart");
-  });
-
   it("renders warnings yellow with ⚠ and other errors red with ✖", () => {
     const out = sink();
     const pretty = createPrettyOutput({ write: out.write, banner: false });
@@ -948,6 +857,23 @@ describe("createPrettyOutput (visual system)", () => {
     const settled = out.raw();
     vi.advanceTimersByTime(300);
     expect(out.raw()).toBe(settled); // no frames after stopSpin
+  });
+
+  /** A stage that runs for minutes behind a bare spinner reads as a hang. Every
+      frame carries the clock, so the screen says how long it has been. */
+  it("carries elapsed time on every spinner frame, in m/s once past a minute", () => {
+    vi.useFakeTimers();
+    const out = sink();
+    const pretty = createPrettyOutput({ write: out.write, banner: false });
+    pretty.spin("Reading your product");
+    expect(out.plain()).toContain("Reading your product 0s");
+    // Advanced in whole frame periods (80ms), so the LAST frame drawn lands on
+    // the second the assertion names.
+    vi.advanceTimersByTime(12_000);
+    expect(out.plain()).toContain("Reading your product 12s");
+    vi.advanceTimersByTime(108_000);
+    expect(out.plain()).toContain("Reading your product 2m00s");
+    pretty.stopSpin();
   });
 });
 

--- a/packages/vendo/tests/cli/sync-flow.test.ts
+++ b/packages/vendo/tests/cli/sync-flow.test.ts
@@ -248,10 +248,11 @@ describe("the slow phases spin when the caller supplies one", () => {
     // `finally` used to stop the spinner right before the prose stages — the
     // two model calls that own minutes of the run — leaving the longest stretch
     // of an install as a dead screen (#1163).
+    // …and the label says how long that stretch takes, because it takes it.
     expect(seen.full!.labels).toEqual([
       "Re-reading your product…",
-      "Reading your product (a scripted engine)…",
-      "Reading your product (a scripted engine)…",
+      "Reading your product (a scripted engine) — this can take several minutes…",
+      "Reading your product (a scripted engine) — this can take several minutes…",
     ]);
     expect(seen.full!.stops).toBe(3);
     // The line became the label; it is not ALSO printed.
@@ -270,7 +271,7 @@ describe("the slow phases spin when the caller supplies one", () => {
       confirm: async () => true,
       judge: { harnesses: [scripted] },
     });
-    expect(logs).toContain("\nReading your product (a scripted engine)…");
+    expect(logs).toContain("\nReading your product (a scripted engine) — this can take several minutes…");
   });
 });
 

--- a/packages/vendo/tests/cli/sync-flow.unattended.test.ts
+++ b/packages/vendo/tests/cli/sync-flow.unattended.test.ts
@@ -113,7 +113,7 @@ describe("the loosening review never blocks an unattended run", () => {
     // The pass owns the count + `vendo sync --review` line; this is the WHY,
     // so a queued result never reads as a refusal or a silent apply.
     expect(output.lines.join("\n")).toContain("held, not applied");
-    expect(output.lines.join("\n")).toContain("re-run `vendo init` in a terminal");
+    expect(output.lines.join("\n")).toContain("review them with `vendo sync --review`");
   });
 
   it("queues loosenings in a non-TTY run", async () => {

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,14 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  // The docs-rot suites live in @vendoai/vendo but READ docs-site/** and
+  // README.md — @vendoai/vendo's registry codes against their troubleshooting
+  // pages, every docs.vendo.run URL the CLI prints against a real file. Those
+  // paths are OUTSIDE the package, and a turbo `inputs` glob cannot escape its
+  // package directory, so the global hash is the only thing that can see them.
+  // Without this a docs-only edit replays a cached green and the tripwire that
+  // exists to catch a retired page never fires. Broader than the one task that
+  // needs it, and deliberately so: correctness over cache depth.
+  "globalDependencies": ["docs-site/**", "README.md"],
   "tasks": {
     "build": { "dependsOn": ["^build"], "outputs": ["dist/**", ".next/**", "!.next/cache/**"] },
     // The screen engine's WebAssembly is copied out of the wasmfile dependency at


### PR DESCRIPTION
Init states facts and links out. Every instruction it used to print — the
`<VendoProvider>` mount paste, the AI SDK and Mastra loop snippets, the MCP
client steps, the agent tail, the doctor gate — was a second copy of something
the docs already carry, and a terminal cannot keep a copy correct. The run now
ends on four computed lines and one URL.

```
Wired: .env.example, .vendo/install.json, …, lib/vendo.ts, next.config.mjs
Detected: Next.js · no auth detected · npm · port 3000
Guard: writes run without approval — how to tighten: vendo.run/agents.md
Continue: https://docs.vendo.run/product/quickstart
```

26 files, **+1083 / −2048**.

## Per-item status

| # | Item | Status |
|---|---|---|
| 1 | Init prints no code and no steps — facts only, in all modes; receipt carries the same as structured fields; dead paste-builders deleted | done |
| 2 | `backend` becomes a real use case | **STRIPPED — product call resolved** |
| 3 | Doctor fully decoupled from init | done, with one recon correction |
| 4 | The models answer drives the wiring | done |
| 5 | Doctor's model-credential check verifies what's wired | done |
| 6 | Service-key without rewrites | done, with one recon correction |
| 7 | Unattended after the up-front questions | done — every mid-run prompt is gone |
| 8 | Honest progress | done |

### 1 — facts only
`printClosingSteps`, `agentTailLines`, `mountStep`, `agentLoopSteps`,
`mcpStepLines`, `editLines`, `manualWiringLines`, `principalLines`,
`mastraAgentFile`, `routeServerActionsEdit`, `themeImportSpecifier`,
`resolveJsonModuleDisabled`, `riskRecommendations`, `missingRegistrationLines`,
the `ManualEdit`/`LayoutWiring` types, and pretty.ts's whole paste-block
renderer are gone. Continue URLs: embedded → `/product/quickstart`, agent-loop →
`/existing-agent/ai-sdk` (or `/existing-agent/mastra` when the host declares
`@mastra/core`), mcp → `/outside-agents/quickstart`.

### 2 — backend — STRIPPED
main's #1509 makes the standalone agent deliberately CLI-free ("no CLI, no
init"), which this item contradicted. Every backend-only hunk is reverted:
`InitUseCase` is back to the three cases, along with the `--use-case` values and
help line, both option lists, the continue-URL table, and doctor's use-case line
(back to its original two-arm ternary, so `doctor-wiring-checks.ts` is now
byte-identical to main). Verified: no `backend` use-case reference survives in
`packages/vendo`.

### 4/5 — the models answer
Choosing Vendo Cloud no longer writes `anthropic("claude-sonnet-4-6")` into a
composition because an `ANTHROPIC_API_KEY` happened to be in the shell — the
runtime resolves from `VENDO_API_KEY` (the selection-law ladder), so no line is
written. Own-key writes the provider line as before. The install records the key
its wiring actually reads, **only ever what that run wired**: a re-run over a
composition init did not author records nothing new, and doctor parses that
file's own `models` line instead. E-MODEL-001 now names one variable rather than
three the resolver never consults; registry text and `e-model-001.mdx` updated
together.

### 7 — nothing prompts after the up-front questions
Killed outright: the theme uncertain-slot review (uncertain slots keep the
extracted value and are listed as `Kept as extracted (uncertain): …`) and the
zod-floor bump confirm (it states the problem and the command; `--yes` still
performs the bump).

Moved into the question phase: **"Where does this app run in dev?"** and the
**AI-spend consent**. The consent/engine-pick is extracted into one
`askJudgmentConsent` (so the copy exists once) and exposed as
`resolveJudgmentConsent`; init asks it with its other questions and hands the
flow a settled `ai`/`engine` pair, so the pass never asks. `--ai`/`--no-ai`,
`--yes` and agent mode keep exactly their current semantics, the multi-engine
picker survives the move (nobody loses the choice of which provider sees their
source), and `vendo sync` is untouched. The gate is the judgment step's OWN
posture — a real TTY no package script drives — not init's run-wide
`interactive`: using the latter walked the engine ladder (subprocess probes) on
runs that would never ask, which timed out two suites before the fix.

The **loosening review no longer blocks**: init passes `queueLoosenings`, so
proposals queue as pending, are never applied, and never prompt. The count is a
fact the run reports — `Pending review: N loosening proposals held, none
applied — vendo sync --review` — and rides the receipt as `pendingLoosenings`.
`vendo sync --review` is still the deliberate inline ask.

## Recon corrections (expected vs found)

- **Item 3** — recon said sync-flow.ts:33-40 is JSDoc'd "init fails loud on a
  doctor-fail". **Not found.** That JSDoc is about the sync flow's own exit
  posture and never mentions doctor, and `offerDoctorCheck` already stated
  "Nothing here can change init's exit code" — its result only fed the footer
  string. There was no exit-code coupling to remove; the command, flags, seams
  and every mention are removed.
- **Item 6** — recon said the create path misses `serviceAuth`. **Not
  reproduced.** I ran the built CLI three ways on a fresh Clerk host:
  `--use-case mcp --posture local --service-key` with and without `--force` both
  wrote the `serviceAuth` ternary correctly. The reported symptom reproduces only
  on a **re-run** over a composition an earlier run authored, which is the law
  holding (init never rewrites a file it did not write). That half is
  implemented: the env key lands, Continue points at the MCP page, and the
  receipt carries `serviceAuthUnwired: true`.
- **Item 8** — no CLI copy implied a five-minute install; nothing to remove.
  `docs-site/index.mdx` says "about five minutes" but docs-site is outside this
  slice's fence.

## Receipt schema

```diff
  { status, root, useCase,
    wrote,
-   pasteEdits,          // ManualEdit[]
-   tools,               // number
-   riskRecommendations, // RiskRecommendation[]
+   detected: { framework, auth, packageManager, port },
+   guardPosture,
+   continueUrl,
+   keptUncertain,
+   pendingLoosenings,
+   serviceAuthUnwired?, // MCP re-run only
    judgment }
```

## Spec-removed tests

Deleted (the behaviour is gone):

- `init.test.ts` — "mcp: the plain transcript indents each step's detail under
  its headline"; "prints a theme-less paste when the project disables
  resolveJsonModule"; "non-interactive runs end with the agent tail"; "the tail
  names a tool the machine turned off"; "a keyless run's tail points at the
  auth.md key flow"; "the tail states auth stubs honestly"; "interactive runs
  keep the clack-style summary — no agent tail"; "the Express tail points at the
  printed wiring lines"; "prints ONE paste — provider AND overlay"; "carries the
  pastes it will not write into the receipt"; "--use-case agent-loop adds the
  snippet"; "offers the doctor check only when nothing is left to paste"; the
  8-test `describe("the mount paste …")`; the 3-test
  `describe("the uncertain-theme-slot review")`
- `init-mcp.test.ts` — `describe("planMcp — the two steps that stay the
  user's")` (3), `describe("planMcp — the sign-in posture")` (2),
  `describe("mcpStepLines …")` (2)
- `init-install-dx.test.ts` — `describe("the agent-loop paste compiles as
  printed")` (5)
- `onboarding-safety.test.ts` — `describe("the closing line tells the truth
  about the model key")` (5); "a pages-only host is told to wire the file it
  actually has" (`clientRoot`'s pages/_app behaviour is still covered by
  doctor.test.ts)
- `pretty.test.ts` — the 5 paste-block renderer tests

Changed (same intent, new surface): 16 in `init.test.ts`, 4 in
`init-mcp.test.ts`, 2 in `init-install-dx.test.ts`, 1 in `doctor.test.ts`
(E-MODEL-001 wording — the "a bare provider key must not green doctor" intent is
kept and strengthened: it now also asserts the message names no provider key),
3 in `cli.test.ts`, 1 in `doctor-codes.test.ts` (registry snapshot), 1 in
`docs-links.test.ts` (the non-vacuity list swaps the retired
`/product/mount-the-surface#the-provider` for `/product/quickstart`), 2 in
`sync-flow.test.ts` (spinner labels), 1 in `sync-flow.unattended.test.ts` (the
queued-loosening line no longer tells an unattended caller to re-run init in a
terminal — init never reviews inline now).

New, each proven red before the fix: 8 in `init.test.ts` (facts block, continue
URLs, receipt, models law, question ordering, up-front consent), 2 in
`doctor.test.ts`, 1 in `init-install-dx.test.ts` (`serviceAuthUnwired`), 1 in
`pretty.test.ts` (spinner clock — reverted the change, watched it fail,
restored).

## Also in this round

- **The packaged `vendo-setup` skill** (what an installing agent actually loads)
  taught the old flow: it gated "done" on `vendo doctor` and claimed the
  receipt's `judgment` is *always* `delegated`. Realigned: doctor is orthogonal
  (init's exit code is about init's own work), the tail is facts + `continueUrl`,
  `judgment` is `graded` or `delegated` depending on engine availability, the
  spend question is up front, and `pendingLoosenings` is a count, not a task.
- **A turbo cache hole that blunted the docs tripwires.** The docs-rot suites
  live in `@vendoai/vendo` but READ `docs-site/**` and `README.md`, so a
  docs-only edit replayed a cached green and the tripwire never fired. Those
  paths now join the global hash. Per-package `inputs` cannot express this — a
  turbo `inputs` glob cannot escape its package directory and `docs-site` is not
  a workspace package — so `globalDependencies` is the only correct mechanism;
  it is broader than the one task that needs it, deliberately. Verified: the
  `@vendoai/vendo` test task's cache key goes `61b0ca44d72b4ff9` →
  `f73cdba9c8d72550` when a docs file is touched (a MISS), and back on restore.

## Gate

`pnpm build`, `pnpm typecheck` and `pnpm lint` all exit 0. `@vendoai/vendo`
**2635 passed / 45 skipped**, `fixtures/install-seam` **5/5**, both after the
rebase onto `f6798d546`. A full `test:affected` was 32/32 green two commits
back; CI is the gate of record for the rest.

`fixtures/install-seam` (#1518) was **not** in turbo's affected set but calls
`vendo init --no-check`, which this PR deletes — so init exited 1 and three of
its five assertions failed. Caught by running it explicitly; fixed by dropping
the dead flag from `fixtures/install-seam/src/stranger.ts`. It now passes 5/5
including the live "answers from the app's own API" leg — packed tarballs → a
real `vendo init` → compiles → the agent answers. That is the end-to-end proof
this redesign works on a real install.

## Test-coverage gap, stated rather than papered over

The `pendingLoosenings > 0` **render** path has no init-level test. Producing a
real queued loosening through init needs a tool, a proposal and a skeptic
uphold; the only cheap alternative was a harness fabricating the pass's output,
which is exactly the "a harness that mocks the counterparty proves nothing" law
in this repo's CLAUDE.md. The queueing itself is proven against the real pass in
`judge/pass.test.ts` and the flow wiring in `sync-flow.unattended.test.ts`;
init's half (never opens the review, prints nothing when none are pending) is
covered.

My first cut of the up-front-consent tests was a blind fixture — they passed
with the change disabled, because the flow's own prompt fires at a similar
point. Caught with a revert-check and rewritten to key off init's write step
(`Wired (N files):`), the real boundary between the question phase and the pass.
They now fail 2 of 3 with the change reverted.
