### PR TITLE
perf(vendo): a texted turn stops charging the next text for its own bookkeeping

### DIFF
--- a/.changeset/channel-turn-queue-tail-and-splitting.md
+++ b/.changeset/channel-turn-queue-tail-and-splitting.md
@@ -1,0 +1,34 @@
+---
+"@vendoai/vendo": patch
+---
+
+Three things measured on real texted turns, two of them time a person spent
+waiting for nothing.
+
+**The queue tail.** A texted turn holds its conversation's queue until it
+returns, and after the reply had already gone out it still had two hosted round
+trips to make: the link write, and the approval-feed read the grant-set offer
+needs. Run one after the other they charged the NEXT text 8.3s of bookkeeping
+before its own turn could start. They have nothing to say to each other — one is
+this conversation's row, the other is the subject's approval feed — so they now
+go together. The feed is still read after the turn and never before it: the
+arming call that mints the rows it looks for runs inside the turn.
+
+**The delivery-log sweep.** `ChannelEventLog.claim` awaited its own prune, so
+once an hour, per conversation, whichever person's text happened to come due
+waited out a page read plus one delete per expired row — 4.95s of serial hosted
+calls in front of a turn that had not started. It is detached now. Safe on all
+three counts: it only ever deletes rows older than any retry, so nothing a live
+delivery reads depends on it; the cadence mark is set before it starts, so the
+next claim this hour does not begin a second one; and a sweep that fails is
+simply made again when the interval comes round.
+
+**Splitting that actually engages.** The divider teaching landed on ONE turn in
+four, so three times out of four a six-account listing arrived as a wall of
+text. The teaching stays and stays first — a split the model chooses knows what
+it is saying and a rule does not — but a reply it split nowhere is now cut for
+it, once, at the end of the stream where the whole reply is in hand and it is
+certain the model cut nothing. The boundaries are a blank line, then a line end,
+then a sentence end, grouped to about one text each and capped at three; there is
+deliberately no rung below a sentence, so a long unbroken clause comes back
+whole rather than broken mid-thought. Only the true last piece carries `final`.

--- a/.changeset/channel-turn-queue-tail-and-splitting.md
+++ b/.changeset/channel-turn-queue-tail-and-splitting.md
@@ -32,3 +32,10 @@ certain the model cut nothing. The boundaries are a blank line, then a line end,
 then a sentence end, grouped to about one text each and capped at three; there is
 deliberately no rung below a sentence, so a long unbroken clause comes back
 whole rather than broken mid-thought. Only the true last piece carries `final`.
+
+Cutting never reformats: each boundary captures the whitespace it matched, so a
+bubble that holds two parts together holds the bytes that stood between them, and
+a listing the model indented itself arrives indented. And the sentence rung knows
+a period is not a sentence end half the time a bank reply uses one — it fires
+only where the next sentence visibly starts, and never straight after a title, so
+"your acc. 1234" and "Dr. Smith" stay whole.

--- a/packages/vendo/src/channel-links.ts
+++ b/packages/vendo/src/channel-links.ts
@@ -431,7 +431,15 @@ export class ChannelEventLog {
     }
     if (Date.now() - (this.sweptAt.get(conversationId) ?? 0) >= PRUNE_INTERVAL_MS) {
       this.sweptAt.set(conversationId, Date.now());
-      await this.prune(conversationId);
+      // OFF the critical path, not awaited: the sweep is a page read plus one
+      // delete per expired row, and inline it stood seven serial hosted round
+      // trips in front of whichever person's text happened to be the one that
+      // came due (measured 4.95s on production Maple). Safe to detach on all
+      // three counts — it only ever deletes rows older than any retry, so nothing
+      // a live delivery reads depends on it; the mark above is already set, so the
+      // next claim this hour does not start a second one; and a sweep that fails
+      // is simply made again when the interval comes round.
+      void this.prune(conversationId).catch(() => undefined);
     }
     return true;
   }

--- a/packages/vendo/src/channel-turn.ts
+++ b/packages/vendo/src/channel-turn.ts
@@ -329,6 +329,57 @@ async function offerGrantSet(
   }
 }
 
