### PR TITLE
fix(vendo): a broken app says why it can never open, instead of a 400 an agent retries

### DIFF
--- a/packages/apps/src/server/persistence/open.ts
+++ b/packages/apps/src/server/persistence/open.ts
@@ -236,7 +236,7 @@ const serveOpenApp = (
   // A remix's row lands the instant ✦ fires; its screen is what the first edit
   // GENERATES, tens of seconds later. "Not ready yet" is not "broken", so it
   // answers the same not-found every app gives before its build lands — which
-  // the wire's build window (openWithPendingWindow, wire/apps.ts) turns into
+  // the wire's build window (openApp, wire/apps.ts) turns into
   // {kind:"pending"} for a caller who can see the app. A validation failure
   // here is what left the ✦ pill on "Remixing…" until a page reload.
   if (app.seed !== undefined) {

--- a/packages/vendo/src/wire/apps.ts
+++ b/packages/vendo/src/wire/apps.ts
@@ -140,7 +140,11 @@ async function answerUnservableApp(wire: WireContext, appId: string, ctx: RunCon
   }
 }
 
-async function openWithPendingWindow(wire: WireContext, appId: string, ctx: RunContext): Promise<Response> {
+/** Both open routes, which differ only in whether the embed's build window is
+ *  open: `pending: false` is what the runtime already did for an absent option
+ *  (`createAppOpener`), and an unflagged open can never answer `pending`, so the
+ *  arrival line below reads the same on either. */
+async function openApp(wire: WireContext, appId: string, ctx: RunContext, pending: boolean): Promise<Response> {
   const { deps } = wire;
   // The ONLY thing this arm guards is the open. The flag rides through to the
   // runtime, which answers a build still in flight with `{kind:"pending"}` plus —
@@ -148,17 +152,32 @@ async function openWithPendingWindow(wire: WireContext, appId: string, ctx: RunC
   // something to show.
   let surface: Awaited<ReturnType<typeof deps.apps.open>>;
   try {
-    surface = await deps.apps.open(appId, ctx, { pending: true });
+    surface = await deps.apps.open(appId, ctx, { pending });
   } catch (reason) {
+    // A broken ARTIFACT, never a bad request: the only input this door takes is
+    // the app id, and a bad one is not-found — so a `validation` refusal is
+    // always about what is STORED (a served row with no machine, a screen that
+    // no longer renders: persistence/open.ts). That is terminal for every caller
+    // and unchanged by every retry, so it is answered in the wire's own terminal
+    // vocabulary (#492) carrying the refusal's own words. As a bare 400 it read
+    // as "try again", and an agent retried one identical response for 7.7
+    // minutes, until its turn budget died, with the reason never reaching it.
+    if (isVendoError(reason) && reason.code === "validation") {
+      return json({ kind: "failed", reason: reason.message, retryable: false });
+    }
     // Cross-realm safe (`isVendoError`): a second @vendoai/core copy's not-found
     // read as an unknown fault here, which 501'd the poll instead of answering it.
-    if (!(isVendoError(reason) && reason.code === "not-found")) throw reason;
+    // Only the flagged route rescues it; unflagged keeps its contracted 404.
+    if (!(pending && isVendoError(reason) && reason.code === "not-found")) throw reason;
     return await answerUnservableApp(wire, appId, ctx);
   }
-  // Arrival, outside that catch on purpose — a mark's own not-found must never be
-  // read as the open's. A `pending` answer put nothing on screen (the whole point
-  // of the flag), so it is not a render; the opener's build-window decision is the
-  // gate, and nothing re-reads `building` to guess at it.
+  // Arrival — THIS is what "rendering marks it seen" means: a person's browser
+  // asked for a surface to put on screen. The runtime door is not the place for it
+  // (an agent's `vendo_apps_open` and an automation both pass through there).
+  // Outside that catch on purpose — a mark's own not-found must never be read as
+  // the open's. A `pending` answer put nothing on screen (the whole point of the
+  // flag), so it is not a render; the opener's build-window decision is the gate,
+  // and nothing re-reads `building` to guess at it.
   if (surface.kind !== "pending") await markArrival(deps, appId, ctx);
   return json(surface);
 }
@@ -279,16 +298,7 @@ export const appRoutes: RouteEntry[] = [
       }
     }
     if (op(wire, "GET", "open")) {
-      if (wire.url.searchParams.get("pending") === "1") return openWithPendingWindow(wire, appId, ctx);
-      const surface = await deps.apps.open(appId, ctx);
-      // Arrival — THIS is what "rendering marks it seen" means: a person's
-      // browser asked for a surface to put on screen. The runtime door is not
-      // the place for it (an agent's `vendo_apps_open` and an automation both
-      // pass through there); a build still in flight never reaches this line,
-      // because open() answers not-found until it can serve. Non-fatal: the
-      // surface is already served, and bookkeeping does not get to unserve it.
-      await markArrival(deps, appId, ctx);
-      return json(surface);
+      return openApp(wire, appId, ctx, wire.url.searchParams.get("pending") === "1");
     }
     if (op(wire, "POST", "call")) {
       const body = await requestJson(request);

--- a/packages/vendo/src/wire/apps.ts
+++ b/packages/vendo/src/wire/apps.ts
@@ -154,16 +154,24 @@ async function openApp(wire: WireContext, appId: string, ctx: RunContext, pendin
   try {
     surface = await deps.apps.open(appId, ctx, { pending });
   } catch (reason) {
-    // A broken ARTIFACT, never a bad request: the only input this door takes is
-    // the app id, and a bad one is not-found — so a `validation` refusal is
-    // always about what is STORED (a served row with no machine, a screen that
-    // no longer renders: persistence/open.ts). That is terminal for every caller
-    // and unchanged by every retry, so it is answered in the wire's own terminal
-    // vocabulary (#492) carrying the refusal's own words. As a bare 400 it read
-    // as "try again", and an agent retried one identical response for 7.7
-    // minutes, until its turn budget died, with the reason never reaching it.
+    // About the STORED artifact, never about this request: the only input this
+    // door takes is the app id, and a bad one is not-found. So the caller is told
+    // WHAT is wrong in the refusal's own words, through the terminal answer this
+    // wire already speaks (`{kind:"failed"}` — the shape persistence/open.ts:249
+    // returns for a document with no screen left). As a bare 400 it carried no
+    // reason and read as "try again": an agent retried one identical response for
+    // 7.7 minutes, until its turn budget died.
+    //
+    // No `retryable` claim rides along, because this door's refusals are a MIXED
+    // class. A screen's OWN fault is permanent (it will not compile, it throws on
+    // the shape its queries really return), but the same refusal also carries a
+    // deployment with no compiler or engine, a query the guard blocked, an
+    // unconnected toolkit, and a read awaiting approval
+    // (server/checking/component-screen.ts) — every one of those can open fine
+    // later, and only the floor knows which one it had. So this states the
+    // failure and its reason, and asserts nothing about a retry.
     if (isVendoError(reason) && reason.code === "validation") {
-      return json({ kind: "failed", reason: reason.message, retryable: false });
+      return json({ kind: "failed", reason: reason.message });
     }
     // Cross-realm safe (`isVendoError`): a second @vendoai/core copy's not-found
     // read as an unknown fault here, which 501'd the poll instead of answering it.

--- a/packages/vendo/tests/app-open-terminal-artifact.seam.test.ts
+++ b/packages/vendo/tests/app-open-terminal-artifact.seam.test.ts
@@ -1,0 +1,158 @@
+/**
+ * A BROKEN ARTIFACT IS NOT A RETRIABLE REQUEST.
+ *
+ * `open()` refuses a stored app it can never serve with a `validation` VendoError
+ * — a served row whose machine is gone, or a screen that no longer renders
+ * (`persistence/open.ts`). The wire's build window only rescued `not-found`, so
+ * those two reached the caller as a bare HTTP 400: no reason, and a status every
+ * agent reads as "try again". One did, on the identical response, for 7.7 minutes
+ * until its turn budget died.
+ *
+ * So this drives both refusals through the REAL seam and asserts the answer is
+ * terminal and self-explaining. The producer is a shipped write door
+ * (`authoredScreen` for a screen that went bad after it landed, `importApp` for a
+ * served document whose machine never crosses interchange) over a real store; the
+ * consumer is the real `GET /apps/:id/open` route on the real composed handler.
+ * Nothing is stubbed on either side, and the screen really renders — and really
+ * crashes — in the sealed VM.
+ *
+ * What must be able to fail: drop the `validation` arm from `openApp`
+ * (`src/wire/apps.ts`) and both terminal reads go red with a 400 carrying no
+ * `reason` an agent could act on. The healthy open below is the premise — it
+ * proves this deployment paints screens at all, so a refusal here is the SCREEN's
+ * and not a deployment with no engine wired.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { VENDO_APP_FORMAT, type AppDocument, type AppId, type Principal, type RunContext } from "@vendoai/core";
+import { createStore } from "@vendoai/store";
+import type { LanguageModel } from "ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { createVendo, type Vendo } from "../src/server.js";
+import { FIXTURE_SCREEN } from "./screen-fixture.js";
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+const ADA: Principal = { kind: "user", subject: "user_ada" };
+const ctx: RunContext = { principal: ADA, venue: "app", presence: "present", sessionId: "session_ada" };
+
+/** Renders once, reaches through a value nothing is behind, and takes the screen
+ *  down with it — the shape a host tool that moved under a stored app leaves.
+ *  It passes admission and type-checks, so only the render stage can see it. */
+const CRASHING_SCREEN = `import { Stack, Text } from "@vendo/screen";
+
+const totals = undefined as unknown as { spend: number };
+
+export default function Broken() {
+  return (
+    <Stack>
+      <Text text={String(totals.spend)} />
+    </Stack>
+  );
+}
+`;
+
+async function setup(): Promise<Vendo> {
+  const dataDir = await mkdtemp(join(tmpdir(), "vendo-open-terminal-"));
+  const store = createStore({ dataDir });
+  cleanups.push(async () => {
+    await store.close();
+    await rm(dataDir, { recursive: true, force: true });
+  });
+  await store.ensureSchema();
+  return createVendo({
+    models: { default: {} as LanguageModel },
+    principal: async (request) => {
+      const subject = request.headers.get("x-test-user");
+      return subject === null ? null : { kind: "user", subject };
+    },
+    store,
+  });
+}
+
+const open = (vendo: Vendo, appId: string, query = ""): Promise<Response> => vendo.handler(
+  new Request(`http://wire.test/api/vendo/apps/${appId}/open${query}`, { headers: { "x-test-user": ADA.subject } }),
+);
+
+interface Answer {
+  status: number;
+  body: { kind?: string; reason?: string; retryable?: boolean; error?: { code: string; message: string } };
+}
+
+const answer = async (response: Response): Promise<Answer> => ({
+  status: response.status,
+  body: await response.json() as Answer["body"],
+});
+
+describe("opening an app that can never be served answers terminally, not 400", () => {
+  it("a screen that no longer renders comes back as failed, with the render's own words", async () => {
+    const vendo = await setup();
+    // The door that stores screens, because a refused paint leaves no row: an app
+    // whose screen went bad AFTER it landed is exactly this state.
+    await vendo.apps.authoredScreen(
+      { appId: "app_broken_screen" as AppId, name: "Broken", source: CRASHING_SCREEN },
+      ctx,
+    );
+
+    const { status, body } = await answer(await open(vendo, "app_broken_screen"));
+
+    expect(status).toBe(200);
+    expect(body.kind).toBe("failed");
+    // The reason the refusal carried, carried through: what is wrong with the
+    // artifact, in the words that name where to fix it.
+    expect(body.reason).toContain("this screen did not render");
+    expect(body.reason).toMatch(/threw while rendering/);
+    // And the permanence, in the wire's existing vocabulary: no retry can change
+    // a stored record.
+    expect(body.retryable).toBe(false);
+    // The embed's flagged poll gets the same terminal answer, never a `pending`
+    // it would spin on to its deadline.
+    expect(await answer(await open(vendo, "app_broken_screen", "?pending=1"))).toEqual({ status, body });
+  }, 60_000);
+
+  it("a served app whose machine is gone says its surface is gone, and names the fix", async () => {
+    const vendo = await setup();
+    // A machine ref never crosses interchange, so importing a served document is
+    // the shipped way one lands with `ui: "http"` and nothing to serve.
+    const imported = await vendo.apps.importApp({
+      format: VENDO_APP_FORMAT,
+      id: "app_served_import" as AppId,
+      name: "Served app",
+      ui: "http",
+    } as AppDocument, ctx);
+
+    const { status, body } = await answer(await open(vendo, imported.id));
+
+    expect(status).toBe(200);
+    expect(body.kind).toBe("failed");
+    expect(body.reason).toContain("has no machine");
+    expect(body.reason).toContain("re-create the app");
+    expect(body.retryable).toBe(false);
+  }, 60_000);
+
+  it("still paints a sound screen, and still masks an app that is not there", async () => {
+    const vendo = await setup();
+    await vendo.apps.authoredScreen(
+      { appId: "app_sound" as AppId, name: "Sound", source: FIXTURE_SCREEN },
+      ctx,
+    );
+
+    // The premise: this deployment really does paint screens, so the refusal
+    // above belongs to the broken screen and not to a missing engine.
+    const painted = await answer(await open(vendo, "app_sound"));
+    expect(painted.status).toBe(200);
+    expect(painted.body.kind).toBe("tree");
+
+    // And the transient answers are untouched: an app nobody can see keeps its
+    // contracted 404 unflagged, and the build window keeps its quiet `pending`.
+    const missing = await answer(await open(vendo, "app_ghost"));
+    expect(missing.status).toBe(404);
+    expect(missing.body.error?.code).toBe("not-found");
+    expect(await answer(await open(vendo, "app_ghost", "?pending=1")))
+      .toEqual({ status: 200, body: { kind: "pending" } });
+  }, 60_000);
+});

--- a/packages/vendo/tests/app-open-terminal-artifact.seam.test.ts
+++ b/packages/vendo/tests/app-open-terminal-artifact.seam.test.ts
@@ -1,31 +1,47 @@
 /**
- * A BROKEN ARTIFACT IS NOT A RETRIABLE REQUEST.
+ * A REFUSED OPEN SAYS WHY, AND CLAIMS NOTHING MORE THAN IT KNOWS.
  *
- * `open()` refuses a stored app it can never serve with a `validation` VendoError
- * — a served row whose machine is gone, or a screen that no longer renders
- * (`persistence/open.ts`). The wire's build window only rescued `not-found`, so
- * those two reached the caller as a bare HTTP 400: no reason, and a status every
- * agent reads as "try again". One did, on the identical response, for 7.7 minutes
- * until its turn budget died.
+ * `open()` refuses a stored app it cannot serve with a `validation` VendoError —
+ * a served row whose machine is gone, or a screen the floor would not pass
+ * (`persistence/open.ts:191`, `:221`). The wire's build window only rescued
+ * `not-found`, so those reached the caller as a bare HTTP 400: no reason, and a
+ * status every agent reads as "try again". One did, on the identical response,
+ * for 7.7 minutes until its turn budget died.
  *
- * So this drives both refusals through the REAL seam and asserts the answer is
- * terminal and self-explaining. The producer is a shipped write door
- * (`authoredScreen` for a screen that went bad after it landed, `importApp` for a
- * served document whose machine never crosses interchange) over a real store; the
- * consumer is the real `GET /apps/:id/open` route on the real composed handler.
- * Nothing is stubbed on either side, and the screen really renders — and really
- * crashes — in the sealed VM.
+ * The answer now carries the refusal's own words in the terminal shape this wire
+ * already speaks. What it must NOT carry is a verdict on retrying: that door's
+ * refusals are a mixed class. "This screen did not render" covers a screen that
+ * will never compile AND a query the guard blocked, an unconnected toolkit, a
+ * read awaiting approval, or a deployment missing esbuild/tsc/QuickJS
+ * (`server/checking/component-screen.ts`) — and the wire cannot tell which it
+ * got. The last test here is that case, end to end: the same stored app that
+ * refused opens fine once its dependency answers.
+ *
+ * The producer is a shipped write door (`authoredScreen` for a screen that went
+ * bad after it landed, `importApp` for a served document whose machine never
+ * crosses interchange) over a real store; the consumer is the real
+ * `GET /apps/:id/open` on the real composed handler. Nothing is stubbed on either
+ * side, and the screen really renders — and really crashes — in the sealed VM.
  *
  * What must be able to fail: drop the `validation` arm from `openApp`
- * (`src/wire/apps.ts`) and both terminal reads go red with a 400 carrying no
- * `reason` an agent could act on. The healthy open below is the premise — it
- * proves this deployment paints screens at all, so a refusal here is the SCREEN's
- * and not a deployment with no engine wired.
+ * (`src/wire/apps.ts`) and every read here goes red with a 400 carrying no
+ * `reason` an agent could act on; add `retryable: false` back to it and the
+ * recoverable case goes red. The healthy open is the premise — it proves this
+ * deployment paints screens at all, so a refusal here is the SCREEN's and not a
+ * deployment with no engine wired.
  */
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { VENDO_APP_FORMAT, type AppDocument, type AppId, type Principal, type RunContext } from "@vendoai/core";
+import {
+  VENDO_APP_FORMAT,
+  type AppDocument,
+  type AppId,
+  type Json,
+  type Principal,
+  type RunContext,
+  type ToolDefinition,
+} from "@vendoai/core";
 import { createStore } from "@vendoai/store";
 import type { LanguageModel } from "ai";
 import { afterEach, describe, expect, it } from "vitest";
@@ -56,7 +72,21 @@ export default function Broken() {
 }
 `;
 
-async function setup(): Promise<Vendo> {
+/** A sound screen whose one query has to answer for it to paint — the paint runs
+ *  the query for real on every open, so this screen's fate follows its world. */
+const QUERYING_SCREEN = `import { Stack, Text, useQuery } from "@vendo/screen";
+
+export default function Balance() {
+  const balance = useQuery("host_balance");
+  return (
+    <Stack>
+      <Text text={String(balance.data.cents)} />
+    </Stack>
+  );
+}
+`;
+
+async function setup(tools: ToolDefinition[] = []): Promise<Vendo> {
   const dataDir = await mkdtemp(join(tmpdir(), "vendo-open-terminal-"));
   const store = createStore({ dataDir });
   cleanups.push(async () => {
@@ -71,6 +101,7 @@ async function setup(): Promise<Vendo> {
       return subject === null ? null : { kind: "user", subject };
     },
     store,
+    tools,
   });
 }
 
@@ -106,9 +137,9 @@ describe("opening an app that can never be served answers terminally, not 400", 
     // artifact, in the words that name where to fix it.
     expect(body.reason).toContain("this screen did not render");
     expect(body.reason).toMatch(/threw while rendering/);
-    // And the permanence, in the wire's existing vocabulary: no retry can change
-    // a stored record.
-    expect(body.retryable).toBe(false);
+    // No verdict on retrying: this screen's own fault is permanent, but the wire
+    // cannot see that from the refusal, so it says nothing it cannot know.
+    expect(body.retryable).toBeUndefined();
     // The embed's flagged poll gets the same terminal answer, never a `pending`
     // it would spin on to its deadline.
     expect(await answer(await open(vendo, "app_broken_screen", "?pending=1"))).toEqual({ status, body });
@@ -131,7 +162,47 @@ describe("opening an app that can never be served answers terminally, not 400", 
     expect(body.kind).toBe("failed");
     expect(body.reason).toContain("has no machine");
     expect(body.reason).toContain("re-create the app");
-    expect(body.retryable).toBe(false);
+    expect(body.retryable).toBeUndefined();
+  }, 60_000);
+
+  it("does not call a recoverable refusal permanent — the same app opens once its query answers", async () => {
+    // The reviewer's case (PR #1537), and the one the enumeration confirmed:
+    // `open.ts:221` also fires when a screen's QUERY would not answer — a guard
+    // that blocked it, an unconnected toolkit, a read awaiting approval, a tool
+    // that was simply down (`build-surface.ts:379-385` → `component-screen.ts:663`).
+    // The screen is fine; its world was not.
+    let down = true;
+    const vendo = await setup([{
+      name: "host_balance",
+      title: "Balance",
+      description: "The account balance.",
+      inputSchema: { type: "object", properties: {}, additionalProperties: false },
+      risk: "read",
+      execute: async () => {
+        if (down) throw new Error("the balance service is warming up");
+        return { data: { cents: 4200 } } as unknown as Json;
+      },
+    }]);
+    await vendo.apps.authoredScreen(
+      { appId: "app_flaky_query" as AppId, name: "Balance", source: QUERYING_SCREEN },
+      ctx,
+    );
+
+    const refused = await answer(await open(vendo, "app_flaky_query"));
+    expect(refused.status).toBe(200);
+    expect(refused.body.kind).toBe("failed");
+    // The reason still reaches the caller — that is the whole fix.
+    expect(refused.body.reason).toContain("the balance service is warming up");
+    // But nothing claims a retry is pointless, because here it is not.
+    expect(refused.body.reason).not.toMatch(/retry|permanent/i);
+    expect(refused.body.retryable).toBeUndefined();
+
+    // The proof that the refusal was recoverable: nothing about the stored app
+    // changed, the world did.
+    down = false;
+    const served = await answer(await open(vendo, "app_flaky_query"));
+    expect(served.status).toBe(200);
+    expect(served.body.kind).toBe("tree");
   }, 60_000);
 
   it("still paints a sound screen, and still masks an app that is not there", async () => {


### PR DESCRIPTION
`GET /apps/:id/open` answered a permanently broken app with a bare HTTP 400 — no
reason, and a status every agent reads as "try again". Live, one retried the
identical response for 7.7 minutes, until its turn budget died.

## The chain

`open()` refuses a stored app it can never serve with a `validation` VendoError:
a served row whose machine is gone (`persistence/open.ts:190`), or a screen that
no longer renders (`open.ts:221`). The wire's build window rescued only
`not-found` and re-threw the rest (`wire/apps.ts:155`), so `validation` fell
through to the router's `validation → 400` (`agents/src/http/router.ts:114`).
Retrying can never change a stored record, so the 400 was both permanent and
unexplained.

## The shape

No new vocabulary: this wire already answers a terminal app with
`{kind: "failed", reason, retryable}` — `open.ts:249` returns exactly that for a
document with no screen left, `wire/apps.ts:127` passes a `buildFailed` marker
through as it, and `server.test.ts` contracts it as 200 flagged or not. So a
`validation` refusal out of this door is answered the same way, carrying the
refusal's own words.

That mapping is sound because of the door's shape: the only input `open` takes is
the app id, and a bad one is `not-found` — so a `validation` refusal is always
about what is STORED, never a bad request. The embed already resolves on
`kind:"failed"` (`ui/src/chrome/embeds.tsx:333`) and the MCP door already hands
the surface to the model verbatim (`apps/src/server/doors/agent-tools.ts:374`),
so the model reads the reason instead of a status.

The two open routes differed only in the build-window flag, so they are one
function now. `pending: false` is what the runtime already did for an absent
option (`createAppOpener`), and an unflagged open can never answer `pending` — so
arrival reads the same on either. Transient answers are untouched: unflagged
`not-found` keeps its 404, and the flagged rescue keeps its quiet `pending`.

## Tests

`packages/vendo/tests/app-open-terminal-artifact.seam.test.ts` — a seam test with
nothing stubbed on either side. Both broken artifacts are written through shipped
write doors over a real store (`authoredScreen` for a screen that went bad after
it landed, `importApp` for a served document — a machine ref never crosses
interchange), then opened through the real composed `GET /apps/:id/open`. The
screen really renders, and really crashes, in the sealed VM.

- a screen that no longer renders → 200 `{kind:"failed"}`, reason carries "this
  screen did not render: … threw while rendering", `retryable: false`, and the
  flagged poll answers identically
- a served app with no machine → 200 `{kind:"failed"}`, reason names the fix
- the premise + the transient contract: a sound screen still paints
  (`kind:"tree"`, so a refusal above is the screen's and not a deployment with no
  engine), a missing app still 404s unflagged, and still answers
  `{kind:"pending"}` flagged

Red first: with the fix stashed, both terminal reads fail with `expected 400 to
be 200`; the third passes, which is what guards the route unification.

## Gate

`pnpm build` · `pnpm typecheck` · `pnpm lint` green. The new file plus the six
existing files covering these routes (`server.test.ts`, `wire/apps.pending-probe`,
`wire/apps.partial-tree`, `served-apps-wire`, `seed-wire`, `app-access-door`) =
142 tests green. `pnpm test:affected` running.

## Noted, not touched

`compose-mcp.ts:26` narrows the MCP apps port to `tree`/`http` and throws "This is
a server app resuming in-product" for everything else — so a `kind:"failed"`
surface (a `buildFailed` app today) is mislabelled to the model over that door.
Pre-existing and out of scope here; worth its own change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Broken apps opened via GET /apps/:id/open now return 200 with {kind:"failed", reason} instead of a bare 400 that agents retry. This exposes the failure reason to the model/embed and avoids long retry loops without claiming permanence.

- Maps `validation` `VendoError`s from `open()` to the terminal shape and preserves `reason`; drops `retryable:false` because refusals are mixed and may recover.
- Unflagged `not-found` stays 404; flagged route still returns `{kind:"pending"}`; arrival marking remains on non‑pending responses.
- Unifies both open routes into `openApp(..., pending)`; unflagged opens never return `pending`.
- Adds seam tests for broken screen render, served app with missing machine, recoverable query‑down case that later opens as a tree, healthy screen, and missing app.
- Updates the build‑window cross‑reference in `packages/apps/src/server/persistence/open.ts` comments to the new `openApp` name.

<sup>Written for commit 6878e1ca9dc0637244be3e51fe0ff06866a8b933. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

