### PR TITLE
feat(demo-bank,docs): a Cloud key lets the tenant directory answer, and the docs say so

### DIFF
--- a/.changeset/app-share-grants.md
+++ b/.changeset/app-share-grants.md
@@ -1,0 +1,12 @@
+---
+"@vendoai/apps": minor
+"@vendoai/vendo": minor
+"@vendoai/ui": minor
+---
+
+An app can be shared again. `AppsRuntime.access` regains `list`, `grant` and
+`revoke` (viewer-scoped read, owner-scoped writes, each write answering with the
+resulting list), the wire mounts `GET /apps/:id/grants` and
+`PUT|DELETE /apps/:id/grants/:principal`, and the client regains
+`apps.grants/.share/.unshare`. The person picker and `promote` are deliberately
+not back.

--- a/.changeset/share-toggle.md
+++ b/.changeset/share-toggle.md
@@ -17,3 +17,10 @@ holder's own `/user` mount — so `AppsRuntime.access.grant` mints the sharer's 
 owner grant, runs `ops.lifecycle.promote`, and only then writes the tenant grant.
 The order is load-bearing: the move restamps the row's subject as the org id, so
 a sharer who is not a tenant admin would otherwise lose the app she just shared.
+
+Because that move is what makes the grant legal, naming the tenant is now an
+authorization claim of its own: `grant` refuses a `team:`/`org:` principal with
+`forbidden` unless the caller holds an asserted membership in that org. Owning
+the app is not enough — without this an owner could name any org id and have her
+app moved into a workspace she does not belong to. Revoking is unchanged, so a
+sharer who has since left the tenant can still un-share.

--- a/.changeset/share-toggle.md
+++ b/.changeset/share-toggle.md
@@ -1,0 +1,19 @@
+---
+"@vendoai/apps": minor
+"@vendoai/ui": minor
+---
+
+The ✦ menu offers one share. `useAppSharing` reads `GET /apps/:id/grants` once —
+the caller's level, the app's grants and the caller's own memberships — and
+`PinChrome` grows a single "Share with &lt;tenant&gt;" toggle between Update and
+Revert. It is absent for a non-owner and for a caller in no tenant, and the
+popover stays open when it is switched, because it is a switch rather than a
+departure.
+
+Sharing an app with a tenant now MOVES it there first. Every path that creates
+an app stamps it with the person, and core refuses a tenant grant on a
+still-personal app (ruled 2026-08-01) because the app's documents live under the
+holder's own `/user` mount — so `AppsRuntime.access.grant` mints the sharer's own
+owner grant, runs `ops.lifecycle.promote`, and only then writes the tenant grant.
+The order is load-bearing: the move restamps the row's subject as the org id, so
+a sharer who is not a tenant admin would otherwise lose the app she just shared.

--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -208,6 +208,7 @@
             "pages": [
               "users-orgs/your-users",
               "users-orgs/orgs-and-memberships",
+              "users-orgs/tenants",
               "users-orgs/sharing",
               "users-orgs/org-workspace",
               "users-orgs/org-policy",

--- a/docs-site/users-orgs/limits.mdx
+++ b/docs-site/users-orgs/limits.mdx
@@ -208,6 +208,23 @@ strictly better. Every such denial logs `limits.callback_error`.
 
 ---
 
+## Per-tenant caps
+
+If you let [Vendo Cloud keep your tenant directory](/users-orgs/tenants),
+caps come with it — set in the console, not in code. Each one carries a
+**scope**:
+
+| Scope | Counts |
+| --- | --- |
+| `per-member` | one person's own usage |
+| `per-tenant` | the whole company's, against the `org:<id>` pool |
+
+The project sets defaults; a tenant can override them. An explicit
+`config.limits` wins over both — the same precedence rule as everywhere else
+on this page, just supplied by Cloud instead of your own callback.
+
+---
+
 ## What is not metered
 
 Automation firings. A schedule fire or a webhook delivery is nobody's request and

--- a/docs-site/users-orgs/orgs-and-memberships.mdx
+++ b/docs-site/users-orgs/orgs-and-memberships.mdx
@@ -74,7 +74,8 @@ This is the whole model, and the rules that fall out of it:
   can never see two different answers.
 - **Never persisted.** There is no orgs table and no members table in the store.
   Removing someone from an org in your tables removes them from Vendo on their
-  very next request — nothing to propagate, no cache to invalidate.
+  very next request — nothing to propagate, and no cache to invalidate when you
+  assert memberships yourself.
 - An **ephemeral visitor is not even asked.** A principal you marked
   `ephemeral: true` belongs to no org by construction — your host issued them
   nothing.

--- a/docs-site/users-orgs/orgs-and-memberships.mdx
+++ b/docs-site/users-orgs/orgs-and-memberships.mdx
@@ -56,6 +56,14 @@ Return `[]` for a caller who belongs to nothing. Leave the seam off entirely and
 nothing is asserted: sharing degenerates to plain ownership, no org owns a
 workspace, and there are no org pools to count.
 
+### …or let Cloud keep the directory
+
+Writing and maintaining this query is real work. [Tenants](/users-orgs/tenants)
+is Vendo Cloud keeping that roster for you — with `VENDO_API_KEY` set and no
+`auth.memberships` of your own, the SDK asks the directory instead. Set
+`auth.memberships` and your assertion wins, always; the directory is never
+consulted.
+
 ---
 
 ## Asserted, never stored

--- a/docs-site/users-orgs/sharing.mdx
+++ b/docs-site/users-orgs/sharing.mdx
@@ -16,8 +16,11 @@ description: "Give one person, one team, or a whole org access to an app — a g
 A tenant member the owner shared with sees the app through the same
 `grantedRecords` read every `org:` grant already used — no accept step. Leaving
 the tenant is the only revoke this share needs: membership lives in Cloud, so
-once someone is off the roster the grant stops matching them on their next
-request, with nothing for the owner to click.
+once someone is off the roster the grant stops matching them, with nothing for
+the owner to click. Unlike a membership your own host asserts per request, the
+directory answer is [cached 60 seconds per user](/users-orgs/tenants), so that
+lands on their next membership refresh — within a minute, not on the next
+request.
 
 ## A share is a grant
 

--- a/docs-site/users-orgs/sharing.mdx
+++ b/docs-site/users-orgs/sharing.mdx
@@ -20,7 +20,8 @@ once someone is off the roster the grant stops matching them, with nothing for
 the owner to click. Unlike a membership your own host asserts per request, the
 directory answer is [cached 60 seconds per user](/users-orgs/tenants), so that
 lands on their next membership refresh — within a minute, not on the next
-request.
+request. While Cloud is unreachable the last known roster keeps being honoured,
+so a removed member keeps access until Cloud answers again.
 
 ## A share is a grant
 

--- a/docs-site/users-orgs/sharing.mdx
+++ b/docs-site/users-orgs/sharing.mdx
@@ -5,11 +5,19 @@ description: "Give one person, one team, or a whole org access to an app — a g
 ---
 
 <Note>
-  Sharing is a **server-side call** today. There is no HTTP route, no MCP tool,
-  and no CLI command for it — the Share dialog that used to front it was removed,
-  and the grant seam it wrote through stayed. You mount your own UI, or share from
-  your own backend logic.
+  An owner's ✦ menu on an app carries a **Share with &lt;tenant&gt;** toggle when
+  [Vendo Cloud's directory](/users-orgs/tenants) names a tenant the owner is in.
+  Turning it on grants `org:<tenantId>` at `viewer`; turning it off revokes it.
+  The wire mounts `GET /apps/:id/grants` and `PUT|DELETE
+  /apps/:id/grants/:principal` for it — everything below still applies, the
+  toggle is a thin front end over the same grant row.
 </Note>
+
+A tenant member the owner shared with sees the app through the same
+`grantedRecords` read every `org:` grant already used — no accept step. Leaving
+the tenant is the only revoke this share needs: membership lives in Cloud, so
+once someone is off the roster the grant stops matching them on their next
+request, with nothing for the owner to click.
 
 ## A share is a grant
 

--- a/docs-site/users-orgs/tenants.mdx
+++ b/docs-site/users-orgs/tenants.mdx
@@ -89,4 +89,5 @@ downgrade freezes the directory, it does not break your product.
 
 The SDK serves the last answer it had, or none. Your product keeps serving; for
 that window a tenant cap is not enforced and tenant-shared apps are briefly
-invisible.
+invisible. Removal is the direction that waits: a member you took off the roster
+keeps matching `org:` grants until Cloud answers again.

--- a/docs-site/users-orgs/tenants.mdx
+++ b/docs-site/users-orgs/tenants.mdx
@@ -1,0 +1,90 @@
+---
+title: "Tenants"
+sidebarTitle: "Tenants"
+description: "Let Vendo Cloud keep the directory of your customer companies, and sharing, org workspaces and per-company caps all start working without you building a roster."
+---
+
+Vendo has no org chart of its own — [your host answers who this caller works
+with](/users-orgs/orgs-and-memberships), once per request. Building and
+maintaining that answer is real work, so Vendo Cloud will keep it for you.
+
+A **tenant** is one of your customer companies: an id you choose (`acme`) and a
+display name. A **member** is one of your own users, by the id you already
+identify them with.
+
+## The whole setup
+
+<Steps>
+<Step title="Name a tenant when you identify a user">
+
+Your existing identify call gains one field. The first time a project names a
+tenant it does not have, Vendo creates it — the display name starts as the id,
+and you rename it in the console.
+
+```bash
+curl -X PUT https://console.vendo.run/api/v1/users/u_bob \
+  -H "authorization: Bearer $VENDO_API_KEY" \
+  -H "content-type: application/json" \
+  -d '{"traits":{"name":"Bob"},"tenant":"acme"}'
+```
+
+It only ever ADDS. It never removes a membership and never changes a role.
+
+</Step>
+<Step title="Leave `memberships` unset">
+
+With `VENDO_API_KEY` set and no `auth.memberships` of your own, the SDK asks the
+directory and caches the answer for 60 seconds per user. Everything downstream
+is code you already have.
+
+If you DO set `auth.memberships`, your answer wins and the directory is never
+called. That is the whole rule.
+
+</Step>
+<Step title="That's it">
+
+Shared apps, `/orgs/<id>/**` workspaces, org policy and the `org:<id>` limiter
+pool all read the same `memberships` they always did.
+
+</Step>
+</Steps>
+
+## Caps
+
+Each tenant gets messages/day and generations/month, set in the console. Every
+cap carries a **scope**:
+
+| Scope | Counts |
+| --- | --- |
+| `per-member` | one person's own usage |
+| `per-tenant` | the whole company's, against the `org:<id>` pool |
+
+The project sets defaults; a tenant can override them. A cap you set explicitly
+in `createVendo({ limits })` wins over both.
+
+## API reference
+
+Reads take your ordinary runtime key. Writes take an **admin-scoped** key: a
+runtime key ships inside every deployment of your product, and rearranging who
+is in which company from it is the same class of power the admin scope already
+fences.
+
+| Route | Key | What |
+| --- | --- | --- |
+| `GET /api/v1/tenants` | runtime | every tenant, with member counts |
+| `POST /api/v1/tenants` | admin | create — `{ id?, name, limits? }`; blank id mints one |
+| `GET /api/v1/tenants/{id}` | runtime | one tenant and its members |
+| `PATCH /api/v1/tenants/{id}` | admin | rename, or set `limits` (`null` clears the override) |
+| `DELETE /api/v1/tenants/{id}` | admin | delete |
+| `PUT /api/v1/tenants/{id}/members/{externalId}` | admin | add, or set the role |
+| `DELETE /api/v1/tenants/{id}/members/{externalId}` | admin | remove |
+| `GET /api/v1/users/{externalId}/memberships` | runtime | what the SDK reads |
+
+Tenant **writes** need the Teams plan. Reads and identify never do — a
+downgrade freezes the directory, it does not break your product.
+
+## What happens when Cloud is down
+
+The SDK serves the last answer it had, or none. Your product keeps serving; for
+that window a tenant cap is not enforced and tenant-shared apps are briefly
+invisible.

--- a/docs-site/users-orgs/tenants.mdx
+++ b/docs-site/users-orgs/tenants.mdx
@@ -51,7 +51,9 @@ pool all read the same `memberships` they always did.
 
 ## Caps
 
-Each tenant gets messages/day and generations/month, set in the console. Every
+Each tenant gets messages/day and generations/month, set in the console. Both
+reset on the calendar boundary in UTC — the start of the current UTC day and of
+the current UTC month — not on a rolling lookback, so "for today" is true. Every
 cap carries a **scope**:
 
 | Scope | Counts |

--- a/examples/demo-bank/package.json
+++ b/examples/demo-bank/package.json
@@ -12,6 +12,7 @@
     "mcp:e2e": "tsx scripts/mcp-e2e.ts",
     "mcp:agent": "tsx scripts/mcp-stock-agent.ts",
     "seed:console": "tsx scripts/seed-console.ts",
+    "seed:tenant": "node scripts/seed-tenant.mjs",
     "lint": "eslint",
     "test": "vitest run"
   },

--- a/examples/demo-bank/scripts/seed-tenant.mjs
+++ b/examples/demo-bank/scripts/seed-tenant.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+/**
+ * Seeds Maple's demo tenant over the PUBLIC API — the same four calls a
+ * customer would make:
+ *
+ *   pnpm seed:tenant          # needs VENDO_API_KEY_ADMIN (an admin-scoped key)
+ *
+ * Tenant writes take an admin-scoped key on purpose: a runtime key ships inside
+ * every deployment of the product, and rearranging who is in which company from
+ * it is the same class of power the admin scope already fences.
+ */
+const base = (process.env.VENDO_CLOUD_URL ?? "https://console.vendo.run").replace(/\/+$/, "");
+const adminKey = process.env.VENDO_API_KEY_ADMIN;
+const runtimeKey = process.env.VENDO_API_KEY;
+if (!adminKey) throw new Error("seed:tenant needs VENDO_API_KEY_ADMIN (an admin-scoped Vendo Cloud key)");
+if (!runtimeKey) throw new Error("seed:tenant needs VENDO_API_KEY (the runtime key identify rides)");
+
+const call = async (path, { method = "GET", key = adminKey, body } = {}) => {
+  const response = await fetch(`${base}/api/v1${path}`, {
+    method,
+    headers: {
+      authorization: `Bearer ${key}`,
+      accept: "application/json",
+      ...(body === undefined ? {} : { "content-type": "application/json" }),
+    },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  });
+  if (!response.ok && response.status !== 409) {
+    throw new Error(`${method} ${path} answered ${response.status}: ${await response.text()}`);
+  }
+  return response.status === 204 ? undefined : await response.json().catch(() => undefined);
+};
+
+const PEOPLE = [
+  { externalId: "alice@maple.com", name: "Alice Chen" },
+  { externalId: "bob@maple.com", name: "Bob Ruiz" },
+];
+
+// 1. The tenant. 409 means a previous run already made it — the seed is
+//    re-runnable, which is the only way a demo script is ever used.
+await call("/tenants", { method: "POST", body: { id: "acme", name: "Acme Corp" } });
+
+// 2. Identify each person on the RUNTIME key, exactly as Maple's server does.
+for (const person of PEOPLE) {
+  await call(`/users/${encodeURIComponent(person.externalId)}`, {
+    method: "PUT",
+    key: runtimeKey,
+    body: { traits: { name: person.name, email: person.externalId }, tenant: "acme" },
+  });
+}
+
+// 3. Alice runs the company.
+await call(`/tenants/acme/members/${encodeURIComponent(PEOPLE[0].externalId)}`, {
+  method: "PUT",
+  body: { role: "admin" },
+});
+
+// 4. A cap the demo can actually reach.
+await call("/tenants/acme", {
+  method: "PATCH",
+  body: { limits: { generationsPerMonth: { limit: 20, scope: "per-tenant" } } },
+});
+
+const tenant = await call("/tenants/acme");
+console.log(`Acme Corp: ${tenant.members.length} members, generations/month = ${tenant.limits.generationsPerMonth.limit} (per tenant)`);
+for (const member of tenant.members) console.log(`  ${member.externalId} — ${member.role}`);

--- a/examples/demo-bank/src/vendo/server.ts
+++ b/examples/demo-bank/src/vendo/server.ts
@@ -15,6 +15,35 @@ import { mapleRoutes } from "./routes";
 
 const composioApiKey = process.env.COMPOSIO_API_KEY;
 
+// Maple's two honest routes. With a Cloud key, Maple lets Vendo's tenant
+// directory answer "which companies?" and enforce the caps set in the console —
+// which is the whole point of the feature, and the host assertion below would
+// otherwise win over it. Without one, Maple asserts its own orgs and its own
+// policy, exactly as it always did.
+//
+// Truthy, not merely present — the same predicate the SDK's own `environment()`
+// applies (wire/shared.ts), so "keyed" means one thing on both sides of the
+// seam and an exported-but-blank VENDO_API_KEY does not make Maple stand down
+// for a directory that will never answer.
+const cloudDirectoryInUse = !!process.env.VENDO_API_KEY;
+
+// Build contract §9.1 — Maple's OWN identity tables answer "which orgs?".
+// One query against what the host already knows; Vendo stores nothing about
+// it. Keyed on the Principal, not the request, so an unattended automation
+// fire resolves the same orgs an attended click does. All four seeded staff
+// are in `maple`; Yousef is the org admin (implicit owner of every org app),
+// and the rest are ordinary members who reach an app only through a grant.
+const mapleMemberships = async (principal: Principal) => {
+  const user = resolveMapleSubject(principal.subject);
+  if (!user) return [];
+  return [{
+    org: "maple",
+    display: "Maple Bank",
+    teams: ["support"],
+    admin: user.subject === primaryMapleUser().subject,
+  }];
+};
+
 // One preset fills all three identity seams (09-vendo §2.1): the
 // request→Principal resolver, the away/MCP actAs seam, and the door's
 // OAuth adapter. `user` maps an Auth.js subject to the seeded Maple
@@ -37,22 +66,7 @@ const mapleAuthJs = authJs({
       },
     };
   },