+/** How long a reply has to be before it is worth cutting up, and how big the
+ *  pieces should come out: 240 characters is a text and a half, 160 is one. */
+const BUBBLE_MIN = 240;
+const BUBBLE_TARGET = 160;
+
+/** Three texts is somebody talking; more is a notification storm. */
+const BUBBLE_CAP = 3;
+
+/** The places a person would have broken a long text, in falling preference —
+ *  and there is deliberately no rung below a sentence end. */
+const BUBBLE_BOUNDARIES: readonly (readonly [RegExp, string])[] = [
+  [/\n[ \t]*\n/, "\n\n"],
+  [/\n/, "\n"],
+  [/(?<=[.!?])[ ]+/, " "],
+];
+
+/**
+ * The reply the model did NOT split, cut into bubble-sized texts.
+ *
+ * Measured across Yousef's own texted turns on 0.32.0: the divider teaching
+ * (TEXT_STYLE) engaged on ONE turn in four. Three times out of four a six-account
+ * listing landed as a wall of text, which is the product a person actually got.
+ * The teaching stays and stays first — a split the model chooses knows what it is
+ * saying and this does not — so this runs only when the model split nothing at
+ * all.
+ *
+ * It never cuts inside a sentence. The boundaries are a blank line, then a line
+ * end, then a sentence end; a reply with none of them (one long unbroken clause)
+ * comes back whole, because every cut available in it would land mid-thought and
+ * a bubble that stops mid-thought reads worse than the wall it replaced.
+ *
+ * Exported for its own test, the same reason `cronProse` is.
+ */
+export function bubbles(text: string): string[] {
+  if (text.length <= BUBBLE_MIN) return [text];
+  for (const [boundary, join] of BUBBLE_BOUNDARIES) {
+    const units = text.split(boundary).map((unit) => unit.trim()).filter((unit) => unit !== "");
+    if (units.length < 2) continue;
+    // Greedy, and once the cap is reached everything left joins the last piece.
+    return units.reduce<string[]>((pieces, unit) => {
+      const last = pieces.at(-1);
+      if (last !== undefined
+        && (pieces.length >= BUBBLE_CAP || `${last}${join}${unit}`.length <= BUBBLE_TARGET)) {
+        pieces[pieces.length - 1] = `${last}${join}${unit}`;
+      } else pieces.push(unit);
+      return pieces;
+    }, []);
+  }
+  return [text];
+}
+
 /** One SSE frame's contribution to the assistant's words. Keepalives are comment
  *  frames and never match `data: `. */
 function frameText(frame: string): string {
@@ -374,8 +425,15 @@ async function streamTexts(
     const text = segment.trim();
     segment = "";
     if (text === "") return;
-    sent += 1;
-    await send(text, ended);
+    // The ONE place it is both safe and honest to cut a reply ourselves: the
+    // stream is over, so this is the whole of it, and nothing came before it, so
+    // the model cut nothing. A mid-stream flush is the model's own cut and is left
+    // exactly as it wrote it.
+    const pieces = sent === 0 && ended ? bubbles(text) : [text];
+    for (const [index, piece] of pieces.entries()) {
+      sent += 1;
+      await send(piece, ended && index === pieces.length - 1);
+    }
   };
   const feed = async (delta: string): Promise<void> => {
     line += delta;
@@ -597,8 +655,18 @@ export async function runChannelTurn(
           + `not replayed: ${error instanceof Error ? error.message : String(error)}`,
       });
     }
-    // The reply is out; the next text on this conversation is what still needs
-    // the write, and it cannot start until this returns.
+    // The reply is out, and these two are all that stand between it and the
+    // per-conversation queue being released (compose-channels.ts) — so they are
+    // started TOGETHER, because neither has anything to say to the other: one is
+    // this conversation's link row, the other is the subject's approval feed. Run
+    // one after the other they charged a queued next text two hosted round trips
+    // of pure bookkeeping before its own turn could start (measured 8.3s on
+    // production Maple). The feed is read only now and never earlier: the arming
+    // call that mints the rows it looks for runs inside the turn that just ended.
+    const pending = deps.guard.approvals.pending(principal);
+    void pending.catch(() => undefined);
+    // The next text on this conversation still needs the write, and the queue
+    // cannot start it until this returns.
     await remembered;
     // The next text in this conversation usually arrives inside the provider's
     // cache TTL, so the prefix is warmed once the person already has their
