### PR TITLE
fix(harnesses,core): the box a warm call boots is the box the conversation gets

### DIFF
--- a/.changeset/warm-spare-box.md
+++ b/.changeset/warm-spare-box.md
@@ -1,0 +1,31 @@
+---
+"@vendoai/core": minor
+"@vendoai/harnesses": patch
+"@vendoai/vendo": patch
+---
+
+On the sandbox rung, warming the chat now warms the machine the conversation
+actually runs on. `POST /threads/warm` — the call the panel fires when the chat
+surface opens — replays a real turn under a throwaway thread id, and the box
+pool keyed on that id: so every warm call booted a real cloud box the user's
+first message could never find, paid a full cold boot anyway, and left the warm
+box idling its whole billed TTL before being destroyed unused. Warming cost a
+box and bought nothing but the provider's prompt cache.
+
+A warm turn's box is now parked as a warm SPARE, and the first real
+conversation claims it: re-keyed to its own thread, liveness-probed on the way
+in, and handed over exactly as a fresh box is — the workspace is materialized
+and the session opened for that conversation, so nothing of the probe's turn
+carries into the user's first message. A spare that died in the meantime falls
+back to a cold boot, a second warm reuses the live spare instead of booting a
+second box, and a spare nobody ever claims is reaped on the same idle budget as
+any other box.
+
+Each box now says how it was obtained, so the saving is greppable rather than
+inferred: `harnesses.claude-code-box-ready` reports `thread-reuse`,
+`spare-claim` or `cold-boot`, with the time it took.
+
+`WARM_THREAD_PREFIX` is new in `@vendoai/core` — the thread-id prefix a warm
+turn carries. It is what the pool reads to recognise one, since `Harness` is
+deliberately unchanged: a warm turn is an ordinary turn, and the id is the
+whole of the seam.

--- a/packages/core/src/ids.ts
+++ b/packages/core/src/ids.ts
@@ -50,6 +50,19 @@ export const runIdSchema = z.string().regex(/^run_.+$/) satisfies z.ZodType<RunI
 /** 01-core §1 */
 export const threadIdSchema = z.string().regex(/^thr_.+$/) satisfies z.ZodType<ThreadId>;
 
+/**
+ * The prefix a WARM turn's thread id carries — and the whole of the seam between
+ * the warm door and a session-owning adapter.
+ *
+ * `HarnessTurns.warm` mints one id per warm call and drops it the moment its
+ * one-token probe ends, so an adapter that pools per conversation would park a
+ * real machine under a conversation nobody will ever ask for again. The
+ * `Harness` contract is frozen — a warm turn IS an ordinary turn — so the id is
+ * the only thing that can carry the fact, and `claude-code/box.ts` reads it to
+ * park its box as a claimable spare instead.
+ */
+export const WARM_THREAD_PREFIX = "thr_warm";
+
 /** 01-core §1 — unlike its neighbours this pins the WHOLE shape rather than a
  *  prefix: a turn id is minted in exactly one place, so there is no older,
  *  looser spelling to keep parsing. */

--- a/packages/harnesses/src/claude-code/box.ts
+++ b/packages/harnesses/src/claude-code/box.ts
@@ -35,7 +35,7 @@
  * resumes on the same session) and worse for cost (a parked write holds a
  * sandbox for up to 90s). Recorded in the lane's close note as a deviation.
  */
-import { log, VENDO_DEV_PORT, VENDO_DEV_PORT_ENV, VendoError } from "@vendoai/core";
+import { log, VENDO_DEV_PORT, VENDO_DEV_PORT_ENV, VendoError, WARM_THREAD_PREFIX } from "@vendoai/core";
 import type { CheckoutFile, SyncFile, TreeState } from "../materialize.js";
 import { emptyTree } from "../materialize.js";
 import { MESSAGE_BUDGET_MS, type SessionMachine, type SessionMessage } from "./machine.js";
@@ -84,13 +84,17 @@ interface BoxEntry {
   token: string;
   /** Has this box been materialized and had its session opened? */
   warm: boolean;
+  /** Set on a CLAIMED spare, whose disk carries the warm probe's live session:
+   *  the next message must close it and open one that resumes nothing. */
+  reopen: boolean;
   /** What this box's disk holds — the sync-back baseline, per conversation. */
   tree: TreeState;
   idle?: ReturnType<typeof setTimeout>;
 }
 
