### PR TITLE
feat(vendo): the catalog report names the file that cures blind tools (#1339)

### DIFF
--- a/.changeset/the-report-names-the-file-that-cures-blindness.md
+++ b/.changeset/the-report-names-the-file-that-cures-blindness.md
@@ -1,0 +1,11 @@
+---
+"@vendoai/vendo": patch
+---
+
+The catalog report names the file that cures blind tools. A blind tool is a
+method and a path with no parameters — the agent cannot use what it cannot
+see — and the single highest-leverage fix, an `openapi.json` at the app root,
+was named nowhere (field-measured: one file took a host from 0/18 to 18/18
+declared schemas). When the schema-coverage line reports blind tools, init
+and sync now follow it with the cure; the API-tools docs page gains the
+matching "Declare your schemas" section.

--- a/docs-site/capabilities/api-tools.mdx
+++ b/docs-site/capabilities/api-tools.mdx
@@ -32,6 +32,22 @@ Only tools in that file exist. Nothing else reaches your API.
 
 Extraction runs in a fixed order: OpenAPI, tRPC, Next.js server actions, then the route scan. Each one skips itself when your app has nothing for it.
 
+### Declare your schemas: openapi.json
+
+The single highest-leverage file you can add is an `openapi.json` at your app root (`public/openapi.json` and `docs/openapi.json` — or `.yaml` — are read too). Without a spec, a plain route scan finds your endpoints but not their shapes: each tool arrives as a method and a path with **no parameters and no output schema**, and the report says so —
+
+```text
+tool schemas: inputs 0/18 · outputs 0/18 — blind: host_customers_get, host_orders_list …
+```
+
+A blind tool is one the agent cannot really use: `GET /api/orders` may support `status`, `customer_id`, and `limit`, and the model has no way to know any of them exist. Add the spec and re-run `npx vendo init` (or `vendo sync`) and the same routes come back with every parameter name, type, and output shape declared:
+
+```text
+tool schemas: inputs 18/18 · outputs 18/18
+```
+
+Most frameworks can generate the file from your existing routes or validators — anything that emits standard OpenAPI 3.x works, and the spec never needs to be served: a file on disk is enough.
+
 ## One tool, honestly
 
 Every entry carries the same five fields. Here is one, whole.

--- a/packages/vendo/src/cli/sync-flow.ts
+++ b/packages/vendo/src/cli/sync-flow.ts
@@ -190,6 +190,14 @@ export function printSyncReport(report: SyncReportWithWarnings, output: Output):
     + (blind.length === 0
       ? ""
       : ` — blind: ${blind.slice(0, 6).join(", ")}${blind.length > 6 ? ` +${blind.length - 6} more` : ""}`));
+  if (blind.length > 0) {
+    // #1339: a blind tool is a method and a path with no parameters — the
+    // agent cannot use what it cannot see, and the file that fixes it was
+    // named nowhere. Field-measured on a Next host: one openapi.json took the
+    // catalog from 0/18 to 18/18 declared schemas.
+    output.log("tool schemas: blind tools take their parameters and output shapes from an openapi.json"
+      + " at the app root (public/ and docs/ are read too) — add one and re-run");
+  }
   output.log(`pins: ${report.pins.captured.length} captured, ${report.pins.drifted.length} drifted`);
   for (const slot of report.pins.pruned ?? []) {
     output.log(`pruned: ${slot} — stale baseline deleted (no <Remixable> wrapper names this slot anymore)`);

--- a/packages/vendo/tests/cli/sync.test.ts
+++ b/packages/vendo/tests/cli/sync.test.ts
@@ -327,7 +327,7 @@ describe("vendo sync", () => {
     expect(logs).toContain("catalog.json: 2 discovered, 1 registered");
   });
 
-  it("prints the schema coverage line, naming the blind tools", async () => {
+  it("prints the schema coverage line, naming the blind tools AND the file that cures them", async () => {
     const logs: string[] = [];
     expect(await runSync({
       targetDir: ".",
@@ -339,6 +339,24 @@ describe("vendo sync", () => {
       }),
     })).toBe(0);
     expect(logs.join("\n")).toContain("tool schemas: inputs 3/3 · outputs 1/3 — blind: host_a, host_b");
+    // #1339: the single highest-leverage file a host can add was named nowhere
+    // — a blind tool is a method and a path with no parameters, and the agent
+    // cannot use what it cannot see. The report itself names the cure.
+    expect(logs.join("\n")).toContain("openapi.json");
+  });
+
+  it("full schema coverage earns no openapi hint — nothing to cure", async () => {
+    const logs: string[] = [];
+    expect(await runSync({
+      targetDir: ".",
+      output: { log: (line) => logs.push(line), error() {} },
+      sync: async () => report([], [], {
+        total: 2,
+        inputs: { known: 2, unknown: [] },
+        outputs: { known: 2, unknown: [] },
+      }),
+    })).toBe(0);
+    expect(logs.join("\n")).not.toContain("openapi.json");
   });
 
   it("--json prints exactly one machine-readable object carrying report and impact", async () => {


### PR DESCRIPTION
## What

Fixes #1339: **the catalog report names the file that cures blind tools.** An `openapi.json` at the app root is the single highest-leverage file a host can add — field-measured on a Next host, one file took the catalog from 0/18 to 18/18 declared tool schemas — and it was documented nowhere. A blind tool is a method and a path with no parameters: the agent cannot use what it cannot see.

## How

- The schema-coverage line (shared by init and sync via `printSyncReport`) now follows any `— blind:` report with one line naming the cure and everywhere the extractor looks (app root, `public/`, `docs/`, `.yaml` variants — the exact candidate list from `packages/actions/src/sync/extractors.ts`). Full coverage earns no hint.
- `docs-site/capabilities/api-tools.mdx` gains a "Declare your schemas: openapi.json" section right where extraction order is explained, carrying the report lines a blind host actually sees and the 0/18 → 18/18 before/after.

## Tests

Both directions pinned red-first: the blind report carries the openapi.json line; full coverage prints no hint. Sync suite green on the touched scope (the two judgment-pass reds reproduce on pristine main — the known Windows env class); typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)