### PR TITLE
fix(store): the store trace reports the door, not the backoff

### DIFF
--- a/.changeset/store-trace-tells-the-truth.md
+++ b/.changeset/store-trace-tells-the-truth.md
@@ -1,0 +1,30 @@
+---
+"@vendoai/store": patch
+---
+
+`VENDO_STORE_TRACE`'s line stops lying about how slow the store is. It printed
+one number, `ms=`, and folded three things that are not the door's latency into
+it: the retry's own backoff (250ms to 10s, whatever `Retry-After` asked for),
+event-loop queueing on a busy container, and the instrument's OWN second full
+read of the response body — a `clone().arrayBuffer()` awaited inside the timed
+span, which also charged every traced call for being measured. A 40ms door with
+one retry behind it reported `ms=1347`; in the field a healthy 54ms read as 2.1s
+and sent an afternoon after a store that was never slow.
+
+The line now separates the clocks and says how many attempts it took:
+
+```
+vendo-store-trace op=engine.get path=/engine/get net=44 total=1046 retried=1 bytes=? outcome=ok
+```
+
+`net=` is time on the wire — request start to response headers, summed over
+attempts — so it is the number to compare against the server's own. `total=` is
+what the caller waited, backoff included, and the gap between the two IS the
+wait rather than a mystery. `retried=` names the replay that opened the gap.
+
+`bytes=` is now the size the server declared in `content-length`, and `?` where
+it declared none: nothing is read to find out, so the body reaches the caller
+whole and unread and a slow transfer is no longer billed to the door twice.
+Losing the size on a chunked answer is the price of that, and the cheaper fix
+lives on the server — the console could stamp its own processing time on the
+response and make `net` decomposable — so the trade is temporary.

--- a/packages/store/src/hosted-store.ts
+++ b/packages/store/src/hosted-store.ts
@@ -338,13 +338,32 @@ type StoreWireOp = keyof typeof STORE_WIRE_PATHS;
 /** Measurement instrument, not a feature: with VENDO_STORE_TRACE set, every
  * call through the store client below — the 50 ops AND the StoreAdapter façade,
  * which rides the same client — emits one greppable stderr line naming the op,
- * its path, the round trip in milliseconds (the body read included, since that
- * is what the caller waits for), the response size in bytes and the outcome.
+ * its path, `net=` the time on the wire (request start → response headers,
+ * summed over attempts), `total=` the time the caller waited, `retried=` how
+ * many replays it took, `bytes=` the size the server declared, and the outcome.
+ *
+ * The two clocks are separate because the ONE number this line used to print
+ * folded three things into the door's own latency and so lied about it: a
+ * retry's 250ms–10s backoff, event-loop queueing on a busy container, and the
+ * instrument's own second full body read (a `clone().arrayBuffer()` inside the
+ * timed span). Field 2026-08-19: a healthy 54ms door read as 2.1s and cost an
+ * afternoon. So size now comes from `content-length` — free, and `?` where the
+ * server declared none — and the door is never charged for being measured. The
+ * server's own processing time would need a header the console does not send.
+ *
  * Read ONCE at import, like the skew latch below: a debug switch belongs to the
  * process, so the adapter itself still reads nothing at construction or on any
  * call, and unset there is no wrapper to pay for. */
 const TRACE = (globalThis as { process?: { env?: Record<string, string | undefined> } })
   .process?.env?.VENDO_STORE_TRACE !== undefined;
