### PR TITLE
test(ui): the export-surface fixtures stop littering the package tree

### DIFF
--- a/packages/ui/test/chrome/export-surface.test.ts
+++ b/packages/ui/test/chrome/export-surface.test.ts
@@ -1,9 +1,10 @@
 import { execFile } from "node:child_process";
-import { rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
-import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { join, relative } from "node:path";
 import { promisify } from "node:util";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterAll, describe, expect, it } from "vitest";
 import * as chrome from "../../src/chrome/index.js";
 
 // Shelf-core Task 1 guard: the thread refactor (vendo-thread.tsx →
@@ -145,10 +146,21 @@ const packageDir = process.cwd(); // packages/ui
 const require = createRequire(join(packageDir, "package.json"));
 const tsc = require.resolve("typescript/bin/tsc");
 
-const fixtures: string[] = [];
-afterEach(() => {
-  for (const path of fixtures.splice(0)) rmSync(path, { force: true });
-});
+// Scratch files live OUTSIDE the package tree, and that is load-bearing rather
+// than tidiness. `packages/actions`' repo-wide guard (tests/sync/
+// protocol-facts.test.ts) lists every *.ts under packages/ and then reads each
+// one, so a fixture written into packages/ui and deleted a moment later made
+// that read die with ENOENT — a test in another package failing for no reason
+// of its own. Only `ai-dual` runs every package on one runner in one tree, so
+// it was the only job where the two could overlap, which made it a ~1-in-8
+// mystery that reddened unrelated PRs. One temp dir per worker also retires the
+// pid and random suffix the old names needed to stay unique in a shared dir.
+const scratch = mkdtempSync(join(tmpdir(), "vendo-chrome-surface-"));
+afterAll(() => rmSync(scratch, { recursive: true, force: true }));
+
+// The fixture imports the chrome entry from wherever it now sits.
+const chromeEntry = relative(scratch, join(packageDir, "src/chrome/index.js"));
+let written = 0;
 
 // AWAITED, never sync: each tsc spawn below takes ~30s, and `execFileSync` spent
 // that time blocking the vitest worker's event loop. birpc hard-codes a 60s RPC