-/** One box per THREAD, for as long as the conversation stays warm. Module-scoped
- *  because that is what "the box outlives the turn" means. */
+/** One box per THREAD, for as long as the conversation stays warm — plus, under
+ *  the spare key below, the box a WARM turn booted, waiting to be claimed.
+ *  Module-scoped because that is what "the box outlives the turn" means. */
 const boxes = new Map<string, BoxEntry>();
 
 const mintToken = (): string => `bxt_${globalThis.crypto.randomUUID()}`;
@@ -174,6 +178,21 @@ export async function boxMachine(options: BoxMachineOptions): Promise<SessionMac
   const idleTtlMs = options.idleTtlMs ?? BOX_IDLE_TTL_MS;
   const template = options.template ?? globalThis.process?.env?.["VENDO_BOX_TEMPLATE"];
 
+  // Where a WARM turn parks its box. Not under its thread id: `WARM_THREAD_PREFIX`
+  // says that id dies with the one-token probe, so a box parked under it is a real
+  // cloud machine — booted, hello'd, billed for the whole idle TTL — that the
+  // conversation it was warmed FOR can never find. That turn arrives under its own
+  // thread id, misses, and boots a second box, which is the entire cost the warm
+  // door exists to remove.
+  //
+  // The key is the CREATE SPEC, because that is what makes a spare interchangeable
+  // with the box a real turn would have booted. `\0` cannot appear in a thread id,
+  // so no conversation collides with it. `env` is deliberately not part of it: the
+  // claimer's own env lands on the box through the `hello` that claims it.
+  const spare = `\0spare ${JSON.stringify([template ?? null, options.allowedDomains])}`;
+  const warming = options.threadId.startsWith(WARM_THREAD_PREFIX);
+  const key = warming ? spare : options.threadId;
+
   /**
    * The credential handoff, and the only one. The box trusts the first hello
    * while it is unclaimed and refuses every other caller after.
@@ -213,34 +232,73 @@ export async function boxMachine(options: BoxMachineOptions): Promise<SessionMac
         "the workspace machine refused the session handshake",
       );
     }
-    const fresh: BoxEntry = { machine, token, warm: false, tree: emptyTree() };
-    boxes.set(options.threadId, fresh);
+    const fresh: BoxEntry = { machine, token, warm: false, reopen: false, tree: emptyTree() };
+    boxes.set(key, fresh);
     return fresh;
   };
 
-  const existing = boxes.get(options.threadId);
-  let entry: BoxEntry | undefined;
-  if (existing !== undefined) {
-    disarmIdle(existing);
-    // PROBE, never assume. A box can be gone without us having asked — a
-    // provider reap, an idle policy on their side, a host that slept. Handing
-    // that corpse out made the thread fail in a third of a second for the whole
-    // process lifetime; only a restart recovered it. `hello` re-presenting the
-    // SAME token is the cheapest round trip the box answers.
-    if (await hello(existing.machine, existing.token)) {
-      entry = existing;
-    } else {
-      log({
-        code: "harnesses.claude-code-box-stale",
-        level: "error",
-        message: "[vendo] claude-code: the box stopped answering; starting fresh",
-      });
-      boxes.delete(options.threadId);
-      await existing.machine.destroy().catch(() => undefined);
+  /** Take the box parked at `at`, if it is still there.
+   *
+   *  PROBE, never assume. A box can be gone without us having asked — a provider
+   *  reap, an idle policy on their side, a host that slept. Handing that corpse
+   *  out made the thread fail in a third of a second for the whole process
+   *  lifetime; only a restart recovered it. `hello` re-presenting the SAME token
+   *  is the cheapest round trip the box answers, and on a spare it doubles as the
+   *  claimer's env handoff.
+   *
+   *  `exclusive` empties the slot BEFORE that probe awaits — what a claim needs
+   *  and a thread key must not have. Two first messages arriving inside one hello
+   *  round trip would otherwise both be handed the same spare, and two
+   *  conversations would share one disk and one session. */
+  const adopt = async (at: string, exclusive = false): Promise<BoxEntry | undefined> => {
+    const held = boxes.get(at);
+    if (held === undefined) return undefined;
+    if (exclusive) boxes.delete(at);
+    disarmIdle(held);
+    if (await hello(held.machine, held.token)) return held;
+    log({
+      code: "harnesses.claude-code-box-stale",
+      level: "error",
+      message: "[vendo] claude-code: the box stopped answering; starting fresh",
+    });
+    boxes.delete(at);
+    await held.machine.destroy().catch(() => undefined);
+    return undefined;
+  };
+
+  const startedAt = Date.now();
+  let served: "thread-reuse" | "spare-claim" | "cold-boot" = "thread-reuse";
+  let entry = await adopt(key);
+  // THE CLAIM. A spare's disk holds the probe's workspace and its live session,
+  // neither of which is this conversation's, so it is handed over as a FRESH box
+  // is — `warm: false` and an empty tree, which is what makes the caller
+  // materialize and re-seed — plus the one thing a fresh box does not need:
+  // `reopen`, because the probe's session is live on that disk and must not be
+  // what the user's first message continues.
+  //
+  // Claimable only while PARKED, and an armed idle timer is exactly that fact:
+  // the warm turn ended and the box is waiting to be reaped. One still mid-probe
+  // is left alone — both turns would materialize over each other on the one disk.
+  if (entry === undefined && !warming && boxes.get(spare)?.idle !== undefined) {
+    entry = await adopt(spare, true);
+    if (entry !== undefined) {
+      served = "spare-claim";
+      boxes.set(key, entry);
+      entry.warm = false;
+      entry.reopen = true;
+      entry.tree = emptyTree();
     }
   }
