### PR TITLE
fix(store): a wasm boot that never started is retried, not surrendered to

### DIFF
--- a/.changeset/pglite-boot-retry.md
+++ b/.changeset/pglite-boot-retry.md
@@ -1,0 +1,18 @@
+---
+"@vendoai/store": patch
+---
+
+A wasm boot that never started gets the retry it already had a place for.
+`PGlite.create`'s delayed retry only fired for `Invalid FS bundle size`, so
+`PGlite failed to initialize properly` — the other way the engine intermittently
+loses a boot — fell straight through. On a `memory://` store that is the end of
+the line: no lock file, so the stale-lock heal above it rethrows on the spot, and
+there is no recovery path at all. CI paid for it twice, killing one random test
+out of ~300 in `packages/agents` on two unrelated branches with a byte-identical
+stack.
+
+Both signatures now share the one delayed retry. `Aborted()` deliberately does
+not join them — it means a half-opened data dir and belongs to the stale-lock
+heal — and only the truncated-bundle case is still reworded into the reinstall
+message, so a second init failure arrives with its own text after exactly two
+attempts.

--- a/packages/store/src/db.ts
+++ b/packages/store/src/db.ts
@@ -263,12 +263,22 @@ async function releaseSharedPglite(dataDir: string, entry: SharedPglite): Promis
     store's copy is visible here as a transiently truncated read, which pglite
     surfaces as `Invalid FS bundle size` (seen on CI 2026-08-16, healed by the
     next read). One delayed retry is the fix; a second identical failure means
