### PR TITLE
docs: cut what CLAUDE.md can already read, move the browser loop to a skill

### DIFF
--- a/.claude/skills/browser-specs/SKILL.md
+++ b/.claude/skills/browser-specs/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: browser-specs
+description: How to iterate on and prove a Playwright browser spec in this repo — the two-speed warm-harness loop for editing, the fresh production build that is the only result worth reporting, and the rule that an agent scripts a browser flow rather than stepping through it click-by-click. Use when writing, debugging, or verifying any browser/Playwright spec, or when a UI-affecting change needs real-browser proof.
+---
+
+# Browser specs
+
+## Iterating is two-speed
+
+While you are editing, start ONE warm hot-reloading harness (`VENDO_HARNESS_DEV=1`
+plus a pinned `VENDO_HARNESS_PORT`) and rerun specs against it with the same two
+variables — reuse is dev-mode-only, so every rerun skips the build and starts in
+seconds.
+
+Then one run WITHOUT the flag — a fresh production build — is the proof of
+record, and the only result worth reporting. A production run never reuses a
+server: `vite preview` serves whatever was built last, so a reused one greens the
+previous build.
+
+## Script the flow, don't step through it
+
+An agent proves a browser flow by SCRIPTING it, never by stepping through it
+click-by-click: write one throwaway Playwright script for the whole flow, run it
+once, judge the screenshot/video artifacts — one model turn instead of fifteen,
+seconds instead of minutes.
+
+Interactive stepping is for two cases only: exploring UI the agent didn't write,
+and diagnosing a scripted run that failed for unclear reasons — and whatever
+stepping teaches gets banked as a script so the flow is never stepped twice.
+
+## Where this runs
+
+No browser runs in CI (2026-08-06) — headless mis-resolves `:focus-visible` and
+`light-dark()`, so the Playwright suites stay a LOCAL pre-PR gate.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,15 +10,6 @@ generated UI in a sandboxed, brand-native surface.
   `vendoai` alias. The behavior contract is the exported types/zod schemas and
   the test suites — there are no prose contract docs; layering enforced by
   `scripts/dependency-guard.mjs` in `pnpm lint`
-- `examples/` — the demo host `demo-bank` (Maple) and the framework integration
-  examples (`ai-sdk-agent`, `mastra-agent`, `claude-code-plugin`)
-- `corpus/` — init-extraction corpus harness (`pnpm corpus`)
-- `docs-site/` — the public docs site
-
-## Commands
-
-- `pnpm install` · `pnpm build` · `pnpm test` · `pnpm test:affected` (scoped to changed packages — the local default) · `pnpm typecheck` · `pnpm lint` (turbo-cached)
-- Demo: `pnpm --filter demo-bank dev` (Maple)
 
 ## Vendo Cloud
 
@@ -91,21 +82,8 @@ generated UI in a sandboxed, brand-native surface.
   names breaks merges. No browser runs in CI (2026-08-06) — headless
   mis-resolves `:focus-visible` and `light-dark()`, so the Playwright suites
   stay a LOCAL pre-PR gate.
-- Iterating on a browser spec is two-speed. While you are editing, start ONE
-  warm hot-reloading harness (`VENDO_HARNESS_DEV=1` plus a pinned
-  `VENDO_HARNESS_PORT`) and rerun specs against it with the same two variables —
-  reuse is dev-mode-only, so every rerun skips the build and starts in seconds.
-  Then one run WITHOUT the flag — a fresh production build — is the proof of
-  record, and the only result worth reporting. A production run never reuses a
-  server: `vite preview` serves whatever was built last, so a reused one greens
-  the previous build.
-- An agent proves a browser flow by SCRIPTING it, never by stepping through it
-  click-by-click: write one throwaway Playwright script for the whole flow, run
-  it once, judge the screenshot/video artifacts — one model turn instead of
-  fifteen, seconds instead of minutes. Interactive stepping is for two cases
-  only: exploring UI the agent didn't write, and diagnosing a scripted run that
-  failed for unclear reasons — and whatever stepping teaches gets banked as a
-  script so the flow is never stepped twice.
+- Iterating on or proving a browser spec has its own workflow — see the
+  **browser-specs** skill (`.claude/skills/browser-specs/SKILL.md`).
 - `--continue` and a turbo concurrency bound are the standing rule wherever the
   suite runs: `--continue` so one red package never hides every other package's
   result; the bound (2 in CI's `test-rest`, 4 in the root `test` /


### PR DESCRIPTION
## What

Two cuts and one move in the root `CLAUDE.md`, which every session in this repo loads in full.

**Cut — the codebase already says it:**
- The whole `## Commands` section. `pnpm install` / `build` / `test` / `test:affected` / `typecheck` / `lint` and `pnpm --filter demo-bank dev` are `package.json`'s `scripts` read back. The one non-obvious thing that line carried — `test:affected` is the local default, never run the full suite locally — is already stated under `## Tests`.
- Three of the four `## Layout` bullets (`examples/`, `corpus/`, `docs-site/`). That is `ls` output.

The `packages/` bullet **stays**: "the behavior contract is the exported types/zod schemas and the test suites — there are no prose contract docs" is a gotcha a new session would get wrong, and it names the enforcement (`scripts/dependency-guard.mjs`).

**Moved to lazy loading:** the browser-spec workflow (the warm `VENDO_HARNESS_DEV=1` harness while editing, the one fresh production build that is the proof of record, and "script the flow, don't step through it click-by-click") now lives in `.claude/skills/browser-specs/SKILL.md`. `CLAUDE.md` keeps a one-line pointer. Only the skill's description stays resident; the body loads when someone is actually writing a browser spec.

8,301 → 6,851 chars.

## Why

Every line of the root `CLAUDE.md` is in context on every session, whatever the task. A line a session could reconstruct with `ls` or by reading `package.json` is paid for on every one of those sessions and buys nothing — the model would have gone and read the manifest anyway.

The browser-spec loop is different: it is not derivable and it is worth keeping, but it only matters while writing a browser spec. A skill is exactly that shape — resident description, lazy body.

**Nothing under `## Rules` moved.** A prohibition that lives in a lazily-loaded skill is a prohibition that may not be loaded at the moment it matters, so those stay where they are regardless of size.

## Verification

- `CLAUDE.md` 8,301 → 6,851 chars; no section other than `## Commands` and the three `## Layout` bullets is touched — see the diff.
- No code, config, or build input changes: the diff is 2 files, both documentation.
- The skill's frontmatter carries `name` and `description`, so it appears in the skill listing and is model-invocable.

The one judgment call worth a reviewer's eye: whether the `## Layout` bullets earn their place for orientation even though `ls` covers them. I cut them; easy to argue back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eb3f3SpvVx9pHvxhhA5u5s