@@ -161,9 +173,8 @@ const execFileAsync = promisify(execFile);
 /** Type-check a fixture that `import type`s `names` from the chrome entry.
  *  Returns tsc's combined output on failure, or null when it exits clean. */
 async function typecheckImports(names: string[]): Promise<string | null> {
-  const fixturePath = join(packageDir, `.chrome-surface.${process.pid}.${Math.random().toString(36).slice(2)}.ts`);
-  fixtures.push(fixturePath);
-  writeFileSync(fixturePath, `import type { ${names.join(", ")} } from "./src/chrome/index.js";\n`);
+  const fixturePath = join(scratch, `surface-${written++}.ts`);
+  writeFileSync(fixturePath, `import type { ${names.join(", ")} } from "${chromeEntry}";\n`);
   try {
     await execFileAsync(
       process.execPath,
@@ -199,4 +210,11 @@ describe("@vendoai/ui/chrome export surface", () => {
     expect(failure).not.toBeNull();
     expect(failure).toContain("TS2305");
   }, 120_000);
+
+  // The suites that read this repo's sources treat packages/ as immutable. This
+  // one writes files to do its job, so where it writes them is a contract with
+  // every one of them, not a private detail.
+  it("writes its scratch fixtures outside the package tree", () => {
+    expect(scratch.startsWith(packageDir)).toBe(false);
+  });
 });


### PR DESCRIPTION
`ai-dual` has been going red at random on unrelated PRs. It is not the AI SDK
major — it is two test suites fighting over the same directory.

## What happens

- `packages/actions/tests/sync/protocol-facts.test.ts:34-39` is a repo-wide
  guard: it walks **every** `*.ts` under `packages/` and then `readFile`s each
  one.
- `packages/ui/test/chrome/export-surface.test.ts` writes its `tsc` fixtures
  **into `packages/ui`** — `` `.chrome-surface.${process.pid}.${random}.ts` `` —
  and deletes them a moment later.

If ui deletes a fixture in the window between actions' directory walk and its
read, the guard dies:

```
FAIL tests/sync/protocol-facts.test.ts > no code path grades a tool from its NAME (D1, AC1)
Error: ENOENT: no such file or directory, open '.../packages/ui/.chrome-surface.8382.0jgpgx4kbym7.ts'
```

A test in one package failing for something another package did.

## Why only `ai-dual`

`ai-dual` is the one job that runs every package on a single runner in one
working tree (`turbo run test --concurrency=2 --filter=./packages/*`), so it is
the only place the two suites can overlap. Everywhere else they are on separate
runners with separate checkouts — `ui` in `test-shards (ui-1/ui-2)`, `actions` in
`test-rest`. Passing it was scheduling luck, roughly 7 times in 8.

## The fix

Fixtures move to an `mkdtemp` dir outside the tree. The fixture never belonged in
a directory other suites treat as immutable source. Two things fall out for free:
`mkdtemp` already guarantees per-worker uniqueness, so the pid and random suffix
in the filenames go away, and one `afterAll` replaces the per-file `afterEach`
cleanup.

The generated fixture's import specifier is now computed with `relative()` rather
than hardcoded `./src/chrome/index.js`. The suite's own "has teeth" case proves
that still resolves: a bogus name must fail with **TS2305** (missing export), and
it does — an unresolved entry would have been TS2307.

## Evidence

**Red, deterministic.** The real guard, run against the real filename pattern in
the real directory, with the write/delete churn rate raised so the walk→read
window is hit every time instead of ~1 in 8:

```
iter 1 FAIL: ENOENT ... /packages/ui/.chrome-surface.81536.twc3wh3gun.ts
iter 2 FAIL: ENOENT ... /packages/ui/.chrome-surface.81536.3jf3tlptc08.ts
iter 3 FAIL: ENOENT ... /packages/ui/.chrome-surface.81536.ej0zheovfgf.ts
BEFORE: 3 of 3 guard runs died on a vanishing in-tree fixture
```

**Red, in the wild.** Both suites concurrently, unmodified, on `origin/main`:
iteration 5 of 8 reproduced the exact CI signature while the ui suite itself
exited 0.

**Green.** An `fs.watch` recorder on `packages/ui` across a full ui run, before
and after:

```
BEFORE  in-tree scratch files observed: 2
          .chrome-surface.80816.15yiosrssky.ts
          .chrome-surface.80816.hgxe97fz5sd.ts
AFTER   in-tree scratch files observed: 0
```

With zero in-tree writes the race has no source, so it is gone by construction
rather than by luck. The concurrent harness confirms: **0 of 10** guard runs
failed with the fix, ui suite green alongside.

## Regression guard

One case, in the suite that has to keep the promise:

```ts
it("writes its scratch fixtures outside the package tree", () => {
  expect(scratch.startsWith(packageDir)).toBe(false);
});
```

## Notes

No changeset: test-only, matching the convention on recent test-only commits
(`test(genbench): the fontless-world control…`, and `test(ui): the
compiler-spawning export-surface tests get a compiler-sized timeout` #1368 — the
same file).

## Gate

`pnpm build` (22/22) · `pnpm test:affected` (35/35) · `pnpm typecheck` (44/44) ·
`pnpm lint` (4/4, 0 errors) — all green.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops `packages/ui` export-surface tests from writing temp TypeScript fixtures inside the package tree, removing cross-suite ENOENT flakes in the `ai-dual` job. Previously the test wrote and quickly deleted files under `packages/ui`; now it writes fixtures to an `mkdtemp` directory outside the repo.

**Details**
- Write fixtures to a per-worker `mkdtemp` dir in OS temp; replace per-file cleanup with a single `afterAll`; remove pid/random suffix from filenames.
- Compute the chrome entry import using `relative()` from the temp dir to keep type-checks accurate.
- Add an assertion that the scratch dir is outside `packages/ui`.
- Eliminates the race with `packages/actions`’ guard that lists and reads every `*.ts` under `packages/`.
- Tests only; no runtime code changed.

<sup>Written for commit f07f31e293007943bd9b7ae4feb1e2f7e7f62196. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1548?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