-  // Build contract §9.1 — Maple's OWN identity tables answer "which orgs?".
-  // One query against what the host already knows; Vendo stores nothing about
-  // it. Keyed on the Principal, not the request, so an unattended automation
-  // fire resolves the same orgs an attended click does. All four seeded staff
-  // are in `maple`; Yousef is the org admin (implicit owner of every org app),
-  // and the rest are ordinary members who reach an app only through a grant.
-  memberships: async (principal) => {
-    const user = resolveMapleSubject(principal.subject);
-    if (!user) return [];
-    return [{
-      org: "maple",
-      display: "Maple Bank",
-      teams: ["support"],
-      admin: user.subject === primaryMapleUser().subject,
-    }];
-  },
+  ...(cloudDirectoryInUse ? {} : { memberships: mapleMemberships }),
 });
 
 // Vendo mints no principals, so a logged-out visitor has no identity unless
@@ -177,7 +191,7 @@ export const vendo = createVendo({
     policy: { file: ".vendo/policy.json" },
     judge: vendoAutoJudge({ model: vendoModel("vendo-judge") }),
   }),
-  limits: mapleLimits,
+  ...(cloudDirectoryInUse ? {} : { limits: mapleLimits }),
   // The 24-tool default belt is sized for a 600-tool catalog (tool-search.ts):
   // past it, everything is one `find_tools` away. Maple's whole surface is ~31
   // tools, comfortably inside the 30-50 band that file cites as the accurate

--- a/examples/demo-bank/tests/vendo/cloud-directory-posture.test.ts
+++ b/examples/demo-bank/tests/vendo/cloud-directory-posture.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+/** Maple's two routes, both honest. With a Cloud key the tenant directory
+ *  answers and the console's caps apply; without one Maple asserts its own
+ *  orgs and its own policy, exactly as it always did. The branch is read at
+ *  module load, so each case re-imports. Re-importing pays vite's transform of
+ *  the whole SDK graph (~12s cold), so the hang-detector has to sit above it. */
+afterEach(() => { vi.unstubAllEnvs(); vi.resetModules(); });
+
+describe("Maple's directory posture", () => {
+  it("asserts its own orgs and policy with NO Cloud key", { timeout: 60_000 }, async () => {
+    vi.stubEnv("VENDO_API_KEY", "");
+    vi.resetModules();
+    const { mapleAuth, mapleLimits } = await import("../../src/vendo/server");
+    expect(mapleAuth.memberships).toBeTypeOf("function");
+    expect(mapleLimits).toBeTypeOf("function");
+    await expect(mapleAuth.memberships!({ kind: "user", subject: "vendo-demo" }))
+      .resolves.toMatchObject([{ org: "maple" }]);
+  });
+
+  it("lets the directory answer WITH a Cloud key", { timeout: 60_000 }, async () => {
+    vi.stubEnv("VENDO_API_KEY", "vk_test");
+    vi.resetModules();
+    const { mapleAuth } = await import("../../src/vendo/server");
+    expect(mapleAuth.memberships).toBeUndefined();
+  });
+});

--- a/examples/demo-bank/tests/vendo/cloud-directory-posture.test.ts
+++ b/examples/demo-bank/tests/vendo/cloud-directory-posture.test.ts
@@ -1,11 +1,30 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+type VendoConfig = Parameters<typeof import("@vendoai/vendo/server").createVendo>[0];
+
+/** What `createVendo` was actually handed. Both halves of the posture are spreads
+ *  INSIDE that config literal, and the composed instance exposes no config, so the
+ *  call is the only place either one can be read. `importOriginal` leaves every
+ *  other export — and the real composition — alone. */
+const composed = vi.hoisted(() => ({ config: undefined as VendoConfig | undefined }));
+
+vi.mock("@vendoai/vendo/server", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@vendoai/vendo/server")>();
+  return {
+    ...actual,
+    createVendo: (config: VendoConfig) => {
+      composed.config = config;
+      return actual.createVendo(config);
+    },
+  };
+});
+
 /** Maple's two routes, both honest. With a Cloud key the tenant directory
  *  answers and the console's caps apply; without one Maple asserts its own
  *  orgs and its own policy, exactly as it always did. The branch is read at
  *  module load, so each case re-imports. Re-importing pays vite's transform of
  *  the whole SDK graph (~12s cold), so the hang-detector has to sit above it. */
