### PR TITLE
fix(vendo): a keyless clerk() host is a state, not an outage (#1338)

### DIFF
--- a/.changeset/a-missing-clerk-key-is-a-state.md
+++ b/.changeset/a-missing-clerk-key-is-a-state.md
@@ -1,0 +1,16 @@
+---
+"@vendoai/vendo": patch
+---
+
+A keyless clerk() host is a state, not an outage. The preset used to THROW
+when a request carried a session token and neither `CLERK_SECRET_KEY` nor
+`CLERK_JWT_KEY` was set — 501-ing the entire wire in exactly the state
+`vendo init --auth clerk` leaves you in, on hosts where Clerk's `__session`
+cookie rides every request — while a forged token nine lines below resolved
+to anonymous. A missing key now resolves to anonymous too, named once and
+loudly in the server log (the v4-cookie-hint pattern). And because nothing
+fails loud enough to send anyone looking, the gap is named early twice over:
+init's detection attaches a clerk env advisory (the supabase mechanism,
+generalized), and doctor grades the same fact statically as **E-AUTH-010**
+(a warning) from the same shared helpers, so init and doctor can never
+disagree.

--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -180,6 +180,7 @@
                   "production/troubleshooting/e-auth-007",
                   "production/troubleshooting/e-auth-008",
                   "production/troubleshooting/e-auth-009",
+                  "production/troubleshooting/e-auth-010",
                   "production/troubleshooting/e-mcp-001",
                   "production/troubleshooting/e-mcp-002",
                   "production/troubleshooting/e-mcp-003",

--- a/docs-site/production/troubleshooting/e-auth-010.mdx
+++ b/docs-site/production/troubleshooting/e-auth-010.mdx
@@ -1,0 +1,42 @@
+---
+title: "E-AUTH-010"
+sidebarTitle: "E-AUTH-010"
+description: "clerk() is wired but neither CLERK_SECRET_KEY nor CLERK_JWT_KEY is set."
+---
+
+```text wiring/clerk-env
+warning: clerk() verifies sessions with CLERK_SECRET_KEY (mirroring Clerk's
+own SDKs) and/or CLERK_JWT_KEY (the instance's PEM public key, networkless) —
+server-side keys, not the NEXT_PUBLIC_* publishable key. Neither is set —
+signed-in users resolve as anonymous until one lands in .env.local.
+```
+
+`check: wiring/clerk-env` · `error_code: E-AUTH-010` · `doctor exits: 0`
+
+## What you're seeing
+
+A warning: your composition wires the `clerk()` auth preset, and neither of
+the keys it verifies sessions with is set.
+
+## Why
+
+Init detects the Clerk family from your dependencies — often a host that
+carries only the `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` — but the preset
+verifies sessions server-side: `CLERK_SECRET_KEY` (mirroring Clerk's own
+SDKs) and/or `CLERK_JWT_KEY` (the instance's PEM public key, which enables
+networkless verification). Without one, every static check passes and every
+signed-in user quietly resolves as **anonymous** — the server logs one loud
+warning, and visitors see the signed-out experience while believing they are
+signed in.
+
+## The fix
+
+Add either key to `.env.local` (both is fine). `CLERK_SECRET_KEY` is in the
+Clerk dashboard's API keys; `CLERK_JWT_KEY` is the instance's public key on
+the same page. A warning, not a failure: production-only env kept outside
+the local files doctor can read is legitimate — but then verify with a real
+signed-in turn where that env exists.
+
+## Related errors
+
+- [E-AUTH-009](/production/troubleshooting/e-auth-009) — the same gap in the supabase() preset

--- a/packages/vendo/src/auth-presets/clerk.ts
+++ b/packages/vendo/src/auth-presets/clerk.ts
@@ -24,6 +24,11 @@ const MISSING_CLERK_BACKEND_MESSAGE =
 const MISSING_KEY_MESSAGE =
   "clerk() has no verification key: set CLERK_SECRET_KEY (mirroring Clerk's own SDKs), optionally with CLERK_JWT_KEY (the instance's PEM public key) for networkless verification.";
 