+
+/** The half of a traced call only the attempt loop can see: the time actually
+ * spent on the wire, and how many replays it took. `call` hands one in and
+ * reads it back afterwards, because from outside `wire` the backoff sleep is
+ * indistinguishable from a slow server — which is precisely the confusion the
+ * old single number caused. A refused attempt's small error body is read inside
+ * `send`, so it lands in `net` too. */
+type TraceMeter = { net: number; retried: number };
 
 /** The `outcome=` field of a FAILED call's trace line. Failures are the tail of
  * the latency distribution, not an afterthought: an exhausted 30s budget is the
@@ -484,8 +503,21 @@ function storeWireClient(
     }),
   });
 
-  const wire = async (op: StoreWireOp, path: string, init?: RequestInit): Promise<Response> => {
-    const attempt = (): Promise<Response> => send(path, init);
+  const wire = async (
+    op: StoreWireOp,
+    path: string,
+    init?: RequestInit,
+    meter?: TraceMeter,
+  ): Promise<Response> => {
+    const attempt = async (): Promise<Response> => {
+      if (meter === undefined) return send(path, init);
+      const started = performance.now();
+      try {
+        return await send(path, init);
+      } finally {
+        meter.net += performance.now() - started;
+      }
+    };
     try {
       // The retry sends the SAME init — same key, same body — so a mutation
       // the server already applied is deduped instead of applied twice.
@@ -493,6 +525,7 @@ function storeWireClient(
         if (!isRetryable(error)) throw error;
         const wait = (error as { retryAfterMs?: number }).retryAfterMs ?? DEFAULT_RETRY_MS;
         await new Promise((resolve) => setTimeout(resolve, wait));
+        if (meter !== undefined) meter.retried += 1;
         return attempt();
       });
     } catch (error) {
@@ -522,41 +555,28 @@ function storeWireClient(
 
   /** Untraced, `call` IS `wire` — see {@link TRACE}. */
   const call: typeof wire = !TRACE ? wire : async (op, path, init) => {
+    const meter: TraceMeter = { net: 0, retried: 0 };
     const started = performance.now();
-    const line = (bytes: number, outcome: string): void =>
+    const line = (bytes: string, outcome: string): void =>
       console.error(
-        `vendo-store-trace op=${op} path=${path} ms=${Math.round(performance.now() - started)} bytes=${bytes} outcome=${outcome}`,
+        `vendo-store-trace op=${op} path=${path} net=${Math.round(meter.net)}`
+          + ` total=${Math.round(performance.now() - started)} retried=${meter.retried}`
+          + ` bytes=${bytes} outcome=${outcome}`,
       );
-    let response: Response;
     try {
-      response = await wire(op, path, init);
+      const response = await wire(op, path, init, meter);
+      // The response goes back untouched, unread and whole: the size is the one
+      // the server DECLARED, so measuring it costs nothing and cannot fail the
+      // call it measures. A server that declared none reads `?` rather than
+      // billing the door for a body read to find out.
+      line(response.headers.get("content-length") ?? "?", "ok");
+      return response;
     } catch (error) {
       // A refusal has a body, but `wire` already consumed it to build this
-      // error — the bytes are gone and the failure is what mattered anyway.
-      line(0, traceOutcome(error));
+      // error — the size is gone and the failure is what mattered anyway.
+      line("?", traceOutcome(error));
       throw error;
     }
-    // Measure a CLONE and hand back the response `wire` returned, untouched.
-    // Rebuilding it instead would be a real behavior change on a null-body
-    // status — `new Response(body, { status: 204 })` throws — and would put the
-    // instrument in the path of every hosted call it is supposed to observe.
-    //
-    // Measuring must never FAIL the call it is measuring either. A body stream
-    // that breaks mid-read is not an error to this client: `json`'s catch reads
-    // it as `{}`, which a void mutation ignores entirely and a payload reader
-    // reports as service misbehavior. Letting the measurement's own rejection
-    // escape would turn tracing on into "some calls now fail", which is the one
-    // thing an instrument may not do — so a broken read is a fact ABOUT the
-    // call, recorded in the line, not a fact that changes it.
-    let bytes = 0;
-    let outcome = "ok";
-    try {
-      bytes = (await response.clone().arrayBuffer()).byteLength;
-    } catch {
-      outcome = "unreadable-body";
-    }
-    line(bytes, outcome);
-    return response;
   };
 
   const json = async (response: Response): Promise<unknown> => response.json().catch(() => ({}));