+  if (entry === undefined) served = "cold-boot";
   entry ??= await bootBox();
   const box = entry;
+  // The one number that says whether warming is working: a cold boot here is a
+  // second of the user's first message, a claim is none of it.
+  log({
+    code: "harnesses.claude-code-box-ready",
+    level: "debug",
+    message: `[vendo] claude-code: box ready by ${served} in ${Date.now() - startedAt}ms`,
+  });
 
   const request = async (path: string, body?: unknown): Promise<Record<string, unknown>> => {
     const { status, json } = await control(box.machine, box.token, path, body);
@@ -309,7 +367,10 @@ export async function boxMachine(options: BoxMachineOptions): Promise<SessionMac
         effort: message.effort,
         maxTurns: message.maxTurns,
         resume: message.resume,
-        reopen: message.reopen,
+        // A claimed spare's live session is the warm probe's. Closing it and
+        // opening one that resumes nothing is what makes this message the user's
+        // FIRST rather than the probe's second.
+        reopen: message.reopen === true || box.reopen,
         pluginPath: message.pluginPath,
         skillNames: message.skillNames,
         toolDoor: message.toolDoor,
@@ -317,6 +378,7 @@ export async function boxMachine(options: BoxMachineOptions): Promise<SessionMac
       // From here on the box holds a session, so a next message on this thread
       // neither re-materializes nor re-seeds.
       box.warm = true;
+      box.reopen = false;
       const messageId = String(started["messageId"] ?? "");
       // Addressable from here until the poll loop lets go: a steer names the
       // MESSAGE, and only the one being answered can take it.
@@ -391,7 +453,7 @@ export async function boxMachine(options: BoxMachineOptions): Promise<SessionMac
       // The box stays up for the next message and is destroyed when the
       // conversation goes quiet. Nothing to carry in `turn.state`: recovery is a
       // fresh box plus the store, not a snapshot ref.
-      armIdle(options.threadId, box, idleTtlMs);
+      armIdle(key, box, idleTtlMs);
     },
   };
 }

