### PR TITLE
feat(ui): Share with <tenant> in the ✦ menu

### DIFF
--- a/.changeset/share-toggle.md
+++ b/.changeset/share-toggle.md
@@ -17,3 +17,10 @@ holder's own `/user` mount — so `AppsRuntime.access.grant` mints the sharer's 
 owner grant, runs `ops.lifecycle.promote`, and only then writes the tenant grant.
 The order is load-bearing: the move restamps the row's subject as the org id, so
 a sharer who is not a tenant admin would otherwise lose the app she just shared.
+
+Because that move is what makes the grant legal, naming the tenant is now an
+authorization claim of its own: `grant` refuses a `team:`/`org:` principal with
+`forbidden` unless the caller holds an asserted membership in that org. Owning
+the app is not enough — without this an owner could name any org id and have her
+app moved into a workspace she does not belong to. Revoking is unchanged, so a
+sharer who has since left the tenant can still un-share.

--- a/.changeset/share-toggle.md
+++ b/.changeset/share-toggle.md
@@ -1,0 +1,19 @@
+---
+"@vendoai/apps": minor
+"@vendoai/ui": minor
+---
+
+The ✦ menu offers one share. `useAppSharing` reads `GET /apps/:id/grants` once —
+the caller's level, the app's grants and the caller's own memberships — and
+`PinChrome` grows a single "Share with &lt;tenant&gt;" toggle between Update and
+Revert. It is absent for a non-owner and for a caller in no tenant, and the
+popover stays open when it is switched, because it is a switch rather than a
+departure.
+
+Sharing an app with a tenant now MOVES it there first. Every path that creates
+an app stamps it with the person, and core refuses a tenant grant on a
+still-personal app (ruled 2026-08-01) because the app's documents live under the
+holder's own `/user` mount — so `AppsRuntime.access.grant` mints the sharer's own
+owner grant, runs `ops.lifecycle.promote`, and only then writes the tenant grant.
+The order is load-bearing: the move restamps the row's subject as the org id, so
+a sharer who is not a tenant admin would otherwise lose the app she just shared.

--- a/packages/apps/src/server/doors/access-surface.ts
+++ b/packages/apps/src/server/doors/access-surface.ts
@@ -7,13 +7,14 @@
  * `config.appAccess` is set unconditionally from the composed store, so the
  * seam is always present under `createVendo`.
  */
-import { VendoError } from "@vendoai/core";
+import { VendoError, encodeGrantPrincipal, parseGrantPrincipal, type AppId, type RunContext } from "@vendoai/core";
+import { APPS_COLLECTION } from "../persistence/persistence.js";
 import type { AppsRuntimeContext } from "../runtime/runtime-context.js";
 import type { AppsRuntime } from "../runtime/types.js";
 
-export type AccessSurfaceDeps = Pick<AppsRuntimeContext, "config" | "holds">;
+export type AccessSurfaceDeps = Pick<AppsRuntimeContext, "config" | "engine" | "holds">;
 