--- a/packages/store/tests/hosted-store.trace.test.ts
+++ b/packages/store/tests/hosted-store.trace.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// VENDO_STORE_TRACE's line is a MEASUREMENT, so its numbers are the behavior
+// under test — a line that prints a plausible-looking millisecond count is worse
+// than no line, because it is believed. The one it used to print folded the
+// retry's backoff and its own second body read into the door's latency, so a
+// healthy 54ms door read as 2.1s. These cases pin the split that fixed it.
+
+const ENGINE_COLLECTION = "vendo_workspace_commits";
+
+/** The client, imported AFTER the switch is set: the flag is read ONCE at
+ * import (a debug switch belongs to the process, not to a call), so a fresh
+ * module registry is the only way to observe both states in one file. */
+const opsWith = async (fetchImpl: typeof fetch, trace = true) => {
+  vi.stubEnv("VENDO_STORE_TRACE", trace ? "1" : undefined);
+  vi.resetModules();
+  const { hostedStoreOps } = await import("../src/hosted-store.js");
+  return hostedStoreOps({ apiKey: "vnd_secret", baseUrl: "https://cloud.test", fetch: fetchImpl });
+};
+
+/** `op=engine.get net=3 total=1004 …` → the fields, by name. */
+const fields = (line: string): Record<string, string> =>
+  Object.fromEntries(line.split(" ").slice(1).map((pair) => pair.split("=") as [string, string]));
+
+describe("VENDO_STORE_TRACE", () => {
+  let stderr: ReturnType<typeof vi.spyOn>;
+  const lines = (): string[] => stderr.mock.calls
+    .map(([first]) => String(first))
+    .filter((line) => line.startsWith("vendo-store-trace "));
+
+  beforeEach(() => {
+    stderr = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    stderr.mockRestore();
+    vi.unstubAllEnvs();
+  });
+
+  it("charges the backoff to total and not to the wire, and counts the retry", async () => {
+    let attempts = 0;
+    const fetchImpl = (async () => {
+      attempts += 1;
+      // The console's own "come back in a second" — the wait that used to be
+      // reported as the store being slow.
+      if (attempts === 1) return new Response("slow down", { status: 429, headers: { "retry-after": "1" } });
+      return Response.json({ record: null }, { headers: { "content-length": "15" } });
+    }) as unknown as typeof fetch;
+
+    const ops = await opsWith(fetchImpl);
+    expect(await ops.engine.get(ENGINE_COLLECTION, "wsc_1")).toBeNull();
+
+    expect(lines()).toHaveLength(1);
+    const line = fields(lines()[0]!);
+    expect(line).toMatchObject({ op: "engine.get", retried: "1", bytes: "15", outcome: "ok" });
+    // Both attempts really happened, and both were fast: the second the caller
+    // spent asleep shows up in `total` alone.
+    expect(Number(line.net)).toBeLessThan(500);
+    expect(Number(line.total)).toBeGreaterThanOrEqual(900);
+  });
+
+  it("does not charge the door for the body — the size is the one the server declared", async () => {
+    // A body that arrives slowly, and only when someone reads it. The old line
+    // awaited a full `clone().arrayBuffer()` inside its own timed span, so this
+    // transfer was billed to the door TWICE.
+    const trickle = () => new ReadableStream<Uint8Array>({
+      async start(controller) {
+        await new Promise((resolve) => setTimeout(resolve, 300));
+        controller.enqueue(new TextEncoder().encode(JSON.stringify({ record: null })));
+        controller.close();
+      },
+    });
+    const ops = await opsWith((async () => new Response(trickle(), {
+      headers: { "content-type": "application/json" },
+    })) as unknown as typeof fetch);
+
+    const started = Date.now();
+    expect(await ops.engine.get(ENGINE_COLLECTION, "wsc_1")).toBeNull();
+
+    // The caller waited for the bytes; the door is not blamed for them.
+    expect(Date.now() - started).toBeGreaterThanOrEqual(280);
+    const line = fields(lines()[0]!);
+    expect(Number(line.total)).toBeLessThan(200);
+    // Nothing was read to find the size out, so an undeclared one stays unknown.
+    expect(line).toMatchObject({ retried: "0", bytes: "?", outcome: "ok" });
+  });
+
+  it("traces a refusal with the server's code, and prints nothing at all when unset", async () => {
+    const refuse = (async () => Response.json({ error: { code: "conflict", message: "taken" } }, { status: 409 })
+    ) as unknown as typeof fetch;
+
+    const traced = await opsWith(refuse);
+    await expect(traced.engine.put(ENGINE_COLLECTION, { id: "wsc_1", data: {} }))
+      .rejects.toMatchObject({ code: "conflict" });
+    // A refusal is an answer, so it is never replayed — and its body is already
+    // spent on building the error.
+    expect(fields(lines()[0]!)).toMatchObject({ retried: "0", bytes: "?", outcome: "conflict" });
+
+    stderr.mockClear();
+    const untraced = await opsWith(refuse, false);
+    await expect(untraced.engine.put(ENGINE_COLLECTION, { id: "wsc_1", data: {} })).rejects.toThrow();
+    expect(lines()).toEqual([]);
+  });
+});