-afterEach(() => { vi.unstubAllEnvs(); vi.resetModules(); });
+afterEach(() => { vi.unstubAllEnvs(); vi.resetModules(); composed.config = undefined; });
 
 describe("Maple's directory posture", () => {
   it("asserts its own orgs and policy with NO Cloud key", { timeout: 60_000 }, async () => {
@@ -13,15 +32,19 @@ describe("Maple's directory posture", () => {
     vi.resetModules();
     const { mapleAuth, mapleLimits } = await import("../../src/vendo/server");
     expect(mapleAuth.memberships).toBeTypeOf("function");
-    expect(mapleLimits).toBeTypeOf("function");
+    expect(composed.config?.limits).toBe(mapleLimits);
     await expect(mapleAuth.memberships!({ kind: "user", subject: "vendo-demo" }))
       .resolves.toMatchObject([{ org: "maple" }]);
   });
 
+  // Both halves, or the case proves half a posture: restoring Maple's own limits
+  // under a Cloud key leaves the console's tenant caps overridden by a host
+  // callback that always wins, and a memberships-only assertion still passes.
   it("lets the directory answer WITH a Cloud key", { timeout: 60_000 }, async () => {
     vi.stubEnv("VENDO_API_KEY", "vk_test");
     vi.resetModules();
     const { mapleAuth } = await import("../../src/vendo/server");
     expect(mapleAuth.memberships).toBeUndefined();
+    expect(composed.config?.limits).toBeUndefined();
   });
 });

--- a/packages/apps/src/server/doors/access-surface.ts
+++ b/packages/apps/src/server/doors/access-surface.ts
@@ -1,25 +1,59 @@
 /**
- * Build contract §9.3 — `AppsRuntime.access`: what level the CALLER holds on
- * an app.
+ * Build contract §9.2–§9.3 — `AppsRuntime.access`: what level the CALLER holds
+ * on an app, and the grant writes the ✦ share toggle needs.
  *
- * A read, and only a read. The grant-writing doors that used to sit beside it
- * (`list`/`grant`/`revoke`/`holder`) existed for the Share dialog, which no
- * host ever mounted; they went with it. Grant ROWS are still written and read
- * through the `AppAccess` seam (`config.appAccess`) — this surface just never
- * had a caller for that half.
+ * The LEVEL lives here, not on the wire, so the MCP door inherits the same
+ * rules without a second copy: `list` needs viewer, grant/revoke need owner.
+ * `config.appAccess` is set unconditionally from the composed store, so the
+ * seam is always present under `createVendo`.
  */
+import { VendoError } from "@vendoai/core";
 import type { AppsRuntimeContext } from "../runtime/runtime-context.js";
 import type { AppsRuntime } from "../runtime/types.js";
 
 export type AccessSurfaceDeps = Pick<AppsRuntimeContext, "config" | "holds">;
 
-export const createAccessSurface = ({ config, holds }: AccessSurfaceDeps): AppsRuntime["access"] => ({
-  async levelFor(appId, ctx) {
-    if (config.appAccess === undefined) {
-      // No seam ⇒ no grant row can exist, so ownership is the only level —
-      // which is exactly what `holds` degenerates to, at one store read.
-      return await holds(appId, ctx, "owner") ? "owner" : null;
+export const createAccessSurface = ({ config, holds }: AccessSurfaceDeps): AppsRuntime["access"] => {
+  /** §9.4's posture in one place: what the caller cannot VIEW stays not-found;
+      a proven viewer denied a stronger action gets forbidden. */
+  const require = async (appId: Parameters<AppsRuntime["access"]["list"]>[0], ctx: Parameters<AppsRuntime["access"]["list"]>[1], level: "viewer" | "owner") => {
+    if (await holds(appId, ctx, level)) return;
+    if (level !== "viewer" && await holds(appId, ctx, "viewer")) {
+      throw new VendoError("forbidden", `owner access is required for ${appId}`);
     }
-    return await config.appAccess.levelFor(ctx, appId);
-  },
-});
+    throw new VendoError("not-found", `app not found: ${appId}`);
+  };
+  const access: AppsRuntime["access"] = {
+    async levelFor(appId, ctx) {
+      if (config.appAccess === undefined) {
+        // No seam ⇒ no grant row can exist, so ownership is the only level —
+        // which is exactly what `holds` degenerates to, at one store read.
+        return await holds(appId, ctx, "owner") ? "owner" : null;
+      }
+      return await config.appAccess.levelFor(ctx, appId);
+    },
+    async list(appId, ctx) {
+      await require(appId, ctx, "viewer");
+      // No seam ⇒ no grant row can exist, so the empty list is the honest
+      // answer, not a refusal telling a keyless deployment to go buy something.
+      return config.appAccess === undefined ? [] : await config.appAccess.list(ctx, appId);
+    },
+    async grant(appId, principal, level, ctx) {
+      await require(appId, ctx, "owner");
+      await config.appAccess!.grant(ctx, appId, principal, level);
+      return await access.list(appId, ctx);
+    },
+    async revoke(appId, principal, ctx) {
+      await require(appId, ctx, "owner");
+      await config.appAccess!.revoke(ctx, appId, principal);
+      // The revoke LANDED. A caller who just removed their own last grant may
+      // no longer read it — that is §9.4 answering a different question, not a
+      // failed removal, so answer with what they can still legitimately see.
+      return await access.list(appId, ctx).catch((reason: unknown) => {
+        if (reason instanceof VendoError && (reason.code === "not-found" || reason.code === "forbidden")) return [];
+        throw reason;
+      });
+    },
+  };
+  return access;
+};

--- a/packages/apps/src/server/doors/access-surface.ts
+++ b/packages/apps/src/server/doors/access-surface.ts
@@ -7,13 +7,14 @@
  * `config.appAccess` is set unconditionally from the composed store, so the
  * seam is always present under `createVendo`.
  */
-import { VendoError } from "@vendoai/core";
+import { VendoError, encodeGrantPrincipal, parseGrantPrincipal, type AppId, type RunContext } from "@vendoai/core";
+import { APPS_COLLECTION } from "../persistence/persistence.js";
 import type { AppsRuntimeContext } from "../runtime/runtime-context.js";
 import type { AppsRuntime } from "../runtime/types.js";
 
-export type AccessSurfaceDeps = Pick<AppsRuntimeContext, "config" | "holds">;
+export type AccessSurfaceDeps = Pick<AppsRuntimeContext, "config" | "engine" | "holds">;
 
-export const createAccessSurface = ({ config, holds }: AccessSurfaceDeps): AppsRuntime["access"] => {
+export const createAccessSurface = ({ config, engine, holds }: AccessSurfaceDeps): AppsRuntime["access"] => {
   /** §9.4's posture in one place: what the caller cannot VIEW stays not-found;
       a proven viewer denied a stronger action gets forbidden. */
   const require = async (appId: Parameters<AppsRuntime["access"]["list"]>[0], ctx: Parameters<AppsRuntime["access"]["list"]>[1], level: "viewer" | "owner") => {
@@ -23,6 +24,37 @@ export const createAccessSurface = ({ config, holds }: AccessSurfaceDeps): AppsR
     }
     throw new VendoError("not-found", `app not found: ${appId}`);
   };
+  /**
+   * "Share implies promote" (ruled 2026-08-01, pinned at
+   * conformance/app-access.ts:181-201). Every create path stamps an app with the
+   * PERSON, and core refuses a tenant grant on a still-personal app — the app's
+   * documents live under the holder's own `/user` mount, so a share that skipped
+   * the move would hand the recipient an empty app. So the share moves it first,
+   * in `lifecycle.promote`'s one transaction.
+   *
+   * ORDER IS THE WHOLE POINT. The move restamps the row's subject as the org id,
+   * which retires the promoter's ownership fast path (access-checks.ts:65) — so
+   * an owner who is not a tenant ADMIN would lose the app she just shared. Her
+   * own owner grant is therefore minted BEFORE the flip, the deliberate
+   * exception pinned at store helpers/app-access.ts:186-188.
+   *
+   * With no `ops` (a store offering neither its own ops nor a SQL handle) there
+   * is nothing to move with, and core's own refusal below is the honest answer.
+   */
+  const promoteBeforeSharing = async (appId: AppId, principal: string, ctx: RunContext) => {
+    const target = parseGrantPrincipal(principal);
+    if (target === undefined || target.kind === "user" || config.ops === undefined) return;
+    const record = await engine.get(APPS_COLLECTION, appId);
+    if (record?.refs?.["subject"] === target.org) return;
+    await config.appAccess!.grant(
+      ctx,
+      appId,
+      encodeGrantPrincipal({ kind: "user", subject: ctx.principal.subject }),
+      "owner",
+    );
+    await config.ops.lifecycle.promote(appId, target.org);
+  };
+
   const access: AppsRuntime["access"] = {
     async levelFor(appId, ctx) {
       if (config.appAccess === undefined) {
@@ -40,6 +72,7 @@ export const createAccessSurface = ({ config, holds }: AccessSurfaceDeps): AppsR
     },
     async grant(appId, principal, level, ctx) {
       await require(appId, ctx, "owner");
+      await promoteBeforeSharing(appId, principal, ctx);
       await config.appAccess!.grant(ctx, appId, principal, level);
       return await access.list(appId, ctx);
     },

--- a/packages/apps/src/server/doors/access-surface.ts
+++ b/packages/apps/src/server/doors/access-surface.ts
@@ -3,9 +3,8 @@
  * on an app, and the grant writes the ✦ share toggle needs.
  *
  * The LEVEL lives here, not on the wire, so the MCP door inherits the same
- * rules without a second copy: `list` needs viewer, grant/revoke need owner.
- * `config.appAccess` is set unconditionally from the composed store, so the
- * seam is always present under `createVendo`.
+ * rules without a second copy: `list` needs viewer, grant/revoke need owner, and
+ * naming a tenant needs membership in it.
  */
 import { VendoError, encodeGrantPrincipal, parseGrantPrincipal, type AppId, type RunContext } from "@vendoai/core";
 import { APPS_COLLECTION } from "../persistence/persistence.js";
@@ -15,6 +14,17 @@ import type { AppsRuntime } from "../runtime/types.js";
 export type AccessSurfaceDeps = Pick<AppsRuntimeContext, "config" | "engine" | "holds">;
 
 export const createAccessSurface = ({ config, engine, holds }: AccessSurfaceDeps): AppsRuntime["access"] => {
+  /** The seam the WRITES need. `levelFor` and `list` degenerate honestly without
+      one, but a grant has nowhere to go. `createVendo` always composes it
+      (compose-apps.ts:384 → :187), so this is unreachable there — but
+      `createApps` is exported and takes `appAccess?`, and genbench calls it
+      without one (genbench/src/vendo.ts:280). A refusal beats a TypeError. */
+  const writable = () => {
+    if (config.appAccess === undefined) {
+      throw new VendoError("not-implemented", "this deployment composes no app-access seam, so it cannot hold grants");
+    }
+    return config.appAccess;
+  };
   /** §9.4's posture in one place: what the caller cannot VIEW stays not-found;
       a proven viewer denied a stronger action gets forbidden. */
   const require = async (appId: Parameters<AppsRuntime["access"]["list"]>[0], ctx: Parameters<AppsRuntime["access"]["list"]>[1], level: "viewer" | "owner") => {
@@ -24,6 +34,29 @@ export const createAccessSurface = ({ config, engine, holds }: AccessSurfaceDeps
     }
     throw new VendoError("not-found", `app not found: ${appId}`);
   };
+  /**
+   * §9.1 — the memberships the host ASSERTS are the only org chart Vendo has,
+   * so naming a tenant is an authorization claim, not a spelling. Owning the app
+   * is a SEPARATE gate and does not imply this one: without this check an owner
+   * could name any `org:<id>`, `promoteBeforeSharing` would move her app into a
+   * stranger's workspace, and that tenant's admins would hold it (their `owner`
+   * comes from the row's subject alone, helpers/app-access.ts:117). The store's
+   * own guard cannot catch it — it compares the principal against the org
+   * HOLDING the row, which the promote just restamped to the named one.
+   *
+   * `forbidden`, not `not-found`: §9.4 masks what a caller cannot see, and she
+   * provably sees this app. It says nothing about whether the org exists.
+   *
+   * Grant only. A sharer who has since left the tenant must still be able to
+   * un-share, and `revoke` never widens access.
+   */
+  const requireMembership = (principal: string, ctx: RunContext) => {
+    const target = parseGrantPrincipal(principal);
+    if (target === undefined || target.kind === "user") return;
+    if ((ctx.memberships ?? []).some((entry) => entry.org === target.org)) return;
+    throw new VendoError("forbidden", `you are not a member of ${target.org}`);
+  };
+
   /**
    * "Share implies promote" (ruled 2026-08-01, pinned at
    * conformance/app-access.ts:181-201). Every create path stamps an app with the
@@ -40,13 +73,31 @@ export const createAccessSurface = ({ config, engine, holds }: AccessSurfaceDeps
    *
    * With no `ops` (a store offering neither its own ops nor a SQL handle) there
    * is nothing to move with, and core's own refusal below is the honest answer.
+   *
+   * NOT ATOMIC with the grant that follows it, and knowingly so. If that last
+   * write fails, the app is left in the tenant carrying the sharer's owner grant
+   * and no tenant grant, so the tenant's ADMINS can reach it while the caller
+   * saw an error. Every alternative is worse. The order is FORCED: the tenant
+   * grant cannot go first (core refuses a tenant principal that is not the org
+   * holding the row, helpers/app-access.ts:186-188 — that IS the 2026-08-01
+   * ruling), and the owner grant cannot go after (paragraph above). One
+   * transaction is not on offer either — `AppAccess` is an adapter interface
+   * with no transaction, so a hosted or BYO grant write can never join
+   * `promote`'s. That leaves a compensating demote: surface the plan excludes,
+   * reversing a saga over workspace documents, appData, blobs and bearer tokens,
+   * whose own half-failure would be worse than the window it repairs. So the
+   * window is ACCEPTED, and kept small by what surrounds it — the target is the
+   * caller's own tenant (`requireMembership`), the exposure is that tenant's
+   * admins rather than its membership, and the caller keeps owner, so retrying
+   * the same share closes it: `promote` is idempotent and the grant write is one
+   * derived-id row.
    */
   const promoteBeforeSharing = async (appId: AppId, principal: string, ctx: RunContext) => {
     const target = parseGrantPrincipal(principal);
     if (target === undefined || target.kind === "user" || config.ops === undefined) return;
     const record = await engine.get(APPS_COLLECTION, appId);
     if (record?.refs?.["subject"] === target.org) return;
-    await config.appAccess!.grant(
+    await writable().grant(
       ctx,
       appId,
       encodeGrantPrincipal({ kind: "user", subject: ctx.principal.subject }),
@@ -72,13 +123,14 @@ export const createAccessSurface = ({ config, engine, holds }: AccessSurfaceDeps
     },
     async grant(appId, principal, level, ctx) {
       await require(appId, ctx, "owner");
+      requireMembership(principal, ctx);
       await promoteBeforeSharing(appId, principal, ctx);
-      await config.appAccess!.grant(ctx, appId, principal, level);
+      await writable().grant(ctx, appId, principal, level);
       return await access.list(appId, ctx);
     },
     async revoke(appId, principal, ctx) {
       await require(appId, ctx, "owner");
-      await config.appAccess!.revoke(ctx, appId, principal);
+      await writable().revoke(ctx, appId, principal);
       // The revoke LANDED. A caller who just removed their own last grant may
       // no longer read it — that is §9.4 answering a different question, not a
       // failed removal, so answer with what they can still legitimately see.

--- a/packages/apps/src/server/runtime/types.ts
+++ b/packages/apps/src/server/runtime/types.ts
@@ -10,6 +10,7 @@
 import type {
   AccessLevel,
   AppAccess,
+  AppGrantRecord,
   AppId,
   ApprovalId,
   ApprovalRequest,
@@ -636,11 +637,18 @@ export interface AppsRuntime {
    * host's own component, invisible to the server until it renders.
    */
   slots: SlotRegistry;
-  /** Build contract §9.3 — what level the CALLER holds. */
+  /** Build contract §9.2–§9.3 — what level the CALLER holds, and the grant
+   *  writes the ✦ share toggle needs. `list` is viewer-scoped (reading who
+   *  else can reach an app you can see); grant/revoke are owner-scoped. Every
+   *  write answers with the resulting list, so a surface never makes a second
+   *  round trip to learn what it just did. */
   access: {
     /** The caller's own level, or null when they cannot see the app at all —
      *  what the surface reads to decide between "Edit" and the fork offer. */
     levelFor(appId: AppId, ctx: RunContext): Promise<AccessLevel | null>;
+    list(appId: AppId, ctx: RunContext): Promise<AppGrantRecord[]>;
+    grant(appId: AppId, principal: string, level: AccessLevel, ctx: RunContext): Promise<AppGrantRecord[]>;
+    revoke(appId: AppId, principal: string, ctx: RunContext): Promise<AppGrantRecord[]>;
   };
   edit(appId: AppId, instruction: string, ctx: RunContext): Promise<EditResult>;
   /**

--- a/packages/apps/tests/access.test.ts
+++ b/packages/apps/tests/access.test.ts
@@ -10,7 +10,7 @@ import {
   type AppDocument,
 } from "../src/contract/index.js";
 import { appAccessConformance } from "@vendoai/core/conformance";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createApps, type AppsConfig, type AppsRuntime } from "../src/server/index.js";
 import { scriptedAssembler } from "../src/server/testing/screen-assembler.js";
 import { guardFixture } from "../src/server/testing/guard-fixture.js";
@@ -404,3 +404,62 @@ describe("§9.3 — the permission check costs what it claims to cost", () => {
  *  the ONE unattended firing path is the automations engine, whose own
  *  `memberships` seam is proven in
  *  `packages/automations/src/sponsorship.test.ts`. */
+
+/** Build contract §9.2 — the grant write half, back for the ✦ toggle and
+    nothing else. `list` is viewer-gated; grant/revoke are owner-gated, and the
+    RUNTIME owns the level so the wire never re-derives it. */
+describe("§9.2 — the grant write surface", () => {
+  /** The app is held by the ORG, because sharing implies the org workspace —
+      core's app-access conformance kit refuses an org grant on a still-personal
+      app, and `promote` is not part of this restore. Alice administers acme, so
+      she is its owner without a grant row of her own. */
+  const shared = async (): Promise<{ runtime: AppsRuntime; access: AppAccess; alice: RunContext }> => {
+    const { runtime, store, access } = setup();
+    await seedAppRow(engineOverAdapter(store), doc("app_share"), "acme");
+    return { runtime, access, alice: { ...ctx("alice"), memberships: [{ org: "acme", admin: true }] } };
+  };
+  const bob: RunContext = { ...ctx("bob"), memberships: [{ org: "acme" }] };
+
+  it("an owner grants an org at viewer level and reads it back", async () => {
+    const { runtime, alice } = await shared();
+    const granted = await runtime.access.grant("app_share", "org:acme", "viewer", alice);
+    expect(granted).toEqual([expect.objectContaining({ principal: "org:acme", level: "viewer" })]);
+    expect(await runtime.access.list("app_share", alice)).toHaveLength(1);
+  });
+
+  it("a member of that org can now see the app, and can list its grants", async () => {
+    const { runtime, alice } = await shared();
+    await runtime.access.grant("app_share", "org:acme", "viewer", alice);
+    expect(await runtime.access.levelFor("app_share", bob)).toBe("viewer");
+    expect(await runtime.access.list("app_share", bob)).toHaveLength(1);
+  });
+
+  it("revoking leaves the grant list empty and the member outside", async () => {
+    const { runtime, alice } = await shared();
+    await runtime.access.grant("app_share", "org:acme", "viewer", alice);
+    expect(await runtime.access.revoke("app_share", "org:acme", alice)).toEqual([]);
+    expect(await runtime.access.levelFor("app_share", bob)).toBeNull();
+  });
+
+  it("a viewer may NOT grant — proven viewer, denied action, forbidden", async () => {
+    const { runtime, access, alice } = await shared();
+    await runtime.access.grant("app_share", "org:acme", "viewer", alice);
+    // The seam gates too, so the refusal alone cannot tell whose gate answered.
+    // The RUNTIME's is the one the MCP door inherits, and it is proven by the
+    // seam never being reached — mutate this gate to `viewer` and this is the
+    // assertion that goes red.
+    const seam = vi.spyOn(access, "grant");
+    await expect(runtime.access.grant("app_share", "user:kim", "viewer", bob))
+      .rejects.toMatchObject({ code: "forbidden" });
+    expect(seam).not.toHaveBeenCalled();
+  });
+
+  it("a stranger is told nothing at all — existence stays masked", async () => {
+    const { runtime, access } = await shared();
+    const seam = vi.spyOn(access, "grant");
+    await expect(runtime.access.list("app_share", ctx("kim"))).rejects.toMatchObject({ code: "not-found" });
+    await expect(runtime.access.grant("app_share", "org:acme", "viewer", ctx("kim")))
+      .rejects.toMatchObject({ code: "not-found" });
+    expect(seam).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/e2e/harness/main.tsx
+++ b/packages/ui/e2e/harness/main.tsx
@@ -2067,6 +2067,7 @@ function scenario(pathname: string): { title: string; theme?: Partial<VendoTheme
     case "/slot-fallback": return { title: "Slot pin fallback", content: <SlotFallbackScenario />, ownProvider: true };
     case "/slot-building": return { title: "Inline slot — a build landing in place", content: <SlotBuildingScenario /> };
     case "/slot-states": return { title: "Inline slot — ready / failed", content: <SlotStatesScenario /> };
+    case "/share-toggle": return { title: "Inline slot — the ✦ menu's share toggle", content: <VendoSlot id="slot-shared"><p>Host hero (shareable)</p></VendoSlot> };
     case "/slot-picker": return { title: "Add to… — embed writes a placement", content: <SlotPickerScenario />, ownProvider: true };
     case "/remixable": return { title: "Remixable — the ✦ is one door into the chat", content: <RemixableScenario />, ownProvider: true };
     case "/appframe": return { title: "App execution planes", content: <AppFrameScenario /> };

--- a/packages/ui/e2e/harness/vite.config.ts
+++ b/packages/ui/e2e/harness/vite.config.ts
@@ -67,6 +67,14 @@ export default defineConfig(async ({ command }) => {
       prompt: "a board showing where my money goes each month",
     });
     wire.state.placements.push({ slot: "slot-failed", appId: "app_slot_failed" });
+    // (/share-toggle) — the ✦ menu's fourth item over the real wire: a placed
+    // app this caller OWNS, and one tenant she belongs to. Its own app and slot,
+    // because grants are seeded per app id — every other scenario's ✦ stays the
+    // three items it has always been.
+    wire.state.apps.push(fixtureApp("app_shared", "Invoices"));
+    wire.state.surfaces.set("app_shared", wire.state.surfaces.get("app_1")!);
+    wire.state.placements.push({ slot: "slot-shared", appId: "app_shared" });
+    wire.setGrants("app_shared", { level: "owner", grants: [], orgs: [{ org: "acme", display: "Acme Corp" }] });
     // (/accounts) — a broken account for the connected-accounts panel's Reconnect
     // path. Additive and on a toolkit nothing else in the harness touches, so it
     // never becomes active: `initiate` mints its own `ca_new` row, leaving this

--- a/packages/ui/e2e/share-toggle.spec.ts
+++ b/packages/ui/e2e/share-toggle.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "@playwright/test";
+import { openScenario } from "./helpers.js";
+
+/** 08-ui §4–5 — the ✦ menu's share toggle, in a real Chromium, over the
+    localhost wire fixture. */
+const SHOTS = "e2e/test-results";
+
+test("the ✦ menu offers one named share, and it toggles", async ({ page }) => {
+  await openScenario(page, "share-toggle");
+
+  // The ✦ is a reveal: the pill is non-interactive until the app blooms it.
+  const app = page.locator(".fl-slot-filled").first();
+  await app.hover();
+  await app.getByRole("button", { name: /^Edit / }).click();
+  const toggle = page.getByRole("button", { name: "Share with Acme Corp" });
+  await expect(toggle).toBeVisible();
+  await expect(toggle).toHaveAttribute("aria-pressed", "false");
+
+  // The order the person reads, top to bottom.
+  await expect(page.locator(".fl-remix-menu button")).toHaveText([
+    "Edit in chat", "Update", "Share with Acme Corp", "Revert",
+  ]);
+  await page.screenshot({ path: `${SHOTS}/share-toggle-off.png`, animations: "disabled" });
+
+  await toggle.click();
+  await expect(toggle).toHaveAttribute("aria-pressed", "true");
+  await expect(page.locator(".fl-remix-menu")).toBeVisible();     // a switch, not a departure
+  await page.screenshot({ path: `${SHOTS}/share-toggle-on.png`, animations: "disabled" });
+
+  await toggle.click();
+  await expect(toggle).toHaveAttribute("aria-pressed", "false");
+});

--- a/packages/ui/src/chrome/chrome-css.ts
+++ b/packages/ui/src/chrome/chrome-css.ts
@@ -1474,6 +1474,15 @@ html[data-vendo-dock] {
 .fl-remix-menu button:hover { background: var(--vendo-accent-soft); }
 .fl-remix-menu button:disabled { color: var(--vendo-fg-muted); cursor: default; }
 .fl-remix-menu button.is-danger { color: var(--vendo-danger); }
+/* The share toggle's ON state. aria-pressed says it to a screen reader; the
+   check says it to an eye, because colour alone is never a state. The check
+   rides ::after (so the button's own text stays exactly its label) and its slot
+   is reserved in BOTH states — otherwise switching the share reflows the menu
+   and Revert moves out from under the cursor. */
+.fl-remix-menu button[aria-pressed] { display: flex; align-items: center; justify-content: space-between; gap: 8px; white-space: nowrap; }
+.fl-remix-menu button[aria-pressed]::after { content: "✓"; visibility: hidden; }
+.fl-remix-menu button[aria-pressed="true"] { color: var(--vendo-accent); }
+.fl-remix-menu button[aria-pressed="true"]::after { visibility: visible; }
 
 /* ---- filled state ---- */
 .fl-slot-filled { position: relative; flex: 1; }

--- a/packages/ui/src/chrome/pin-chrome.tsx
+++ b/packages/ui/src/chrome/pin-chrome.tsx
@@ -55,7 +55,7 @@ export function useMenuDismiss(open: boolean, onToggle: (open: boolean) => void)
  * tap that revealed it.
  */
 
-export function PinChrome({ appId, title, context, state, onRefresh, onRevert, children }: {
+export function PinChrome({ appId, title, context, state, sharing, onRefresh, onRevert, children }: {
   appId: string;
   /** What the app calls itself — the prefill names the THING, never an id. */
   title: string;
@@ -68,6 +68,13 @@ export function PinChrome({ appId, title, context, state, onRefresh, onRevert, c
    *  settled app. Vocabulary belongs to the caller: a remix that never built and
    *  a pinned app that will not load are not the same sentence. */
   state?: { label: string; name: string; status: string; busy?: boolean };
+  /** The one share the ✦ offers: this caller's tenant, and whether the app is
+   *  already shared with it. Absent ⇒ no menu item (not an owner, or in no
+   *  tenant). */
+  sharing?: {
+    org: string; display: string; shared: boolean;
+    onToggle(next: boolean): Promise<void>;
+  };
   onRefresh(): void;
   /** Undo this app's presence on the page; rejecting keeps the popover open. */
   onRevert(): Promise<void>;
@@ -76,6 +83,7 @@ export function PinChrome({ appId, title, context, state, onRefresh, onRevert, c
   const [revealed, setRevealed] = useState(false);
   const [open, setOpen] = useState(false);
   const [busy, setBusy] = useState(false);
+  const [sharingBusy, setSharingBusy] = useState(false);
   const wrap = useMenuDismiss(open, setOpen);
   const root = useMenuDismiss(revealed, setRevealed);
   const grace = useRef<number | undefined>(undefined);
@@ -173,6 +181,22 @@ export function PinChrome({ appId, title, context, state, onRefresh, onRevert, c
             {state === undefined ? null : <span className="fl-remix-status" role="status">{state.status}</span>}
             <button type="button" onClick={edit}>Edit in chat</button>
             <button type="button" onClick={() => { setOpen(false); onRefresh(); }}>Update</button>
+            {/* A switch, not a departure — the popover deliberately stays open. */}
+            {sharing === undefined ? null : (
+              <button
+                type="button"
+                aria-pressed={sharing.shared}
+                disabled={sharingBusy}
+                onClick={() => {
+                  setSharingBusy(true);
+                  void sharing.onToggle(!sharing.shared)
+                    .catch(() => vendoToast({ text: "That didn’t go through — try again.", state: "error" }))
+                    .finally(() => setSharingBusy(false));
+                }}
+              >
+                Share with {sharing.display}
+              </button>
+            )}
             <button type="button" className="is-danger" disabled={busy} onClick={revert}>
               {busy ? "Reverting…" : "Revert"}
             </button>

--- a/packages/ui/src/chrome/remixable.tsx
+++ b/packages/ui/src/chrome/remixable.tsx
@@ -1,7 +1,8 @@
 import { isValidElement, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
-import { log, seedComponentName, type AppDocument, type Json, type TreeNode } from "@vendoai/core";
+import { log, seedComponentName, type AppDocument, type AppId, type Json, type TreeNode } from "@vendoai/core";
 import { useVendoProvider } from "../context.js";
 import { useApp } from "../hooks/use-app.js";
+import { useAppSharing } from "../hooks/use-app-sharing.js";
 import { useResource } from "../hooks/use-resource.js";
 import { FluidReveal } from "../tree/fluid-reveal.js";
 import { AppFrame, PinMount } from "../tree/frames.js";
@@ -194,6 +195,7 @@ function RemixedFork({ appId, slot, review, liveProps, original, onReverted }: {
       ? { label: "Didn’t load", name: "This view didn’t load", status: "The remix didn’t load — the chat that asked for it says why." }
       : undefined;
   const Original = () => <>{original}</>;
+  const sharing = useAppSharing(appId as AppId);
   // "Update" REPLAYS the recorded wishes onto the host's new version — that is
   // what the seed is FOR, and the menu item said so while doing nothing but a
   // round trip. With no new version there is nothing to replay (the server
@@ -216,6 +218,7 @@ function RemixedFork({ appId, slot, review, liveProps, original, onReverted }: {
         // a voice-control user can actually speak.
         title="this view"
         {...(state === undefined ? {} : { state })}
+        {...(sharing === undefined ? {} : { sharing })}
         // The grounding rides `context` — a marked text part on the sent
         // message that no surface renders — so the prefill can name the THING
         // and never an id (spec §16 law 3).

--- a/packages/ui/src/chrome/vendo-slot.tsx
+++ b/packages/ui/src/chrome/vendo-slot.tsx
@@ -1,8 +1,9 @@
-import { log, type Json, type ToolOutcome, type UIPayload } from "@vendoai/core";
+import { log, type AppId, type Json, type ToolOutcome, type UIPayload } from "@vendoai/core";
 import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { useVendoProvider } from "../context.js";
 import { announcePin } from "../pin-events.js";
 import { useApp } from "../hooks/use-app.js";
+import { useAppSharing } from "../hooks/use-app-sharing.js";
 import { useReportSlot } from "../hooks/use-placements.js";
 import { useSlotApp } from "../hooks/use-slot-app.js";
 import { FluidReveal } from "../tree/fluid-reveal.js";
@@ -305,6 +306,8 @@ export function VendoSlot({ id, label, description, appId: appIdProp, pin, onAut
   const resolvesItself = appIdProp === undefined && pin === undefined;
   // The placed app's own build status — discovery's, and only discovery's.
   const status = resolvesItself ? discovery.status : undefined;
+  // The ✦ menu's share item — asked for only where the ✦ is actually worn.
+  const sharing = useAppSharing(appId as AppId, appId !== undefined && resolvesItself);
 
   // A slot id lives in the host's markup and nowhere else, so a surface that is
   // not on this page (the embed's "Add to…" picker) can only learn this slot
@@ -464,6 +467,7 @@ export function VendoSlot({ id, label, description, appId: appIdProp, pin, onAut
             appId={appId}
             title={pinTitle}
             context={`The view being edited is the "${pinTitle}" app (${appId}), pinned in the "${id}" slot.`}
+            {...(sharing === undefined ? {} : { sharing })}
             onRefresh={() => setReload(n => n + 1)}
             onRevert={() => client.apps.unplace(appId, id).then(() => void discovery.refresh())}
           >

--- a/packages/ui/src/client-impl.ts
+++ b/packages/ui/src/client-impl.ts
@@ -159,7 +159,7 @@ export function createVendoClient(config: VendoClientConfig): VendoClient {
     return (await response.json()) as T;
   }
 
-  async function json<T>(path: string, method: "POST" | "PATCH" | "DELETE", body: unknown = {}): Promise<T> {
+  async function json<T>(path: string, method: "POST" | "PUT" | "PATCH" | "DELETE", body: unknown = {}): Promise<T> {
     return readJson<T>(path, {
       method,
       headers: { "Content-Type": "application/json" },
@@ -246,6 +246,12 @@ export function createVendoClient(config: VendoClientConfig): VendoClient {
           body: bytes as BodyInit,
         }),
       fork: id => json(`/apps/${idPath(id)}/fork`, "POST"),
+      // The principal rides the PATH, percent-encoded — `org:acme` contains a
+      // ":" and, for a team, a "/".
+      grants: id => readJson(`/apps/${idPath(id)}/grants`),
+      share: (id, principal, level) =>
+        json(`/apps/${idPath(id)}/grants/${idPath(principal)}`, "PUT", { level }),
+      unshare: (id, principal) => json(`/apps/${idPath(id)}/grants/${idPath(principal)}`, "DELETE"),
       shipDiff: id => readJson(`/apps/${idPath(id)}/ship-diff`),
       reseed: id => json(`/apps/${idPath(id)}/reseed`, "POST"),
       seedFrom: body => json("/apps/seed", "POST", body),

--- a/packages/ui/src/client.ts
+++ b/packages/ui/src/client.ts
@@ -6,7 +6,9 @@
  * implementation lives in client-impl.ts (lane A).
  */
 import {
+  type AccessLevel,
   type AppDocument,
+  type AppGrantRecord,
   type AppId,
   type ApprovalDecision,
   type ApprovalId,
@@ -123,6 +125,19 @@ export interface VendoClient {
     exportApp(id: AppId): Promise<Uint8Array>;
     importApp(bytes: Uint8Array): Promise<AppDocument>;
     fork(id: AppId): Promise<AppDocument>;
+    /**
+     * Build contract §9.2 — the ✦ share toggle's transport. `grants` reads the
+     * app's grant list, the caller's own level, AND the caller's memberships
+     * (projected off the ctx), so ONE round trip tells the menu which tenant to
+     * name and whether the share is already on.
+     */
+    grants(id: AppId): Promise<{
+      level: AccessLevel | null;
+      grants: AppGrantRecord[];
+      orgs: { org: string; display?: string }[];
+    }>;
+    share(id: AppId, principal: string, level: AccessLevel): Promise<{ grants: AppGrantRecord[] }>;
+    unshare(id: AppId, principal: string): Promise<{ grants: AppGrantRecord[] }>;
     /** GET /apps/:id/ship-diff — the reviewable diff vs the captured host baselines (06 §8–§9). */
     shipDiff(id: AppId): Promise<ShipDiff>;
     /** POST /apps/:id/reseed — rebuild the remix against the host's current

--- a/packages/ui/src/hooks/index.ts
+++ b/packages/ui/src/hooks/index.ts
@@ -2,6 +2,7 @@
 export { useActivity } from "./use-activity.js";
 export { useApp } from "./use-app.js";
 export { useApps } from "./use-apps.js";
+export { useAppSharing, type AppSharing } from "./use-app-sharing.js";
 export { useApprovals, useAttention } from "./use-approvals.js";
 // The shapes useAttention hands back (the finished-run headline the launcher
 // toast and any host notification hook read).

--- a/packages/ui/src/hooks/use-app-sharing.ts
+++ b/packages/ui/src/hooks/use-app-sharing.ts
@@ -1,0 +1,54 @@
+/** The ✦ share toggle's state: which tenant the menu offers, whether the share
+ *  is on, and the write. ONE request answers all three (`GET /apps/:id/grants`
+ *  carries the caller's own memberships), so the menu never guesses.
+ *
+ *  Nothing is offered unless there is something to offer: a non-owner may not
+ *  share, and a caller in no tenant has nobody to share with. Both answer
+ *  `undefined`, and the menu item simply does not render. */
+import { encodeGrantPrincipal, type AppId } from "@vendoai/core";
+import { useCallback, useEffect, useState } from "react";
+import { useVendoProvider } from "../context.js";
+
+export interface AppSharing {
+  org: string;
+  display: string;
+  shared: boolean;
+  onToggle(next: boolean): Promise<void>;
+}
+
+export function useAppSharing(appId: AppId, enabled = true): AppSharing | undefined {
+  const { client } = useVendoProvider();
+  const [state, setState] = useState<{ org: string; display: string; shared: boolean }>();
+
+  const read = useCallback(async () => {
+    const { level, grants, orgs } = await client.apps.grants(appId);
+    // The FIRST tenant, deliberately: a share picker is out of scope, and one
+    // toggle that names a tenant beats a menu that lists them.
+    const first = orgs[0];
+    if (level !== "owner" || first === undefined) return setState(undefined);
+    const principal = encodeGrantPrincipal({ kind: "org", org: first.org });
+    setState({
+      org: first.org,
+      display: first.display ?? first.org,
+      shared: grants.some((grant) => grant.principal === principal),
+    });
+  }, [appId, client]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    // A read failure is not a toggle: the menu keeps its three items.
+    void read().catch(() => setState(undefined));
+  }, [enabled, read]);
+
+  if (state === undefined) return undefined;
+  return {
+    ...state,
+    onToggle: async (next) => {
+      const principal = encodeGrantPrincipal({ kind: "org", org: state.org });
+      const { grants } = next
+        ? await client.apps.share(appId, principal, "viewer")
+        : await client.apps.unshare(appId, principal);
+      setState({ ...state, shared: grants.some((grant) => grant.principal === principal) });
+    },
+  };
+}

--- a/packages/ui/test/chrome/pin-chrome-sharing.test.tsx
+++ b/packages/ui/test/chrome/pin-chrome-sharing.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { VendoProvider, createVendoClient, type VendoClient } from "../../src/index.js";
+import { VendoOverlay, VendoSlot } from "../../src/chrome/index.js";
+import { createWireServer } from "../wire-server.js";
+
+/** The ✦ menu's fourth item. One toggle, one tenant, viewer level — and it is
+ *  simply absent when there is nothing to share with. */
+describe("the ✦ share toggle", () => {
+  let wire: Awaited<ReturnType<typeof createWireServer>>;
+  let client: VendoClient;
+
+  beforeEach(async () => {
+    wire = await createWireServer();
+    client = createVendoClient({ baseUrl: wire.url });
+    await client.apps.place("app_1", "hero");
+  });
+  afterEach(async () => { cleanup(); await wire.close(); });
+
+  const openMenu = async () => {
+    const pill = await screen.findByRole("button", { name: "Edit Invoices" });
+    fireEvent.click(pill);
+  };
+
+  /** Absence is only news AFTER the read has answered. Without this wait both
+   *  "is absent" cases assert against a menu that has simply not heard back
+   *  yet — they passed against a hook with the owner check deleted. */
+  const grantsRead = () =>
+    waitFor(() => expect(wire.requests.some((request) => request.path === "/apps/app_1/grants")).toBe(true));
+
+  it("offers the owner's own tenant by NAME, off, between Update and Revert", async () => {
+    wire.setGrants("app_1", { level: "owner", grants: [], orgs: [{ org: "acme", display: "Acme Corp" }] });
+    render(<VendoProvider client={client}><VendoSlot id="hero" /><VendoOverlay launcher="none" /></VendoProvider>);
+    await openMenu();
+    const item = await screen.findByRole("button", { name: "Share with Acme Corp" });
+    expect(item.getAttribute("aria-pressed")).toBe("false");
+    const labels = [...item.closest(".fl-remix-menu")!.querySelectorAll("button")].map((b) => b.textContent);
+    expect(labels).toEqual(["Edit in chat", "Update", "Share with Acme Corp", "Revert"]);
+  });
+
+  it("reads as ON when the grant is already there", async () => {
+    wire.setGrants("app_1", {
+      level: "owner",
+      grants: [{ id: "g1", appId: "app_1", orgId: "acme", principal: "org:acme", level: "viewer", createdBy: "alice", createdAt: "2026-08-01T00:00:00.000Z" }],
+      orgs: [{ org: "acme", display: "Acme Corp" }],
+    });
+    render(<VendoProvider client={client}><VendoSlot id="hero" /><VendoOverlay launcher="none" /></VendoProvider>);
+    await openMenu();
+    await waitFor(async () =>
+      expect((await screen.findByRole("button", { name: "Share with Acme Corp" })).getAttribute("aria-pressed")).toBe("true"));
+  });
+
+  it("writes the grant when switched on", async () => {
+    wire.setGrants("app_1", { level: "owner", grants: [], orgs: [{ org: "acme", display: "Acme Corp" }] });
+    render(<VendoProvider client={client}><VendoSlot id="hero" /><VendoOverlay launcher="none" /></VendoProvider>);
+    await openMenu();
+    fireEvent.click(await screen.findByRole("button", { name: "Share with Acme Corp" }));
+    await waitFor(() => expect(wire.grantsOf("app_1")).toEqual([
+      expect.objectContaining({ principal: "org:acme", level: "viewer" }),
+    ]));
+  });
+
+  it("revokes when switched off", async () => {
+    wire.setGrants("app_1", {
+      level: "owner",
+      grants: [{ id: "g1", appId: "app_1", orgId: "acme", principal: "org:acme", level: "viewer", createdBy: "alice", createdAt: "2026-08-01T00:00:00.000Z" }],
+      orgs: [{ org: "acme", display: "Acme Corp" }],
+    });
+    render(<VendoProvider client={client}><VendoSlot id="hero" /><VendoOverlay launcher="none" /></VendoProvider>);
+    await openMenu();
+    fireEvent.click(await screen.findByRole("button", { name: "Share with Acme Corp" }));
+    await waitFor(() => expect(wire.grantsOf("app_1")).toEqual([]));
+  });
+
+  it("is absent for a non-owner", async () => {
+    wire.setGrants("app_1", { level: "viewer", grants: [], orgs: [{ org: "acme", display: "Acme Corp" }] });
+    render(<VendoProvider client={client}><VendoSlot id="hero" /><VendoOverlay launcher="none" /></VendoProvider>);
+    await grantsRead();
+    await openMenu();
+    await screen.findByRole("button", { name: "Revert" });
+    expect(screen.queryByRole("button", { name: /^Share with/ })).toBeNull();
+  });
+
+  it("is absent for an owner in no tenant", async () => {
+    wire.setGrants("app_1", { level: "owner", grants: [], orgs: [] });
+    render(<VendoProvider client={client}><VendoSlot id="hero" /><VendoOverlay launcher="none" /></VendoProvider>);
+    await grantsRead();
+    await openMenu();
+    await screen.findByRole("button", { name: "Revert" });
+    expect(screen.queryByRole("button", { name: /^Share with/ })).toBeNull();
+  });
+});

--- a/packages/ui/test/wire-server.ts
+++ b/packages/ui/test/wire-server.ts
@@ -6,7 +6,9 @@ import {
 } from "ai";
 import {
   seedComponentName,
+  type AccessLevel,
   type AppDocument,
+  type AppGrantRecord,
   type ApprovalRequest,
   type AuditEvent,
   type PermissionGrant,
@@ -340,6 +342,11 @@ export async function createWireServer(options: WireServerOptions = {}) {
      *  screen, and "not ready yet" is the build window's pending, never a
      *  failure (persistence/open.ts, wire/apps.ts). */
     pendingScreens: new Map<string, number>(),
+    /** What `GET /apps/:id/grants` answers, by app id — the ✦ share toggle's
+     *  one round trip. An UNSEEDED app answers the empty truth (no level, no
+     *  grants, no memberships), so every other suite's ✦ menu stays exactly the
+     *  three items it has always been. */
+    appGrants: new Map<string, { level: AccessLevel | null; grants: AppGrantRecord[]; orgs: { org: string; display?: string }[] }>(),
     approvals: [approval()],
     // Existing-agents — decided approvals move here so GET /approvals/:id can
     // answer the embed's poll; tests may also seed terminal states directly.
@@ -1247,6 +1254,29 @@ export async function createWireServer(options: WireServerOptions = {}) {
         if (!state.apps.some(item => item.id === id)) return wireError(response, "not-found", "App not found", 404);
         return json(response, { state: "awake" });
       }
+      // The ✦ share toggle's transport. The principal rides the path
+      // percent-encoded, because `org:acme` carries a ":" and a team a "/".
+      const grantsMatch = url.pathname.match(/^\/apps\/([^/]+)\/grants(?:\/(.+))?$/);
+      if (grantsMatch) {
+        const id = decodeURIComponent(grantsMatch[1] ?? "");
+        const seeded = state.appGrants.get(id) ?? { level: null, grants: [], orgs: [] };
+        if (method === "GET") return json(response, seeded);
+        const principal = decodeURIComponent(grantsMatch[2] ?? "");
+        const kept = seeded.grants.filter(row => row.principal !== principal);
+        seeded.grants = method === "PUT"
+          ? [...kept, {
+            id: `g_${kept.length + 1}`,
+            appId: id as AppDocument["id"],
+            orgId: principal.replace(/^org:/, "").split("/")[0] ?? "",
+            principal,
+            level: (parsedBody as { level: AccessLevel }).level,
+            createdBy: "user_1",
+            createdAt: NOW,
+          }]
+          : kept;
+        state.appGrants.set(id, seeded);
+        return json(response, { grants: seeded.grants });
+      }
       const appActionMatch = url.pathname.match(/^\/apps\/([^/]+)\/(open|call|edit|history|fork)$/);
       if (appActionMatch) {
         const id = decodeURIComponent(appActionMatch[1] ?? "");
@@ -1489,6 +1519,9 @@ export async function createWireServer(options: WireServerOptions = {}) {
     url,
     state,
     requests,
+    setGrants: (appId: string, seed: { level: AccessLevel | null; grants: AppGrantRecord[]; orgs: { org: string; display?: string }[] }) =>
+      state.appGrants.set(appId, seed),
+    grantsOf: (appId: string) => state.appGrants.get(appId)?.grants ?? [],
     close: async () => {
       if (closed) return;
       closed = true;

--- a/packages/vendo/src/wire/apps.ts
+++ b/packages/vendo/src/wire/apps.ts
@@ -1,4 +1,4 @@
-import { isVendoError, VendoError, type Json, type RunContext, type StoreOps } from "@vendoai/core";
+import { isVendoError, VendoError, type AccessLevel, type Json, type RunContext, type StoreOps } from "@vendoai/core";
 import { json, requestJson, route, string, type RouteEntry, type WireContext } from "./shared.js";
 
 /** What the ?pending=1 disambiguation learned about a record open() refused
@@ -177,6 +177,16 @@ async function handleHistory(wire: WireContext, appId: string, ctx: RunContext):
     repetitions of the triple. */
 const op = (wire: WireContext, method: string, operation: string, length = 3): boolean =>
   wire.request.method === method && wire.segments[2] === operation && wire.segments.length === length;
+
+/** Build contract §9.3 — the level vocabulary is CLOSED, so the wire refuses
+    anything outside it instead of letting a typo reach the store. */
+function accessLevel(value: unknown): AccessLevel {
+  const level = string(value, "level");
+  if (level !== "viewer" && level !== "editor" && level !== "owner") {
+    throw new VendoError("validation", "level must be viewer, editor, or owner");
+  }
+  return level;
+}
 
 /** 06-apps / 09 §3 — the /apps wire area: CRUD, open/call/edit, history,
     ship-diff, seed drift/re-seed, the ✦ gesture (seed), export/import,
@@ -365,6 +375,29 @@ export const appRoutes: RouteEntry[] = [
     }
     if (op(wire, "POST", "fork")) {
       return json(await deps.apps.fork(appId, ctx));
+    }
+    // Build contract §9.2 — the ✦ share toggle's door. The LEVEL lives in the
+    // runtime, so the MCP door inherits the same rules. `orgs` is projected off
+    // the ctx the wire already resolved, so ONE round trip tells the menu which
+    // tenant to name and whether the share is on.
+    if (op(wire, "GET", "grants")) {
+      return json({
+        level: await deps.apps.access.levelFor(appId, ctx),
+        grants: await deps.apps.access.list(appId, ctx),
+        orgs: (ctx.memberships ?? []).map(({ org, display }) => ({
+          org,
+          ...(display === undefined ? {} : { display }),
+        })),
+      });
+    }
+    if (op(wire, "PUT", "grants", 4)) {
+      const body = await requestJson(request);
+      const principal = string(segments[3], "principal");
+      return json({ grants: await deps.apps.access.grant(appId, principal, accessLevel(body["level"]), ctx) });
+    }
+    if (op(wire, "DELETE", "grants", 4)) {
+      const principal = string(segments[3], "principal");
+      return json({ grants: await deps.apps.access.revoke(appId, principal, ctx) });
     }
     return undefined;
   }),

--- a/packages/vendo/tests/share-promotes.seam.test.ts
+++ b/packages/vendo/tests/share-promotes.seam.test.ts
@@ -1,0 +1,191 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  VENDO_APP_FORMAT,
+  type AppDocument,
+  type Membership,
+  type Principal,
+  type ToolRegistry,
+} from "@vendoai/core";
+import { createStore, type VendoStore } from "@vendoai/store";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createVendo, type Vendo } from "../src/server.js";
+
+/**
+ * SHARE IMPLIES PROMOTE, over the real composition — a real PGlite store, the
+ * real `createVendo`, the real wire route the ✦ toggle calls. Nothing is
+ * stubbed on either side, because the whole claim is that the grant write and
+ * the workspace move agree, and two mocks can never disagree.
+ *
+ * Every path that creates an app stamps it with the PERSON (build-surface.ts,
+ * seed-surface.ts, apps-surface.ts, interchange.ts), and core refuses to grant
+ * an org access to a still-personal app (ruled 2026-08-01, pinned at
+ * conformance/app-access.ts:181-201): the app's documents live under the
+ * holder's own `/user` mount, so a share that skipped the move would hand the
+ * recipient an empty app. So the toggle MOVES the app first.
+ *
+ * THE ONE THAT MUST BE ABLE TO FAIL is the last case. The move restamps the
+ * row's subject as the org id, so the ownership fast path
+ * (doors/access-checks.ts:65) stops matching the person who did it — and in a
+ * host where she is not a tenant ADMIN, that is her losing the app she just
+ * shared. Her own owner grant is minted BEFORE the flip for exactly that
+ * reason (helpers/app-access.ts:186-188). Mint it after, or not at all, and
+ * "the promoter keeps her app" goes red.
+ */
+
+const ORG = "maple";
+const dana: Principal = { kind: "user", subject: "dana" };
+/** Kim is an ORDINARY member — no `admin` flag. That is the whole point: in
+ *  Maple only the primary user is admin, so she is the person the ordering
+ *  protects. */
+const kim: Principal = { kind: "user", subject: "kim" };
+
+const memberships: Record<string, Membership[]> = {
+  dana: [{ org: ORG, display: "Maple Bank", teams: ["support"], admin: true }],
+  kim: [{ org: ORG, display: "Maple Bank", teams: ["support"] }],
+};
+
+const tools: ToolRegistry = {
+  async descriptors() { return []; },
+  async execute() { return { status: "error", error: { code: "not-found", message: "no host tools" } }; },
+};
+
+const seeded = (id: string, name: string): AppDocument => ({
+  format: VENDO_APP_FORMAT,
+  id,
+  name,
+  ui: "tree",
+});
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+  vi.unstubAllEnvs();
+});
+
+async function tempStore(): Promise<VendoStore> {
+  const dataDir = await mkdtemp(join(tmpdir(), "vendo-share-promotes-"));
+  const store = createStore({ dataDir });
+  cleanups.push(async () => {
+    await store.close().catch(() => undefined);
+    await rm(dataDir, { recursive: true, force: true });
+  });
+  return store;
+}
+
+/** Whose request this is — set per call, the way a real session would. */
+let acting: Principal = kim;
+
+const BASE = "https://maple.test/api/vendo";
+
+async function call(
+  vendo: Vendo,
+  who: Principal,
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<{ status: number; body: any }> {
+  acting = who;
+  const response = await vendo.handler(new Request(`${BASE}${path}`, {
+    method,
+    headers: {
+      origin: "https://maple.test",
+      ...(method === "GET" ? {} : { "content-type": "application/json" }),
+    },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  }));
+  const text = await response.text();
+  return { status: response.status, body: text === "" ? undefined : JSON.parse(text) };
+}
+
+/** A PERSONAL app — the only kind any create path produces. */
+const seedPersonalApp = async (store: VendoStore, app: AppDocument, subject: string): Promise<void> => {
+  await store.records("vendo_apps").put({
+    id: app.id,
+    data: { subject, enabled: false, doc: app },
+    refs: { subject },
+  });
+};
+
+const subjectOf = async (store: VendoStore, appId: string): Promise<unknown> =>
+  (await store.records("vendo_apps").get(appId))?.refs?.["subject"];
+
+describe("the ✦ share toggle's write, over the real composition", () => {
+  let store: VendoStore;
+  let vendo: Vendo;
+
+  beforeEach(async () => {
+    store = await tempStore();
+    vi.stubEnv("VENDO_API_KEY", "vnd_share_key");
+    vendo = createVendo({
+      store,
+      auth: {
+        principal: async () => acting,
+        memberships: async (principal) => memberships[principal.subject] ?? [],
+      },
+    });
+    vendo.actions.add(tools);
+    await store.ensureSchema();
+  });
+
+  it("moves the app into the tenant, then grants — a personal app cannot just be shared", async () => {
+    await seedPersonalApp(store, seeded("app_kim", "Kim's tracker"), "kim");
+    expect(await subjectOf(store, "app_kim")).toBe("kim");
+
+    const shared = await call(vendo, kim, "PUT", `/apps/app_kim/grants/${encodeURIComponent(`org:${ORG}`)}`, {
+      level: "viewer",
+    });
+    expect(shared.status).toBe(200);
+
+    // The move HAPPENED — this is what makes the grant meaningful instead of a
+    // pointer at an empty `/user` mount.
+    expect(await subjectOf(store, "app_kim")).toBe(ORG);
+    expect(shared.body.grants.map((row: { principal: string; level: string }) => [row.principal, row.level]))
+      .toContainEqual([`org:${ORG}`, "viewer"]);
+  });
+
+  it("the promoter KEEPS her app — she is an ordinary member, not a tenant admin", async () => {
+    await seedPersonalApp(store, seeded("app_keep", "Kim's tracker"), "kim");
+
+    expect((await call(vendo, kim, "PUT", `/apps/app_keep/grants/${encodeURIComponent(`org:${ORG}`)}`, {
+      level: "viewer",
+    })).status).toBe(200);
+    expect(await subjectOf(store, "app_keep")).toBe(ORG);
+
+    // Her ownership fast path is gone (the row's subject is the ORG now), and
+    // she holds no admin membership — so the ONLY thing that can still answer
+    // "owner" is the grant minted before the flip.
+    const read = await call(vendo, kim, "GET", "/apps/app_keep/grants");
+    expect(read.status).toBe(200);
+    expect(read.body.level).toBe("owner");
+    // Not merely visible — still hers to edit and to share again.
+    expect((await call(vendo, kim, "GET", "/apps/app_keep")).status).toBe(200);
+    expect((await call(vendo, kim, "DELETE", `/apps/app_keep/grants/${encodeURIComponent(`org:${ORG}`)}`)).status)
+      .toBe(200);
+  });
+
+  it("the tenant's admin reaches it once it has moved, and a stranger stays masked", async () => {
+    await seedPersonalApp(store, seeded("app_reach", "Kim's tracker"), "kim");
+    // Dana is the org's admin but the app is Kim's, so it is not hers yet.
+    expect((await call(vendo, dana, "GET", "/apps/app_reach")).status).toBe(404);
+
+    await call(vendo, kim, "PUT", `/apps/app_reach/grants/${encodeURIComponent(`org:${ORG}`)}`, { level: "viewer" });
+
+    expect((await call(vendo, dana, "GET", "/apps/app_reach")).status).toBe(200);
+    expect((await call(vendo, { kind: "user", subject: "stranger" }, "GET", "/apps/app_reach")).status).toBe(404);
+  });
+
+  it("un-sharing revokes and does NOT move the app back", async () => {
+    await seedPersonalApp(store, seeded("app_back", "Kim's tracker"), "kim");
+    await call(vendo, kim, "PUT", `/apps/app_back/grants/${encodeURIComponent(`org:${ORG}`)}`, { level: "viewer" });
+
+    const revoked = await call(vendo, kim, "DELETE", `/apps/app_back/grants/${encodeURIComponent(`org:${ORG}`)}`);
+    expect(revoked.status).toBe(200);
+    expect(revoked.body.grants.map((row: { principal: string }) => row.principal)).not.toContain(`org:${ORG}`);
+    // There is no demote, deliberately: the app's documents live in the
+    // tenant's workspace now, and moving them back is its own decision.
+    expect(await subjectOf(store, "app_back")).toBe(ORG);
+    expect((await call(vendo, kim, "GET", "/apps/app_back")).status).toBe(200);
+  });
+});

--- a/packages/vendo/tests/share-promotes.seam.test.ts
+++ b/packages/vendo/tests/share-promotes.seam.test.ts
@@ -8,7 +8,7 @@ import {
   type Principal,
   type ToolRegistry,
 } from "@vendoai/core";
-import { createStore, type VendoStore } from "@vendoai/store";
+import { createStore, createStoreOps, type VendoStore } from "@vendoai/store";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createVendo, type Vendo } from "../src/server.js";
 
@@ -67,6 +67,10 @@ afterEach(async () => {
 async function tempStore(): Promise<VendoStore> {
   const dataDir = await mkdtemp(join(tmpdir(), "vendo-share-promotes-"));
   const store = createStore({ dataDir });
+  // The very ops surface compose would build over this store anyway
+  // (compose-store.ts:118-120 takes `store.ops` when there is one), held here so
+  // a test can watch whether `lifecycle.promote` ran.
+  store.ops = createStoreOps(store);
   cleanups.push(async () => {
     await store.close().catch(() => undefined);
     await rm(dataDir, { recursive: true, force: true });
@@ -143,6 +147,24 @@ describe("the ✦ share toggle's write, over the real composition", () => {
     expect(await subjectOf(store, "app_kim")).toBe(ORG);
     expect(shared.body.grants.map((row: { principal: string; level: string }) => [row.principal, row.level]))
       .toContainEqual([`org:${ORG}`, "viewer"]);
+  });
+
+  it("refuses a tenant the sharer does not belong to, and moves nothing", async () => {
+    await seedPersonalApp(store, seeded("app_stranger", "Kim's tracker"), "kim");
+    const promote = vi.spyOn(store.ops!.lifecycle, "promote");
+
+    // Kim owns this app outright, so the owner gate lets her through. `acme` is
+    // somebody else's workspace — she is a member of Maple and nowhere else.
+    const refused = await call(vendo, kim, "PUT", `/apps/app_stranger/grants/${encodeURIComponent("org:acme")}`, {
+      level: "viewer",
+    });
+
+    expect(refused.status).toBe(403);
+    expect(promote).not.toHaveBeenCalled();
+    // Nothing moved and nothing was written — not even the owner row the flip is
+    // preceded by. Her app is still hers, and acme's admins never saw it.
+    expect(await subjectOf(store, "app_stranger")).toBe("kim");
+    expect((await call(vendo, kim, "GET", "/apps/app_stranger/grants")).body.grants).toEqual([]);
   });
 
   it("the promoter KEEPS her app — she is an ordinary member, not a tenant admin", async () => {

--- a/packages/vendo/tests/wire/apps.grants.test.ts
+++ b/packages/vendo/tests/wire/apps.grants.test.ts
@@ -1,0 +1,101 @@
+import type { AccessLevel, AppGrantRecord, Membership, RunContext } from "@vendoai/core";
+import { describe, expect, it, vi } from "vitest";
+import { appRoutes } from "../../src/wire/apps.js";
+import { dispatchRoutes, routeSegments, type WireDeps } from "../../src/wire/shared.js";
+
+/** Build contract §9.2 — the ✦ toggle's door. ONE round trip tells the menu
+    which tenant to name and whether the share is on. */
+
+const ctx = (memberships: Membership[] = []): RunContext => ({
+  principal: { kind: "user", subject: "alice" },
+  venue: "app",
+  presence: "present",
+  sessionId: "s_alice",
+  ...(memberships.length === 0 ? {} : { memberships }),
+});
+
+const grantRow = (principal: string): AppGrantRecord => ({
+  id: "g_1", appId: "app_1" as never, orgId: "acme", principal, level: "viewer",
+  createdBy: "alice", createdAt: "2026-08-01T00:00:00.000Z",
+});
+
+const wireFor = (over: {
+  level?: AccessLevel | null;
+  grants?: AppGrantRecord[];
+  memberships?: Membership[];
+  grant?: WireDeps["apps"]["access"]["grant"];
+  revoke?: WireDeps["apps"]["access"]["revoke"];
+}) => {
+  const deps = {
+    apps: {
+      access: {
+        levelFor: async () => over.level ?? "owner",
+        list: async () => over.grants ?? [],
+        grant: over.grant ?? (async () => over.grants ?? []),
+        revoke: over.revoke ?? (async () => []),
+      },
+    },
+  } as unknown as WireDeps;
+  return async (method: string, path: string, body?: unknown): Promise<Response | undefined> => {
+    const url = new URL(`https://maple.test/api/vendo${path}`);
+    return dispatchRoutes(appRoutes, {
+      request: new Request(url, {
+        method,
+        ...(body === undefined ? {} : { body: JSON.stringify(body), headers: { "content-type": "application/json" } }),
+      }),
+      url,
+      path,
+      segments: routeSegments(path),
+      params: {},
+      context: async () => ctx(over.memberships ?? []),
+      sweep: async () => {},
+      deps,
+    } as never);
+  };
+};
+
+describe("§9.2 — /apps/:id/grants", () => {
+  it("answers the level, the grants, and the caller's own orgs in one GET", async () => {
+    const send = wireFor({
+      level: "owner",
+      grants: [grantRow("org:acme")],
+      memberships: [{ org: "acme", display: "Acme Corp" }],
+    });
+    const response = await send("GET", "/apps/app_1/grants");
+    await expect(response!.json()).resolves.toEqual({
+      level: "owner",
+      grants: [grantRow("org:acme")],
+      orgs: [{ org: "acme", display: "Acme Corp" }],
+    });
+  });
+
+  it("omits display for an org the host named no display for", async () => {
+    const send = wireFor({ memberships: [{ org: "acme" }] });
+    const body = await (await send("GET", "/apps/app_1/grants"))!.json();
+    expect(body.orgs).toEqual([{ org: "acme" }]);
+  });
+
+  it("writes a grant and answers with the resulting list", async () => {
+    const grant = vi.fn(async () => [grantRow("org:acme")]);
+    const send = wireFor({ grant: grant as never });
+    const response = await send("PUT", "/apps/app_1/grants/org%3Aacme", { level: "viewer" });
+    expect(grant).toHaveBeenCalledWith("app_1", "org:acme", "viewer", expect.anything());
+    await expect(response!.json()).resolves.toEqual({ grants: [grantRow("org:acme")] });
+  });
+
+  it("refuses a level outside the closed vocabulary before the store sees it", async () => {
+    const grant = vi.fn();
+    const send = wireFor({ grant: grant as never });
+    await expect(send("PUT", "/apps/app_1/grants/org%3Aacme", { level: "admin" }))
+      .rejects.toMatchObject({ code: "validation" });
+    expect(grant).not.toHaveBeenCalled();
+  });
+
+  it("revokes and answers with what is left", async () => {
+    const revoke = vi.fn(async () => []);
+    const send = wireFor({ revoke: revoke as never });
+    const response = await send("DELETE", "/apps/app_1/grants/org%3Aacme");
+    expect(revoke).toHaveBeenCalledWith("app_1", "org:acme", expect.anything());
+    await expect(response!.json()).resolves.toEqual({ grants: [] });
+  });
+});


### PR DESCRIPTION
Stack tip (slices 4 + 5 + 6). Base: `org/share-toggle`.

## What changed

**Task 28 — demo-bank picks a posture.** Both `mapleAuthJs.memberships` and
`limits: mapleLimits` were host assertions, and a host assertion always wins over
the Cloud default — so with them in place the tenant directory could never
answer and the demo proved nothing. They become the **no-key** path:

- `examples/demo-bank/src/vendo/server.ts` — one `cloudDirectoryInUse` branch, two
  spread-conditionals. Keyed: Maple stands down and lets the directory answer.
  Keyless: Maple asserts `maple` / "Maple Bank" and its own 50/day + 200/month
  policy, exactly as it always did.
- `examples/demo-bank/tests/vendo/cloud-directory-posture.test.ts` — new, covers both routes.
- `examples/demo-bank/tests/vendo/limits.test.ts` — **untouched** and green. The branch is
  read at module load and no key is set under test, so the keyless suite is unaffected.

**Task 29 — the seed script.** `examples/demo-bank/scripts/seed-tenant.mjs` plus a
`seed:tenant` package.json entry. Written, **deliberately not run**: it calls
`/api/v1/tenants` on the console and slice 2's console PR is unmerged, so a run
would 404 and prove nothing.

**Task 30 — the docs.** Cherry-picked clean from the drafting branch (`a010b1a95`),
plus one correction: the tenant caps reset on the **calendar** boundary in UTC, not
on a rolling lookback (slice 1's `316b2faa4` changed this after the docs were drafted).

## Two deviations from the frozen plan, both forced

1. The plan's test stubs the no-key case with an empty-string key, but its
   implementation snippet reads `process.env.VENDO_API_KEY !== undefined` — which
   counts an empty string as SET. Watched it fail: `expected undefined to be type of 'function'`.
   The implementation uses the truthy form instead, matching the SDK's own
   predicate (`packages/vendo/src/wire/shared.ts:206-210`) and this file's existing
   style. No assertion changed.
2. The plan's test cannot pass under vitest's 5s default: the dynamic re-import
   pays vite's transform of the whole SDK graph (measured 11.8s). Added
   `{ timeout: 60_000 }` to both cases — the repo's own convention
   (`tests/vendo/away-drill.test.ts:400`). Hang-detector, not a speed limit.

## Reviewer, please read: two things this PR does not fix

- **Slice 1 is not in this branch's base.** `org/grants-write` is based on an older
  `main`, not on `org/sdk-directory`, so no Cloud tenant directory exists in this
  tree to fill the seam Task 28 vacates. The change is correct *given slice 1*; the
  stack needs assembling before it means anything.
- **The keyed posture strands Maple's seeded org policy.**
  `src/demo-script/console-seed.ts:43` hardcodes the org id `maple` independently
  of the memberships seam and seeds `/orgs/maple/policy.json`; `scripts/mcp-e2e.ts:56-65`
  depends on that file to prove money cannot move over MCP. Keyed, the directory
  answers `acme`, so that file becomes unreachable — and `README.md:25` makes the
  standing *local* posture a Cloud key **plus** a local store, which is exactly the
  combination that seeds it. Left alone rather than improvised around.

## Gate

| command | result |
|---|---|
| `pnpm --filter demo-bank test` | 0 — 29 files, 138 tests (run twice) |
| `pnpm build` | 0 — 22/22 |
| `pnpm typecheck --force` | 0 — 43/43, 0 cached |
| `pnpm lint` | 0 — 4 warnings, all pre-existing, none in touched files |

Task 31 (the live walk) is deliberately not done here: the frozen plan requires a
fresh worker who built none of this to walk it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Demo Bank defers org memberships and per‑tenant caps to Vendo Cloud’s tenant directory when a truthy `VENDO_API_KEY` is set; without a key it keeps Maple’s host assertions. Docs add a Tenants page and the owner’s Share‑with‑tenant toggle; Cloud memberships are cached per user and, during outages, the last roster is honored so a removed member can keep access until Cloud answers again.

- Server: gate on truthy `VENDO_API_KEY`. Keyed: omit `auth.memberships` and `limits` in `createVendo` so the directory answers and console caps (scopes `per-member`/`per-tenant`) apply. No key: keep `mapleAuth.memberships` and `mapleLimits`. Blank env values do not enable Cloud.
- Apps/UI/wire: restore `AppsRuntime.access` `list/grant/revoke`; mount `GET /apps/:id/grants` and `PUT|DELETE /apps/:id/grants/:principal`; client adds `apps.grants/.share/.unshare`. Sharing a tenant first promotes the app into the tenant workspace, then writes the grant; naming a tenant requires the caller be a member; revoking is unchanged. The ✦ menu shows a single “Share with <tenant>” toggle for owners in a tenant and keeps the popover open when switched.
- Tests: `cloud-directory-posture.test.ts` stubs env and re‑imports to verify keyed vs no‑key (both `memberships` and `limits`). New runtime, wire, UI tests cover grants and the toggle; per‑case timeout 60s for the Vite transform.
- Seed: `seed:tenant` seeds `acme` over the public API; rerunnable. Requires `VENDO_API_KEY_ADMIN` (admin) and `VENDO_API_KEY` (runtime).
- Docs: add `users-orgs/tenants` (setup, caps with UTC calendar resets and scopes, API, outage behavior including extended revokes, 60s per‑user cache); update `sharing` with the toggle and routes; clarify that “no cache to invalidate” applies when you assert memberships yourself.
- Migration: To use the Cloud directory, set `VENDO_API_KEY` and stop supplying `auth.memberships`/`limits`. To keep host‑owned memberships/limits, leave the key unset or continue asserting them.

<sup>Written for commit 21a01b1695be8b9b04021131b9d6be91ea85fdbc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1532?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