--- a/packages/harnesses/tests/claude-code/warm-spare.test.ts
+++ b/packages/harnesses/tests/claude-code/warm-spare.test.ts
@@ -1,0 +1,79 @@
+/**
+ * A warm turn's box is parked as a SPARE rather than under the throwaway thread
+ * id it was booted for — and a spare nobody claims must still go.
+ *
+ * The claim itself is proven at the seam it spans, in
+ * `packages/vendo/tests/warm-spare.test.ts`: the real warm door minting the id and
+ * the real pool reading it, with only the SandboxAdapter faked. What lives HERE is
+ * the one rule that seam cannot reach, because no wire exposes the idle budget: a
+ * spare is a real cloud machine, so if it were exempt from the idle sweep the warm
+ * door would leak a billed box per process instead of per call — a worse bug than
+ * the one this whole change fixes.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { WARM_THREAD_PREFIX } from "@vendoai/core";
+import { afterEach, expect, test } from "vitest";
+// The REAL box door, over a fake transport: `hello` is a protocol, and a fake that
+// simply says yes to it is how a live blocker hid once already.
+import { createSessionRoutes } from "../../box/turn-routes.mjs";
+import { boxMachine, disposeSessionMachines, type SandboxAdapterLike } from "../../src/claude-code/box.js";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+const boxRoots: string[] = [];
+afterEach(async () => {
+  await disposeSessionMachines();
+  for (const root of boxRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function fakeSandbox(): SandboxAdapterLike & { destroyed: boolean[] } {
+  const destroyed: boolean[] = [];
+  return {
+    destroyed,
+    async create() {
+      const root = mkdtempSync(path.join(tmpdir(), "vendo-spare-unit-"));
+      boxRoots.push(root);
+      const at = destroyed.push(false) - 1;
+      const routes = createSessionRoutes({ root, token: "", env: {} }) as {
+        handle: (method: string, pathname: string, headers: Record<string, string>, payload: unknown)
+          => Promise<{ status: number; body: unknown }>;
+      };
+      return {
+        id: `box_${at}`,
+        files: {
+          read: async () => new Uint8Array(),
+          write: async () => undefined,
+          list: async () => [],
+        },
+        url: async () => `https://box-${at}.fake-provider.test`,
+        async request(req) {
+          const payload = req.body === undefined
+            ? {}
+            : JSON.parse(typeof req.body === "string" ? req.body : decoder.decode(req.body)) as unknown;
+          const answer = await routes.handle(req.method, req.path, req.headers ?? {}, payload);
+          return { status: answer.status, headers: {}, body: encoder.encode(JSON.stringify(answer.body)) };
+        },
+        async destroy() { destroyed[at] = true; },
+      };
+    },
+    async destroy() { /* no machine to reap by ref */ },
+  };
+}
+
+test("a spare no conversation ever claims is destroyed on the same idle budget as a thread's box", async () => {
+  const sandbox = fakeSandbox();
+  const spare = await boxMachine({
+    sandbox,
+    threadId: `${WARM_THREAD_PREFIX}abc123`,
+    env: {},
+    allowedDomains: [],
+    idleTtlMs: 5,
+  });
+  await spare.release();
+  await new Promise((resolve) => setTimeout(resolve, 60));
+
+  expect(sandbox.destroyed).toEqual([true]);
+});