### PR DESCRIPTION
`VENDO_STORE_TRACE` is a measurement instrument, and it was lying. It printed one
number, `ms=`, and folded three things that are not the door's latency into it:

- the silent retry's backoff — 250ms to 10s, whatever the console's `Retry-After` asked for;
- event-loop queueing on a busy container;
- the instrument's **own** second full read of the response body, a
  `clone().arrayBuffer()` awaited *inside* the timed span, which also charged
  every traced call for being measured.

A 40ms door with one retry behind it reported `ms=1347`. In the field today a
healthy 54ms read as 2.1s and sent an afternoon after a store that was never slow.

## The line

Before, on a 40ms door that retried once and streamed its body over 300ms:

```
vendo-store-trace op=engine.get path=/engine/get ms=1347 bytes=15 outcome=ok
```

After, same scenario:

```
vendo-store-trace op=engine.get path=/engine/get net=44 total=1046 retried=1 bytes=? outcome=ok
```

- **`net=`** — time on the wire: request start to response headers, summed over
  attempts. The number to compare against the server's own.
- **`total=`** — what the caller waited, backoff included. The gap between the
  two *is* the wait, instead of a mystery.
- **`retried=`** — the replay that opened the gap.
- **`bytes=`** — the size the server declared in `content-length`, and `?` where
  it declared none. Nothing is read to find out, so the body reaches the caller
  whole and unread, and a slow transfer is no longer billed to the door twice.

The timings can only be taken from inside the attempt loop — from outside, a
backoff sleep is indistinguishable from a slow server — so the trace passes a
small meter into `wire` and reads it back. Untraced, `call` is still literally
`wire`: no wrapper, no meter, nothing to pay for.

## Tradeoff

Losing the size on a chunked answer is the price of not reading the body. That is
the honest trade for now; the cheaper fix lives on the server.

## Follow-up (not in this PR)

The console could stamp its own processing time on the store response — one
header on the existing `/api/v1/store/*` door — which would decompose `net` into
server time vs. transit and restore an accurate body size for free. That is a
`vendo-web` change and deliberately out of scope here.

## Tests

New `packages/store/tests/hosted-store.trace.test.ts` (3 cases) pins the numbers,
since a plausible-looking millisecond count is worse than no line at all:

1. a retried call keeps the backoff out of `net`, puts it in `total`, and reports `retried=1`;
2. a body that trickles in over 300ms is *not* charged to the door — `total` stays
   under 200ms while the caller genuinely waits — and an undeclared size reads `?`;
3. a refusal traces with the server's code and `retried=0`; with the switch unset,
   nothing is printed at all.

All three fail against the old code (verified by reverting the source and
re-running: `expected NaN to be less than 200`, etc.). The 122 existing
`hosted-store*` tests pass unchanged.

## Gate

`pnpm build` (22/22) · `pnpm test:affected` (34/34) · `pnpm typecheck` (44/44) ·
`pnpm lint` (4/4, 0 errors; 4 pre-existing demo-bank warnings) — all green on the
touched scope.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `VENDO_STORE_TRACE` report the door’s network time and expose retry backoff separately. Previously, the single `ms=` folded in retry backoff, event-loop queueing, and a second body read; now the line prints `net=`, `total=`, `retried=`, and `bytes=` from `content-length`, so callers see true door latency.

- Old: `ms=` included backoff and a clone read, inflating latency. New: `net=` sums request→headers across attempts; `total=` is caller wait; `retried=` counts replays; `bytes=` uses `content-length` or `?`. Calls no longer pay for measurement and the response body is left unread.

**Impact and migration**
- Update log parsers: replace `ms=` with `net=` and `total=`; handle `bytes=?` when no `content-length`.
- No API changes for `@vendoai/store`; only trace output changes when `VENDO_STORE_TRACE` is set.

**Review notes**
- `packages/store/src/hosted-store.ts`: introduce a per-call meter, time each attempt inside `wire()`, stop cloning/reading bodies, emit new fields; untraced path still calls `wire()` directly.
- `packages/store/tests/hosted-store.trace.test.ts`: pins separation of backoff vs. net time, avoids double-charging body transfer, and reports refusal codes.
- Changeset publishes a patch to `@vendoai/store`.

<sup>Written for commit 9df3222bb0d2e305295e7451f8a2829b083ac2a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1542?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