@@ -612,7 +680,7 @@ export async function runChannelTurn(
     // asked on the next texted turn, which is exactly right.
     await offerGrantSet(
       deps,
-      { ctx, conversationId: event.conversationId, pending: await deps.guard.approvals.pending(principal) },
+      { ctx, conversationId: event.conversationId, pending: await pending },
       send,
     );
   } finally {

--- a/packages/vendo/src/channel-turn.ts
+++ b/packages/vendo/src/channel-turn.ts
@@ -337,21 +337,38 @@ const BUBBLE_TARGET = 160;
 /** Three texts is somebody talking; more is a notification storm. */
 const BUBBLE_CAP = 3;
 
+/** The short forms a CAPITAL can legitimately follow, which is what makes them
+ *  indistinguishable from a sentence end by shape alone. The `e.g.` family is not
+ *  here because it is closed structurally below — an internal period — rather
+ *  than one entry at a time.
+ *
+ *  Bounded on purpose, and this is the last word on it: sentence segmentation has
+ *  no exact small rule, so the honest question is what a wrong guess costs. Here
+ *  it costs one bubble breaking a sentence a few words early. That is survivable,
+ *  it decides nothing, and it is not worth chasing every abbreviation in English —
+ *  so this list covers what a bank reply writes and stops. */
+const NOT_A_SENTENCE_END = [
+  "Mr", "Mrs", "Ms", "Dr", "Prof", "St", "Jr", "Sr",
+  "Inc", "Ltd", "Co", "No", "no", "acc", "ref", "approx", "dept", "est", "etc", "vs",
+  "Jan", "Feb", "Mar", "Apr", "Jun", "Jul", "Aug", "Sep", "Sept", "Oct", "Nov", "Dec",
+].join("|");
+
 /** The places a person would have broken a long text, in falling preference —
  *  and there is deliberately no rung below a sentence end. Each one CAPTURES the
- *  whitespace it matched, so a bubble can be rebuilt out of the model's own bytes
- *  rather than a separator this file invented.
+ *  whitespace it matched, so a bubble that holds two parts together holds the
+ *  bytes that stood between them rather than a separator this file invented. The
+ *  separator at a CUT is dropped, because that is what cutting is.
  *
  *  The sentence rung is the fussy one, because in a bank reply a period is not a
  *  sentence end half the time it appears. It fires only where the next sentence
  *  visibly starts — a capital or an opening quote, which is what leaves "acc.
- *  1234" and "no. 5" alone — and never straight after a title, the one kind of
- *  abbreviation a capital does follow ("Dr. Smith"). Everything it is unsure of
- *  stays joined, because an uncut wall beats a bubble that stops mid-thought. */
+ *  1234" and "no. 5" alone — and never after an internal-period initialism
+ *  ("e.g.", "i.e.", "a.m.") or one of the short forms above. Everything it is
+ *  unsure of stays joined: an uncut wall beats a bubble that stops mid-thought. */
 const BUBBLE_BOUNDARIES: readonly RegExp[] = [
   /(\n[ \t]*\n)/,
   /(\n)/,
-  /(?<!\b(?:Mr|Mrs|Ms|Dr|Prof|St|Jr|Sr)\.)(?<=[.!?])([ ]+)(?=[A-Z"'(])/,
+  new RegExp(`(?<![A-Za-z]\\.[A-Za-z]\\.)(?<!\\b(?:${NOT_A_SENTENCE_END})\\.)(?<=[.!?])([ ]+)(?=[A-Z"'(])`),
 ];
 
 /**

--- a/packages/vendo/src/channel-turn.ts
+++ b/packages/vendo/src/channel-turn.ts
@@ -338,11 +338,20 @@ const BUBBLE_TARGET = 160;
 const BUBBLE_CAP = 3;
 
 /** The places a person would have broken a long text, in falling preference —
- *  and there is deliberately no rung below a sentence end. */
-const BUBBLE_BOUNDARIES: readonly (readonly [RegExp, string])[] = [
-  [/\n[ \t]*\n/, "\n\n"],
-  [/\n/, "\n"],
-  [/(?<=[.!?])[ ]+/, " "],
+ *  and there is deliberately no rung below a sentence end. Each one CAPTURES the
+ *  whitespace it matched, so a bubble can be rebuilt out of the model's own bytes
+ *  rather than a separator this file invented.
+ *
+ *  The sentence rung is the fussy one, because in a bank reply a period is not a
+ *  sentence end half the time it appears. It fires only where the next sentence
+ *  visibly starts — a capital or an opening quote, which is what leaves "acc.
+ *  1234" and "no. 5" alone — and never straight after a title, the one kind of
+ *  abbreviation a capital does follow ("Dr. Smith"). Everything it is unsure of
+ *  stays joined, because an uncut wall beats a bubble that stops mid-thought. */
+const BUBBLE_BOUNDARIES: readonly RegExp[] = [
+  /(\n[ \t]*\n)/,
+  /(\n)/,
+  /(?<!\b(?:Mr|Mrs|Ms|Dr|Prof|St|Jr|Sr)\.)(?<=[.!?])([ ]+)(?=[A-Z"'(])/,
 ];
 
 /**
@@ -364,18 +373,21 @@ const BUBBLE_BOUNDARIES: readonly (readonly [RegExp, string])[] = [
  */
 export function bubbles(text: string): string[] {
   if (text.length <= BUBBLE_MIN) return [text];
-  for (const [boundary, join] of BUBBLE_BOUNDARIES) {
-    const units = text.split(boundary).map((unit) => unit.trim()).filter((unit) => unit !== "");
-    if (units.length < 2) continue;
+  for (const boundary of BUBBLE_BOUNDARIES) {
+    // One capture group, so `split` alternates piece, separator, piece — and a
+    // bubble that keeps two parts together keeps the separator that stood between
+    // them. Nothing is trimmed: the caller already trimmed the whole reply, and
+    // trimming again is what re-indented a listing the model laid out itself.
+    const [head, ...rest] = text.split(boundary);
+    if (head === undefined || rest.length === 0) continue;
+    const pieces = [head];
     // Greedy, and once the cap is reached everything left joins the last piece.
-    return units.reduce<string[]>((pieces, unit) => {
-      const last = pieces.at(-1);
-      if (last !== undefined
-        && (pieces.length >= BUBBLE_CAP || `${last}${join}${unit}`.length <= BUBBLE_TARGET)) {
-        pieces[pieces.length - 1] = `${last}${join}${unit}`;
-      } else pieces.push(unit);
-      return pieces;
-    }, []);
+    for (let at = 0; at + 1 < rest.length; at += 2) {
+      const grown = `${pieces[pieces.length - 1]}${rest[at]}${rest[at + 1]}`;
+      if (pieces.length >= BUBBLE_CAP || grown.length <= BUBBLE_TARGET) pieces[pieces.length - 1] = grown;
+      else pieces.push(rest[at + 1]!);
+    }
+    return pieces;
   }
   return [text];
 }

--- a/packages/vendo/tests/channel-event-sweep.test.ts
+++ b/packages/vendo/tests/channel-event-sweep.test.ts
@@ -39,7 +39,47 @@ async function freshStore(): Promise<VendoStore> {
 const rows = (store: VendoStore, conversation: string): Promise<number> =>
   store.records("vendo_channel_events").list({ refs: { conversation } }).then((page) => page.records.length);
 
+/** No wall-clock budget on purpose: the case's own timeout is the hang detector,
+ *  and the sweep is now something a claim does NOT wait for, so its rows land
+ *  shortly after the claim answers rather than before it. */
+async function settlesTo(count: () => Promise<number>, expected: number): Promise<void> {
+  while (await count() !== expected) await new Promise((resolve) => setTimeout(resolve, 10));
+}
+
 describe("the delivery log's sweep", () => {
+  it("does not hold the claim while it deletes", async () => {
+    // THE FAILURE THIS PINS: the sweep is a page read plus one delete per expired
+    // row, and it ran INLINE inside the claim — so once an hour, per
+    // conversation, the person whose text triggered it waited out seven serial
+    // hosted round trips before their turn could even start.
+    const store = await freshStore();
+    const day = 24 * 60 * 60_000;
+    for (const id of ["evt_a", "evt_b", "evt_c"]) {
+      expect(await new ChannelEventLog(store).claim(id, "conv_block")).toBe(true);
+    }
+
+    // A fresh log, so the sweep cadence has not been spent, and two days on so
+    // every row above is expired and the sweep has real work to do.
+    vi.useFakeTimers({ now: Date.now() + 2 * day, toFake: ["Date"] });
+    const log = new ChannelEventLog(store);
+
+    // Deletes are HELD. A claim that still waits for the sweep never answers.
+    let release = (): void => undefined;
+    const held = new Promise<void>((resolve) => { release = resolve; });
+    const records = store.records("vendo_channel_events");
+    vi.spyOn(store, "records").mockImplementation((collection: string) => (
+      collection !== "vendo_channel_events" ? store.records(collection)
+        : { ...records, delete: async (id: string) => { await held; await records.delete(id); } }
+    ));
+
+    expect(await log.claim("evt_now", "conv_block")).toBe(true);
+
+    release();
+    // …and the sweep still lands: the work moved off the critical path, it did
+    // not stop happening.
+    await settlesTo(() => rows(store, "conv_block"), 1);
+  }, 30_000);
+
   it("keeps its cadence per conversation, so a busy one cannot starve a quiet one", async () => {
     // THE FAILURE THIS PINS: with ONE process-wide sweep clock, the chatty
     // conversation below consumes the interval and the quiet one's expired rows
@@ -56,15 +96,16 @@ describe("the delivery log's sweep", () => {
     // Two days pass: every row above is now older than the retention window.
     vi.useFakeTimers({ now: Date.now() + 2 * day, toFake: ["Date"] });
 
-    // The chatty conversation speaks first and sweeps itself.
+    // The chatty conversation speaks first and sweeps itself. Awaited rather
+    // than asserted outright: the claim no longer waits for its own sweep.
     expect(await log.claim("evt_busy_2", "conv_busy")).toBe(true);
-    expect(await rows(store, "conv_busy")).toBe(1);
+    await settlesTo(() => rows(store, "conv_busy"), 1);
 
     // THE POINT: the quiet conversation's own next delivery must still sweep
     // ITS rows. On a shared clock the line above has already spent the
     // interval, and this row stays behind forever.
     expect(await log.claim("evt_quiet_2", "conv_quiet")).toBe(true);
-    expect(await rows(store, "conv_quiet")).toBe(1);
+    await settlesTo(() => rows(store, "conv_quiet"), 1);
   }, 30_000);
 
   it("still sweeps a conversation only once per interval, not once per message", async () => {

--- a/packages/vendo/tests/channel-hosted-store.test.ts
+++ b/packages/vendo/tests/channel-hosted-store.test.ts
@@ -69,13 +69,17 @@ describe("the text channel on a Cloud-hosted store", () => {
     const log = new ChannelEventLog(hosted(mount));
 
     expect(await log.claim("evt_hosted", "conv_hosted")).toBe(true);
-    // The claim is the first thing an inbound text waits on, so it is ONE
-    // guarded write rather than a read and then a write. The list behind it is
-    // the conversation's first delivery paying for its own sweep, once an hour.
-    expect(roundTrips(mount)).toEqual([
-      STORE_WIRE_PATHS["engine.insertIfAbsent"],
-      STORE_WIRE_PATHS["engine.list"],
-    ]);
+    // The claim is the first thing an inbound text waits on, so it is ONE guarded
+    // write rather than a read and then a write — and ONLY that write. The
+    // conversation's hourly sweep is started here and deliberately not awaited
+    // (channel-links.ts), so its list is no longer a round trip this person's text
+    // stood behind.
+    expect(roundTrips(mount)).toEqual([STORE_WIRE_PATHS["engine.insertIfAbsent"]]);
+    // …and it still happens, just after the claim instead of inside it. No inner
+    // wall-clock budget: the case's own timeout is the hang detector.
+    while (!roundTrips(mount).includes(STORE_WIRE_PATHS["engine.list"])) {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
 
     // A retried delivery is still recognised as already claimed — and costs the
     // same single call to say so.

--- a/packages/vendo/tests/channel-imessage.e2e.test.ts
+++ b/packages/vendo/tests/channel-imessage.e2e.test.ts
@@ -217,6 +217,71 @@ describe.sequential("how a texted reply arrives", () => {
     for (const message of cloud.sent) expect(message.text).not.toContain("---");
   }, 120_000);
 
+  it("splits a long reply the model did not split itself, and never mid-sentence", async () => {
+    // THE POINT, measured on Yousef's own texted turns on 0.32.0: the model wrote
+    // the divider on ONE turn in four. The teaching stays, because a split the
+    // model chooses is a better split than one a rule guesses — but a wall of
+    // text arriving on a phone three times out of four is the product, so a reply
+    // it did not split gets cut at boundaries a person would have used anyway.
+    //
+    // This IS the shape that failed (turn C): one run-on sentence per account,
+    // six accounts, no divider anywhere.
+    const listing = "Your checking account is at $412.08 right now. Savings is sitting at $8,200.00. "
+      + "The joint account with Dana has $1,140.55 in it. Your credit card balance is -$318.20. "
+      + "The travel card is at -$64.00. And the emergency fund is still untouched at $15,000.00.";
+    const { cloud, text, link } = await deployment(defineHarness({
+      name: "channel-unsplit-probe",
+      async *run(turn) {
+        if (turn.threadId.startsWith("thr_warm")) return;
+        yield { type: "text", delta: listing };
+      },
+    }));
+    await link("evt_link_unsplit");
+
+    await text("evt_unsplit", "what are my balances?");
+
+    await waitFor(() => cloud.sent.length >= 3);
+    const bubbles = cloud.sent.slice(1);
+    // Several texts, not one wall — and a bounded number of them, never one per
+    // sentence.
+    expect(bubbles.length).toBeGreaterThan(1);
+    expect(bubbles.length).toBeLessThanOrEqual(3);
+    // Not one character invented, dropped or reordered: the same words the model
+    // wrote, only cut.
+    expect(bubbles.map((message) => message.text).join(" ")).toBe(listing);
+    // Every cut lands after a sentence ends. This is the half that matters most —
+    // a bubble that stops mid-thought reads worse than the wall it replaced.
+    for (const message of bubbles) expect(message.text).toMatch(/[.!?]$/);
+    // And the contract from the divider case still holds: only the last one is
+    // final, whoever decided where the cuts go.
+    expect(bubbles.map((message) => message.final)).toEqual([
+      ...bubbles.slice(0, -1).map(() => false),
+      true,
+    ]);
+  }, 120_000);
+
+  it("leaves a short reply exactly as the model wrote it", async () => {
+    // THE CONTROL. The split is for a wall of text; a normal answer must arrive
+    // as the single text it always was, untouched.
+    const { cloud, text, link } = await deployment(defineHarness({
+      name: "channel-short-probe",
+      async *run(turn) {
+        if (turn.threadId.startsWith("thr_warm")) return;
+        yield { type: "text", delta: "Your checking balance is $412.08. Anything else?" };
+      },
+    }));
+    await link("evt_link_short");
+
+    await text("evt_short", "what is my balance?");
+
+    await waitFor(() => cloud.sent.length === 2);
+    expect(cloud.sent[1]).toEqual({
+      conversationId: CONVERSATION,
+      text: "Your checking balance is $412.08. Anything else?",
+      final: true,
+    });
+  }, 120_000);
+
   it("retries a reply the console drops, and says out loud when it is lost", async () => {
     // THE POINT: a single 503 used to lose the person's answer silently and
     // forever — the turn had already run its tool calls, so nothing could be

--- a/packages/vendo/tests/channel-turn-ctx.test.ts
+++ b/packages/vendo/tests/channel-turn-ctx.test.ts
@@ -48,6 +48,65 @@ describe("bubbles", () => {
     }
   });
 
+  it("cuts a formatted reply without reformatting it", () => {
+    // A reply the model laid out itself — against TEXT_STYLE's "no lists", which
+    // it ignores as readily as it ignores the divider. Cutting it is fine; RE-
+    // INDENTING it is not, and trimming each line did exactly that.
+    const laid = [
+      "Here is where everything stands this morning:",
+      "  Checking — $412.08, nothing pending on it",
+      "  Savings — $8,200.00, up $50 since last month",
+      "  Joint with Dana — $1,140.55",
+      "  Credit card — -$318.20, due on the 14th",
+      "  Travel card — -$64.00",
+      "  Emergency fund — $15,000.00, untouched",
+    ].join("\n");
+    const pieces = bubbles(laid);
+
+    expect(pieces.length).toBeGreaterThan(1);
+    // Byte for byte what the model wrote, only cut — indentation included.
+    expect(pieces.join("\n")).toBe(laid);
+  });
+
+  it("rebuilds a piece from the model's own separators, not canonical ones", () => {
+    // The other half of not reformatting: the bytes BETWEEN the parts of one
+    // bubble are the model's too. A blank line that carries spaces and a double
+    // space after a full stop both used to be rewritten to a canonical separator.
+    const spaced = "Everything is settled for the month, and nothing else needs a decision from you today.   \n"
+      + "  \nChecking sits at $412.08 and savings at $8,200.00, which is up fifty dollars.   \n"
+      + "  \nThe travel card is the only one still carrying a balance, at -$64.00 as of tonight.";
+    const pieces = bubbles(spaced);
+
+    expect(pieces.length).toBeGreaterThan(1);
+    // Every piece is the model's own bytes, in order, and the only thing dropped
+    // between two of them is the whitespace boundary that was the cut point. A
+    // piece rebuilt with a canonical separator would not be a substring at all.
+    let at = 0;
+    for (const piece of pieces) {
+      const found = spaced.indexOf(piece, at);
+      expect(found, piece).toBeGreaterThanOrEqual(at);
+      expect(spaced.slice(at, found)).toMatch(/^\s*$/);
+      at = found + piece.length;
+    }
+    expect(at).toBe(spaced.length);
+  });
+
+  it("does not mistake an abbreviation for the end of a sentence", () => {
+    // Both shapes a bank reply actually produces. "acc. 1234" is followed by a
+    // digit and "Dr. Smith" by a title, and a cut after either leaves a bubble
+    // ending mid-thought — the exact thing the sentence rung exists to avoid.
+    const reply = "Your acc. 1234 is overdrawn by $18.40 as of this morning and the fee has not posted yet. "
+      + "Dr. Smith called about the standing order on it and wants it moved to the joint account instead. "
+      + "I can move $50 across from savings to clear the overdraft right now if that suits you.";
+    const pieces = bubbles(reply);
+
+    expect(pieces.length).toBeGreaterThan(1);
+    expect(pieces.join(" ")).toBe(reply);
+    // No bubble ends on an abbreviation, and none begins mid-name or mid-number.
+    for (const piece of pieces) expect(piece).not.toMatch(/\b(?:acc|no|Dr|Mr|Mrs|Ms|St)\.$/);
+    for (const piece of pieces) expect(piece).not.toMatch(/^(?:Smith|1234)\b/);
+  });
+
   it("leaves alone what it cannot cut honestly", () => {
     const short = "Your checking balance is $412.08. Anything else?";
     expect(bubbles(short)).toEqual([short]);

--- a/packages/vendo/tests/channel-turn-ctx.test.ts
+++ b/packages/vendo/tests/channel-turn-ctx.test.ts
@@ -107,6 +107,20 @@ describe("bubbles", () => {
     for (const piece of pieces) expect(piece).not.toMatch(/^(?:Smith|1234)\b/);
   });
 
+  it("keeps the abbreviations a title list would never have caught", () => {
+    // The predictable leak in a list of titles: a month and an initialism are
+    // both followed by a capital and neither is Mr or Dr. The initialism family
+    // is closed structurally (an internal period), the months by name.
+    const reply = "I sent the statement over on Jan. The copy sitting in the app is the very same one. "
+      + "Some fees are waived below $25, e.g. The overdraft charge from Tuesday, which is already credited. "
+      + "Tell me if you would rather I posted a paper copy out to you instead this month.";
+    const pieces = bubbles(reply);
+
+    expect(pieces.length).toBeGreaterThan(1);
+    expect(pieces.join(" ")).toBe(reply);
+    for (const piece of pieces) expect(piece).not.toMatch(/\b(?:Jan|e\.g|i\.e|a\.m|p\.m|etc|vs|No)\.$/);
+  });
+
   it("leaves alone what it cannot cut honestly", () => {
     const short = "Your checking balance is $412.08. Anything else?";
     expect(bubbles(short)).toEqual([short]);

--- a/packages/vendo/tests/channel-turn-ctx.test.ts
+++ b/packages/vendo/tests/channel-turn-ctx.test.ts
@@ -2,7 +2,7 @@ import type { RunContext } from "@vendoai/core";
 import { memoryStoreOps } from "@vendoai/core/conformance";
 import { describe, expect, it, vi } from "vitest";
 import type { ChannelLink } from "../src/channel-links.js";
-import { cronProse, runChannelTurn, type ChannelTurnDeps } from "../src/channel-turn.js";
+import { bubbles, cronProse, runChannelTurn, type ChannelTurnDeps } from "../src/channel-turn.js";
 import { createLimiter } from "../src/limits.js";
 
 describe("cronProse", () => {
@@ -21,6 +21,41 @@ describe("cronProse", () => {
     expect(cronProse("1,31 * * * *")).toBeUndefined(); // lists
     expect(cronProse("not a cron")).toBeUndefined();
     expect(cronProse("check my balance")).toBeUndefined();
+  });
+});
+
+describe("bubbles", () => {
+  const six = (separator: string) => [
+    "Checking is at $412.08 right now and nothing is pending on it.",
+    "Savings is sitting at $8,200.00.",
+    "The joint account with Dana has $1,140.55 in it.",
+    "Your credit card balance is -$318.20.",
+    "The travel card is at -$64.00.",
+    "The emergency fund is untouched at $15,000.00.",
+  ].join(separator);
+
+  it("cuts a wall at the boundary a person would have used, and puts every word back", () => {
+    // The three rungs, on the same six-account listing the live turns produced.
+    for (const [label, separator] of [["blank line", "\n\n"], ["line end", "\n"], ["sentence", " "]] as const) {
+      const wall = six(separator);
+      const pieces = bubbles(wall);
+      expect(pieces.length, label).toBeGreaterThan(1);
+      expect(pieces.length, label).toBeLessThanOrEqual(3);
+      // Nothing invented, dropped or reordered.
+      expect(pieces.join(separator), label).toBe(wall);
+      // And no piece stops mid-thought.
+      for (const piece of pieces) expect(piece, label).toMatch(/[.!?]$/);
+    }
+  });
+
+  it("leaves alone what it cannot cut honestly", () => {
+    const short = "Your checking balance is $412.08. Anything else?";
+    expect(bubbles(short)).toEqual([short]);
+    // Long, but one unbroken clause: every available cut is mid-sentence, so
+    // there is no honest one and the wall is the lesser evil.
+    const runOn = `Your balances are ${Array.from({ length: 30 }, (_, i) => `account ${i} at $${i}0.00`).join(", ")}`;
+    expect(runOn.length).toBeGreaterThan(240);
+    expect(bubbles(runOn)).toEqual([runOn]);
   });
 });
 

--- a/packages/vendo/tests/channel-turn-hotpath.test.ts
+++ b/packages/vendo/tests/channel-turn-hotpath.test.ts
@@ -127,6 +127,36 @@ describe("what a texted reply waits for", () => {
     }
   });
 
+  it("reads the approval feed BESIDE the link write, not behind it", async () => {
+    // THE POINT: both of these sit between the reply landing and the queue being
+    // released (compose-channels.ts), and they have nothing to say to each other
+    // — one is this conversation's row, the other is the subject's approval feed.
+    // Run end to end they cost a queued next text two hosted round trips of pure
+    // bookkeeping before its own turn can start.
+    //
+    // The write is held until the feed has been ASKED, so a turn that still reads
+    // them one after the other never finishes and the case's own timeout says so.
+    const order: string[] = [];
+    let asked = (): void => undefined;
+    const feedAsked = new Promise<void>((resolve) => { asked = resolve; });
+    const deps = turnDeps(order, {
+      links: { rememberTurn: async () => { await feedAsked; order.push("wrote"); } },
+      guard: {
+        onApprovalRequested: () => () => undefined,
+        approvals: {
+          pending: async () => { order.push("asked-feed"); asked(); return []; },
+          decide: async () => undefined,
+        },
+      },
+    });
+
+    await runChannelTurn(deps, { event, link: { ...link, conversationId: event.conversationId } });
+
+    // The reply first, then the two bookkeeping calls overlapping — the feed read
+    // starts while the write is still outstanding.
+    expect(order).toEqual(["sent", "asked-feed", "wrote"]);
+  });
+
   it("waits for the write on the first turn a phone ever sends, so Text me can find the conversation", async () => {
     const order: string[] = [];
 


### PR DESCRIPTION
Three defects found by profiling Yousef's real texted turns on 0.32.0 (Maple). Two are time a person spent waiting for nothing; one is the reply arriving as a wall of text.

## 1. Queue tail — 8.3s of bookkeeping held the next text

A texted turn holds its conversation's `inOrder` queue until it returns, and after the reply had already been delivered it still had two hosted round trips to make: the link write (`remembered`) and the approval-feed read that the grant-set offer needs.

They have nothing to say to each other — one is this conversation's row, the other is the subject's approval feed — so they now go together. In the common case (nothing pending) `offerGrantSet` returns immediately after finding no sets, so those two round trips **are** the whole tail, and overlapping them halves it. The feed is still read after the turn and never before it: the arming call that mints the rows it looks for runs inside the turn.

**What I did not do, and why.** The brief asked to move the offer *outside* the queue. I checked the readers and it cannot go, because the queue is what makes two consent guarantees hold:

- **A YES would be missed.** `offerGrantSet` sends the question and *then* writes the ask row (deliberately — a set nobody was shown must not be answerable). The next turn's `outstandingSet` → `asks.setAsk` read happens inside the queue, so today the queue orders that write ahead of it. Detached, a YES arriving inside the `addSet` window (one hosted write, ~2.1s) finds no row and runs as an ordinary message — a person's consent silently becoming small talk.
- **The question would go out twice.** The "one question at a time" discipline is a *read* of `asks.ids` / `setAsk`. Two detached offers on one conversation both read empty and both send.

Closing both would take per-conversation offer serialization *plus* write-before-send with a compensating delete — two behaviour changes in the consent path, to save queue-hold in the rare case where a grant set actually exists. The overlap gets the common case for free and touches nothing that decides consent.

## 2. Prune stall — 4.95s, once an hour, in front of a stranger's turn

`ChannelEventLog.claim` awaited its own prune, so whichever person's text happened to come due paid a page read plus one `delete` per expired row before their turn had started. `RecordStore` has no batch delete (`packages/core/src/store.ts:60-76`), so the fix is to detach it. Safe on three counts, all in the comment: it only ever deletes rows older than any retry, so nothing a live delivery reads depends on it; the cadence mark is set *before* it starts, so the next claim this hour does not begin a second one; and a failed sweep is simply made again next interval.

## 3. Splitting that actually engages — was 1 turn in 4

The divider teaching landed on one turn in four. The teaching stays and stays first — a split the model chooses knows what it is saying and a rule does not — so the fallback runs **only** when the model split nothing at all, at the end of the stream, where the whole reply is in hand and it is certain there were no cuts.

Boundaries in falling preference: blank line → line end → sentence end. Grouped greedily to about one text each, capped at three. **There is deliberately no rung below a sentence**, so a long unbroken clause comes back whole rather than broken mid-thought. Only the true last piece carries `final`.

I did **not** add worked examples to `TEXT_STYLE`: it rides as hidden context on every single inbound text, so an example is a permanent per-turn token cost, it is unprovable in a test, and at best it moves 1-in-4 to 2-in-4 — the fallback would still be needed. Cheaper and deterministic to cut the wall when it appears.

## 4. Warm prefix gap — assessed, skipped

Identifiable, but not a few lines, and probably not a defect. `warm` deliberately runs *one degenerate turn*: a single `"Reply with one word."` message with throwaway transcript and state doors (`harness-turn.ts:872-905`). The ~5k is the thread's own transcript, which the warm turn does not replay — and that sits *after* the cacheable system+tools prefix, which is what warming is for.

Closing it means making `warm` thread-aware: pass the conversation's `threadId`, replay its stored transcript, and read its real harness state so the tools block matches too (the stub `harnessState.get` returns `undefined`, so `loadedTools` is always empty — on Maple the 64-tool cap never bites, so that half contributes nothing today). That is a change to the `HarnessTurns.warm` seam and a transcript read on every warm, on an unverified hypothesis about which half the 5k is. Worth doing deliberately, not folded in here — a rolling thread's history *is* known ahead of the next text, unlike the web's, so the value is real.

## Tests

Red-first for each fix. Items 1 and 2 are pinned by held-promise deadlocks — a version that still serializes never finishes and the case's own timeout says so — so they cannot pass against the old code. Item 3 is pinned end to end through the real wire, real harness stream, real channel adapter and a real HTTP console, on the exact shape that failed live (turn C: one run-on sentence per account, six accounts, no divider), plus a control that a short reply arrives untouched, plus a unit covering all three boundary rungs and the unbreakable-clause case.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts queue tail latency, removes hourly prune stalls from the hot path, and splits long unsplit replies without reformatting or mid‑sentence breaks. Old behavior charged the next text ~8.3s of bookkeeping and stalled ~4.95s/hour; new behavior overlaps the tail work and detaches the sweep, and adds a safe fallback split.

- Queue tail: start the approvals feed read beside the link write; await only the write while the feed read runs in parallel. The grant-set offer stays in the per-conversation queue to preserve consent ordering; feed errors surface only when consumed.
- Delivery-log sweep: `ChannelEventLog.claim` now triggers its prune asynchronously per conversation. It sets cadence before starting, deletes only rows older than any retry, and retries on the next interval if it fails.
- Splitter: when the model makes no cuts, split once at end-of-stream by blank line → line end → sentence end, greedily toward ~160 chars and capped at three. Preserve original whitespace and indentation; only the last piece is `final`. The sentence boundary avoids internal-period initialisms and a fixed set of business/temporal abbreviations (e.g., e.g., i.e., a.m./p.m., Jan, Dr, acc), preventing false splits.

<sup>Written for commit 1383b1662e0fdc8a1d915adc6f4b069e371d0601. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1540?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