+/** Once per process, like auth-js's v4-cookie hint: a configuration gap
+    belongs in the startup log exactly once, never in a request-path
+    exception (#1338). */
+let warnedMissingKey = false;
+
 type ClerkVerifyToken = (
   token: string,
   options: { secretKey?: string; jwtKey?: string },
@@ -64,7 +69,19 @@ export function clerk(options: HostAuthPresetOptions = {}): HostAuthPreset {
     const jwtKey = environment("CLERK_JWT_KEY");
     const secretKey = environment("CLERK_SECRET_KEY");
     if (jwtKey === undefined && secretKey === undefined) {
-      throw new Error(MISSING_KEY_MESSAGE);
+      // A missing local key means "no verified session" — a state the wire
+      // already handles — never an outage (#1338): Clerk hosts carry
+      // __session broadly, so the old throw 501'd the ENTIRE wire in exactly
+      // the state `vendo init --auth clerk` leaves you in, while a FORGED
+      // token nine lines below already answered null. A missing key must not
+      // answer worse than a forgery. (supabase's equivalent throw stays: its
+      // cookie exists only for signed-in sessions, so the blast radius is a
+      // signed-in turn, not every visitor's every request.)
+      if (!warnedMissingKey) {
+        warnedMissingKey = true;
+        console.warn(`[vendo] ${MISSING_KEY_MESSAGE} Signed-in users resolve as anonymous until a key lands.`);
+      }
+      return null;
     }
     const verifyToken = await loadVerifyToken();
     try {

--- a/packages/vendo/src/cli/doctor-codes.ts
+++ b/packages/vendo/src/cli/doctor-codes.ts
@@ -66,6 +66,7 @@ export const DOCTOR_ERROR_CODES = {
   "E-AUTH-007": "RETIRED — doctor no longer probes actAs",
   "E-AUTH-008": "RETIRED — doctor no longer probes actAs",
   "E-AUTH-009": "supabase() is wired but neither SUPABASE_JWT_SECRET nor SUPABASE_URL is set",
+  "E-AUTH-010": "clerk() is wired but neither CLERK_SECRET_KEY nor CLERK_JWT_KEY is set",
   "E-MCP-001": "RETIRED — doctor no longer fetches MCP discovery documents",
   "E-MCP-002": "RETIRED — doctor no longer fetches MCP discovery documents",
   "E-MCP-003": "RETIRED — doctor no longer fetches the MCP server card",

--- a/packages/vendo/src/cli/doctor-wiring-checks.ts
+++ b/packages/vendo/src/cli/doctor-wiring-checks.ts
@@ -1,12 +1,12 @@
 import { readFile } from "node:fs/promises";
 import { dirname, join, relative } from "node:path";
 import { installedVersion } from "./dep-versions.js";
-import { composesOwnStore, detectFramework, detectVendoWiring, SUPABASE_PRESET_IMPORT, wiresSupabaseAuth, wiresTenantConnectors, type VendoWiring } from "./framework.js";
+import { CLERK_PRESET_IMPORT, composesOwnStore, detectFramework, detectVendoWiring, SUPABASE_PRESET_IMPORT, wiresClerkAuth, wiresSupabaseAuth, wiresTenantConnectors, type VendoWiring } from "./framework.js";
 import { vendoPackageInvocation } from "./provider-deps.js";
 import { compositionModulePath, importsGeneratedMap, importsSplitComposition, missingRegistrations, registrationKey, requiredServerActions, serverActionsWiring } from "./init-scaffolds.js";
 import { readUseCase } from "./install-record.js";
 import { checkMcpBaseUrl } from "./doctor-mcp-checks.js";
-import { SUPABASE_ENV_GUIDANCE, supabaseServerEnvSatisfied } from "./init-auth.js";
+import { CLERK_ENV_GUIDANCE, clerkServerEnvSatisfied, SUPABASE_ENV_GUIDANCE, supabaseServerEnvSatisfied } from "./init-auth.js";
 import type { DoctorRun } from "./doctor-report.js";
 import { walk } from "./theme/walk.js";
 import { clientRoot, exists, readOptional, stripBom } from "./shared.js";
@@ -206,22 +206,47 @@ async function checkVendoResolvable(run: DoctorRun): Promise<void> {
  *  where a bare `supabase()` call is trusted; anywhere else only the preset
  *  IMPORT is evidence — a bare call in arbitrary host source is the host's
  *  own Supabase client. */
-async function checkSupabasePresetEnv(run: DoctorRun): Promise<void> {
+const PRESET_ENV_CHECKS = [
+  {
+    id: "wiring/supabase-env",
+    code: "E-AUTH-009",
+    importMarker: SUPABASE_PRESET_IMPORT,
+    bareCall: /[^\w.]supabase\s*\(/,
+    wiresAnywhere: wiresSupabaseAuth,
+    satisfied: supabaseServerEnvSatisfied,
+    pass: "supabase() has a server-side session secret (SUPABASE_JWT_SECRET and/or SUPABASE_URL)",
+    warn: () => `${SUPABASE_ENV_GUIDANCE} Neither is set — the first signed-in turn fails loud until one lands in .env.local.`,
+  },
+  {
+    // #1338 — the same disease, third preset. The consequence differs: the
+    // keyless clerk wire resolves signed-in users as ANONYMOUS (one loud
+    // server warning), so nothing fails loud enough to send anyone here —
+    // which makes the static warning the only early signpost.
+    id: "wiring/clerk-env",
+    code: "E-AUTH-010",
+    importMarker: CLERK_PRESET_IMPORT,
+    bareCall: /[^\w.]clerk\s*\(/,
+    wiresAnywhere: wiresClerkAuth,
+    satisfied: clerkServerEnvSatisfied,
+    pass: "clerk() has a server-side verification key (CLERK_SECRET_KEY and/or CLERK_JWT_KEY)",
+    warn: () => `${CLERK_ENV_GUIDANCE} Neither is set — signed-in users resolve as anonymous until one lands in .env.local.`,
+  },
+] as const;
+
+async function checkPresetEnv(run: DoctorRun): Promise<void> {
   const { root } = run;
   const routePath = await nextRoutePath(root);
-  let wiresSupabase: boolean;
-  if (routePath === null) {
-    wiresSupabase = await wiresSupabaseAuth(root);
-  } else {
-    const { source } = await compositionOf(root, routePath);
-    wiresSupabase = SUPABASE_PRESET_IMPORT.test(source) || /[^\w.]supabase\s*\(/.test(source);
-  }
-  if (!wiresSupabase) return;
-  if (await supabaseServerEnvSatisfied(root, run.env)) {
-    run.pass("wiring/supabase-env", "supabase() has a server-side session secret (SUPABASE_JWT_SECRET and/or SUPABASE_URL)");
-  } else {
-    run.warn("wiring/supabase-env", "E-AUTH-009",
-      `${SUPABASE_ENV_GUIDANCE} Neither is set — the first signed-in turn fails loud until one lands in .env.local.`);
+  const source = routePath === null ? null : (await compositionOf(root, routePath)).source;
+  for (const check of PRESET_ENV_CHECKS) {
+    // With a Next route we read its composition, where a bare call is trusted;
+    // anywhere else only the preset IMPORT is evidence (both spellings — the
+    // #1374/#1383 lessons baked into the table).
+    const wires = source !== null
+      ? check.importMarker.test(source) || check.bareCall.test(source)
+      : await check.wiresAnywhere(root);
+    if (!wires) continue;
+    if (await check.satisfied(root, run.env)) run.pass(check.id, check.pass);
+    else run.warn(check.id, check.code, check.warn());
   }
 }
 
@@ -298,7 +323,7 @@ export async function checkWiring(run: DoctorRun): Promise<void> {
   // Static, so it fires on a project nobody has started yet — which is exactly
   // when a missing base URL is still cheap to fix.
   await checkMcpBaseUrl(run);
-  await checkSupabasePresetEnv(run);
+  await checkPresetEnv(run);
   await checkTenantConnectorVault(run);
 
   if (await hasDependency(root)) run.pass("wiring/dependency", "@vendoai/vendo dependency is declared");

--- a/packages/vendo/src/cli/framework.ts
+++ b/packages/vendo/src/cli/framework.ts
@@ -156,6 +156,10 @@ export async function workspaceHostCandidates(root: string): Promise<string[]> {
     LEGACY_ROOT_IMPORT above). */
 export const SUPABASE_PRESET_IMPORT = /["'](?:@vendoai\/vendo|vendoai)\/auth\/supabase["']/;
 
+/** The clerk preset's specifier, both spellings — same shape, same reasons
+    (#1338 rides the same table E-AUTH-009 does). */
+export const CLERK_PRESET_IMPORT = /["'](?:@vendoai\/vendo|vendoai)\/auth\/clerk["']/;
+
 /** Both supported spellings of the server entry, for the same reason: an
     alias-wired host (`createVendo` imported from the unscoped package's
     /server) is WIRED, and reading it as bare misdiagnosed it E-WIRE-001/007. */
@@ -180,6 +184,10 @@ async function hostSourceMatches(root: string, marker: RegExp): Promise<boolean>
     a helper). */
 export async function wiresSupabaseAuth(root: string): Promise<boolean> {
   return hostSourceMatches(root, SUPABASE_PRESET_IMPORT);
+}
+
+export async function wiresClerkAuth(root: string): Promise<boolean> {
+  return hostSourceMatches(root, CLERK_PRESET_IMPORT);
 }
 
 /** Whether any host source reaches the tenant-connector API. A property read on

--- a/packages/vendo/src/cli/init-auth.test.ts
+++ b/packages/vendo/src/cli/init-auth.test.ts
@@ -128,3 +128,48 @@ describe("supabase server-env advisory (ENG-422 / #1370)", () => {
     expect(auth.advice).toContain("SUPABASE_JWT_SECRET");
   });
 });
+
+// The same disease in the third preset (#1338): detection sees @clerk/* while
+// the preset verifies with CLERK_SECRET_KEY/CLERK_JWT_KEY — and post-#1338 the
+// keyless wire resolves signed-in users as ANONYMOUS (one loud warning), so
+// naming the gap at install time is the only thing standing between a
+// newcomer and a silently signed-out agent.
+describe("clerk server-env advisory (#1338)", () => {
+  const CLERK = { dependencies: { "@clerk/nextjs": "^6.5.0" } };
+
+  it("detection carries the advisory when neither key name is anywhere", async () => {
+    const root = await hostRoot(CLERK);
+    const detection = await detectAuthPreset(root, {});
+    expect(detection.wired?.preset).toBe("clerk");
+    expect(detection.wired?.advisory).toContain("CLERK_SECRET_KEY");
+    expect(detection.wired?.advisory).toContain("CLERK_JWT_KEY");
+  });
+
+  it("an env file carrying either name silences it", async () => {
+    const root = await hostRoot(CLERK);
+    await writeFile(join(root, ".env.local"), 'CLERK_SECRET_KEY="sk_test_x"\n', "utf8");
+    const detection = await detectAuthPreset(root, {});
+    expect(detection.wired?.preset).toBe("clerk");
+    expect(detection.wired?.advisory).toBeUndefined();
+  });
+
+  it("the process env carrying either name silences it", async () => {
+    const root = await hostRoot(CLERK);
+    const detection = await detectAuthPreset(root, { CLERK_JWT_KEY: "-----BEGIN PUBLIC KEY-----" });
+    expect(detection.wired?.advisory).toBeUndefined();
+  });
+
+  it("a publishable-key-only host still gets the advisory — the key the preset reads is server-side", async () => {
+    const root = await hostRoot(CLERK);
+    await writeFile(join(root, ".env"), 'NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY="pk_test_x"\n', "utf8");
+    const detection = await detectAuthPreset(root, {});
+    expect(detection.wired?.advisory).toContain("CLERK_SECRET_KEY");
+  });
+
+  it("the silent (non-interactive) path surfaces it as advice", async () => {
+    const root = await hostRoot(CLERK);
+    const auth = await resolveScaffoldAuth(root, COMPOSITION, undefined, undefined, undefined, {});
+    expect(auth.wired?.preset).toBe("clerk");
+    expect(auth.advice).toContain("CLERK_SECRET_KEY");
+  });
+});

--- a/packages/vendo/src/cli/init-auth.ts
+++ b/packages/vendo/src/cli/init-auth.ts
@@ -87,26 +87,42 @@ function nextAuthV4Advisory(range: string): string {
 }
 
 const SUPABASE_SERVER_ENV = ["SUPABASE_JWT_SECRET", "SUPABASE_URL"] as const;
+const CLERK_SERVER_ENV = ["CLERK_SECRET_KEY", "CLERK_JWT_KEY"] as const;
 
 /** Env files a Next/Node host actually loads in development, checked in the
     same spirit the login flow writes `.env.local`: presence anywhere counts. */
 const HOST_ENV_FILES = [".env", ".env.local", ".env.development", ".env.development.local"];
 
-/** True when either server-side name is in the process env or any host env
-    file. Shared by init's advisory and doctor's E-AUTH-009 — the two must
-    never disagree about whether a supabase() host can verify sessions. */
-export async function supabaseServerEnvSatisfied(
+/** True when any of the names is in the process env or any host env file —
+    the one satisfaction rule every preset-env advisory and doctor check
+    shares, so init and doctor can never disagree about the same host. */
+async function serverEnvSatisfied(
   root: string,
   env: Record<string, string | undefined>,
+  names: readonly string[],
 ): Promise<boolean> {
-  if (SUPABASE_SERVER_ENV.some((name) => Boolean(env[name]))) return true;
+  if (names.some((name) => Boolean(env[name]))) return true;
   for (const file of HOST_ENV_FILES) {
     const body = await readOptional(join(root, file));
-    if (body !== null && SUPABASE_SERVER_ENV.some((name) => new RegExp(`^\\s*${name}\\s*=`, "m").test(body))) {
+    if (body !== null && names.some((name) => new RegExp(`^\\s*${name}\\s*=`, "m").test(body))) {
       return true;
     }
   }
   return false;
+}
+
+export async function supabaseServerEnvSatisfied(
+  root: string,
+  env: Record<string, string | undefined>,
+): Promise<boolean> {
+  return serverEnvSatisfied(root, env, SUPABASE_SERVER_ENV);
+}
+
+export async function clerkServerEnvSatisfied(
+  root: string,
+  env: Record<string, string | undefined>,
+): Promise<boolean> {
+  return serverEnvSatisfied(root, env, CLERK_SERVER_ENV);
 }
 
 /** The wire's own remediation copy, verbatim-adjacent: doctor and the first
@@ -115,11 +131,19 @@ export const SUPABASE_ENV_GUIDANCE =
   "supabase() verifies sessions with SUPABASE_JWT_SECRET (HS256, offline) and/or " +
   "SUPABASE_URL (ES256 via GoTrue's JWKS) — server-side names, not the NEXT_PUBLIC_* pair.";
 
-/** The second caveat: supabase() verifies sessions with server-side env the
-    NEXT_PUBLIC_* pair does not cover — a host detected FROM that pair wires
-    cleanly and then fails its first signed-in turn (ENG-422, field:
-    expense.fyi). Attached only when neither name is in the process env or any
-    host env file; a present name means the host already knows. */
+/** Same shape for clerk — and the same wording the keyless wire warns with
+    (#1338): the preset reads server-side keys, not the publishable key
+    detection saw. */
+export const CLERK_ENV_GUIDANCE =
+  "clerk() verifies sessions with CLERK_SECRET_KEY (mirroring Clerk's own SDKs) and/or " +
+  "CLERK_JWT_KEY (the instance's PEM public key, networkless) — server-side keys, not the NEXT_PUBLIC_* publishable key.";
+
+/** The second caveat, per preset: a family detected from its CLIENT-side
+    dependency verifies sessions with SERVER-side env the detection never saw —
+    the host wires cleanly and then signed-in turns misbehave (supabase fails
+    loud, ENG-422; clerk resolves signed-in users as anonymous, #1338).
+    Attached only when no name is in the process env or any host env file; a
+    present name means the host already knows. */
 async function supabaseEnvAdvisory(
   root: string,
   env: Record<string, string | undefined>,
@@ -128,6 +152,22 @@ async function supabaseEnvAdvisory(
   return `Auth: ${SUPABASE_ENV_GUIDANCE} ` +
     "Neither is set; add one to .env.local before the first signed-in turn (the wire fails loud until then).";
 }
+
+async function clerkEnvAdvisory(
+  root: string,
+  env: Record<string, string | undefined>,
+): Promise<string | undefined> {
+  if (await clerkServerEnvSatisfied(root, env)) return undefined;
+  return `Auth: ${CLERK_ENV_GUIDANCE} ` +
+    "Neither is set; add one to .env.local — signed-in users resolve as anonymous until then.";
+}
+
+/** The env advisories detection attaches post-hoc, one per family that has a
+    server-side half detection cannot see. */
+const ENV_ADVISORIES = [
+  { preset: "supabase", advisory: supabaseEnvAdvisory },
+  { preset: "clerk", advisory: clerkEnvAdvisory },
+] as const;
 
 /** Silent auth-preset detection from the host's package.json (zero-question
     contract): one unambiguous family gets wired; none or several stay
@@ -156,10 +196,12 @@ export async function detectAuthPreset(
       : undefined;
     return [{ preset, dependency, ...(advisory === undefined ? {} : { advisory }) }];
   });
-  const supabase = matches.find((match) => match.preset === "supabase");
-  if (supabase !== undefined && supabase.advisory === undefined) {
-    const advisory = await supabaseEnvAdvisory(root, env);
-    if (advisory !== undefined) supabase.advisory = advisory;
+  for (const { preset, advisory: envAdvisory } of ENV_ADVISORIES) {
+    const match = matches.find((candidate) => candidate.preset === preset);
+    if (match !== undefined && match.advisory === undefined) {
+      const advisory = await envAdvisory(root, env);
+      if (advisory !== undefined) match.advisory = advisory;
+    }
   }
   return { wired: matches.length === 1 ? matches[0]! : null, matches };
 }

--- a/packages/vendo/tests/auth-presets/clerk.test.ts
+++ b/packages/vendo/tests/auth-presets/clerk.test.ts
@@ -114,11 +114,26 @@ describe("clerk() session resolution (Clerk's own conventions)", () => {
       .resolves.toBeNull();
   });
 
-  it("throws an actionable error naming CLERK_SECRET_KEY when no verification key is configured", async () => {
+  // Reversed pin (#1338): this used to assert a THROW — which 501'd the whole
+  // wire in exactly the state `vendo init --auth clerk` leaves you in, on hosts
+  // where Clerk's __session cookie rides every request. A missing local key
+  // means "no verified session", a state the wire already handles; the key is
+  // named once, loudly, like the v4-cookie hint — never per-request, and a
+  // forged token nine lines below already answers null.
+  it("a missing verification key resolves null and warns ONCE naming CLERK_SECRET_KEY — never an outage", async () => {
     vi.unstubAllEnvs();
-    const preset = clerk();
-    await expect(preset.principal(withSessionCookie(await sessionToken("user_nokey"))))
-      .rejects.toThrow(/CLERK_SECRET_KEY/);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const preset = clerk();
+      await expect(preset.principal(withSessionCookie(await sessionToken("user_nokey"))))
+        .resolves.toBeNull();
+      await expect(preset.principal(withSessionCookie(await sessionToken("user_nokey_again"))))
+        .resolves.toBeNull();
+      const keyWarnings = warn.mock.calls.filter(call => String(call[0]).includes("CLERK_SECRET_KEY"));
+      expect(keyWarnings).toHaveLength(1);
+    } finally {
+      warn.mockRestore();
+    }
   });
 });
 

--- a/packages/vendo/tests/cli/doctor-codes.test.ts
+++ b/packages/vendo/tests/cli/doctor-codes.test.ts
@@ -30,6 +30,7 @@ describe("doctor error-code registry", () => {
         "E-AUTH-007": "RETIRED — doctor no longer probes actAs",
         "E-AUTH-008": "RETIRED — doctor no longer probes actAs",
         "E-AUTH-009": "supabase() is wired but neither SUPABASE_JWT_SECRET nor SUPABASE_URL is set",
+        "E-AUTH-010": "clerk() is wired but neither CLERK_SECRET_KEY nor CLERK_JWT_KEY is set",
         "E-CFG-001": "a required .vendo/ config file is missing",
         "E-CFG-002": ".vendo/data/.gitignore is missing",
         "E-CFG-003": "the OpenAPI spec's relative server mount and VENDO_BASE_URL's path prefix disagree",

--- a/packages/vendo/tests/cli/doctor.test.ts
+++ b/packages/vendo/tests/cli/doctor.test.ts
@@ -1185,6 +1185,52 @@ describe("vendo doctor error codes + fix_refs", () => {
     expect(report.checks.find((check) => check.id === "wiring/supabase-env")).toBeUndefined();
   });
 
+  // The same disease in the third preset (#1338): clerk() verifies with
+  // server-side keys detection never saw, and post-#1338 the keyless wire
+  // resolves signed-in users as ANONYMOUS — so doctor names the gap statically,
+  // the same table row supabase rides.
+  const clerkRoute =
+    'import { clerk } from "@vendoai/vendo/auth/clerk";\n' +
+    'import { createVendo, nextVendoHandler } from "@vendoai/vendo/server";\n' +
+    "const vendo = createVendo({ auth: clerk() });\n" +
+    "export const { GET, POST } = nextVendoHandler(vendo);\n";
+
+  it("warns E-AUTH-010 when clerk() is wired and neither key name is set", async () => {
+    const root = await healthy();
+    await writeFile(join(root, "app", "api", "vendo", "[...vendo]", "route.ts"), clerkRoute);
+    const { report } = await jsonChecks({ targetDir: root, env: {} });
+    expect(report.checks.find((check) => check.id === "wiring/clerk-env")).toMatchObject({
+      status: "warning",
+      error_code: "E-AUTH-010",
+    });
+  });
+
+  it("passes wiring/clerk-env when either key name is present", async () => {
+    const root = await healthy();
+    await writeFile(join(root, "app", "api", "vendo", "[...vendo]", "route.ts"), clerkRoute);
+    const { report } = await jsonChecks({ targetDir: root, env: { CLERK_SECRET_KEY: "sk_test_x" } });
+    expect(report.checks.find((check) => check.id === "wiring/clerk-env")).toMatchObject({ status: "ok" });
+  });
+
+  it("warns E-AUTH-010 on an Express host wiring clerk() — framework-neutral from day one", async () => {
+    const root = await expressHost(true);
+    await writeFile(join(root, "src", "server.ts"),
+      'import { clerk } from "@vendoai/vendo/auth/clerk";\n' +
+      'import { createVendo } from "@vendoai/vendo/server";\n' +
+      "createVendo({ auth: clerk(), models: { default: model }, principal });\n");
+    const { report } = await jsonChecks({ targetDir: root, env: {} });
+    expect(report.checks.find((check) => check.id === "wiring/clerk-env")).toMatchObject({
+      status: "warning",
+      error_code: "E-AUTH-010",
+    });
+  });
+
+  it("says nothing about clerk env on a host that does not wire clerk()", async () => {
+    const root = await healthy();
+    const { report } = await jsonChecks({ targetDir: root, env: {} });
+    expect(report.checks.find((check) => check.id === "wiring/clerk-env")).toBeUndefined();
+  });
+
   // The check is framework-neutral (greptile on #1374): a non-Next host that
   // wires the preset fails its first signed-in turn just the same, so it gets
   // the same warning — discovered by import marker, not by Next's file layout.

--- a/packages/vendo/tests/cli/init.test.ts
+++ b/packages/vendo/tests/cli/init.test.ts
@@ -341,10 +341,10 @@ describe("vendo init (zero-question)", () => {
       name: "host",
       dependencies: { next: "16.0.0", [dependency]: "1.0.0" },
     }));
-    // ENG-422: a supabase host with no server env would rightly carry the
-    // env advisory — a satisfied env keeps this test about SILENT wiring
-    // (the advisory has its own tests in init-auth.test.ts).
-    await writeFile(join(root, ".env.local"), "SUPABASE_URL=http://127.0.0.1:54321\n");
+    // ENG-422 / #1338: a supabase or clerk host with no server env would
+    // rightly carry the env advisory — a satisfied env keeps this test about
+    // SILENT wiring (the advisories have their own tests in init-auth.test.ts).
+    await writeFile(join(root, ".env.local"), "SUPABASE_URL=http://127.0.0.1:54321\nCLERK_SECRET_KEY=sk_test_x\n");
     const sink = output();
     expect(await run(root, sink)).toBe(0);
     const route = await readFile(join(root, "lib", "vendo.ts"), "utf8");


### PR DESCRIPTION
## What

Fixes #1338: **a keyless clerk() host is a state, not an outage.** The preset THREW when a request carried a session token and neither `CLERK_SECRET_KEY` nor `CLERK_JWT_KEY` was set — 501-ing the entire wire in exactly the state `vendo init --auth clerk` leaves you in, on hosts where Clerk's `__session` cookie rides every request — while a FORGED token nine lines below resolved to anonymous. A missing key must not answer worse than a forgery.

## How

- **Wire**: token + no key now resolves null, named once and loudly in the server log (the `warnedV4Cookie` pattern from auth-js). Deliberately asymmetric with supabase, whose equivalent throw stays: its cookie exists only for signed-in sessions, so its loud failure has a bounded blast radius and still teaches; Clerk's omnipresent cookie made the throw an outage. The old throw-pin test is reversed with the argument inline.
- **Init**: detection attaches a clerk env advisory when neither key name is in the process env or host env files — the ENG-422 supabase mechanism, generalized to an `ENV_ADVISORIES` table over one shared `serverEnvSatisfied`.
- **Doctor**: **E-AUTH-010** (warning) via a `PRESET_ENV_CHECKS` table that also carries E-AUTH-009 — same shared helpers so init and doctor can never disagree, framework-neutral and alias-aware from day one (the #1374/#1383 review lessons, baked in rather than re-learned).
- **Docs**: `production/troubleshooting/e-auth-010.mdx` + nav; registry + snapshot + parity extended.

## Tests

TDD red-first throughout: preset suite 17/17 (real `@clerk/backend` against unit-minted RS256 keys — the keyless state needs no Clerk account, which is rather the point), init-auth 18/18 (5 new advisory pins), doctor clerk group 4/4 including an Express host pin, codes snapshot + docs parity green. The silent-wiring init fixture gains a satisfied clerk key — the #1374 consumer-scope lesson, caught locally this round. Residual local reds (models-line, judgment-pass, onboarding pair) all reproduce on pristine main: the known Windows env class; CI is the gate of record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)