### PR TITLE
fix(apps,vendo): the reason a screen did not paint reaches the person, so a failed remix can be repaired

### DIFF
--- a/packages/apps/src/server/generation/render-seam.ts
+++ b/packages/apps/src/server/generation/render-seam.ts
@@ -106,12 +106,43 @@ export function hotPathAppId(path: string): AppId | undefined {
  * through untouched, and a `CommitResult` is what the store said, not what the
  * seam did with it.
  */
-const paintedByCommit = new WeakMap<CommitResult, readonly AppId[]>();
+const paintedByCommit = new WeakMap<CommitResult, {
+  readonly painted: readonly AppId[];
+  readonly unpainted: ReadonlyMap<AppId, UnpaintedReason>;
+}>();
 
 /** The apps `result`'s commit painted, or undefined for a result this seam did not
  *  produce — which is "not known", never "nothing painted". */
 export const paintedIn = (result: CommitResult): readonly AppId[] | undefined =>
-  paintedByCommit.get(result);
+  paintedByCommit.get(result)?.painted;
+
+/**
+ * Why `appId`'s landed write never reached the screen, or undefined when it
+ * painted — and for a result this seam did not produce, the same "not known"
+ * `paintedIn` answers.
+ *
+ * The seam's own refusal channel is a console line to the OPERATOR, which the
+ * hand that wrote the screen cannot read. Without this the writer had the bare
+ * fact "nothing painted" and no reason to give, so a person heard the loop's
+ * last-resort sentence instead of what actually happened.
+ */
+export const unpaintedIn = (result: CommitResult, appId: AppId): UnpaintedReason | undefined =>
+  paintedByCommit.get(result)?.unpainted.get(appId);
+
+/** Why a landed write did not paint, in the floor's own vocabulary so the loop
+ *  reads one kind of finding wherever it came from. */
+export interface UnpaintedReason {
+  /** Repair instructions for the screen — what to fix, as the floor words it. */
+  readonly blocking: readonly string[];
+  /** The DEPLOYMENT could not paint, so nothing the writer saves changes it: no
+   *  screen engine is wired here. A screen fault leaves this absent. */
+  readonly environment?: true;
+}
+
+/** A landed hot-path write, and either the view it painted or why it did not. */
+export type PaintAttempt =
+  | { readonly painted: true; readonly streamId: string; readonly part: VendoViewPart }
+  | { readonly painted: false; readonly reason?: UnpaintedReason };
 
 export interface RenderSeamOptions {
   /** Write the part on the stable per-app stream id, so successive views
@@ -178,27 +209,36 @@ const viewPart = (
 ): { streamId: string; part: VendoViewPart } | undefined =>
   vendoViewPart({ appId, payload: { ...payload, streaming: false }, ...(turnId === undefined ? {} : { turnId }) });
 
-/** The view a landed hot-path commit produces, or undefined if it does not paint. */
+/** The view a landed hot-path commit produces, or why it did not paint. */
 export async function viewForWrite(
   path: string,
   content: string,
   options: RenderSeamOptions,
-): Promise<{ streamId: string; part: VendoViewPart } | undefined> {
+): Promise<PaintAttempt> {
   const appId = hotPathAppId(path);
-  if (appId === undefined || hotPathFile(path) === undefined) return undefined;
+  // Not an app screen at all, so there is no paint to explain.
+  if (appId === undefined || hotPathFile(path) === undefined) return { painted: false };
 
   // The component gauntlet lives behind the floor, like every other check —
   // the seam never learns how to read TSX. No door means this build carries
   // no screen engine: nothing paints, the last good view stays.
   const door = options.floor?.component?.bind(options.floor);
-  if (door === undefined) return undefined;
+  if (door === undefined) {
+    return {
+      painted: false,
+      reason: {
+        blocking: ["This deployment has no screen engine wired, so no screen can paint here."],
+        environment: true,
+      },
+    };
+  }
   const result = await door({ appId, source: content });
   if (!result.ok) {
     console.error(
       `[vendo] ${appId} did not pass the checks floor; nothing painted and the last good view stays — `
       + result.blocking.join("; "),
     );
-    return undefined;
+    return { painted: false, reason: { blocking: result.blocking } };
   }
   const payload = stripServerAuthoritativeFields(
     assembleTree({ tree: { nodes: Object.values(result.nodes), root: result.root } }),
@@ -211,12 +251,9 @@ export async function viewForWrite(
   // already lives by for a screen the gauntlet refused.
   const description = screenDescriptionSchema.safeParse(payload);
   if (!description.success) {
-    console.error(
-      `[vendo] ${appId}'s compiled screen is not a valid description; nothing painted — ${
-        description.error.issues[0]?.message ?? "unknown"
-      }`,
-    );
-    return undefined;
+    const why = description.error.issues[0]?.message ?? "unknown";
+    console.error(`[vendo] ${appId}'s compiled screen is not a valid description; nothing painted — ${why}`);
+    return { painted: false, reason: { blocking: [`The compiled screen is not a valid screen description — ${why}`] } };
   }
   // The same paint, offered to the embed's build-window poll as SHAPE
   // (persistence/forming.ts strips it to geometry and holds it in memory only).
@@ -225,7 +262,16 @@ export async function viewForWrite(
   // has already happened.
   recordForming(appId, payload);
   // The gauntlet already ran its queries, so this paint is FINAL.
-  return viewPart(appId, payload, options.turnId);
+  const view = viewPart(appId, payload, options.turnId);
+  // `vendoViewPart` refuses a payload the view channel cannot carry — the last
+  // exit that used to leave the writer with nothing at all to say.
+  if (view === undefined) {
+    return {
+      painted: false,
+      reason: { blocking: ["The screen compiled, but its view could not be carried to the screen channel."] },
+    };
+  }
+  return { painted: true, ...view };
 }
 
 /**
@@ -233,19 +279,23 @@ export async function viewForWrite(
  * other operation passes straight through, so the result is still a `WorkspaceFs`.
  */
 export function wrapWorkspaceForRender(workspace: WorkspaceFs, options: RenderSeamOptions): WorkspaceFs {
-  /** True iff this path put a view on screen. */
-  const emitFor = async (path: string): Promise<boolean> => {
+  /** Whether this path put a view on screen, and why not when it did not. */
+  const emitFor = async (path: string): Promise<PaintAttempt> => {
     try {
       // Read back what the store now holds rather than trusting a remembered
       // argument: append, encoding and any store-side normalization land here.
       const content = await workspace.readFile(path);
-      const view = await viewForWrite(path, content, options);
-      if (view === undefined) return false;
-      options.emit(view.streamId, view.part);
-      return true;
-    } catch {
-      // A view is a courtesy on top of a landed commit. It can never fail one.
-      return false;
+      const attempt = await viewForWrite(path, content, options);
+      if (attempt.painted) options.emit(attempt.streamId, attempt.part);
+      return attempt;
+    } catch (error) {
+      // A view is a courtesy on top of a landed commit. It can never fail one —
+      // so the throw is still swallowed. Losing the REASON with it is what made a
+      // throw indistinguishable from a screen that simply did not paint.
+      return {
+        painted: false,
+        reason: { blocking: [error instanceof Error ? error.message : String(error)] },
+      };
     }
   };
 
@@ -301,12 +351,16 @@ export function wrapWorkspaceForRender(workspace: WorkspaceFs, options: RenderSe
         // and the last good view stays on screen until something actually does.
         if (result.status !== "ok") return result;
         const painted = new Set<AppId>();
+        const unpainted = new Map<AppId, UnpaintedReason>();
         for (const path of result.changed) {
           const appId = hotPathAppId(path);
-          if (appId !== undefined && await emitFor(path)) painted.add(appId);
+          if (appId === undefined) continue;
+          const attempt = await emitFor(path);
+          if (attempt.painted) painted.add(appId);
+          else if (attempt.reason !== undefined) unpainted.set(appId, attempt.reason);
         }
         await persistSource(result.changed);
-        paintedByCommit.set(result, [...painted]);
+        paintedByCommit.set(result, { painted: [...painted], unpainted });
         return result;
       };
     },

--- a/packages/apps/src/server/index.ts
+++ b/packages/apps/src/server/index.ts
@@ -134,9 +134,12 @@ export {
   HOT_PATH_WATCH,
   hotPathAppId,
   paintedIn,
+  unpaintedIn,
   viewForWrite,
   wrapWorkspaceForRender,
+  type PaintAttempt,
   type RenderSeamOptions,
+  type UnpaintedReason,
 } from "./generation/render-seam.js";
 // The builder's validate gate (§7.1 item 4) — "validate must pass before done",
 // as a function any harness's loop can call. Public because the loop that needs

--- a/packages/apps/tests/render-seam.test.ts
+++ b/packages/apps/tests/render-seam.test.ts
@@ -18,7 +18,7 @@ import { vendoViewPartSchema, vendoViewStreamId, type AppId, type UIPayload, typ
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import { warmScreenEngine } from "../src/contract/index.js";
 import { createAppFloor } from "../src/server/checking/floor.js";
-import { HOT_PATH_FILES, HOT_PATH_WATCH, hotPathAppId, paintedIn, viewForWrite, wrapWorkspaceForRender } from "../src/server/generation/render-seam.js";
+import { HOT_PATH_FILES, HOT_PATH_WATCH, hotPathAppId, paintedIn, unpaintedIn, viewForWrite, wrapWorkspaceForRender } from "../src/server/generation/render-seam.js";
 import { testWorkspace } from "./test-doubles.test-util.js";
 
 const APP = "app_1";
@@ -255,6 +255,65 @@ describe("a save the floor refuses", () => {
   });
 });
 
+/**
+ * The seam knows WHY a landed write never reached the screen, and used to tell
+ * only the operator's console — so the hand that wrote the screen had "nothing
+ * painted" and no reason, and the sentence a person finally read was the loop's
+ * last-resort "assembly produced nothing that renders". The reason travels
+ * beside the commit now, exactly as the painted list does.
+ */
+describe("the reason a landed write did not paint", () => {
+  it("says the DEPLOYMENT could not paint when no screen engine is wired", async () => {
+    const workspace = wrapWorkspaceForRender(testWorkspace(), { emit: () => undefined });
+    await workspace.writeFile(APP_TSX, GOOD_APP);
+    const result = await workspace.commit();
+
+    const reason = unpaintedIn(result, APP as AppId);
+    // `environment` is the difference between "fix your screen" and "fix this
+    // deployment": nothing the writer saves can put a screen engine here, so the
+    // loop must stop rather than spend its repair budget rewriting a good screen.
+    expect(reason?.environment).toBe(true);
+    expect(reason?.blocking.join(" ")).toContain("screen engine");
+  });
+
+  it("carries the floor's own words when the floor refused", async () => {
+    const { workspace } = seam();
+    await workspace.writeFile(APP_TSX, "just some prose, no components at all");
+    const result = await workspace.commit();
+
+    expect(unpaintedIn(result, APP as AppId)?.blocking.join(" ")).toContain("does not compile as TSX");
+    expect(unpaintedIn(result, APP as AppId)?.environment).toBeUndefined();
+  });
+
+  it("survives an emit that throws — the commit still lands, and the throw is the reason", async () => {
+    // A view is a courtesy on top of a landed commit and can never fail one. That
+    // is why the seam swallows this — but swallowing the REASON with it made a
+    // throw indistinguishable from a clean no-paint.
+    const workspace = wrapWorkspaceForRender(testWorkspace(), {
+      emit: () => { throw new Error("the host's view channel is closed"); },
+      floor: floor(),
+    });
+    await workspace.writeFile(APP_TSX, GOOD_APP);
+    const result = await workspace.commit();
+
+    expect(result.status).toBe("ok");
+    expect(paintedIn(result)).toEqual([]);
+    expect(unpaintedIn(result, APP as AppId)?.blocking.join(" ")).toContain("the host's view channel is closed");
+  });
+
+  it("says nothing about an app that painted, and nothing about a commit it never saw", async () => {
+    const { workspace } = seam();
+    await workspace.writeFile(APP_TSX, GOOD_APP);
+    const painted = await workspace.commit();
+    expect(unpaintedIn(painted, APP as AppId)).toBeUndefined();
+
+    // "Not known", never "nothing painted" — the same reading `paintedIn` has for
+    // a result this seam did not produce.
+    expect(unpaintedIn({ status: "ok", changed: [] } as unknown as Parameters<typeof unpaintedIn>[0], APP as AppId))
+      .toBeUndefined();
+  });
+});
+
 describe("saves that are not hot paths", () => {
   it("emit nothing", async () => {
     const { emitted, save } = seam();
@@ -445,17 +504,23 @@ describe("the wrapper", () => {
 describe("the seam's payload settles", () => {
   const OTHER_TSX = "/user/apps/app_5/app.tsx";
 
+  /** The painted part, or a failure that names why the paint never happened —
+   *  which is the whole point of the attempt carrying its reason. */
+  const paintedPart = async (): Promise<VendoViewPart> => {
+    const attempt = await viewForWrite(OTHER_TSX, GOOD_APP, { emit: () => undefined, floor: floor() });
+    if (!attempt.painted) throw new Error(attempt.reason?.blocking.join("; ") ?? "nothing painted, and no reason");
+    return attempt.part;
+  };
+
   it("settles the finished paint, so the app leaves \"building\" and can reach a verdict", async () => {
-    const view = await viewForWrite(OTHER_TSX, GOOD_APP, { emit: () => undefined, floor: floor() });
-    expect((view?.part.payload as { streaming?: boolean }).streaming).toBe(false);
+    expect(((await paintedPart()).payload as { streaming?: boolean }).streaming).toBe(false);
   });
 
   it("carries what the renderer re-boots the screen from", async () => {
     // The gauntlet already ran the screen's queries, so the paint is final — and
     // the compiled screen and its answers ride along, which is what makes the
     // emitted view a LIVE screen rather than a snapshot of one.
-    const view = await viewForWrite(OTHER_TSX, GOOD_APP, { emit: () => undefined, floor: floor() });
-    const interactive = (view?.part.payload as { interactive?: { compiledSource?: string } }).interactive;
+    const interactive = ((await paintedPart()).payload as { interactive?: { compiledSource?: string } }).interactive;
     expect(interactive?.compiledSource).toContain("require(");
   });
 });

--- a/packages/vendo/src/screen-agent.ts
+++ b/packages/vendo/src/screen-agent.ts
@@ -72,6 +72,7 @@ import {
 import {
   buildingAppsSkill,
   paintedIn,
+  unpaintedIn,
   SCREEN_FILE,
   screenName,
   VALIDATE_TOOL,
@@ -911,7 +912,15 @@ export async function assembleScreen(
      */
     record.painted = paintedIn(committed)?.includes(input.appId);
     if (record.painted === false) {
-      const { blocking, environment } = surface.screenIssues?.() ?? { blocking: [] };
+      const floorSaid = surface.screenIssues?.() ?? { blocking: [] };
+      // The floor's own words WIN. The seam speaks only for the exits where the
+      // floor never did — no screen engine, a compiled screen that is not a valid
+      // description, a view that threw — which reached the operator's console and
+      // nobody else, leaving this run to answer "produced nothing that renders"
+      // for three different reasons.
+      const { blocking, environment } = floorSaid.blocking.length > 0
+        ? floorSaid
+        : unpaintedIn(committed, input.appId) ?? floorSaid;
       // A refusal about the DEPLOYMENT is not a screen this loop can fix: no
       // compiler where the checks run refuses every screen, so handing these
       // sentences over as repair instructions spends the whole budget rewriting a
@@ -1319,8 +1328,16 @@ export async function assembleScreen(
     };
   }
   // The floor's own sentences first: they name what is wrong with the screen the
-  // person asked for, which no sentence about the loop can.
-  return { kind: "unavailable", why: record.refused || failure || "assembly produced nothing that renders" };
+  // person asked for, which no sentence about the loop can. Last comes the run's
+  // own shape, and a run that never saved is not a screen that failed to render:
+  // saying so sent people looking for a broken screen that was never written.
+  // WHY the model did not save is not knowable here — that is the model's
+  // behaviour, not the seam's state — so this says only what happened.
+  return {
+    kind: "unavailable",
+    why: record.refused || failure
+      || (record.assembled ? "assembly produced nothing that renders" : "this run never saved a screen"),
+  };
 }
 
 // ─── The `vendo_make` route ──────────────────────────────────────────────────

--- a/packages/vendo/tests/screen-agent.test.ts
+++ b/packages/vendo/tests/screen-agent.test.ts
@@ -196,6 +196,10 @@ function harness(options: {
    *  own v3→v4 adapter (`asLanguageModelV4`) is exactly this relabel, so the
    *  label is the whole of the difference on either major. */
   spec?: "v3" | "v4";
+  /** Compose with NO checks floor, which is a deployment carrying no screen
+   *  engine: the seam has no door to paint through, so every save lands its bytes
+   *  and reaches nobody. */
+  screenEngine?: false;
 }): Harness {
   const guard = testGuard(options.guardPolicy);
   const descriptors = options.tools
@@ -264,7 +268,7 @@ function harness(options: {
       if (options.conflict === true) workspace.conflictOn = ["*"];
       return workspace;
     },
-    render: () => ({ floor }),
+    render: () => (options.screenEngine === false ? {} : { floor }),
     ...(options.remember === undefined ? {} : { remember: options.remember }),
   });
 
@@ -572,6 +576,54 @@ describe("assembly writes through the real path and the seam paints it", () => {
     const result = await screen.assemble("show me my spending");
     expect(screen.emitted).toHaveLength(0);
     expect(result.kind).toBe("unavailable");
+  });
+});
+
+/**
+ * "assembly produced nothing that renders" was the answer to THREE different
+ * questions — a run that never saved, a deployment with no screen engine, and a
+ * screen that compiled but could not be described — and the sentence naming which
+ * one existed only on the operator's console. A person reading the chat learned
+ * nothing they could act on, and the run above them reported `failed` over a
+ * screen that was, in the ported case, sitting there painted.
+ */
+describe("what a run that painted nothing actually says", () => {
+  it("names the run that never saved a screen, rather than blaming the assembly", async () => {
+    // The model talks and never writes. Nothing landed, so there is no paint to
+    // explain — but "produced nothing that renders" describes a screen that
+    // failed, and no screen was ever written.
+    const screen = harness({ turns: [textTurn("I had a think about it")] });
+    const result = await screen.assemble("show me my spending");
+
+    expect(screen.workspace.commits).toHaveLength(0);
+    expect(result.kind).toBe("unavailable");
+    expect(result.why).toContain("never saved a screen");
+    expect(result.why).not.toContain("produced nothing that renders");
+  });
+
+  it("names the DEPLOYMENT when no screen engine is wired, in words an operator can act on", async () => {
+    // The save is good and its bytes land. There is simply no door to paint
+    // through, which no rewrite of the screen can fix — so the run must say that
+    // rather than send the model back to repair a screen that was never the
+    // problem.
+    const screen = harness({ turns: [saveApp(GOOD_APP), textTurn("done")], screenEngine: false });
+    const result = await screen.assemble("show me my spending");
+
+    expect(screen.workspace.commits).toHaveLength(1);
+    expect(screen.emitted).toHaveLength(0);
+    expect(result.kind).toBe("unavailable");
+    expect(result.why).toContain("screen engine");
+    expect(result.why).not.toContain("produced nothing that renders");
+  });
+
+  it("still prefers the floor's own words when the floor is the one that refused", async () => {
+    // The seam's reason is a FALLBACK for the exits where the floor never spoke.
+    // A floor that did speak keeps the sentence, because it is the one that names
+    // what to fix in the screen.
+    const screen = harness({ turns: [saveApp(BROKEN_APP), textTurn("done")] });
+    const result = await screen.assemble("show me my spending");
+
+    expect(result.why).toContain("does not compile as TSX");
   });
 });
 


### PR DESCRIPTION
`"assembly produced nothing that renders"` was the answer to **five different questions**, and the sentence naming which one existed only on the operator's console. A person read `failed` in chat and learned nothing they could act on.

## The headline is not the message

When the floor refuses with real findings — `prop "value" sets unknown prop`, a missing required `valueCents`, a `series` given `{x, value}[]` where it takes `number[]` — **those are exactly the words that let the repair round succeed.** With `blocking` empty, `refusal()` built no instruction and the screen silently forfeited its one repair attempt.

So this is not a cosmetic message fix. Carrying the reason re-arms that round, which is the difference between a remix that can be edited and one that silently cannot. A live proof run showed the wish never reaching the rendered card in any run (`wishInSource: true`, `wishPainted: false`) while the chat said only "produced nothing that renders".

## Why the floor's words were dropped at all

This is the part that moved the fix down a layer. The refusal capture is a closure private to **one of the four production wrap sites**:

| wrap site | floor | captures refusal |
|---|---|---|
| `vendo/src/screen-agent.ts` | real | yes |
| `vendo/src/harness-turn.ts` | real | **no** |
| `agents/src/session.ts` | bare | n/a |
| `agents/src/turn.ts` | bare | n/a |

A refusal on `harness-turn.ts` was logged by the seam and dropped with nothing to read it. Recording in the **seam** covers every wrap site, including the three that had no channel before — patching the closure would have fixed one caller.

## The change

`viewForWrite` returns why it did not paint instead of a bare `undefined`; `paintedByCommit` carries those reasons per app; `unpaintedIn` reads them back. `screen-agent` consults it **only when the floor said nothing**, so the floor's own words keep priority and the working path is untouched.

Five exits now carry a reason, not the three first counted:

1. **No screen engine wired** — an ENVIRONMENT fault, routed to `record.blocked`. No rewrite of a good screen puts a compiler where there is none, so the loop stops rather than spending its repair budget.
2. **The floor's own refusal** — relayed verbatim.
3. **A compiled screen that is not a valid description.**
4. **A view part the channel cannot carry** — found while building; `viewPart` can return `undefined` too.
5. **A throw.** Still swallowed — a view is a courtesy on top of a landed commit and can never fail one — but swallowing the *reason* with it made a throw indistinguishable from a clean no-paint.

A run that never saved is not a screen that failed to render, so it says so.

## Honest limits

- **Why the model did not save is not knowable here.** That is model behaviour, not seam state, so case 1 claims only what happened, and stays clear of the guard-blocked path that already exits with its own message.
- **Exit 3 has no end-to-end test.** Reaching it needs a floor that passes and then contradicts itself; doubling the floor is the exact mistake `render-seam.test.ts` and `screen-agent.test.ts` both forbid in their docblocks. The reason is carried because the branch is real, not because a test drove it.

## Invariants held

- `record.painted === undefined` stays "not known, nothing claimed" for an unwrapped workspace and never becomes a failure.
- A commit still never fails because a view did.

## Tests

Through the real `vendo_make` path and the real render seam, no stub on either side — deliberately **not** the `paintPort` harness, which bypasses `assembleScreen` and so can prove `painted` but not what the user is *told*. That gap is how this shipped.

Red first, both outputs read: the two new verdict tests failed with the literal string `'assembly produced nothing that renders'` before the change and pass after.

Local gate: build 22/22, typecheck 44/44, lint 0 errors, `@vendoai/apps` 1528 passed, and every `@vendoai/vendo` file touching this seam (51 tests). Full suite is CI's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Carries the specific reason a landed screen write did not paint back to the author, replacing the generic “assembly produced nothing that renders.” This makes failed remixes actionable and preserves the floor’s own findings when present.

- `viewForWrite` now returns a `PaintAttempt` (painted or a structured `UnpaintedReason`), `paintedByCommit` stores painted and unpainted per commit, and `unpaintedIn` exposes reasons by app. `screen-agent` prefers floor messages; it falls back to seam reasons only when the floor was silent and distinguishes “run never saved a screen” from “nothing rendered.”

**Key changes**
- Five no-paint exits report distinct reasons:
  - No screen engine wired (environment fault, stops repair loop).
  - Floor refusal (verbatim floor `blocking`).
  - Compiled screen is not a valid description.
  - View part could not be carried on the channel.
  - Throw during emit (swallowed but captured as the reason).
- `apps`: `viewForWrite` returns `PaintAttempt`; `paintedIn` unchanged; new `unpaintedIn`, `UnpaintedReason`. Exports updated.
- `vendo`: `assembleScreen` consumes `unpaintedIn` only if the floor provided no issues and reports “never saved a screen” when nothing landed.

**Review and rollout**
- Verify reason propagation across all wrap sites (real floor and harness paths) and that floor messages have priority.
- Confirm invariants: commits never fail due to view, and `record.painted === undefined` remains “not known” for unwrapped workspaces.
- Required action only if you call `viewForWrite`: update callers to handle the `PaintAttempt` union and check `painted` before using the view.

<sup>Written for commit bb0ff5ee10dcc8557e6c974d67ce8de888a38d30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1535?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