-export const createAccessSurface = ({ config, holds }: AccessSurfaceDeps): AppsRuntime["access"] => {
+export const createAccessSurface = ({ config, engine, holds }: AccessSurfaceDeps): AppsRuntime["access"] => {
   /** §9.4's posture in one place: what the caller cannot VIEW stays not-found;
       a proven viewer denied a stronger action gets forbidden. */
   const require = async (appId: Parameters<AppsRuntime["access"]["list"]>[0], ctx: Parameters<AppsRuntime["access"]["list"]>[1], level: "viewer" | "owner") => {
@@ -23,6 +24,37 @@ export const createAccessSurface = ({ config, holds }: AccessSurfaceDeps): AppsR
     }
     throw new VendoError("not-found", `app not found: ${appId}`);
   };
+  /**
+   * "Share implies promote" (ruled 2026-08-01, pinned at
+   * conformance/app-access.ts:181-201). Every create path stamps an app with the
+   * PERSON, and core refuses a tenant grant on a still-personal app — the app's
+   * documents live under the holder's own `/user` mount, so a share that skipped
+   * the move would hand the recipient an empty app. So the share moves it first,
+   * in `lifecycle.promote`'s one transaction.
+   *
+   * ORDER IS THE WHOLE POINT. The move restamps the row's subject as the org id,
+   * which retires the promoter's ownership fast path (access-checks.ts:65) — so
+   * an owner who is not a tenant ADMIN would lose the app she just shared. Her
+   * own owner grant is therefore minted BEFORE the flip, the deliberate
+   * exception pinned at store helpers/app-access.ts:186-188.
+   *
+   * With no `ops` (a store offering neither its own ops nor a SQL handle) there
+   * is nothing to move with, and core's own refusal below is the honest answer.
+   */
+  const promoteBeforeSharing = async (appId: AppId, principal: string, ctx: RunContext) => {
+    const target = parseGrantPrincipal(principal);
+    if (target === undefined || target.kind === "user" || config.ops === undefined) return;
+    const record = await engine.get(APPS_COLLECTION, appId);
+    if (record?.refs?.["subject"] === target.org) return;
+    await config.appAccess!.grant(
+      ctx,
+      appId,
+      encodeGrantPrincipal({ kind: "user", subject: ctx.principal.subject }),
+      "owner",
+    );
+    await config.ops.lifecycle.promote(appId, target.org);
+  };
+
   const access: AppsRuntime["access"] = {
     async levelFor(appId, ctx) {
       if (config.appAccess === undefined) {
@@ -40,6 +72,7 @@ export const createAccessSurface = ({ config, holds }: AccessSurfaceDeps): AppsR
     },
     async grant(appId, principal, level, ctx) {
       await require(appId, ctx, "owner");
+      await promoteBeforeSharing(appId, principal, ctx);
       await config.appAccess!.grant(ctx, appId, principal, level);
       return await access.list(appId, ctx);
     },

--- a/packages/apps/src/server/doors/access-surface.ts
+++ b/packages/apps/src/server/doors/access-surface.ts
@@ -3,9 +3,8 @@
  * on an app, and the grant writes the ✦ share toggle needs.
  *
  * The LEVEL lives here, not on the wire, so the MCP door inherits the same
- * rules without a second copy: `list` needs viewer, grant/revoke need owner.
- * `config.appAccess` is set unconditionally from the composed store, so the
- * seam is always present under `createVendo`.
+ * rules without a second copy: `list` needs viewer, grant/revoke need owner, and
+ * naming a tenant needs membership in it.
  */
 import { VendoError, encodeGrantPrincipal, parseGrantPrincipal, type AppId, type RunContext } from "@vendoai/core";
 import { APPS_COLLECTION } from "../persistence/persistence.js";
@@ -15,6 +14,17 @@ import type { AppsRuntime } from "../runtime/types.js";
 export type AccessSurfaceDeps = Pick<AppsRuntimeContext, "config" | "engine" | "holds">;
 
 export const createAccessSurface = ({ config, engine, holds }: AccessSurfaceDeps): AppsRuntime["access"] => {
+  /** The seam the WRITES need. `levelFor` and `list` degenerate honestly without
+      one, but a grant has nowhere to go. `createVendo` always composes it
+      (compose-apps.ts:384 → :187), so this is unreachable there — but
+      `createApps` is exported and takes `appAccess?`, and genbench calls it
+      without one (genbench/src/vendo.ts:280). A refusal beats a TypeError. */
+  const writable = () => {
+    if (config.appAccess === undefined) {
+      throw new VendoError("not-implemented", "this deployment composes no app-access seam, so it cannot hold grants");
+    }
+    return config.appAccess;
+  };
   /** §9.4's posture in one place: what the caller cannot VIEW stays not-found;
       a proven viewer denied a stronger action gets forbidden. */
   const require = async (appId: Parameters<AppsRuntime["access"]["list"]>[0], ctx: Parameters<AppsRuntime["access"]["list"]>[1], level: "viewer" | "owner") => {
@@ -24,6 +34,29 @@ export const createAccessSurface = ({ config, engine, holds }: AccessSurfaceDeps
     }
     throw new VendoError("not-found", `app not found: ${appId}`);
   };
+  /**
+   * §9.1 — the memberships the host ASSERTS are the only org chart Vendo has,
+   * so naming a tenant is an authorization claim, not a spelling. Owning the app
+   * is a SEPARATE gate and does not imply this one: without this check an owner
+   * could name any `org:<id>`, `promoteBeforeSharing` would move her app into a
+   * stranger's workspace, and that tenant's admins would hold it (their `owner`
+   * comes from the row's subject alone, helpers/app-access.ts:117). The store's
+   * own guard cannot catch it — it compares the principal against the org
+   * HOLDING the row, which the promote just restamped to the named one.
+   *
+   * `forbidden`, not `not-found`: §9.4 masks what a caller cannot see, and she
+   * provably sees this app. It says nothing about whether the org exists.
+   *
+   * Grant only. A sharer who has since left the tenant must still be able to
+   * un-share, and `revoke` never widens access.
+   */
+  const requireMembership = (principal: string, ctx: RunContext) => {
+    const target = parseGrantPrincipal(principal);
+    if (target === undefined || target.kind === "user") return;
+    if ((ctx.memberships ?? []).some((entry) => entry.org === target.org)) return;
+    throw new VendoError("forbidden", `you are not a member of ${target.org}`);
+  };
+
   /**
    * "Share implies promote" (ruled 2026-08-01, pinned at
    * conformance/app-access.ts:181-201). Every create path stamps an app with the
@@ -40,13 +73,31 @@ export const createAccessSurface = ({ config, engine, holds }: AccessSurfaceDeps
    *
    * With no `ops` (a store offering neither its own ops nor a SQL handle) there
    * is nothing to move with, and core's own refusal below is the honest answer.
+   *
+   * NOT ATOMIC with the grant that follows it, and knowingly so. If that last
+   * write fails, the app is left in the tenant carrying the sharer's owner grant
+   * and no tenant grant, so the tenant's ADMINS can reach it while the caller
+   * saw an error. Every alternative is worse. The order is FORCED: the tenant
+   * grant cannot go first (core refuses a tenant principal that is not the org
+   * holding the row, helpers/app-access.ts:186-188 — that IS the 2026-08-01
+   * ruling), and the owner grant cannot go after (paragraph above). One
+   * transaction is not on offer either — `AppAccess` is an adapter interface
+   * with no transaction, so a hosted or BYO grant write can never join
+   * `promote`'s. That leaves a compensating demote: surface the plan excludes,
+   * reversing a saga over workspace documents, appData, blobs and bearer tokens,
+   * whose own half-failure would be worse than the window it repairs. So the
+   * window is ACCEPTED, and kept small by what surrounds it — the target is the
+   * caller's own tenant (`requireMembership`), the exposure is that tenant's
+   * admins rather than its membership, and the caller keeps owner, so retrying
+   * the same share closes it: `promote` is idempotent and the grant write is one
+   * derived-id row.
    */
   const promoteBeforeSharing = async (appId: AppId, principal: string, ctx: RunContext) => {
     const target = parseGrantPrincipal(principal);
     if (target === undefined || target.kind === "user" || config.ops === undefined) return;
     const record = await engine.get(APPS_COLLECTION, appId);
     if (record?.refs?.["subject"] === target.org) return;
-    await config.appAccess!.grant(
+    await writable().grant(
       ctx,
       appId,
       encodeGrantPrincipal({ kind: "user", subject: ctx.principal.subject }),
@@ -72,13 +123,14 @@ export const createAccessSurface = ({ config, engine, holds }: AccessSurfaceDeps
     },
     async grant(appId, principal, level, ctx) {
       await require(appId, ctx, "owner");
+      requireMembership(principal, ctx);
       await promoteBeforeSharing(appId, principal, ctx);
-      await config.appAccess!.grant(ctx, appId, principal, level);
+      await writable().grant(ctx, appId, principal, level);
       return await access.list(appId, ctx);
     },
     async revoke(appId, principal, ctx) {
       await require(appId, ctx, "owner");
-      await config.appAccess!.revoke(ctx, appId, principal);
+      await writable().revoke(ctx, appId, principal);
       // The revoke LANDED. A caller who just removed their own last grant may
       // no longer read it — that is §9.4 answering a different question, not a
       // failed removal, so answer with what they can still legitimately see.

--- a/packages/ui/e2e/harness/main.tsx
+++ b/packages/ui/e2e/harness/main.tsx
@@ -2067,6 +2067,7 @@ function scenario(pathname: string): { title: string; theme?: Partial<VendoTheme
     case "/slot-fallback": return { title: "Slot pin fallback", content: <SlotFallbackScenario />, ownProvider: true };
     case "/slot-building": return { title: "Inline slot — a build landing in place", content: <SlotBuildingScenario /> };
     case "/slot-states": return { title: "Inline slot — ready / failed", content: <SlotStatesScenario /> };
+    case "/share-toggle": return { title: "Inline slot — the ✦ menu's share toggle", content: <VendoSlot id="slot-shared"><p>Host hero (shareable)</p></VendoSlot> };
     case "/slot-picker": return { title: "Add to… — embed writes a placement", content: <SlotPickerScenario />, ownProvider: true };
     case "/remixable": return { title: "Remixable — the ✦ is one door into the chat", content: <RemixableScenario />, ownProvider: true };
     case "/appframe": return { title: "App execution planes", content: <AppFrameScenario /> };

--- a/packages/ui/e2e/harness/vite.config.ts
+++ b/packages/ui/e2e/harness/vite.config.ts
@@ -67,6 +67,14 @@ export default defineConfig(async ({ command }) => {
       prompt: "a board showing where my money goes each month",
     });
     wire.state.placements.push({ slot: "slot-failed", appId: "app_slot_failed" });
+    // (/share-toggle) — the ✦ menu's fourth item over the real wire: a placed
+    // app this caller OWNS, and one tenant she belongs to. Its own app and slot,
+    // because grants are seeded per app id — every other scenario's ✦ stays the
+    // three items it has always been.
+    wire.state.apps.push(fixtureApp("app_shared", "Invoices"));
+    wire.state.surfaces.set("app_shared", wire.state.surfaces.get("app_1")!);
+    wire.state.placements.push({ slot: "slot-shared", appId: "app_shared" });
+    wire.setGrants("app_shared", { level: "owner", grants: [], orgs: [{ org: "acme", display: "Acme Corp" }] });
     // (/accounts) — a broken account for the connected-accounts panel's Reconnect
     // path. Additive and on a toolkit nothing else in the harness touches, so it
     // never becomes active: `initiate` mints its own `ca_new` row, leaving this

--- a/packages/ui/e2e/share-toggle.spec.ts
+++ b/packages/ui/e2e/share-toggle.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "@playwright/test";
+import { openScenario } from "./helpers.js";
+
+/** 08-ui §4–5 — the ✦ menu's share toggle, in a real Chromium, over the
+    localhost wire fixture. */
+const SHOTS = "e2e/test-results";
+
+test("the ✦ menu offers one named share, and it toggles", async ({ page }) => {
+  await openScenario(page, "share-toggle");
+
+  // The ✦ is a reveal: the pill is non-interactive until the app blooms it.
+  const app = page.locator(".fl-slot-filled").first();
+  await app.hover();
+  await app.getByRole("button", { name: /^Edit / }).click();
+  const toggle = page.getByRole("button", { name: "Share with Acme Corp" });
+  await expect(toggle).toBeVisible();
+  await expect(toggle).toHaveAttribute("aria-pressed", "false");
+
+  // The order the person reads, top to bottom.
+  await expect(page.locator(".fl-remix-menu button")).toHaveText([
+    "Edit in chat", "Update", "Share with Acme Corp", "Revert",
+  ]);
+  await page.screenshot({ path: `${SHOTS}/share-toggle-off.png`, animations: "disabled" });
+
+  await toggle.click();
+  await expect(toggle).toHaveAttribute("aria-pressed", "true");
+  await expect(page.locator(".fl-remix-menu")).toBeVisible();     // a switch, not a departure
+  await page.screenshot({ path: `${SHOTS}/share-toggle-on.png`, animations: "disabled" });
+
+  await toggle.click();
+  await expect(toggle).toHaveAttribute("aria-pressed", "false");
+});

--- a/packages/ui/src/chrome/chrome-css.ts
+++ b/packages/ui/src/chrome/chrome-css.ts
@@ -1474,6 +1474,15 @@ html[data-vendo-dock] {
 .fl-remix-menu button:hover { background: var(--vendo-accent-soft); }
 .fl-remix-menu button:disabled { color: var(--vendo-fg-muted); cursor: default; }
 .fl-remix-menu button.is-danger { color: var(--vendo-danger); }
+/* The share toggle's ON state. aria-pressed says it to a screen reader; the
+   check says it to an eye, because colour alone is never a state. The check
+   rides ::after (so the button's own text stays exactly its label) and its slot
+   is reserved in BOTH states — otherwise switching the share reflows the menu
+   and Revert moves out from under the cursor. */
+.fl-remix-menu button[aria-pressed] { display: flex; align-items: center; justify-content: space-between; gap: 8px; white-space: nowrap; }
+.fl-remix-menu button[aria-pressed]::after { content: "✓"; visibility: hidden; }
+.fl-remix-menu button[aria-pressed="true"] { color: var(--vendo-accent); }
+.fl-remix-menu button[aria-pressed="true"]::after { visibility: visible; }
 
 /* ---- filled state ---- */
 .fl-slot-filled { position: relative; flex: 1; }

--- a/packages/ui/src/chrome/pin-chrome.tsx
+++ b/packages/ui/src/chrome/pin-chrome.tsx
@@ -55,7 +55,7 @@ export function useMenuDismiss(open: boolean, onToggle: (open: boolean) => void)
  * tap that revealed it.
  */
 
-export function PinChrome({ appId, title, context, state, onRefresh, onRevert, children }: {
+export function PinChrome({ appId, title, context, state, sharing, onRefresh, onRevert, children }: {
   appId: string;
   /** What the app calls itself — the prefill names the THING, never an id. */
   title: string;
@@ -68,6 +68,13 @@ export function PinChrome({ appId, title, context, state, onRefresh, onRevert, c
    *  settled app. Vocabulary belongs to the caller: a remix that never built and
    *  a pinned app that will not load are not the same sentence. */
   state?: { label: string; name: string; status: string; busy?: boolean };
+  /** The one share the ✦ offers: this caller's tenant, and whether the app is
+   *  already shared with it. Absent ⇒ no menu item (not an owner, or in no
+   *  tenant). */
+  sharing?: {
+    org: string; display: string; shared: boolean;
+    onToggle(next: boolean): Promise<void>;
+  };
   onRefresh(): void;
   /** Undo this app's presence on the page; rejecting keeps the popover open. */
   onRevert(): Promise<void>;
@@ -76,6 +83,7 @@ export function PinChrome({ appId, title, context, state, onRefresh, onRevert, c
   const [revealed, setRevealed] = useState(false);
   const [open, setOpen] = useState(false);
   const [busy, setBusy] = useState(false);
+  const [sharingBusy, setSharingBusy] = useState(false);
   const wrap = useMenuDismiss(open, setOpen);
   const root = useMenuDismiss(revealed, setRevealed);
   const grace = useRef<number | undefined>(undefined);
@@ -173,6 +181,22 @@ export function PinChrome({ appId, title, context, state, onRefresh, onRevert, c
             {state === undefined ? null : <span className="fl-remix-status" role="status">{state.status}</span>}
             <button type="button" onClick={edit}>Edit in chat</button>
             <button type="button" onClick={() => { setOpen(false); onRefresh(); }}>Update</button>
+            {/* A switch, not a departure — the popover deliberately stays open. */}
+            {sharing === undefined ? null : (
+              <button
+                type="button"
+                aria-pressed={sharing.shared}
+                disabled={sharingBusy}
+                onClick={() => {
+                  setSharingBusy(true);
+                  void sharing.onToggle(!sharing.shared)
+                    .catch(() => vendoToast({ text: "That didn’t go through — try again.", state: "error" }))
+                    .finally(() => setSharingBusy(false));
+                }}
+              >
+                Share with {sharing.display}
+              </button>
+            )}
             <button type="button" className="is-danger" disabled={busy} onClick={revert}>
               {busy ? "Reverting…" : "Revert"}
             </button>

--- a/packages/ui/src/chrome/remixable.tsx
+++ b/packages/ui/src/chrome/remixable.tsx
@@ -1,7 +1,8 @@
 import { isValidElement, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
-import { log, seedComponentName, type AppDocument, type Json, type TreeNode } from "@vendoai/core";
+import { log, seedComponentName, type AppDocument, type AppId, type Json, type TreeNode } from "@vendoai/core";
 import { useVendoProvider } from "../context.js";
 import { useApp } from "../hooks/use-app.js";
+import { useAppSharing } from "../hooks/use-app-sharing.js";
 import { useResource } from "../hooks/use-resource.js";
 import { FluidReveal } from "../tree/fluid-reveal.js";
 import { AppFrame, PinMount } from "../tree/frames.js";
@@ -194,6 +195,7 @@ function RemixedFork({ appId, slot, review, liveProps, original, onReverted }: {
       ? { label: "Didn’t load", name: "This view didn’t load", status: "The remix didn’t load — the chat that asked for it says why." }
       : undefined;
   const Original = () => <>{original}</>;
+  const sharing = useAppSharing(appId as AppId);
   // "Update" REPLAYS the recorded wishes onto the host's new version — that is
   // what the seed is FOR, and the menu item said so while doing nothing but a
   // round trip. With no new version there is nothing to replay (the server
@@ -216,6 +218,7 @@ function RemixedFork({ appId, slot, review, liveProps, original, onReverted }: {
         // a voice-control user can actually speak.
         title="this view"
         {...(state === undefined ? {} : { state })}
+        {...(sharing === undefined ? {} : { sharing })}
         // The grounding rides `context` — a marked text part on the sent
         // message that no surface renders — so the prefill can name the THING
         // and never an id (spec §16 law 3).

--- a/packages/ui/src/chrome/vendo-slot.tsx
+++ b/packages/ui/src/chrome/vendo-slot.tsx
@@ -1,8 +1,9 @@
-import { log, type Json, type ToolOutcome, type UIPayload } from "@vendoai/core";
+import { log, type AppId, type Json, type ToolOutcome, type UIPayload } from "@vendoai/core";
 import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { useVendoProvider } from "../context.js";
 import { announcePin } from "../pin-events.js";
 import { useApp } from "../hooks/use-app.js";
+import { useAppSharing } from "../hooks/use-app-sharing.js";
 import { useReportSlot } from "../hooks/use-placements.js";
 import { useSlotApp } from "../hooks/use-slot-app.js";
 import { FluidReveal } from "../tree/fluid-reveal.js";
@@ -305,6 +306,8 @@ export function VendoSlot({ id, label, description, appId: appIdProp, pin, onAut
   const resolvesItself = appIdProp === undefined && pin === undefined;
   // The placed app's own build status — discovery's, and only discovery's.
   const status = resolvesItself ? discovery.status : undefined;
+  // The ✦ menu's share item — asked for only where the ✦ is actually worn.
+  const sharing = useAppSharing(appId as AppId, appId !== undefined && resolvesItself);
 
   // A slot id lives in the host's markup and nowhere else, so a surface that is
   // not on this page (the embed's "Add to…" picker) can only learn this slot
@@ -464,6 +467,7 @@ export function VendoSlot({ id, label, description, appId: appIdProp, pin, onAut
             appId={appId}
             title={pinTitle}
             context={`The view being edited is the "${pinTitle}" app (${appId}), pinned in the "${id}" slot.`}
+            {...(sharing === undefined ? {} : { sharing })}
             onRefresh={() => setReload(n => n + 1)}
             onRevert={() => client.apps.unplace(appId, id).then(() => void discovery.refresh())}
           >

--- a/packages/ui/src/hooks/index.ts
+++ b/packages/ui/src/hooks/index.ts
@@ -2,6 +2,7 @@
 export { useActivity } from "./use-activity.js";
 export { useApp } from "./use-app.js";
 export { useApps } from "./use-apps.js";
+export { useAppSharing, type AppSharing } from "./use-app-sharing.js";
 export { useApprovals, useAttention } from "./use-approvals.js";
 // The shapes useAttention hands back (the finished-run headline the launcher
 // toast and any host notification hook read).

--- a/packages/ui/src/hooks/use-app-sharing.ts
+++ b/packages/ui/src/hooks/use-app-sharing.ts
@@ -1,0 +1,54 @@
+/** The ✦ share toggle's state: which tenant the menu offers, whether the share
+ *  is on, and the write. ONE request answers all three (`GET /apps/:id/grants`
+ *  carries the caller's own memberships), so the menu never guesses.
+ *
+ *  Nothing is offered unless there is something to offer: a non-owner may not
+ *  share, and a caller in no tenant has nobody to share with. Both answer
+ *  `undefined`, and the menu item simply does not render. */
+import { encodeGrantPrincipal, type AppId } from "@vendoai/core";
+import { useCallback, useEffect, useState } from "react";
+import { useVendoProvider } from "../context.js";
+
+export interface AppSharing {
+  org: string;
+  display: string;
+  shared: boolean;
+  onToggle(next: boolean): Promise<void>;
+}
+
+export function useAppSharing(appId: AppId, enabled = true): AppSharing | undefined {
+  const { client } = useVendoProvider();
+  const [state, setState] = useState<{ org: string; display: string; shared: boolean }>();
+
+  const read = useCallback(async () => {
+    const { level, grants, orgs } = await client.apps.grants(appId);
+    // The FIRST tenant, deliberately: a share picker is out of scope, and one
+    // toggle that names a tenant beats a menu that lists them.
+    const first = orgs[0];
+    if (level !== "owner" || first === undefined) return setState(undefined);
+    const principal = encodeGrantPrincipal({ kind: "org", org: first.org });
+    setState({
+      org: first.org,
+      display: first.display ?? first.org,
+      shared: grants.some((grant) => grant.principal === principal),
+    });
+  }, [appId, client]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    // A read failure is not a toggle: the menu keeps its three items.
+    void read().catch(() => setState(undefined));
+  }, [enabled, read]);
+
+  if (state === undefined) return undefined;
+  return {
+    ...state,
+    onToggle: async (next) => {
+      const principal = encodeGrantPrincipal({ kind: "org", org: state.org });
+      const { grants } = next
+        ? await client.apps.share(appId, principal, "viewer")
+        : await client.apps.unshare(appId, principal);
+      setState({ ...state, shared: grants.some((grant) => grant.principal === principal) });
+    },
+  };
+}

--- a/packages/ui/test/chrome/pin-chrome-sharing.test.tsx
+++ b/packages/ui/test/chrome/pin-chrome-sharing.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { VendoProvider, createVendoClient, type VendoClient } from "../../src/index.js";
+import { VendoOverlay, VendoSlot } from "../../src/chrome/index.js";
+import { createWireServer } from "../wire-server.js";
+
+/** The ✦ menu's fourth item. One toggle, one tenant, viewer level — and it is
+ *  simply absent when there is nothing to share with. */
+describe("the ✦ share toggle", () => {
+  let wire: Awaited<ReturnType<typeof createWireServer>>;
+  let client: VendoClient;
+
+  beforeEach(async () => {
+    wire = await createWireServer();
+    client = createVendoClient({ baseUrl: wire.url });
+    await client.apps.place("app_1", "hero");
+  });
+  afterEach(async () => { cleanup(); await wire.close(); });
+
+  const openMenu = async () => {
+    const pill = await screen.findByRole("button", { name: "Edit Invoices" });
+    fireEvent.click(pill);
+  };
+
+  /** Absence is only news AFTER the read has answered. Without this wait both
+   *  "is absent" cases assert against a menu that has simply not heard back
+   *  yet — they passed against a hook with the owner check deleted. */
+  const grantsRead = () =>
+    waitFor(() => expect(wire.requests.some((request) => request.path === "/apps/app_1/grants")).toBe(true));
+
+  it("offers the owner's own tenant by NAME, off, between Update and Revert", async () => {
+    wire.setGrants("app_1", { level: "owner", grants: [], orgs: [{ org: "acme", display: "Acme Corp" }] });
+    render(<VendoProvider client={client}><VendoSlot id="hero" /><VendoOverlay launcher="none" /></VendoProvider>);
+    await openMenu();
+    const item = await screen.findByRole("button", { name: "Share with Acme Corp" });
+    expect(item.getAttribute("aria-pressed")).toBe("false");
+    const labels = [...item.closest(".fl-remix-menu")!.querySelectorAll("button")].map((b) => b.textContent);
+    expect(labels).toEqual(["Edit in chat", "Update", "Share with Acme Corp", "Revert"]);
+  });
+
+  it("reads as ON when the grant is already there", async () => {
+    wire.setGrants("app_1", {
+      level: "owner",
+      grants: [{ id: "g1", appId: "app_1", orgId: "acme", principal: "org:acme", level: "viewer", createdBy: "alice", createdAt: "2026-08-01T00:00:00.000Z" }],
+      orgs: [{ org: "acme", display: "Acme Corp" }],
+    });
+    render(<VendoProvider client={client}><VendoSlot id="hero" /><VendoOverlay launcher="none" /></VendoProvider>);
+    await openMenu();
+    await waitFor(async () =>
+      expect((await screen.findByRole("button", { name: "Share with Acme Corp" })).getAttribute("aria-pressed")).toBe("true"));
+  });
+
+  it("writes the grant when switched on", async () => {
+    wire.setGrants("app_1", { level: "owner", grants: [], orgs: [{ org: "acme", display: "Acme Corp" }] });
+    render(<VendoProvider client={client}><VendoSlot id="hero" /><VendoOverlay launcher="none" /></VendoProvider>);
+    await openMenu();
+    fireEvent.click(await screen.findByRole("button", { name: "Share with Acme Corp" }));
+    await waitFor(() => expect(wire.grantsOf("app_1")).toEqual([
+      expect.objectContaining({ principal: "org:acme", level: "viewer" }),
+    ]));
+  });
+
+  it("revokes when switched off", async () => {
+    wire.setGrants("app_1", {
+      level: "owner",
+      grants: [{ id: "g1", appId: "app_1", orgId: "acme", principal: "org:acme", level: "viewer", createdBy: "alice", createdAt: "2026-08-01T00:00:00.000Z" }],
+      orgs: [{ org: "acme", display: "Acme Corp" }],
+    });
+    render(<VendoProvider client={client}><VendoSlot id="hero" /><VendoOverlay launcher="none" /></VendoProvider>);
+    await openMenu();
+    fireEvent.click(await screen.findByRole("button", { name: "Share with Acme Corp" }));
+    await waitFor(() => expect(wire.grantsOf("app_1")).toEqual([]));
+  });
+
+  it("is absent for a non-owner", async () => {
+    wire.setGrants("app_1", { level: "viewer", grants: [], orgs: [{ org: "acme", display: "Acme Corp" }] });
+    render(<VendoProvider client={client}><VendoSlot id="hero" /><VendoOverlay launcher="none" /></VendoProvider>);
+    await grantsRead();
+    await openMenu();
+    await screen.findByRole("button", { name: "Revert" });
+    expect(screen.queryByRole("button", { name: /^Share with/ })).toBeNull();
+  });
+
+  it("is absent for an owner in no tenant", async () => {
+    wire.setGrants("app_1", { level: "owner", grants: [], orgs: [] });
+    render(<VendoProvider client={client}><VendoSlot id="hero" /><VendoOverlay launcher="none" /></VendoProvider>);
+    await grantsRead();
+    await openMenu();
+    await screen.findByRole("button", { name: "Revert" });
+    expect(screen.queryByRole("button", { name: /^Share with/ })).toBeNull();
+  });
+});

--- a/packages/ui/test/wire-server.ts
+++ b/packages/ui/test/wire-server.ts
@@ -6,7 +6,9 @@ import {
 } from "ai";
 import {
   seedComponentName,
+  type AccessLevel,
   type AppDocument,
+  type AppGrantRecord,
   type ApprovalRequest,
   type AuditEvent,
   type PermissionGrant,
@@ -340,6 +342,11 @@ export async function createWireServer(options: WireServerOptions = {}) {
      *  screen, and "not ready yet" is the build window's pending, never a
      *  failure (persistence/open.ts, wire/apps.ts). */
     pendingScreens: new Map<string, number>(),
+    /** What `GET /apps/:id/grants` answers, by app id — the ✦ share toggle's
+     *  one round trip. An UNSEEDED app answers the empty truth (no level, no
+     *  grants, no memberships), so every other suite's ✦ menu stays exactly the
+     *  three items it has always been. */
+    appGrants: new Map<string, { level: AccessLevel | null; grants: AppGrantRecord[]; orgs: { org: string; display?: string }[] }>(),
     approvals: [approval()],
     // Existing-agents — decided approvals move here so GET /approvals/:id can
     // answer the embed's poll; tests may also seed terminal states directly.
@@ -1247,6 +1254,29 @@ export async function createWireServer(options: WireServerOptions = {}) {
         if (!state.apps.some(item => item.id === id)) return wireError(response, "not-found", "App not found", 404);
         return json(response, { state: "awake" });
       }
+      // The ✦ share toggle's transport. The principal rides the path
+      // percent-encoded, because `org:acme` carries a ":" and a team a "/".
+      const grantsMatch = url.pathname.match(/^\/apps\/([^/]+)\/grants(?:\/(.+))?$/);
+      if (grantsMatch) {
+        const id = decodeURIComponent(grantsMatch[1] ?? "");
+        const seeded = state.appGrants.get(id) ?? { level: null, grants: [], orgs: [] };
+        if (method === "GET") return json(response, seeded);
+        const principal = decodeURIComponent(grantsMatch[2] ?? "");
+        const kept = seeded.grants.filter(row => row.principal !== principal);
+        seeded.grants = method === "PUT"
+          ? [...kept, {
+            id: `g_${kept.length + 1}`,
+            appId: id as AppDocument["id"],
+            orgId: principal.replace(/^org:/, "").split("/")[0] ?? "",
+            principal,
+            level: (parsedBody as { level: AccessLevel }).level,
+            createdBy: "user_1",
+            createdAt: NOW,
+          }]
+          : kept;
+        state.appGrants.set(id, seeded);
+        return json(response, { grants: seeded.grants });
+      }
       const appActionMatch = url.pathname.match(/^\/apps\/([^/]+)\/(open|call|edit|history|fork)$/);
       if (appActionMatch) {
         const id = decodeURIComponent(appActionMatch[1] ?? "");
@@ -1489,6 +1519,9 @@ export async function createWireServer(options: WireServerOptions = {}) {
     url,
     state,
     requests,
+    setGrants: (appId: string, seed: { level: AccessLevel | null; grants: AppGrantRecord[]; orgs: { org: string; display?: string }[] }) =>
+      state.appGrants.set(appId, seed),
+    grantsOf: (appId: string) => state.appGrants.get(appId)?.grants ?? [],
     close: async () => {
       if (closed) return;
       closed = true;

--- a/packages/vendo/tests/share-promotes.seam.test.ts
+++ b/packages/vendo/tests/share-promotes.seam.test.ts
@@ -1,0 +1,191 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  VENDO_APP_FORMAT,
+  type AppDocument,
+  type Membership,
+  type Principal,
+  type ToolRegistry,
+} from "@vendoai/core";
+import { createStore, type VendoStore } from "@vendoai/store";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createVendo, type Vendo } from "../src/server.js";
+
+/**
+ * SHARE IMPLIES PROMOTE, over the real composition — a real PGlite store, the
+ * real `createVendo`, the real wire route the ✦ toggle calls. Nothing is
+ * stubbed on either side, because the whole claim is that the grant write and
+ * the workspace move agree, and two mocks can never disagree.
+ *
+ * Every path that creates an app stamps it with the PERSON (build-surface.ts,
+ * seed-surface.ts, apps-surface.ts, interchange.ts), and core refuses to grant
+ * an org access to a still-personal app (ruled 2026-08-01, pinned at
+ * conformance/app-access.ts:181-201): the app's documents live under the
+ * holder's own `/user` mount, so a share that skipped the move would hand the
+ * recipient an empty app. So the toggle MOVES the app first.
+ *
+ * THE ONE THAT MUST BE ABLE TO FAIL is the last case. The move restamps the
+ * row's subject as the org id, so the ownership fast path
+ * (doors/access-checks.ts:65) stops matching the person who did it — and in a
+ * host where she is not a tenant ADMIN, that is her losing the app she just
+ * shared. Her own owner grant is minted BEFORE the flip for exactly that
+ * reason (helpers/app-access.ts:186-188). Mint it after, or not at all, and
+ * "the promoter keeps her app" goes red.
+ */
+
+const ORG = "maple";
+const dana: Principal = { kind: "user", subject: "dana" };
+/** Kim is an ORDINARY member — no `admin` flag. That is the whole point: in
+ *  Maple only the primary user is admin, so she is the person the ordering
+ *  protects. */
+const kim: Principal = { kind: "user", subject: "kim" };
+
+const memberships: Record<string, Membership[]> = {
+  dana: [{ org: ORG, display: "Maple Bank", teams: ["support"], admin: true }],
+  kim: [{ org: ORG, display: "Maple Bank", teams: ["support"] }],
+};
+
+const tools: ToolRegistry = {
+  async descriptors() { return []; },
+  async execute() { return { status: "error", error: { code: "not-found", message: "no host tools" } }; },
+};
+
+const seeded = (id: string, name: string): AppDocument => ({
+  format: VENDO_APP_FORMAT,
+  id,
+  name,
+  ui: "tree",
+});
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+  vi.unstubAllEnvs();
+});
+
+async function tempStore(): Promise<VendoStore> {
+  const dataDir = await mkdtemp(join(tmpdir(), "vendo-share-promotes-"));
+  const store = createStore({ dataDir });
+  cleanups.push(async () => {
+    await store.close().catch(() => undefined);
+    await rm(dataDir, { recursive: true, force: true });
+  });
+  return store;
+}
+
+/** Whose request this is — set per call, the way a real session would. */
+let acting: Principal = kim;
+
+const BASE = "https://maple.test/api/vendo";
+
+async function call(
+  vendo: Vendo,
+  who: Principal,
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<{ status: number; body: any }> {
+  acting = who;
+  const response = await vendo.handler(new Request(`${BASE}${path}`, {
+    method,
+    headers: {
+      origin: "https://maple.test",
+      ...(method === "GET" ? {} : { "content-type": "application/json" }),
+    },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  }));
+  const text = await response.text();
+  return { status: response.status, body: text === "" ? undefined : JSON.parse(text) };
+}
+
+/** A PERSONAL app — the only kind any create path produces. */
+const seedPersonalApp = async (store: VendoStore, app: AppDocument, subject: string): Promise<void> => {
+  await store.records("vendo_apps").put({
+    id: app.id,
+    data: { subject, enabled: false, doc: app },
+    refs: { subject },
+  });
+};
+
+const subjectOf = async (store: VendoStore, appId: string): Promise<unknown> =>
+  (await store.records("vendo_apps").get(appId))?.refs?.["subject"];
+
+describe("the ✦ share toggle's write, over the real composition", () => {
+  let store: VendoStore;
+  let vendo: Vendo;
+
+  beforeEach(async () => {
+    store = await tempStore();
+    vi.stubEnv("VENDO_API_KEY", "vnd_share_key");
+    vendo = createVendo({
+      store,
+      auth: {
+        principal: async () => acting,
+        memberships: async (principal) => memberships[principal.subject] ?? [],
+      },
+    });
+    vendo.actions.add(tools);
+    await store.ensureSchema();
+  });
+
+  it("moves the app into the tenant, then grants — a personal app cannot just be shared", async () => {
+    await seedPersonalApp(store, seeded("app_kim", "Kim's tracker"), "kim");
+    expect(await subjectOf(store, "app_kim")).toBe("kim");
+
+    const shared = await call(vendo, kim, "PUT", `/apps/app_kim/grants/${encodeURIComponent(`org:${ORG}`)}`, {
+      level: "viewer",
+    });
+    expect(shared.status).toBe(200);
+
+    // The move HAPPENED — this is what makes the grant meaningful instead of a
+    // pointer at an empty `/user` mount.
+    expect(await subjectOf(store, "app_kim")).toBe(ORG);
+    expect(shared.body.grants.map((row: { principal: string; level: string }) => [row.principal, row.level]))
+      .toContainEqual([`org:${ORG}`, "viewer"]);
+  });
+
+  it("the promoter KEEPS her app — she is an ordinary member, not a tenant admin", async () => {
+    await seedPersonalApp(store, seeded("app_keep", "Kim's tracker"), "kim");
+
+    expect((await call(vendo, kim, "PUT", `/apps/app_keep/grants/${encodeURIComponent(`org:${ORG}`)}`, {
+      level: "viewer",
+    })).status).toBe(200);
+    expect(await subjectOf(store, "app_keep")).toBe(ORG);
+
+    // Her ownership fast path is gone (the row's subject is the ORG now), and
+    // she holds no admin membership — so the ONLY thing that can still answer
+    // "owner" is the grant minted before the flip.
+    const read = await call(vendo, kim, "GET", "/apps/app_keep/grants");
+    expect(read.status).toBe(200);
+    expect(read.body.level).toBe("owner");
+    // Not merely visible — still hers to edit and to share again.
+    expect((await call(vendo, kim, "GET", "/apps/app_keep")).status).toBe(200);
+    expect((await call(vendo, kim, "DELETE", `/apps/app_keep/grants/${encodeURIComponent(`org:${ORG}`)}`)).status)
+      .toBe(200);
+  });
+
+  it("the tenant's admin reaches it once it has moved, and a stranger stays masked", async () => {
+    await seedPersonalApp(store, seeded("app_reach", "Kim's tracker"), "kim");
+    // Dana is the org's admin but the app is Kim's, so it is not hers yet.
+    expect((await call(vendo, dana, "GET", "/apps/app_reach")).status).toBe(404);
+
+    await call(vendo, kim, "PUT", `/apps/app_reach/grants/${encodeURIComponent(`org:${ORG}`)}`, { level: "viewer" });
+
+    expect((await call(vendo, dana, "GET", "/apps/app_reach")).status).toBe(200);
+    expect((await call(vendo, { kind: "user", subject: "stranger" }, "GET", "/apps/app_reach")).status).toBe(404);
+  });
+
+  it("un-sharing revokes and does NOT move the app back", async () => {
+    await seedPersonalApp(store, seeded("app_back", "Kim's tracker"), "kim");
+    await call(vendo, kim, "PUT", `/apps/app_back/grants/${encodeURIComponent(`org:${ORG}`)}`, { level: "viewer" });
+
+    const revoked = await call(vendo, kim, "DELETE", `/apps/app_back/grants/${encodeURIComponent(`org:${ORG}`)}`);
+    expect(revoked.status).toBe(200);
+    expect(revoked.body.grants.map((row: { principal: string }) => row.principal)).not.toContain(`org:${ORG}`);
+    // There is no demote, deliberately: the app's documents live in the
+    // tenant's workspace now, and moving them back is its own decision.
+    expect(await subjectOf(store, "app_back")).toBe(ORG);
+    expect((await call(vendo, kim, "GET", "/apps/app_back")).status).toBe(200);
+  });
+});

--- a/packages/vendo/tests/share-promotes.seam.test.ts
+++ b/packages/vendo/tests/share-promotes.seam.test.ts
@@ -8,7 +8,7 @@ import {
   type Principal,
   type ToolRegistry,
 } from "@vendoai/core";
-import { createStore, type VendoStore } from "@vendoai/store";
+import { createStore, createStoreOps, type VendoStore } from "@vendoai/store";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createVendo, type Vendo } from "../src/server.js";
 
@@ -67,6 +67,10 @@ afterEach(async () => {
 async function tempStore(): Promise<VendoStore> {
   const dataDir = await mkdtemp(join(tmpdir(), "vendo-share-promotes-"));
   const store = createStore({ dataDir });
+  // The very ops surface compose would build over this store anyway
+  // (compose-store.ts:118-120 takes `store.ops` when there is one), held here so
+  // a test can watch whether `lifecycle.promote` ran.
+  store.ops = createStoreOps(store);
   cleanups.push(async () => {
     await store.close().catch(() => undefined);
     await rm(dataDir, { recursive: true, force: true });
@@ -143,6 +147,24 @@ describe("the ✦ share toggle's write, over the real composition", () => {
     expect(await subjectOf(store, "app_kim")).toBe(ORG);
     expect(shared.body.grants.map((row: { principal: string; level: string }) => [row.principal, row.level]))
       .toContainEqual([`org:${ORG}`, "viewer"]);
+  });
+
+  it("refuses a tenant the sharer does not belong to, and moves nothing", async () => {
+    await seedPersonalApp(store, seeded("app_stranger", "Kim's tracker"), "kim");
+    const promote = vi.spyOn(store.ops!.lifecycle, "promote");
+
+    // Kim owns this app outright, so the owner gate lets her through. `acme` is
+    // somebody else's workspace — she is a member of Maple and nowhere else.
+    const refused = await call(vendo, kim, "PUT", `/apps/app_stranger/grants/${encodeURIComponent("org:acme")}`, {
+      level: "viewer",
+    });
+
+    expect(refused.status).toBe(403);
+    expect(promote).not.toHaveBeenCalled();
+    // Nothing moved and nothing was written — not even the owner row the flip is
+    // preceded by. Her app is still hers, and acme's admins never saw it.
+    expect(await subjectOf(store, "app_stranger")).toBe("kim");
+    expect((await call(vendo, kim, "GET", "/apps/app_stranger/grants")).body.grants).toEqual([]);
   });
 
   it("the promoter KEEPS her app — she is an ordinary member, not a tenant admin", async () => {


### PR DESCRIPTION
Slice 5 of the Tenant Organizations build. Stacks on `org/grants-write` (slice 4).

## What a person sees

The ✦ menu grows exactly one item, **between Update and Revert**, naming the tenant:

```
  Edit in chat
  Update
  Share with Acme Corp        ← off
  Revert

  Edit in chat
  Update
  Share with Acme Corp   ✓    ← on (accent + check, highlighted row)
  Revert
```

The check's slot is reserved in **both** states, so switching the share never reflows the
menu and Revert never moves out from under the cursor.

It is **absent** for a non-owner, and absent for a caller in no tenant. The popover
deliberately stays open when it is switched — it is a switch, not a departure.

Screenshots from the flagless production run (real Chromium, fresh build):
`packages/ui/e2e/test-results/share-toggle-off.png` and `share-toggle-on.png`.

## The scope addition Yousef approved

The plan had the toggle write a bare grant. That throws every time: every path that
creates an app stamps it with the **person** (`build-surface.ts:271`, `seed-surface.ts:92,145`,
`apps-surface.ts:157`, `interchange.ts:260`), and core **refuses** to grant a tenant access to a
still-personal app (ruled 2026-08-01, pinned at `conformance/app-access.ts:181-201`) — the app's
documents live under the holder's own `/user` mount, so a share that skipped the move would hand
the recipient an empty app.

So sharing **promotes, then grants**, and the door is `AppsRuntime.access.grant` rather than the
wire arm — the MCP door inherits the ordering instead of keeping a second copy of it.
`config.ops` was already reachable there, so this is 8 lines and no new plumbing.

**The order is the whole point.** The move restamps the row's subject as the org id, which retires
the sharer's ownership fast path (`access-checks.ts:65`). In a host where only the primary user is
an admin, a sharer who is *not* a tenant admin would lose the app she just shared. Her own owner
grant is therefore minted **before** the flip — the exception pinned at
`store/helpers/app-access.ts:186-188`.

Un-sharing revokes and nothing else. There is deliberately no demote.

## Proof

- `packages/vendo/tests/share-promotes.seam.test.ts` — real PGlite, real `createVendo`, real wire
  route, nothing stubbed on either side. Kim is an **ordinary** member, not an admin. Swap the mint
  and the flip and "the promoter KEEPS her app" goes red (404), while the admin case correctly
  stays green — which is exactly the discrimination the ordering is for.
- `packages/ui/test/chrome/pin-chrome-sharing.test.tsx` — 6 cases over the real wire fixture.
  Deleting the owner check turns "is absent for a non-owner" red.
- `packages/ui/e2e/share-toggle.spec.ts` — one scripted run, fresh production build, real Chromium.

Local gate on the touched scope: build ✅ · typecheck ✅ · lint ✅ · scoped suites ✅ (run twice).
The full suite is CI's job — the green `ci` check is the gate of record.

## Needs Yousef's eye

The toggle's **place** among Edit / Update / Revert, its **wording** ("Share with Acme Corp"),
and that it is **absent** for a non-owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a single “Share with <tenant>” toggle to the ✦ menu. Sharing now promotes a personal app into the tenant, mints the sharer’s owner grant first, then writes the tenant grant; the caller must belong to the named tenant. Previously, granting an org on a personal app failed, and an owner could name any org id.

- UI
  - `@vendoai/ui`: `PinChrome` adds “Share with <tenant>” between Update and Revert when the caller is an owner with a tenant; absent otherwise. The popover stays open; the button uses aria-pressed and a checkmark with a reserved slot.
  - Adds `useAppSharing`: reads `GET /apps/:id/grants` once (caller level, app grants, memberships) and toggles via share/unshare. Exported and wired into `VendoSlot` and `Remixable`. E2E and unit tests cover presence, ordering, and toggle behavior.

- Server behavior
  - `@vendoai/apps`: `AppsRuntime.access.grant` now requires owner level and membership in the target org; otherwise returns forbidden. It mints the sharer’s owner grant, promotes the app, then writes the org grant. Unsharing only revokes; there is no demote.
  - Deployments must provide memberships in the auth context; without them, sharing to a tenant is forbidden.
  - Guards missing app-access seams with a refusal instead of a runtime error. A seam test exercises ordering and the membership check over the real store and route.

<sup>Written for commit 2f7a55d8ea5dead0acaf194e9d2db453570d7041. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1531?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

