### PR TITLE
fix(ui,apps): the ✦ appears only where sync could split the component

### DIFF
--- a/packages/apps/src/server/remix/seed-surface.ts
+++ b/packages/apps/src/server/remix/seed-surface.ts
@@ -16,9 +16,11 @@
  * provenance: what the remix started from, and what a re-seed replays the
  * recorded wishes against.
  *
- * A baseline with no `ported` half was not provably splittable. It gets NO remix:
- * the gesture refuses, loudly, rather than falling back to regenerating the
- * component from scratch.
+ * A baseline with no `ported` half was not provably splittable. It gets NO remix
+ * and, upstream of here, no ✦ at all: the chrome offers the gesture only on the
+ * slots the generated wiring names. A direct call is refused at the lookup,
+ * before anything is minted — never a fallback that regenerates the component
+ * from scratch.
  */
 import {
   VendoError,
@@ -52,7 +54,19 @@ export type SeedSurfaceDeps = Pick<
   | "replaySources"
 >;
 
-const baselineFor = (deps: SeedSurfaceDeps, component: string): SeedBaseline => {
+/** A baseline with its ported half — the only kind a remix can start from, and
+ *  the type says so, so no path below can reach for a port that is not there. */
+type PortedBaseline = SeedBaseline & { ported: SeedPort };
+
+/** The one lookup, and the one refusal. A component the splitter could not port
+ *  has nothing for a fork to START from, so it is no more remixable than one
+ *  nobody captured — regenerating it from scratch would hand the person a
+ *  different component wearing this one's name. Both refusals land HERE, before
+ *  anything is minted, so a remix that cannot exist leaves no row behind. The
+ *  chrome never offers the ✦ on one of these (the generated wiring names only
+ *  the slots that ported), and sync already said why in its report; this is what
+ *  a direct API caller gets, as an ordinary reportable wire error. */
+const baselineFor = (deps: SeedSurfaceDeps, component: string): PortedBaseline => {
   const baseline = (deps.config.seedBaselines ?? []).find(({ slot }) => slot === component);
   if (baseline === undefined) {
     throw new VendoError(
@@ -60,14 +74,6 @@ const baselineFor = (deps: SeedSurfaceDeps, component: string): SeedBaseline => 
       `remixable component "${component}" has no captured baseline; wrap it in <Remixable> and run vendo sync`,
     );
   }
-  return baseline;
-};
-
-/** The ported half, or no remix at all. A component the splitter could not port
- *  has nothing for a fork to START from, and the honest answer is to say so —
- *  regenerating it from scratch would hand the person a different component
- *  wearing this one's name. */
-const portOf = (baseline: SeedBaseline): SeedPort => {
   if (baseline.ported === undefined) {
     throw new VendoError(
       "validation",
@@ -75,7 +81,7 @@ const portOf = (baseline: SeedBaseline): SeedPort => {
       + "run vendo sync and read its report for why this component could not be ported",
     );
   }
-  return baseline.ported;
+  return baseline as PortedBaseline;
 };
 
 /**
@@ -90,10 +96,10 @@ const portOf = (baseline: SeedBaseline): SeedPort => {
 const seedScreen = async (
   deps: SeedSurfaceDeps,
   appId: AppId,
-  baseline: SeedBaseline,
+  baseline: PortedBaseline,
   ctx: RunContext,
 ): Promise<void> => {
-  const painted = await deps.runtime().floor(ctx).component({ appId, source: portOf(baseline).source });
+  const painted = await deps.runtime().floor(ctx).component({ appId, source: baseline.ported.source });
   if (!painted.ok) {
     throw new VendoError(
       "validation",
@@ -114,10 +120,6 @@ const seedFrom = async (
   ctx: RunContext,
 ): Promise<AppDocument> => {
   const baseline = baselineFor(deps, input.component);
-  // No ported half, no ✦ — refused BEFORE anything is minted, because a remix of
-  // a component nothing could port has nothing to be a remix of, and a row that
-  // can only ever fail is worse than a refusal the chrome can read.
-  portOf(baseline);
   // Idempotent per (subject, component): the gesture dedupes SERVER-side, so a
   // double-tap can never mint two apps and the chrome's latch stays cosmetic.
   // The OLDEST matching row wins, which is the same winner the chrome's own
@@ -283,7 +285,7 @@ const reseed = async (
   // throwing, so rebasing ahead of it left the OLD screen claiming the host's
   // current version — no drift warning, and every retry refused as a conflict
   // above.
-  deps.replaySources.set(app.id, portOf(baseline).source);
+  deps.replaySources.set(app.id, baseline.ported.source);
   const unapplied: string[] = [];
   let replayed = app;
   try {

--- a/packages/ui/e2e/harness/main.tsx
+++ b/packages/ui/e2e/harness/main.tsx
@@ -956,6 +956,10 @@ function RemixHolesScenario() {
   return (
     <VendoProvider client={baseClient} remixWiring={holeWiring}>
       <VendoSlot id="spend-card" pin={{ payload: holePayload }} />
+    </VendoProvider>
+  );
+}
+
 /** Two host components, both wrapped in `<Remixable>`. `SpendCard` split;
  *  `LegacyCard` did not, and `vendo sync` said so in its report. */
 function SpendCard() {

--- a/packages/ui/e2e/harness/main.tsx
+++ b/packages/ui/e2e/harness/main.tsx
@@ -956,6 +956,30 @@ function RemixHolesScenario() {
   return (
     <VendoProvider client={baseClient} remixWiring={holeWiring}>
       <VendoSlot id="spend-card" pin={{ payload: holePayload }} />
+/** Two host components, both wrapped in `<Remixable>`. `SpendCard` split;
+ *  `LegacyCard` did not, and `vendo sync` said so in its report. */
+function SpendCard() {
+  return <article className="host-card"><h3>Spend card</h3><p>This one split.</p></article>;
+}
+SpendCard.displayName = "SpendCard";
+
+function LegacyCard() {
+  return <article className="host-card"><h3>Legacy card</h3><p>This one did not split.</p></article>;
+}
+LegacyCard.displayName = "LegacyCard";
+
+/** `.vendo/generated/remix-wiring.ts` as the host hands it to the provider — the
+ *  SAME const `createVendo({ remixWiring })` takes. Its keys are the slots sync
+ *  could split, and `LegacyCard` is not among them. */
+const gateWiring = { SpendCard: { tools: {}, holes: {} } };
+
+function RemixGateScenario() {
+  return (
+    <VendoProvider client={baseClient} remixWiring={gateWiring} theme={mapleTheme}>
+      <div style={{ display: "grid", gap: 24, maxWidth: 560 }}>
+        <Remixable><SpendCard /></Remixable>
+        <Remixable><LegacyCard /></Remixable>
+      </div>
     </VendoProvider>
   );
 }
@@ -2105,6 +2129,7 @@ function scenario(pathname: string): { title: string; theme?: Partial<VendoTheme
     case "/tree": return { title: "Tree containment", content: <TreeScenario /> };
     case "/tree-injected": return { title: "Injected payload (captured host component)", content: <InjectedTreeScenario /> };
     case "/tree-holes": return { title: "Remix holes — npm + host sub-component, from the generated wiring", content: <RemixHolesScenario />, ownProvider: true };
+    case "/remixable-gate": return { title: "Remix ✦ — offered only where sync could split the component", content: <RemixGateScenario />, ownProvider: true };
     case "/tree-inclient": return { title: "In-client venue (hash-pinned approval)", content: <InClientScenario /> };
     case "/tree-review": return { title: "Review-kind standing (pending / rejected)", content: <ReviewStandingScenario /> };
     case "/tree-drift": return { title: "Seed drift (host component updated)", content: <SeedDriftScenario /> };

--- a/packages/ui/e2e/remix-sparkle-gate.spec.ts
+++ b/packages/ui/e2e/remix-sparkle-gate.spec.ts
@@ -25,7 +25,7 @@ test("the ✦ blooms on a ported component and does not exist on one that could 
   // The ported one carries the resting seed, and the cursor blooms it into the
   // pill. Opacity, not presence: the pill is in the DOM either way.
   const seed = ported.locator(".fl-remix-seed");
-  const pill = ported.getByRole("button", { name: "Remix SpendCard with Vendo" });
+  const pill = ported.getByRole("button", { name: "Remix this view with Vendo" });
   await expect(seed).toHaveCount(1);
   await expect(pill).toHaveCSS("opacity", "0");
   // The bloom is a HANDOFF: the seed goes as the pill arrives, in one corner.
@@ -42,6 +42,6 @@ test("the ✦ blooms on a ported component and does not exist on one that could 
   await expect(pill).toHaveCSS("opacity", "0");
   await expect(unported.locator(".fl-remixable-chrome")).toHaveCount(0);
   await expect(unported.locator(".fl-remix-seed")).toHaveCount(0);
-  await expect(page.getByRole("button", { name: "Remix LegacyCard with Vendo" })).toHaveCount(0);
+  await expect(unported.getByRole("button", { name: "Remix this view with Vendo" })).toHaveCount(0);
   await page.screenshot({ path: `${SHOTS}/unported-bare.png`, fullPage: true, animations: "disabled" });
 });

--- a/packages/ui/e2e/remix-sparkle-gate.spec.ts
+++ b/packages/ui/e2e/remix-sparkle-gate.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "@playwright/test";
+import { openScenario } from "./helpers.js";
+
+const SHOTS = "/tmp/remix-sparkle-gate";
+
+/**
+ * The ✦ is an OFFER, so it may only appear where sync could split the
+ * component. Both cards on this page are wrapped in `<Remixable>`; only
+ * `SpendCard` is named by the generated wiring.
+ *
+ * A real browser is the only proof of record here. The pill is revealed by
+ * OPACITY under a real pointer, so jsdom can neither see the bloom nor tell an
+ * invisible affordance from an absent one — and "absent" is the whole claim.
+ */
+test("the ✦ blooms on a ported component and does not exist on one that could not split", async ({ page }) => {
+  await openScenario(page, "remixable-gate");
+
+  const ported = page.locator('[data-vendo-remixable="SpendCard"]');
+  const unported = page.locator('[data-vendo-remixable="LegacyCard"]');
+
+  // Both host components render exactly the markup the host wrote.
+  await expect(page.getByText("This one split.")).toBeVisible();
+  await expect(page.getByText("This one did not split.")).toBeVisible();
+
+  // The ported one carries the resting seed, and the cursor blooms it into the
+  // pill. Opacity, not presence: the pill is in the DOM either way.
+  const seed = ported.locator(".fl-remix-seed");
+  const pill = ported.getByRole("button", { name: "Remix SpendCard with Vendo" });
+  await expect(seed).toHaveCount(1);
+  await expect(pill).toHaveCSS("opacity", "0");
+  // The bloom is a HANDOFF: the seed goes as the pill arrives, in one corner.
+  await ported.hover();
+  await expect(pill).toHaveCSS("opacity", "1");
+  await expect(seed).toHaveCSS("opacity", "0");
+  await page.screenshot({ path: `${SHOTS}/ported-blooms.png`, fullPage: true, animations: "disabled" });
+
+  // The one that could not split carries no Vendo chrome AT ALL — not a hidden
+  // ✦, not a disabled one, not a greyed one. Hovering it changes nothing.
+  await unported.hover();
+  // The reveal is per-wrapper, so the ported pill retracts once its own grace
+  // period lapses — and this page then holds exactly one ✦, at rest.
+  await expect(pill).toHaveCSS("opacity", "0");
+  await expect(unported.locator(".fl-remixable-chrome")).toHaveCount(0);
+  await expect(unported.locator(".fl-remix-seed")).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Remix LegacyCard with Vendo" })).toHaveCount(0);
+  await page.screenshot({ path: `${SHOTS}/unported-bare.png`, fullPage: true, animations: "disabled" });
+});

--- a/packages/ui/src/chrome/remixable.tsx
+++ b/packages/ui/src/chrome/remixable.tsx
@@ -245,6 +245,7 @@ function RemixedFork({ appId, slot, review, liveProps, original, onReverted }: {
 }
 
 export function Remixable({ review = false, children }: RemixableProps) {
+  const { remixSlots } = useVendoProvider();
   const [revealed, setRevealed] = useState(false);
   const root = useMenuDismiss(revealed, setRevealed);
   const grace = useRef<number | undefined>(undefined);
@@ -322,6 +323,14 @@ export function Remixable({ review = false, children }: RemixableProps) {
           original={children}
           onReverted={refresh}
         />
+      ) : !remixSlots.has(slot) ? (
+        // No port, no offer. The generated wiring names the slots sync could
+        // split, and a slot it does not name has nothing for a fork to start
+        // from — sync already said why, loudly, in its report. So the host's
+        // own markup renders alone: not a disabled ✦, not a greyed one, none.
+        // The gate is on the OFFER only; the arm above still mounts and still
+        // manages a remix that already exists, because revert is the way back.
+        children
       ) : (
         <>
           {children}

--- a/packages/ui/src/context.tsx
+++ b/packages/ui/src/context.tsx
@@ -17,6 +17,10 @@ export interface VendoContextValue {
   client: VendoClient;
   /** Host catalog implementations, by registered name (08 §2). */
   components: Record<string, ComponentType>;
+  /** The slots `vendo sync` could split — the generated wiring's own keys, and
+      exactly the components a ✦ may appear on. Empty when the host wired no
+      wiring: nothing has ported, so nothing offers a remix. */
+  remixSlots: ReadonlySet<string>;
   /** Resolved brand tokens (defaults ⊕ provider overrides). */
   theme: VendoTheme;
   /** The host's `.vendo/fonts.css` text — the brand's `@font-face` rules, as
@@ -116,10 +120,14 @@ export function hostComponentMap(components: HostComponentsInput | undefined): R
 
 /** The client half of the generated remix wiring (`vendo sync` writes
  * `.vendo/generated/remix-wiring.ts`; `holes` binds a name the ported screen
- * renders to the component itself). Read STRUCTURALLY, so the host hands the
- * whole generated const over — `tools` and all — exactly as it hands it to
+ * renders to the component itself, and the wiring's KEYS are the slots sync
+ * could split). Read STRUCTURALLY, so the host hands the whole generated const
+ * over — `tools` and all — exactly as it hands it to
  * `createVendo({ remixWiring })`. */
-export type RemixWiringInput = Record<string, { holes?: Record<string, ComponentType<never>> }>;
+export type RemixWiringInput = Record<string, {
+  tools?: Record<string, unknown>;
+  holes?: Record<string, ComponentType<never>>;
+}>;
 
 /** Every slot's holes, folded name-keyed — a component name is global here, so
  * two slots rendering the same hole are one entry rather than a collision. */
@@ -142,6 +150,10 @@ export function VendoProvider(props: {
       `components` entry for the same name still wins. Both ends need it: the
       client screen VM's vocabulary is built from this map too (tree/renderer.tsx),
       so a hole missing here is a name the port cannot even paint. */
+  /** The same generated const `createVendo({ remixWiring })` takes. It names
+      the slots sync could split, and `<Remixable>` offers the ✦ on those and
+      only those — sync already refused the rest, loudly, in its report. Unset
+      is the honest zero: no slot has ported, so no component offers a remix. */
   remixWiring?: RemixWiringInput;
   theme?: Partial<VendoTheme>;
   /** The host's `.vendo/fonts.css` text — see VendoContextValue.fonts. */
@@ -180,6 +192,7 @@ export function VendoProvider(props: {
     () => ({
       client: client ?? createVendoClient(baseUrl === undefined ? {} : { baseUrl }),
       components: { ...remixHoles(remixWiring), ...hostComponentMap(components) },
+      remixSlots: new Set(Object.keys(remixWiring ?? {})),
       theme: resolveTheme(defaultVendoTheme, theme),
       fonts,
       transport,

--- a/packages/ui/src/context.tsx
+++ b/packages/ui/src/context.tsx
@@ -144,16 +144,20 @@ export function VendoProvider(props: {
       carries its own base. */
   baseUrl?: string;
   components?: HostComponentsInput;
-  /** The same generated const `createVendo({ remixWiring })` takes. Its holes
-      join the components map as its WEAKEST leg — mirroring the server, where a
-      hole is the weakest leg of the catalog (`vendo` compose-surfaces.ts) — so a
-      `components` entry for the same name still wins. Both ends need it: the
-      client screen VM's vocabulary is built from this map too (tree/renderer.tsx),
-      so a hole missing here is a name the port cannot even paint. */
-  /** The same generated const `createVendo({ remixWiring })` takes. It names
-      the slots sync could split, and `<Remixable>` offers the ✦ on those and
-      only those — sync already refused the rest, loudly, in its report. Unset
-      is the honest zero: no slot has ported, so no component offers a remix. */
+  /** The same generated const `createVendo({ remixWiring })` takes. It is read
+      two ways, and both ends need it.
+
+      Its HOLES join the components map as its WEAKEST leg — mirroring the
+      server, where a hole is the weakest leg of the catalog (`vendo`
+      compose-surfaces.ts) — so a `components` entry for the same name still
+      wins. The client screen VM's vocabulary is built from this map too
+      (tree/renderer.tsx), so a hole missing here is a name the port cannot even
+      paint.
+
+      Its KEYS name the slots sync could split, and `<Remixable>` offers the ✦
+      on those and only those — sync already refused the rest, loudly, in its
+      report. Unset is the honest zero: no slot has ported, so no component
+      offers a remix, and none paints a hole. */
   remixWiring?: RemixWiringInput;
   theme?: Partial<VendoTheme>;
   /** The host's `.vendo/fonts.css` text — see VendoContextValue.fonts. */

--- a/packages/ui/test/chrome/remixable.test.tsx
+++ b/packages/ui/test/chrome/remixable.test.tsx
@@ -116,6 +116,10 @@ describe("Remixable — one door into the chat, one ✦ menu on the remix", () =
   const chromeIn = (slot: string) =>
     document.querySelector(`[data-vendo-remixable="${slot}"] .fl-remixable-chrome`);
 
+  /** The ✦ mark itself, for a named slot and WITHOUT assuming what it says. */
+  const pillIn = (slot: string) =>
+    document.querySelector(`[data-vendo-remixable="${slot}"] .fl-remix-pill`);
+
   // The ✦ is an OFFER, and an offer nothing can honour must never be made. A
   // component the splitter could not port has no source for a fork to start
   // from; sync says so, loudly, in its report, and the wiring it writes simply
@@ -140,14 +144,14 @@ describe("Remixable — one door into the chat, one ✦ menu on the remix", () =
   // that stops porting a slot must not strand someone's remix on the page with
   // no way back. The management ✦ — status / open in panel / revert — stays.
   //
-  // `managePill()` is the file's own name for that mark, so this assertion
-  // tracks whatever the pin chrome currently calls it rather than pinning a
-  // sentence. On the integration base that is "Edit this view" (S2 retired the
-  // slot-name form with the identifier-leak fix); the helper moves with it.
+  // The mark, not its wording: what this test owns is that the mark is THERE,
+  // and the pin chrome has renamed it before. The sentence it carries is
+  // asserted where that rename lives, so pinning one here would only buy a
+  // second stale expectation.
   it("still mounts and manages an EXISTING remix on a slot that no longer ports", async () => {
     await client.apps.seedFrom({ component: "Unsplittable", instruction: "make it a chart" });
     mount(<Remixable><Unsplittable /></Remixable>);
-    await waitFor(() => expect(managePill()).toBeTruthy());
+    await waitFor(() => expect(pillIn("Unsplittable")).toBeTruthy());
   });
 
   it("blooms on hover and holds through the grace period on the way out", () => {

--- a/packages/ui/test/chrome/remixable.test.tsx
+++ b/packages/ui/test/chrome/remixable.test.tsx
@@ -130,14 +130,14 @@ describe("Remixable — one door into the chat, one ✦ menu on the remix", () =
     expect(screen.getByText("Unported host markup")).toBeTruthy();
     expect(chromeIn("Unsplittable")).toBeNull();
     expect(document.querySelector(".fl-remix-seed")).toBeNull();
-    expect(screen.queryByRole("button", { name: "Remix Unsplittable with Vendo" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Remix this view with Vendo" })).toBeNull();
   });
 
   it("shows NO ✦ when the host wired no remix wiring at all — nothing has ported", () => {
     mount(undefined, null);
     expect(screen.getByText("Blue Bottle")).toBeTruthy();
     expect(chromeIn(SLOT)).toBeNull();
-    expect(screen.queryByRole("button", { name: `Remix ${SLOT} with Vendo` })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Remix this view with Vendo" })).toBeNull();
   });
 
   // The gate is on the OFFER, never on a remix that already exists: a re-sync

--- a/packages/ui/test/chrome/remixable.test.tsx
+++ b/packages/ui/test/chrome/remixable.test.tsx
@@ -6,7 +6,7 @@
 // The inline wish form, its status line, and its pill states are deleted.
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { VendoProvider, createVendoClient, type VendoClient } from "../../src/index.js";
+import { VendoProvider, createVendoClient, type RemixWiringInput, type VendoClient } from "../../src/index.js";
 import { Remixable, VendoOverlay } from "../../src/chrome/index.js";
 import { CHROME_CSS } from "../../src/chrome/chrome-css.js";
 import { createWireServer } from "../wire-server.js";
@@ -31,6 +31,17 @@ if (typeof window.PointerEvent !== "function") {
 
 /** The slot is the wrapped component's identifier — what sync captures under. */
 const SLOT = "TopMerchants";
+
+/** `.vendo/generated/remix-wiring.ts` as the host hands it to the provider —
+ *  the SAME const `createVendo({ remixWiring })` takes. Its keys are the slots
+ *  `vendo sync` could split, so they are exactly the slots a ✦ may appear on. */
+const WIRING = { [SLOT]: { tools: {}, holes: {} } };
+
+/** A wrapped component the splitter could not port: it has a `<Remixable>` and
+ *  a captured baseline, and the wiring does not name it. */
+function Unsplittable() {
+  return <p>Unported host markup</p>;
+}
 
 function TopMerchants(_props: {
   title?: string;
@@ -75,9 +86,14 @@ describe("Remixable — one door into the chat, one ✦ menu on the remix", () =
   /** The remix the CHAT minted — the wrapper no longer mints anything itself. */
   const seedRemix = () => client.apps.seedFrom({ component: SLOT, instruction: "make it a chart" });
 
-  function mount(node = <Remixable><TopMerchants title="Top merchants" /></Remixable>) {
+  function mount(
+    node = <Remixable><TopMerchants title="Top merchants" /></Remixable>,
+    // `null` is "the host wired none at all" — an `undefined` argument would
+    // silently re-apply the default below.
+    remixWiring: RemixWiringInput | null = WIRING,
+  ) {
     return render(
-      <VendoProvider client={client}>
+      <VendoProvider client={client} remixWiring={remixWiring ?? undefined}>
         {node}
         <VendoOverlay launcher="none" />
       </VendoProvider>,
@@ -94,6 +110,39 @@ describe("Remixable — one door into the chat, one ✦ menu on the remix", () =
     expect(remixDoor()).toBeTruthy();
     // At rest the pill is inert — nothing invisible to misclick.
     expect(revealed()).toBe(false);
+  });
+
+  /** The whole ✦ apparatus for one slot — one node, or none at all. */
+  const chromeIn = (slot: string) =>
+    document.querySelector(`[data-vendo-remixable="${slot}"] .fl-remixable-chrome`);
+
+  // The ✦ is an OFFER, and an offer nothing can honour must never be made. A
+  // component the splitter could not port has no source for a fork to start
+  // from; sync says so, loudly, in its report, and the wiring it writes simply
+  // does not name the slot. So the wrapper renders the host's own markup and
+  // nothing else — not a disabled ✦, not a greyed one.
+  it("shows NO ✦ at all on a component the splitter could not port", () => {
+    mount(<Remixable><Unsplittable /></Remixable>);
+    expect(screen.getByText("Unported host markup")).toBeTruthy();
+    expect(chromeIn("Unsplittable")).toBeNull();
+    expect(document.querySelector(".fl-remix-seed")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Remix Unsplittable with Vendo" })).toBeNull();
+  });
+
+  it("shows NO ✦ when the host wired no remix wiring at all — nothing has ported", () => {
+    mount(undefined, null);
+    expect(screen.getByText("Blue Bottle")).toBeTruthy();
+    expect(chromeIn(SLOT)).toBeNull();
+    expect(screen.queryByRole("button", { name: `Remix ${SLOT} with Vendo` })).toBeNull();
+  });
+
+  // The gate is on the OFFER, never on a remix that already exists: a re-sync
+  // that stops porting a slot must not strand someone's remix on the page with
+  // no way back. The management ✦ — status / open in panel / revert — stays.
+  it("still mounts and manages an EXISTING remix on a slot that no longer ports", async () => {
+    await client.apps.seedFrom({ component: "Unsplittable", instruction: "make it a chart" });
+    mount(<Remixable><Unsplittable /></Remixable>);
+    await waitFor(() => expect(managePill()).toBeTruthy());
   });
 
   it("blooms on hover and holds through the grace period on the way out", () => {
@@ -176,7 +225,10 @@ describe("Remixable — one door into the chat, one ✦ menu on the remix", () =
     vi.stubEnv("NODE_ENV", "development");
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     render(
-      <VendoProvider client={client}>
+      // Its own provider, deliberately WITHOUT the overlay — that absence is
+      // what this test is about. The wiring is not: without it the slot has no
+      // port, so the gate hides the ✦ and there is no door to press.
+      <VendoProvider client={client} remixWiring={WIRING}>
         <Remixable><TopMerchants title="Top merchants" /></Remixable>
       </VendoProvider>,
     );

--- a/packages/ui/test/chrome/remixable.test.tsx
+++ b/packages/ui/test/chrome/remixable.test.tsx
@@ -139,6 +139,11 @@ describe("Remixable — one door into the chat, one ✦ menu on the remix", () =
   // The gate is on the OFFER, never on a remix that already exists: a re-sync
   // that stops porting a slot must not strand someone's remix on the page with
   // no way back. The management ✦ — status / open in panel / revert — stays.
+  //
+  // `managePill()` is the file's own name for that mark, so this assertion
+  // tracks whatever the pin chrome currently calls it rather than pinning a
+  // sentence. On the integration base that is "Edit this view" (S2 retired the
+  // slot-name form with the identifier-leak fix); the helper moves with it.
   it("still mounts and manages an EXISTING remix on a slot that no longer ports", async () => {
     await client.apps.seedFrom({ component: "Unsplittable", instruction: "make it a chart" });
     mount(<Remixable><Unsplittable /></Remixable>);


### PR DESCRIPTION
**The last piece of the remix story.** Base `main`. 6 files, and it is the change that stops the ✦ appearing where it cannot work.

## What changed

`<Remixable>` now checks membership before rendering the affordance. `<VendoProvider>` takes the same generated `remixWiring` const the server does; the wiring's **top-level keys are the slots `vendo sync` could split**, because sync only writes a slot in when the split succeeded. So the ✦ is offered on those slots and only those — sync already refused the rest, loudly, in its report.

**The gate is on the OFFER only.** An existing remix still mounts and is still managed, because revert has to stay reachable: a re-sync that stops porting a slot must not strand someone's remix on the page with no way back.

**It is fail-closed.** A host that has wired no `remixWiring` sees **no ✦ at all** — the honest zero, since nothing has ported. That is why this had to land after the holes work (#1505): ported slots only become remixable once both the provider prop and hole rendering are present, and shipping the gate first would have shown a ✦ whose holes could not paint.

Also folds `portOf` into `baselineFor`, so the server's refusal for an unported baseline happens at a single lookup before anything is minted. The refusal stays a typed `VendoError("validation")` → HTTP 400 carrying the sync-report pointer; it is now unreachable by a user gesture, because the ✦ never appears.

## Verification

Proven **both directions** — a ported slot blooms, an unported one renders the host's own markup and nothing else — in jsdom **and** in a real Chromium production build, each proven able to fail. `@vendoai/ui`: **161 files / 1498 tests, zero failures**. Build 3/3, typecheck 4/4, after wiping `core`/`apps`/`ui` `dist` and rebuilding clean.

## Integration note

Rebased onto `main` from its original base `aee9a37e8` (a mid-S4 commit), so it crossed S2, S3, S4 and S5 landing. Resolutions, all pre-agreed:

- **`remixable.test.tsx`** — taken as **`main`'s version plus the integration patch**, discarding this branch's copy. That is deliberate: this branch's copy still asserted the pre-S2 accessible name, while the patch inherits `main`'s `managePill` (`"Edit this view"`) and adds `remixWiring={WIRING}` to the one test that builds its own provider. Result carries zero `strict` references.
- **`context.tsx`** — union with #1505: `RemixWiringInput` in its ruled shape (`tools?` and `holes?` both declared, so the exported type describes what sync actually emits), both doc sentences kept, and the value composing `components` with `remixSlots`.
- **`remixable.tsx`** — `const { remixSlots } = useVendoProvider();`. This branch originally replaced a `const { client } = …` that no longer exists in `Remixable`; keeping `client` would have left it declared and unused, since it fed the `fork()` call S2 deleted.
- **`seed-surface.ts`** — S3's wish-list accumulator kept, with `baseline.ported.source` replacing the removed `portOf`.
- **`e2e/harness/main.tsx`** — straight union of two independent scenarios, this branch's `/remixable-gate` alongside #1505's `/tree-holes`.

`packages/ui/src/index.ts` dropped out of the diff entirely: #1505 already exports `RemixWiringInput`, so this branch's change there became a no-op.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate the Remix ✦ so it appears only on components `vendo sync` actually ported. Previously any `<Remixable>` showed the ✦; now it renders only for slots named in the generated wiring, and unwired hosts show no ✦. Existing remixes still mount and remain manageable so revert stays reachable.

- UI: `\ <VendoProvider>` accepts the generated `remixWiring` const; the provider exposes `remixSlots`, and `\ <Remixable>` checks membership before rendering chrome. Fail-closed: no wiring → no ✦ anywhere.
- Required: pass `.vendo/generated/remix-wiring.ts` to `remixWiring` in your provider; tests that mount a provider must do the same or the ✦ will be hidden.
- Types: exported `RemixWiringInput` now matches the ruled shape `{ tools?: Record<string, unknown>; holes?: Record<string, ComponentType<never>> }`.
- Server: `seed-surface` folds the “ported” check into `baselineFor`, which now returns a typed ported baseline and rejects unsplittable components with `VendoError("validation")` (HTTP 400). No fallback regeneration; this path is only reachable via direct API calls.
- Verification: jsdom tests updated to supply `remixWiring` and assert absence of chrome on unported/unspecified slots; new Playwright spec (`e2e/remix-sparkle-gate.spec.ts`) and `/remixable-gate` harness scenario verify the ✦ blooms only on a ported card and is absent otherwise. Locators target the slot-free aria-label (“Remix this view with Vendo”) and scope negatives to the unported wrapper; duplicate JSDoc on `remixWiring` consolidated.

<sup>Written for commit 3b471d2700bb479b8f385120ca4293a4845f0c89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1550?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

