### PR TITLE
fix(harnesses): pin every model slot the SDK reads, and stop blaming the sandbox for a spent budget

### DIFF
--- a/packages/harnesses/src/claude-code/box.ts
+++ b/packages/harnesses/src/claude-code/box.ts
@@ -165,6 +165,9 @@ export interface BoxMachineOptions {
   template?: string;
   /** Test seam; production uses {@link BOX_IDLE_TTL_MS}. */
   idleTtlMs?: number;
+  /** Test seam; production uses {@link MESSAGE_BUDGET_MS}. Same seam the local
+   *  rung carries, so neither rung's budget can be exercised only in theory. */
+  messageBudgetMs?: number;
 }
 
 export async function boxMachine(options: BoxMachineOptions): Promise<SessionMachine> {
@@ -318,7 +321,8 @@ export async function boxMachine(options: BoxMachineOptions): Promise<SessionMac
       // Addressable from here until the poll loop lets go: a steer names the
       // MESSAGE, and only the one being answered can take it.
       inFlight = messageId;
-      const deadline = Date.now() + MESSAGE_BUDGET_MS;
+      const budgetMs = options.messageBudgetMs ?? MESSAGE_BUDGET_MS;
+      const deadline = Date.now() + budgetMs;
       let cursor = 0;
 
       // Interrupt the TURN, not the conversation — and do it the moment Stop is
@@ -343,7 +347,14 @@ export async function boxMachine(options: BoxMachineOptions): Promise<SessionMac
           if (stopped) return;
           if (Date.now() > deadline) {
             await request(`/session/${messageId}/interrupt`, {}).catch(() => undefined);
-            throw new VendoError("sandbox-unavailable", "the box message outran its budget");
+            // NOT `sandbox-unavailable`: that code is this file's answer for a
+            // machine that refused the handshake or a control port that stopped
+            // answering, and a turn which merely ran long shares neither cause.
+            // Sending an operator to inspect a healthy box is a bug of its own.
+            throw new VendoError(
+              "unavailable",
+              `the turn outran its ${budgetMs}ms message budget`,
+            );
           }
           const polled = await request(`/session/${messageId}/poll`, { cursor, waitMs: POLL_WAIT_MS });
           for (const event of Array.isArray(polled["events"]) ? polled["events"] : []) {

--- a/packages/harnesses/src/claude-code/index.ts
+++ b/packages/harnesses/src/claude-code/index.ts
@@ -145,6 +145,30 @@ export interface ClaudeCodeDeps
 }
 
 /**
+ * Every env var the Agent SDK reads a MODEL ID from — the default, the small/fast
+ * step, subagent spawns, and the four family aliases.
+ *
+ * Taken from the SDK's own model-env array (`_Ne` in `sdk.mjs`,
+ * `@anthropic-ai/claude-agent-sdk@0.3.214`) rather than guessed. The rest of that
+ * array is display metadata (`_NAME`, `_DESCRIPTION`,
+ * `_SUPPORTED_CAPABILITIES`) and `ANTHROPIC_SMALL_FAST_MODEL_AWS_REGION`, none of
+ * which name a model to ask for.
+ *
+ * Pinning the default alone is what shipped, and it was not enough: a step on any
+ * other slot asked the Cloud gateway for the SDK's built-in `claude-opus-4-8` and
+ * the `400 Unknown model id` reached an end user's chat verbatim.
+ */
+const SDK_MODEL_SLOT_ENV = [
+  "ANTHROPIC_MODEL",
+  "ANTHROPIC_SMALL_FAST_MODEL",
+  "CLAUDE_CODE_SUBAGENT_MODEL",
+  "ANTHROPIC_DEFAULT_OPUS_MODEL",
+  "ANTHROPIC_DEFAULT_SONNET_MODEL",
+  "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+  "ANTHROPIC_DEFAULT_FABLE_MODEL",
+] as const;
+
+/**
  * The recorded v0 inference exception (design §9): a boxed harness must reach a
  * model to think, and that is the ONLY credential in the machine.
  *
@@ -187,11 +211,12 @@ export function inferenceEnv(): Record<string, string> {
     const base = (set("VENDO_CLOUD_URL") ?? "https://console.vendo.run").replace(/\/+$/, "");
     key = cloudKey;
     url = base.endsWith("/api/v1") ? base : `${base}/api/v1`;
-    // The gateway serves the vendo model family as literal ids, so the DEFAULT
-    // model is pinned to the family name — the SDK's own default is a raw
-    // claude-* id the gateway would grace-remap. Only the default: an explicit
-    // `options.model` rides the session-open payload, which beats ANTHROPIC_MODEL.
-    env["ANTHROPIC_MODEL"] = "vendo";
+    // The gateway serves the vendo model family as literal ids, so EVERY slot is
+    // pinned to the family name — each one the SDK leaves unset falls back to a
+    // raw claude-* id, which this gateway answers `400 Unknown model id`. Env
+    // only: an explicit `options.model` rides the session-open payload, which
+    // beats ANTHROPIC_MODEL.
+    for (const slot of SDK_MODEL_SLOT_ENV) env[slot] = "vendo";
   }
   if (key === undefined || url === undefined) return env;
   env["ANTHROPIC_API_KEY"] = key;

--- a/packages/harnesses/src/claude-code/local.ts
+++ b/packages/harnesses/src/claude-code/local.ts
@@ -390,7 +390,8 @@ export async function localMachine(options: LocalMachineOptions): Promise<Sessio
       const running = held.session!;
       try {
         const sending = running.send(message.prompt);
-        if (!await withinBudget(sending, options.messageBudgetMs ?? MESSAGE_BUDGET_MS)) {
+        const budgetMs = options.messageBudgetMs ?? MESSAGE_BUDGET_MS;
+        if (!await withinBudget(sending, budgetMs)) {
           // A turn that outran its budget is one nobody can reason about any
           // more — and it is not just this turn at stake. `ClaudeSession` answers
           // pushed messages in order, so a `send()` left pending holds every
@@ -407,9 +408,11 @@ export async function localMachine(options: LocalMachineOptions): Promise<Sessio
           // waiting on the loop we just declared stuck is how one hang becomes
           // two.
           void running.end().catch(() => undefined);
+          // Same honesty the box rung owes (see its twin): nothing about this
+          // machine is unavailable — the TURN ran out of budget.
           throw new VendoError(
-            "sandbox-unavailable",
-            "the local session's message outran its budget",
+            "unavailable",
+            `the turn outran its ${budgetMs}ms message budget`,
           );
         }
       } finally {

--- a/packages/harnesses/tests/claude-code/budget-error.test.ts
+++ b/packages/harnesses/tests/claude-code/budget-error.test.ts
@@ -1,0 +1,114 @@
+/**
+ * A turn that outran its message budget is not a broken sandbox.
+ *
+ * Both rungs used to answer `sandbox-unavailable` — the same code the box throws
+ * when the machine refuses the session handshake (`box.ts`) or when its control
+ * port answers non-200. So a turn that merely ran long (observed live: an agent
+ * retry-loop burning 7.7–9.0 minutes) sent an operator to check a machine that
+ * was healthy the whole time, while the real cause — the budget — was only
+ * visible in the message text.
+ *
+ * The budget is one of `MESSAGE_BUDGET_MS`'s two rungs, and its own doc says both
+ * rungs owe the caller the SAME answer, so both are covered here.
+ */
+import { VendoError } from "@vendoai/core";
+import { afterEach, describe, expect, test } from "vitest";
+import { boxMachine, type SandboxAdapterLike } from "../../src/claude-code/box.js";
+import { disposeLocalSessions, localMachine } from "../../src/claude-code/local.js";
+
+/** Well under the test timeout: the budget is the hang-detector here, not a
+ *  second speed limit (see the testing note in CLAUDE.md). */
+const BUDGET_MS = 300;
+
+const encoder = new TextEncoder();
+
+/**
+ * A box that is perfectly HEALTHY and simply never finishes the message: it
+ * greets, accepts the message, and then answers every poll "nothing yet". That is
+ * the shape the budget exists for, and the shape whose error used to blame it.
+ */
+function neverFinishingBox(): SandboxAdapterLike {
+  const answer = (body: unknown) => ({
+    status: 200,
+    headers: {},
+    body: encoder.encode(JSON.stringify(body)),
+  });
+  const machine = {
+    id: "box_budget",
+    request: async (req: { path: string }) => {
+      if (req.path === "/session/message") return answer({ messageId: "msg_1" });
+      if (req.path.endsWith("/poll")) return answer({ events: [], done: false, cursor: 0 });
+      // /session/hello and /session/<id>/interrupt
+      return answer({ ok: true });
+    },
+    files: {
+      read: async () => new Uint8Array(),
+      write: async () => undefined,
+      list: async () => [],
+    },
+    url: async () => "https://box_budget.fake-provider.test",
+    destroy: async () => undefined,
+  };
+  return {
+    create: async () => machine as never,
+    destroy: async () => undefined,
+  };
+}
+
+/** A live session whose turn never produces its `result` — the local twin of the
+ *  box above. Nothing here is broken; the answer simply never comes. */
+const neverSettlingSession = () => ({
+  send: () => new Promise<void>(() => { /* never settles */ }),
+  steer: () => false,
+  interrupt: async () => undefined,
+  end: async () => undefined,
+});
+
+/** What a rejected `send()` threw. `send()` resolves to void, so the catch's
+ *  union needs narrowing before the code and message can be read. */
+const rejection = async (sending: Promise<void>): Promise<VendoError> =>
+  (await sending.catch((thrown: unknown) => thrown)) as VendoError;
+
+afterEach(async () => { await disposeLocalSessions(); });
+
+describe("a message that outruns its budget names the BUDGET, not the sandbox", () => {
+  test("BOX rung: the error is not sandbox-unavailable", async () => {
+    const machine = await boxMachine({
+      sandbox: neverFinishingBox(),
+      threadId: "thr_box_budget",
+      env: {},
+      allowedDomains: [],
+      messageBudgetMs: BUDGET_MS,
+    });
+
+    const sending = machine.send({ prompt: "reconcile everything", emit: () => undefined });
+
+    await expect(sending).rejects.toThrow(VendoError);
+    const error = await rejection(sending);
+    // The whole point: an operator triaging `sandbox-unavailable` must not find
+    // this turn in the pile.
+    expect(error.code).not.toBe("sandbox-unavailable");
+    expect(error.code).toBe("unavailable");
+    // And the message has to say which budget, or the code alone is a shrug.
+    expect(error.message).toMatch(/budget/);
+    expect(error.message).toContain(String(BUDGET_MS));
+  }, 20_000);
+
+  test("LOCAL rung: the same answer, because both rungs owe the same one", async () => {
+    const machine = await localMachine({
+      threadId: `thr_local_budget_${Math.random().toString(36).slice(2)}`,
+      env: {},
+      messageBudgetMs: BUDGET_MS,
+      openSession: () => neverSettlingSession() as never,
+    });
+
+    const sending = machine.send({ prompt: "reconcile everything", emit: () => undefined });
+
+    await expect(sending).rejects.toThrow(VendoError);
+    const error = await rejection(sending);
+    expect(error.code).not.toBe("sandbox-unavailable");
+    expect(error.code).toBe("unavailable");
+    expect(error.message).toMatch(/budget/);
+    expect(error.message).toContain(String(BUDGET_MS));
+  }, 20_000);
+});

--- a/packages/harnesses/tests/claude-code/model-slots.test.ts
+++ b/packages/harnesses/tests/claude-code/model-slots.test.ts
@@ -1,0 +1,91 @@
+/**
+ * The Cloud gateway serves the vendo family as LITERAL ids and 400s anything
+ * else, so every env var the Agent SDK can read a model id from has to name one.
+ *
+ * Pinning only `ANTHROPIC_MODEL` left every OTHER slot on the SDK's built-in
+ * `claude-*` defaults. Observed live in a cloud-sandbox proof: a step that used
+ * a different slot asked the gateway for `claude-opus-4-8`, and the gateway's
+ * `400 Unknown model id` was printed raw into the end user's chat.
+ *
+ * The slot list is the SDK's OWN, not a guess — `sdk.mjs` in
+ * `@anthropic-ai/claude-agent-sdk@0.3.214` carries a model-env array (`_Ne`)
+ * whose model-VALUE entries are exactly these seven; its siblings in that array
+ * are `_NAME` / `_DESCRIPTION` / `_SUPPORTED_CAPABILITIES` display metadata and
+ * `ANTHROPIC_SMALL_FAST_MODEL_AWS_REGION`, none of which name a model to ask for.
+ */
+import { describe, expect, test } from "vitest";
+import { inferenceEnv } from "../../src/claude-code/index.js";
+
+/** Every env var the SDK reads a MODEL ID from. */
+const MODEL_SLOTS = [
+  "ANTHROPIC_MODEL",
+  "ANTHROPIC_SMALL_FAST_MODEL",
+  "CLAUDE_CODE_SUBAGENT_MODEL",
+  "ANTHROPIC_DEFAULT_OPUS_MODEL",
+  "ANTHROPIC_DEFAULT_SONNET_MODEL",
+  "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+  "ANTHROPIC_DEFAULT_FABLE_MODEL",
+] as const;
+
+/** Pin the process env for one read — `inferenceEnv()` reads it directly. */
+const withEnv = (vars: Record<string, string | undefined>): Record<string, string> => {
+  const source = globalThis.process.env as Record<string, string | undefined>;
+  const before = Object.fromEntries(Object.keys(vars).map((key) => [key, source[key]]));
+  for (const [key, value] of Object.entries(vars)) {
+    if (value === undefined) delete source[key];
+    else source[key] = value;
+  }
+  try {
+    return inferenceEnv();
+  } finally {
+    for (const [key, value] of Object.entries(before)) {
+      if (value === undefined) delete source[key];
+      else source[key] = value;
+    }
+  }
+};
+
+const CLOUD_RUNG = {
+  ANTHROPIC_API_KEY: undefined,
+  ANTHROPIC_BASE_URL: undefined,
+  VENDO_INFERENCE_KEY: undefined,
+  VENDO_INFERENCE_URL: undefined,
+  VENDO_API_KEY: "vnd-key",
+  VENDO_CLOUD_URL: undefined,
+};
+
+describe("the box's model slots — every one the SDK reads, not just the default", () => {
+  test("the Cloud rung pins EVERY slot to the gateway's family id", () => {
+    const env = withEnv(CLOUD_RUNG);
+    // Not `toContain`-style: a slot left out is a slot that falls back to a
+    // `claude-*` id this gateway answers with 400.
+    for (const slot of MODEL_SLOTS) expect(env[slot]).toBe("vendo");
+  });
+
+  test("a host that named its OWN endpoint gets no slot pinned at all", () => {
+    // The explicit pair is the host choosing where inference goes, and their
+    // endpoint serves their own ids — pinning `vendo` into it would break a
+    // deployment that is not on the Cloud gateway. The same reasoning the
+    // existing `ANTHROPIC_MODEL` pin already follows.
+    const env = withEnv({
+      ANTHROPIC_API_KEY: undefined,
+      ANTHROPIC_BASE_URL: undefined,
+      VENDO_INFERENCE_KEY: "gw-key",
+      VENDO_INFERENCE_URL: "https://gateway.example/v1",
+      VENDO_API_KEY: "vnd-key",
+    });
+    for (const slot of MODEL_SLOTS) expect(env[slot]).toBeUndefined();
+  });
+
+  test("no inference credential at all pins nothing — there is no gateway to name", () => {
+    const env = withEnv({
+      ANTHROPIC_API_KEY: undefined,
+      ANTHROPIC_BASE_URL: undefined,
+      VENDO_INFERENCE_KEY: undefined,
+      VENDO_INFERENCE_URL: undefined,
+      VENDO_API_KEY: undefined,
+      VENDO_CLOUD_URL: undefined,
+    });
+    for (const slot of MODEL_SLOTS) expect(env[slot]).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

Two harness-side bugs a live cloud-sandbox proof turned up.

### A — every model slot the SDK reads is now pinned, not just the default

`inferenceEnv()` pinned `ANTHROPIC_MODEL: "vendo"` and nothing else, so any step of
the sandboxed Claude Code that reads a *different* slot fell back to the SDK's
built-in `claude-*` id. The Cloud gateway serves the vendo family as literal ids
only, so it answered `400 Unknown model id` for `claude-opus-4-8` — printed raw
into an end user's chat.

The slot list is the SDK's own, not a guess. `@anthropic-ai/claude-agent-sdk@0.3.214`
carries a model-env array (`_Ne` in `sdk.mjs`) whose model-**value** entries are
exactly seven:

| slot env var | what it controls |
| --- | --- |
| `ANTHROPIC_MODEL` | the default model (already pinned) |
| `ANTHROPIC_SMALL_FAST_MODEL` | the small/fast step |
| `CLAUDE_CODE_SUBAGENT_MODEL` | subagent spawns |
| `ANTHROPIC_DEFAULT_OPUS_MODEL` | the `opus` alias — the one observed failing |
| `ANTHROPIC_DEFAULT_SONNET_MODEL` | the `sonnet` alias |
| `ANTHROPIC_DEFAULT_HAIKU_MODEL` | the `haiku` alias |
| `ANTHROPIC_DEFAULT_FABLE_MODEL` | the `fable` alias |

The array's other entries are display metadata (`_NAME`, `_DESCRIPTION`,
`_SUPPORTED_CAPABILITIES`) and `ANTHROPIC_SMALL_FAST_MODEL_AWS_REGION`, none of
which name a model to ask for, so none are pinned.

Two scoping decisions, both matching how the existing `ANTHROPIC_MODEL` pin
already behaves:

- **Cloud rung only.** A host that named its own endpoint (the explicit
  `VENDO_INFERENCE_URL`+`KEY` pair) gets nothing pinned — their gateway serves
  their own ids, and `"vendo"` would break them. `claude-code.test.ts:519` already
  pinned that rule for the default; it now holds for every slot.
- **Both legs, one change.** `inferenceEnv()` is computed once
  (`index.ts:580`) and handed to `localMachine` (`:587`) and `boxMachine` (`:612`),
  so the box and the local subprocess are covered by the same edit.

### B — a turn that outran its budget no longer blames the sandbox

`MESSAGE_BUDGET_MS` exhaustion threw `sandbox-unavailable` — the same code
`box.ts` throws when a machine refuses the session handshake or its control port
stops answering. So a turn that merely ran long (observed: an agent retry-loop
burning 7.7–9.0 min) sent an operator to inspect a machine that was healthy the
whole time. It now throws `unavailable` with a message naming the budget.

Fixed on **both** rungs. `MESSAGE_BUDGET_MS`'s own doc says both rungs owe the
caller the same answer, and `local.ts` had the identical wrong code, so the box
alone would have left the drift the constant exists to prevent.

`unavailable` rather than a new `VendoErrorCode`: it is documented as explicitly
distinct from `sandbox-unavailable` ("names one specific capability" vs.
"something downstream broke"), wire-maps to 503, and needs no change to the three
exhaustive `Record<VendoErrorCode, number>` status maps. This error is logged with
its code under `harnesses.claude-code-turn-failed` (`index.ts:748`) rather than
returned as a wire envelope, so the code+message in that log is exactly what the
operator triages.

## Changes

- `packages/harnesses/src/claude-code/index.ts:162-184` — `SDK_MODEL_SLOT_ENV`, the
  SDK's seven model-value slots, cited to `sdk.mjs`.
- `packages/harnesses/src/claude-code/index.ts:211-219` — pin every slot on the
  Cloud rung.
- `packages/harnesses/src/claude-code/box.ts:347-357` — budget exhaustion throws
  `unavailable`, naming the budget.
- `packages/harnesses/src/claude-code/box.ts:166-169,324-325` — `messageBudgetMs`
  test seam, mirroring the `idleTtlMs` seam already on that interface and the
  `messageBudgetMs` seam already on the local rung, so the box budget is
  exercisable instead of theoretical.
- `packages/harnesses/src/claude-code/local.ts:393,408-415` — the same honest code
  on the local rung.

## Verification

- `tests/claude-code/model-slots.test.ts` — 3 tests. RED first:
  `expected undefined to be 'vendo'`. Also pins the two non-regressions (a
  host-named endpoint and a no-credential deployment get nothing pinned), which
  passed before and after.
- `tests/claude-code/budget-error.test.ts` — 2 tests, one per rung, driven through
  a healthy-but-never-finishing box and a never-settling local session. RED first
  on both: `expected 'sandbox-unavailable' not to be 'sandbox-unavailable'`.
- The pre-existing `local-steer-budget.test.ts` (asserts `/budget/`) stays green.
- `packages/harnesses` full package suite: **583 passed, 0 failed**.

- [x] `pnpm build && pnpm typecheck && pnpm lint` green; full suite is CI's job
- [ ] Screenshots attached (if UI-affecting) — not UI-affecting


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins all SDK model-slot env vars to the `vendo` family on the Cloud rung and returns an honest budget error when a turn exceeds `MESSAGE_BUDGET_MS`. This prevents Cloud 400s from SDK fallback model ids and stops mislabeling budget overruns as sandbox failures.

- Pins all SDK model slots: `ANTHROPIC_MODEL`, `ANTHROPIC_SMALL_FAST_MODEL`, `CLAUDE_CODE_SUBAGENT_MODEL`, and `ANTHROPIC_DEFAULT_{OPUS,SONNET,HAIKU,FABLE}_MODEL`. Cloud rung only; hosts using `VENDO_INFERENCE_URL`+`VENDO_INFERENCE_KEY` or with no creds get no pinning. `options.model` still overrides env. The same `inferenceEnv()` feeds both `localMachine` and `boxMachine`.
- A turn that exceeds its message budget now throws `unavailable` with the budget value instead of `sandbox-unavailable`, on both rungs. Adds a `messageBudgetMs` test seam to `boxMachine`. New tests: `model-slots.test.ts`, `budget-error.test.ts`.

**Migration**
- If you treat budget exhaustion as `sandbox-unavailable`, update handlers and alerts to expect `unavailable` for this case.

<sup>Written for commit 0b58cdabf2b921f5390dac4a951d4ce6ed201390. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1539?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