-    the installed package really is truncated. */
-async function createPgliteRetryingTruncatedBundle(dataDir: string): Promise<PGlite> {
+    the installed package really is truncated.
+
+    `PGlite failed to initialize properly` joins it: the wasm engine intermittently
+    loses a boot with no lock file and no short read to blame, which on a
+    `memory://` store left zero recovery path (CI killed one random test out of
+    ~300 in `packages/agents` on two unrelated branches). Both are signatures of a
+    boot that never started, so a second attempt is free of side effects — unlike
+    `Aborted()`, which means a half-opened data dir and belongs to the stale-lock
+    heal below, not here. */
+const TRANSIENT_BOOT = /Invalid FS bundle size|failed to initialize properly/;
+
+async function createPgliteRetryingTransientBoot(dataDir: string): Promise<PGlite> {
   try {
     return await PGlite.create(dataDir);
   } catch (error) {
-    if (!/Invalid FS bundle size/.test(errorMessage(error))) throw error;
+    if (!TRANSIENT_BOOT.test(errorMessage(error))) throw error;
     await wait(500);
     try {
       return await PGlite.create(dataDir);
@@ -284,7 +294,7 @@ async function createPgliteRetryingTruncatedBundle(dataDir: string): Promise<PGl
 /** ENG-350 — self-heal a stale lock instead of hard-aborting boot. */
 async function createPgliteHealingStaleLock(dataDir: string): Promise<PGlite> {
   try {
-    return await createPgliteRetryingTruncatedBundle(dataDir);
+    return await createPgliteRetryingTransientBoot(dataDir);
   } catch (error) {
     const lock = readPgliteLock(dataDir);
     if (!lock) throw error;
@@ -298,7 +308,7 @@ async function createPgliteHealingStaleLock(dataDir: string): Promise<PGlite> {
     );
     fs.rmSync(lock.path, { force: true });
     try {
-      return await createPgliteRetryingTruncatedBundle(dataDir);
+      return await createPgliteRetryingTransientBoot(dataDir);
     } catch (retryError) {
       throw new Error(
         `[vendo] PGlite data directory "${dataDir}" failed to open even after clearing its stale lock — the store is likely corrupt. Back up and delete the directory to start fresh, or set a Postgres url. Cause: ${errorMessage(retryError)}`,

--- a/packages/store/tests/db.fs-bundle-retry.test.ts
+++ b/packages/store/tests/db.fs-bundle-retry.test.ts
@@ -14,6 +14,7 @@ vi.mock("@electric-sql/pglite", () => ({
 const { createDb } = await import("../src/db.js");
 
 const truncatedBundle = () => new Error("Invalid FS bundle size: 3030528 !== 6293225");
+const initFailure = () => new Error("PGlite failed to initialize properly");
 const fakePglite = () => ({
   query: vi.fn(async () => ({ rows: [{ ok: 1 }] })),
   close: vi.fn(async () => {}),
@@ -21,7 +22,7 @@ const fakePglite = () => ({
 
 // memory:// keeps the subject alone: no data dir, so neither the writer lock
 // nor the stale-postmaster.pid heal has anything to say about these failures.
-describe("PGlite truncated FS bundle retry", () => {
+describe("PGlite transient boot retry", () => {
   beforeEach(() => {
     pgliteCreate.mockReset();
   });
@@ -46,6 +47,34 @@ describe("PGlite truncated FS bundle retry", () => {
     expect((error as Error).message).toContain("[vendo]");
     expect((error as Error).message).toContain("Reinstall dependencies");
     expect((error as Error).message).toContain("Invalid FS bundle size: 3030528 !== 6293225");
+    expect(pgliteCreate).toHaveBeenCalledTimes(2);
+    await db.close();
+  });
+
+  // The CI flake this second signature exists for: one memory:// store in a
+  // ~300-test file loses its wasm boot, with no lock file and no short read to
+  // heal (`tests/session.test.ts` on run 32311392574, `tests/interruptions.test.ts`
+  // on run 32234929102 — byte-identical stack, different random victim).
+  it("heals a transient wasm init failure with one retry", async () => {
+    pgliteCreate.mockRejectedValueOnce(initFailure()).mockResolvedValueOnce(fakePglite());
+
+    const db = createDb({ dataDir: "memory://boot-init-heals" });
+    await expect(db.query("select 1")).resolves.toEqual({ rows: [{ ok: 1 }] });
+
+    expect(pgliteCreate).toHaveBeenCalledTimes(2);
+    await db.close();
+  });
+
+  // Bounded, and honest about the cause: a second init failure is believed, and
+  // only the truncated-bundle case is reworded — this one keeps its own message.
+  it("gives up after one retry and keeps a permanent init failure's own message", async () => {
+    pgliteCreate.mockRejectedValue(initFailure());
+
+    const db = createDb({ dataDir: "memory://boot-init-permanent" });
+    const error = await db.query("select 1").catch((caught: unknown) => caught);
+
+    expect((error as Error).message).toBe("PGlite failed to initialize properly");
+    expect((error as Error).message).not.toContain("Reinstall dependencies");
     expect(pgliteCreate).toHaveBeenCalledTimes(2);
     await db.close();
   });


### PR DESCRIPTION
`PGlite.create`'s delayed retry only fired for `Invalid FS bundle size`, so `PGlite failed to initialize properly` fell straight through. On a `memory://` store that is the end of the line: no lock file, so `createPgliteHealingStaleLock` rethrows on the spot (`db.ts:290`) — zero recovery path.

Real recurring flake, same suite, random victim, byte-identical stack, unrelated branches:
- run 32311392574 — `packages/agents/tests/session.test.ts`, `1 failed | 299 passed (300)`
- run 32234929102 — `packages/agents/tests/interruptions.test.ts`, branch `agents-dx/pr8-docs`, `1 failed | 299 passed (300)`

Both signatures now share the one delayed retry. `Aborted()` deliberately does **not** join them — it means a half-opened data dir and belongs to the stale-lock heal — and only the truncated-bundle case is still reworded into the reinstall message, so a second init failure arrives with its own text after exactly two attempts.

Two new tests in `db.fs-bundle-retry.test.ts` (transient heals; permanent keeps its own message, bounded at 2 calls); the three existing cases are untouched, as are the ENG-350/351 suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retries PGlite wasm boots that never started to remove a no-recovery path on `memory://` stores. Previously only "Invalid FS bundle size" retried; now "PGlite failed to initialize properly" also retries once, reducing intermittent CI flakes.

- Replace the truncated-bundle helper with `createPgliteRetryingTransientBoot`, matching both signatures via `TRANSIENT_BOOT`, and use it in `createPgliteHealingStaleLock`.
- Keep `Aborted()` on the stale-lock heal path; do not join the transient boot retry.
- Preserve original messaging on a second init failure; only the truncated-bundle case is reworded into the reinstall hint.
- Add tests for transient init retry and permanent failure messaging; unrelated errors still propagate without retry.
- No API changes; retry is delayed 500ms and bounded at two attempts.

<sup>Written for commit c6fc8ffca300094d3207f9478458f920deae9774. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1546?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