--- a/packages/vendo/src/harness-turn.ts
+++ b/packages/vendo/src/harness-turn.ts
@@ -22,6 +22,7 @@ import {
   isUnattended,
   situationPromptBlock,
   toVendoWirePart,
+  WARM_THREAD_PREFIX,
   type FilesAdapter,
   type Harness,
   type Membership,
@@ -887,7 +888,7 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
       const system = await config.system(input.ctx, { discovery: rail });
       const response = await runtime.run<{ maxSteps: number; maxOutputTokens: number }>({
         harness: config.harness,
-        threadId: `thr_warm${globalThis.crypto.randomUUID().replaceAll("-", "")}` as ThreadId,
+        threadId: `${WARM_THREAD_PREFIX}${globalThis.crypto.randomUUID().replaceAll("-", "")}` as ThreadId,
         messages: [{
           id: "warm",
           role: "user",

--- a/packages/vendo/tests/warm-spare.test.ts
+++ b/packages/vendo/tests/warm-spare.test.ts
@@ -1,0 +1,236 @@
+/**
+ * The box a WARM call boots must be the box the CONVERSATION gets.
+ *
+ * `HarnessTurns.warm` replays a real turn under a throwaway thread id
+ * (`WARM_THREAD_PREFIX`), and the sandbox leg pools boxes per thread. Those two
+ * facts together made warming worse than useless on this rung: the warm turn
+ * booted a real cloud machine, hello'd it, materialized it — and the user's first
+ * message arrived under its OWN thread id, missed the pool, and paid a full cold
+ * boot anyway, while the warm box idled its whole billed TTL and was destroyed
+ * unused. Every warm call was a guaranteed miss.
+ *
+ * The seam this covers is a producer and a consumer in different blocks: vendo's
+ * warm door mints the id, the harnesses box pool reads it. Both halves are REAL
+ * here — the actual `POST /threads/warm` and `POST /threads`, the actual
+ * `createVendo` composition, the actual `claudeCode()` driver, the actual box
+ * door (`packages/harnesses/box/turn-routes.mjs`) over an in-process transport.
+ * The SandboxAdapter is the one thing faked, because it is the legitimate BYO
+ * boundary; the SDK loop inside the box is scripted, because a test cannot run a
+ * model.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { LanguageModel, UIMessage } from "ai";
+import type { Principal } from "@vendoai/core";
+import { createSessionRoutes } from "@vendoai/harnesses/box-door";
+import { claudeCode, disposeSessionMachines } from "@vendoai/harnesses/claude-code";
+import { createStore, type VendoStore } from "@vendoai/store";
+import { afterEach, describe, expect, it } from "vitest";
+import { liveDoor } from "../src/agent-doubles.test-util.js";
+import { createVendo, type Vendo } from "../src/server.js";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+const principal: Principal = { kind: "user", subject: "user_spare" };
+
+const cleanups: Array<() => Promise<void>> = [];
+const boxRoots: string[] = [];
+afterEach(async () => {
+  // The pool is module-scoped, and so is the spare slot: without this, one case's
+  // spare would be claimed by the next case's turn.
+  await disposeSessionMachines();
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+  for (const root of boxRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+/** One machine, as a test can see it. */
+interface FakeBox {
+  id: string;
+  /** Every session the REAL door opened on this machine, in order — what it was
+   *  asked to resume, and every prompt that session was sent. A claimed spare
+   *  carries the probe's live session, so "did the user's first message land in a
+   *  SECOND session that resumes nothing" is the whole question. */
+  opens: Array<{ resume?: string; prompts: string[] }>;
+  /** The provider reaping the machine out from under us — no notice, no error,
+   *  the box simply stops answering. */
+  kill: () => void;
+}
+
+/**
+ * A stand-in for a real box, adapted from the fake in
+ * `packages/vendo/tests/claude-code-composed.test.ts`: `request()` is a transport
+ * adapter over the ACTUAL box door, so the session protocol under test is the
+ * real one — including the reopen rule a claimed spare depends on.
+ */
+function fakeSandbox(): {
+  create: (spec: { env: Record<string, string> }) => Promise<unknown>;
+  destroy: (ref: string) => Promise<void>;
+  boxes: FakeBox[];
+} {
+  const boxes: FakeBox[] = [];
+  return {
+    boxes,
+    async create() {
+      const root = mkdtempSync(join(tmpdir(), "vendo-spare-box-"));
+      boxRoots.push(root);
+      let dead = false;
+      const box: FakeBox = {
+        id: `box_${boxes.length}`,
+        opens: [],
+        kill: () => { dead = true; },
+      };
+      boxes.push(box);
+      const routes = createSessionRoutes({
+        root,
+        // Unclaimed, so the host's first `/session/hello` claims it.
+        token: "",
+        env: {},
+        openSession: (input: {
+          emit: (event: Record<string, unknown>) => void;
+          resume?: string;
+        }) => {
+          const session: { resume?: string; prompts: string[] } = {
+            ...(input.resume === undefined ? {} : { resume: input.resume }),
+            prompts: [],
+          };
+          box.opens.push(session);
+          return {
+            async send(prompt: string) {
+              session.prompts.push(prompt);
+              // A session id the door will remember — without one, "resumed
+              // nothing" would be true of every session and prove nothing.
+              input.emit({ type: "session", sessionId: `sess_${box.id}_${box.opens.length}` });
+              input.emit({ type: "text", delta: "Nothing is open." });
+            },
+            async interrupt() { /* the turn stops; the session lives */ },
+            async end() { /* the box is going away */ },
+          };
+        },
+      }) as {
+        handle: (method: string, pathname: string, headers: Record<string, string>, payload: unknown)
+          => Promise<{ status: number; body: unknown }>;
+      };
+      return {
+        id: box.id,
+        async request(req: {
+          method: string;
+          path: string;
+          headers?: Record<string, string>;
+          body?: Uint8Array | string;
+        }) {
+          if (dead) throw new Error("machine is gone");
+          const payload = req.body === undefined
+            ? {}
+            : JSON.parse(typeof req.body === "string" ? req.body : decoder.decode(req.body)) as unknown;
+          const answer = await routes.handle(req.method, req.path, req.headers ?? {}, payload);
+          return { status: answer.status, headers: {}, body: encoder.encode(JSON.stringify(answer.body)) };
+        },
+        async destroy() { dead = true; },
+      };
+    },
+    async destroy() { /* no machine to reap by ref */ },
+  };
+}
+
+async function compose(sandbox: unknown): Promise<Vendo> {
+  const dataDir = await mkdtemp(join(tmpdir(), "vendo-spare-"));
+  const store: VendoStore = createStore({ dataDir });
+  const door = await liveDoor();
+  cleanups.push(door.close);
+  cleanups.push(async () => {
+    await store.close();
+    await rm(dataDir, { recursive: true, force: true });
+  });
+  return createVendo({
+    // Never reached: the thinker is the scripted box, not a provider.
+    models: { default: {} as LanguageModel },
+    principal: async () => principal,
+    store,
+    // A composed `claudeCode()` refuses a turn whose door nothing answers, so the
+    // origin has to be one a machine could really dial — and the door mints its
+    // principals through the oauth seam, so it cannot open without one.
+    mcp: { baseUrl: door.origin },
+    oauth: {
+      async authorize() { return { subject: principal.subject }; },
+      async principal(subject: string) { return { kind: "user" as const, subject }; },
+    },
+    sandbox,
+    harness: claudeCode(),
+  } as Parameters<typeof createVendo>[0]);
+}
+
+const post = (vendo: Vendo, path: string, body: unknown = {}): Promise<Response> =>
+  vendo.handler(new Request(`https://host.test/api/vendo${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  }));
+
+const firstMessage = (vendo: Vendo, threadId: string): Promise<Response> =>
+  post(vendo, "/threads", {
+    threadId,
+    message: { id: "m1", role: "user", parts: [{ type: "text", text: "how many invoices are open?" }] } as UIMessage,
+  });
+
+describe("a warm turn's box is parked as a spare the conversation claims", () => {
+  it("warm boots ONE box, and the first real message runs on it instead of booting another", async () => {
+    const sandbox = fakeSandbox();
+    const vendo = await compose(sandbox);
+
+    expect((await post(vendo, "/threads/warm")).status).toBe(204);
+    // The probe really did boot a machine — otherwise everything below is vacuous.
+    expect(sandbox.boxes).toHaveLength(1);
+    expect(sandbox.boxes[0]!.opens).toHaveLength(1);
+
+    const turn = await firstMessage(vendo, "thr_claims_the_spare");
+    expect(turn.status).toBe(200);
+    const body = await turn.text();
+    expect(body).not.toContain("missing its workspace machine");
+    expect(body).toContain("Nothing is open.");
+
+    // THE assertion: the user's first message paid for no boot at all.
+    expect(sandbox.boxes).toHaveLength(1);
+
+    // …and it is the user's conversation on that machine, not the probe's. The
+    // spare's session is live on its disk, so the claim closes it and opens one
+    // that resumes NOTHING; the probe's session never sees the user's words.
+    const [spare] = sandbox.boxes as [FakeBox];
+    expect(spare.opens).toHaveLength(2);
+    expect(spare.opens[1]!.resume).toBeUndefined();
+    expect(spare.opens[0]!.prompts.join("\n")).not.toContain("invoices");
+    expect(spare.opens[1]!.prompts.join("\n")).toContain("invoices");
+  });
+
+  it("a second warm while a live spare is parked boots no second box", async () => {
+    const sandbox = fakeSandbox();
+    const vendo = await compose(sandbox);
+
+    expect((await post(vendo, "/threads/warm")).status).toBe(204);
+    expect((await post(vendo, "/threads/warm")).status).toBe(204);
+
+    expect(sandbox.boxes).toHaveLength(1);
+  });
+
+  it("a spare the provider reaped is not handed out — the conversation boots cold", async () => {
+    const sandbox = fakeSandbox();
+    const vendo = await compose(sandbox);
+
+    expect((await post(vendo, "/threads/warm")).status).toBe(204);
+    expect(sandbox.boxes).toHaveLength(1);
+    // Gone without us asking, which is the one thing a pool may never assume away.
+    sandbox.boxes[0]!.kill();
+
+    const turn = await firstMessage(vendo, "thr_spare_was_dead");
+    expect(turn.status).toBe(200);
+    expect(await turn.text()).toContain("Nothing is open.");
+
+    expect(sandbox.boxes).toHaveLength(2);
+    // The replacement is a FRESH box carrying the user's conversation and nothing
+    // else: one session, resuming nothing.
+    expect(sandbox.boxes[1]!.opens).toHaveLength(1);
+    expect(sandbox.boxes[1]!.opens[0]!.resume).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## The gap

`POST /api/vendo/threads/warm` — the call the panel fires when the chat surface opens — replays the harness's normal `run()` with a throwaway one-token turn under a freshly minted `thr_warm<uuid>` thread id (`packages/vendo/src/harness-turn.ts`). The `claudeCode()` sandbox leg pools boxes **keyed by threadId** (`packages/harnesses/src/claude-code/box.ts`).

Those two facts made warming worse than useless on that rung:

- every warm call booted a **real cloud box**, hello'd it and materialized it;
- the conversation it was warmed FOR arrived under its own thread id, **missed the pool, and paid a full cold boot anyway**;
- the warm box then idled its whole billed `BOX_IDLE_TTL_MS` (5 min) and was destroyed **unused**.

So a warm call cost a box and bought nothing but the provider's prompt cache. The UI's trigger was never the problem — the waste was entirely in the pool keying.

## What changed

A warm turn's box is parked as a warm **SPARE**, and the first real conversation that misses claims it.

| file | what |
| --- | --- |
| `packages/core/src/ids.ts:53` | `WARM_THREAD_PREFIX` — the magic literal, now stated once in the one layer both blocks may import (`harnesses → core`, `vendo → core` per `scripts/dependency-guard.mjs`). `Harness` is deliberately untouched: a warm turn IS an ordinary turn, so the id is the whole of the seam. |
| `packages/vendo/src/harness-turn.ts:891` | mints from the constant instead of the literal. |
| `packages/harnesses/src/claude-code/box.ts:178-190` | the spare slot: keyed on the **create spec** (template + `allowedDomains`), not a thread nobody will ask for again. `\0` cannot appear in a thread id, so no conversation collides with it. `env` is deliberately out of the key — the claimer's own env lands on the box through the `hello` that claims it. |
| `box.ts:232-256` | `adopt(at, exclusive?)` — the pre-existing peek-probe-or-evict, extracted so the spare slot and a thread key share one implementation. |
| `box.ts:258-290` | the claim: re-key to the real thread, `hello`-probe on the way in, hand over as a FRESH box (`warm: false`, empty tree) **plus `reopen`**; cold boot if the spare is dead. |
| `box.ts:355-372` | `reopen` reaches the real box door, so the claimer's first message closes the probe's live session and opens one that resumes nothing. |

### Two races the shared slot would otherwise open, closed with it

The old pool could never hand one box to two conversations (thread ids don't collide). A shared spare slot can, so:

1. **claim ↔ claim** — `adopt(spare, exclusive)` empties the slot **before** its probe awaits. Two first messages arriving inside one `hello` round trip would otherwise both be handed the same box, and two conversations would share one disk and one session.
2. **claim ↔ probe** — only a **PARKED** spare is claimable, and an armed idle timer is exactly that fact (its warm turn ended; it is waiting to be reaped). A claim landing mid-probe would have both turns materialize over each other on the one disk.

### Why `reopen` is load-bearing

The box door reuses its live session when the brief is unchanged, and *resumes* it when the brief differs (`packages/harnesses/box/turn-routes.mjs:221-227`). A warm turn's prefix is byte-identical to a real turn's by design (that is what `warm-prefix.test.ts` guards), so without `reopen` the user's first message would land in the probe's conversation — with `"Reply with one word."` in front of it. The seam test asserts the probe's session never sees the user's words.

## Observability

One line per box, via the existing `log` seam:

```
[vendo] claude-code: box ready by cold-boot in 1043ms
[vendo] claude-code: box ready by spare-claim in 41ms
[vendo] claude-code: box ready by thread-reuse in 12ms
```

`harnesses.claude-code-box-ready`, so the saving is greppable rather than inferred. No workbench event kind was invented — a debug-channel part consumed nowhere would be speculative surface.

## Tests — the SEAM, no stub on either side

`packages/vendo/tests/warm-spare.test.ts` drives the **real** producer into the **real** consumer: the actual `POST /threads/warm` and `POST /threads`, the actual `createVendo` composition, the actual `claudeCode()` driver, the actual box door over an in-process transport. The `SandboxAdapter` is the one thing faked (the legitimate BYO boundary) and the SDK loop is scripted, because a test cannot run a model.

- **warm boots ONE box, and the first real message runs on it instead of booting another** — plus: the claimed machine opened a SECOND session that resumes nothing, and the probe's session never saw the user's words.
- **a second warm while a live spare is parked boots no second box**
- **a spare the provider reaped is not handed out — the conversation boots cold** (fresh box, one session, resuming nothing)

`packages/harnesses/tests/claude-code/warm-spare.test.ts` covers the one rule no wire exposes: **a spare no conversation ever claims is destroyed on the same idle budget as a thread's box** — otherwise the warm door would leak a billed box per process instead of per call.

### Red first, proven

With only `box.ts` reverted (`git stash push` on that one file, rebuilt):

```
× warm boots ONE box, and the first real message runs on it instead of booting another
  → expected [ { id: 'box_0', …(2) }, …(1) ] to have a length of 1 but got 2
× a second warm while a live spare is parked boots no second box
  → expected [ { id: 'box_0', …(2) }, …(1) ] to have a length of 1 but got 2
✓ a spare the provider reaped is not handed out — the conversation boots cold
Tests  2 failed | 1 passed (3)
```

The dead-spare case passes both ways by design — it is the fallback guard, not the new behaviour.

## Local gate

`pnpm build` ✅ · `pnpm typecheck` (44 tasks) ✅ · `pnpm lint` ✅ · `dependency-guard: OK (32 packages checked)` ✅
`packages/harnesses`: **579 passed**, 7 skipped ✅ (includes the 76 existing `claude-code.test.ts` tests, untouched)

`pnpm test:affected` is green apart from 5 failures that are artifacts of this worktree's path containing a space — `store`'s two durability drills and `vendo`'s `your-agent-docs.docs` / `cli/init-mcp`, all failing on `Cool%20Code` because they build paths from `URL.pathname` without decoding. Unrelated to this change (nothing here touches store, docs-site or the CLI); CI runs from a path without spaces.

## One thing to know

`packages/harnesses/tests/claude-code/claude-code.test.ts:730` uses the literal `"thr_warm"` as an ordinary thread id, so it now matches `WARM_THREAD_PREFIX` and exercises spare→spare reuse rather than thread reuse. **It passes untouched and I did not edit it** — per-thread reuse stays covered by the `thr_named` and `thr_reaped` cases in the same file. Worth renaming in a future pass so the test proves what its name says; flagging rather than changing it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Warm calls now park the booted box as a claimable spare keyed by the create spec, so the first real conversation claims it instead of cold-booting. Old behavior booted a real box under `thr_warm<uuid>` that the real thread never reused; new behavior re-keys on claim, probes liveness, and hands over a fresh session via `reopen`. Side effects: second warm reuses the spare; dead spares fall back to cold boot; unclaimed spares are reaped on the normal idle TTL.

- **Review focus**
  - packages/harnesses/src/claude-code/box.ts: adds a spare slot keyed by create spec; `adopt(at, exclusive?)` probes-and-evicts to close double-claim races; claiming sets `warm: false`, `reopen: true`, clears the tree; logs `harnesses.claude-code-box-ready` with `thread-reuse` | `spare-claim` | `cold-boot` and duration.
  - packages/core/src/ids.ts: adds `WARM_THREAD_PREFIX` for shared warm-id detection.
  - packages/vendo/src/harness-turn.ts: mints warm ids using `WARM_THREAD_PREFIX`.
  - Tests: end-to-end tests cover spare claim, second warm reuse, and dead-spare cold boot; harness test ensures unclaimed spares are reaped on the same idle TTL. No API changes or migrations.

<sup>Written for commit db4453cd0514b48de364c930ca51c1e827e3d2ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

