### PR TITLE
ci(release): a release the changeset race swallowed fails instead of going green

### DIFF
--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -86,6 +86,20 @@ jobs:
             exit 1
           fi
 
+      # THE CHANGESET RACE: a changeset-carrying PR landed in the gap between
+      # this version PR being cut and it merging, so the tag step below sees
+      # those leftover changesets and skips — a green run that released nothing
+      # (phantom 0.31.0 on 2026-08-19, run 32250259707). Every other skip is a
+      # healthy no-op; this one loses a release, so it has to be loud. Nothing to
+      # repair by hand: the version PR the step above just re-opened ships this
+      # one's changelog too, under the next number.
+      - name: Fail a swallowed release
+        # Quoted because the commit subject it matches contains a colon.
+        if: "steps.changesets.outputs.hasChangesets == 'true' && startsWith(github.event.head_commit.message, 'chore: version packages')"
+        run: |
+          echo "::error::Release skipped: changesets landed after this version PR was cut. Nothing was published — merge the next Version Packages PR to release."
+          exit 1
+
       # No changesets left = this push is the version PR landing (or an ordinary
       # commit after a release, where the tag already exists and this no-ops), so
       # package.json already holds the released version. `changeset tag` is


### PR DESCRIPTION
## What

One step in `version-packages.yml`. When the push being processed is the **version PR landing** and changesets are **still pending**, the run now fails with:

> Release skipped: changesets landed after this version PR was cut. Nothing was published — merge the next Version Packages PR to release.

```yaml
- name: Fail a swallowed release
  if: "steps.changesets.outputs.hasChangesets == 'true' && startsWith(github.event.head_commit.message, 'chore: version packages')"
```

It reuses the existing `steps.changesets.outputs.hasChangesets` — nothing is recomputed. No inputs, no options, no change to the tag or publish steps.

## Why

`Push the release tag` and `Publish the tag` are both gated on `hasChangesets == 'false'`. That guard is correct for ordinary main pushes — most of them still have pending changesets, and skipping is the healthy state.

It is wrong for exactly one push: the merge of the version PR itself, when a changeset-carrying PR merged in the gap between that version PR being cut and it landing. The leftover changesets make the tag step skip, so nothing publishes — **and the run reports success**. Main is left carrying a version npm never got.

That happened twice on 2026-08-19. Evidence, run [32250259707](https://github.com/runvendo/vendo/actions/runs/32250259707) on `chore: version packages (#1520)`:

| step | conclusion |
| --- | --- |
| `Guard the 0.x ceiling` | success — so `hasChangesets` was `true` |
| `Push the release tag` | **skipped** |
| `Publish the tag` | **skipped** |
| run | **success** |

Phantom 0.31.0: on main, never on npm, and nothing anywhere said so.

Nothing needs repairing by hand when this fires — the version PR the changesets step re-opens on the same run ships the swallowed changelog too, under the next number. The failure exists to say "you are not released yet", not to signal damage.

## Both paths, walked

`hasChangesets` is `'true'` on most main pushes, so the head-commit half is what keeps this narrow:

| push | `hasChangesets` | head commit is `chore: version packages…` | result |
| --- | --- | --- | --- |
| ordinary feature merge, changesets pending | `true` | no | **quiet green no-op** (unchanged) |
| version PR lands cleanly | `false` | yes | tag pushed, release dispatched (unchanged) |
| ordinary merge after a release, no changesets | `false` | no | tag step no-ops on the existing tag (unchanged) |
| **version PR lands with changesets left** | `true` | **yes** | **run fails with the message above** |

Placed immediately before `Push the release tag`, as the complement of that step's own comment: no changesets left = legitimate landing; changesets left *and* this is the landing = a lost release.

## Verification

- [x] `pnpm build` green, `pnpm lint` green (dependency-guard OK, portability-gate OK, 4 pre-existing `demo-bank` warnings, 0 errors)
- [x] `actionlint .github/workflows/version-packages.yml` → exit 0
- [ ] Screenshots attached (if UI-affecting) — n/a

**A workflow cannot be fully tested locally**: the trigger is a real push of a version-PR merge with pending changesets, so the honest proof here is a static one. What was actually verified:

1. **`actionlint` caught a real bug and it is fixed.** The first draft left the `if:` value unquoted; `'chore: version packages'` contains `: `, so YAML parsed it as a mapping and the whole file failed to parse (`mapping values are not allowed in this context`, line 96). Quoting the expression fixed it — the file now lints clean at exit 0. A hand-read would have shipped that.
2. **The condition was evaluated against real commit subjects** taken from `git log origin/main`, with `startsWith` semantics: fires on `chore: version packages (#1520)` and on the bare `chore: version packages` (merge-commit form, as in #1182); does not fire on ordinary subjects, does not fire whenever `hasChangesets` is `false`, and does not fire when `head_commit` is `null` (null casts to `''`, `startsWith` is false) — so a payload without a head commit stays a quiet no-op rather than a spurious failure.

**On the injection warning:** `github.event.head_commit.message` is attacker-influenceable and would be unsafe interpolated into a `run:` script. It is used only inside an `if:` expression, evaluated as data by the Actions expression engine — the value never reaches a shell. The `run:` body is a fixed string with no interpolation.

No changeset: workflow-only change, consistent with past workflow-only PRs (#1342, #1344 touched `.github/workflows/` and added none).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail the `version-packages` workflow when the version PR merges with leftover changesets so swallowed releases don’t go green. Previously these runs skipped tag/publish and reported success; now they fail with a clear error instructing to merge the next Version Packages PR.

- Adds one step before the tag push: `if: steps.changesets.outputs.hasChangesets == 'true' && startsWith(github.event.head_commit.message, 'chore: version packages')`, then exits 1 with an error message.
- Reuses `steps.changesets.outputs.hasChangesets`; no new inputs and no changes to the tag or publish steps.
- Scope: only the version PR landing with leftover changesets changes; ordinary merges remain quiet green no-ops, and clean version PR landings still tag and publish.
- Workflow-only change; no migration required and no changeset.

<sup>Written for commit cde6dd38f6985188b5a0f1bd35c624792ee42d7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

