### PR TITLE
fix(ui): a failed app surface says why, instead of printing its own discriminant

### DIFF
--- a/.changeset/failed-surface-says-why.md
+++ b/.changeset/failed-surface-says-why.md
@@ -1,0 +1,17 @@
+---
+"@vendoai/ui": patch
+---
+
+A failed app surface says why, instead of printing its own discriminant. The
+terminal `{kind:"failed", reason}` that `open` started answering had no consumer
+on either renderer: `AppFrame` fell through to its unknown-kind catch-all and put
+`Unsupported app surface "failed".` on a host's logged-in dashboard, and a slot
+never reached the card that already knows how to say this — a placement's status
+is build-time truth, so a build that landed and a screen that has since stopped
+compiling both read as "ready", and only the open knows the difference.
+
+Both consumers read the kind now. `AppFrame` contains the reason in the same
+notice every other in-surface failure uses, and a mounted slot hands the failed
+surface to the existing build-failed card: the reason, and the way back to the
+host's own markup. Placement status is untouched — it reports the build honestly,
+and the consumer side is where this belonged.

--- a/packages/ui/src/chrome/vendo-slot.tsx
+++ b/packages/ui/src/chrome/vendo-slot.tsx
@@ -190,7 +190,7 @@ function SlotBuildFailed({ appId, slotId, onChanged }: {
   );
 }
 
-function MountedApp({ appId, slotId, onChanged, onParked }: { appId: string; slotId: string; onChanged(): void; onParked?: (parked: ParkedPress) => void }) {
+function MountedApp({ appId, placement, onParked }: { appId: string; placement?: { slotId: string; onChanged(): void }; onParked?: (parked: ParkedPress) => void }) {
   const { client, components } = useVendoProvider();
   const { surface, error, isLoading, refresh } = useApp(appId);
   // The served-surface keepalive: an on-screen embed pings the
@@ -207,8 +207,13 @@ function MountedApp({ appId, slotId, onChanged, onParked }: { appId: string; slo
   // "ready" — build-time truth, honestly reported — so only the open knows, and
   // the card that names the reason and clears the slot has to be reachable from
   // here too, or the slot prints the wire's own vocabulary at the person.
-  if (surface?.kind === "failed") {
-    return <SlotBuildFailed appId={appId} slotId={slotId} onChanged={onChanged} />;
+  //
+  // Only a PLACEMENT gets that card, for the same reason the ✦ below hides
+  // Revert from a host-asserted app: there is no row to clear, and discovery is
+  // stood down, so both of its buttons would write to the wire and leave the
+  // screen exactly as it was. Without one the frame still says the reason.
+  if (surface?.kind === "failed" && placement !== undefined) {
+    return <SlotBuildFailed appId={appId} slotId={placement.slotId} onChanged={placement.onChanged} />;
   }
   if (!surface) {
     if (error && !isLoading) return <SlotLoadFailed reason={error} onRetry={() => void refresh()} />;
@@ -455,7 +460,7 @@ export function VendoSlot({ id, label, description, appId: appIdProp, pin, onAut
   const mounted = appId
     // `reload` remounts the app, so Refresh is a real round trip through
     // get+open — and the wait is the shape-true skeleton, not a frozen view.
-    ? <MountedApp key={reload} appId={appId} slotId={id} onChanged={() => void discovery.refresh()} onParked={parked} />
+    ? <MountedApp key={reload} appId={appId} placement={resolvesItself ? { slotId: id, onChanged: () => void discovery.refresh() } : undefined} onParked={parked} />
     : <AppFrame surface={{ kind: "tree", payload: pin!.payload }} components={components} data={pin!.data} onAction={pin!.onAction} onParked={parked} />;
   const body = (
     <FluidReveal stateKey={appId ? `app:${appId}` : `pin:${id}`} initialExit={children}>

--- a/packages/ui/src/chrome/vendo-slot.tsx
+++ b/packages/ui/src/chrome/vendo-slot.tsx
@@ -190,7 +190,7 @@ function SlotBuildFailed({ appId, slotId, onChanged }: {
   );
 }
 
-function MountedApp({ appId, onParked }: { appId: string; onParked?: (parked: ParkedPress) => void }) {
+function MountedApp({ appId, slotId, onChanged, onParked }: { appId: string; slotId: string; onChanged(): void; onParked?: (parked: ParkedPress) => void }) {
   const { client, components } = useVendoProvider();
   const { surface, error, isLoading, refresh } = useApp(appId);
   // The served-surface keepalive: an on-screen embed pings the
@@ -203,6 +203,13 @@ function MountedApp({ appId, onParked }: { appId: string; onParked?: (parked: Pa
   useEffect(() => {
     if (surface?.kind === "tree") rememberShape(appId, surface.payload);
   }, [appId, surface]);
+  // A build that landed and a screen that no longer opens. The placement says
+  // "ready" — build-time truth, honestly reported — so only the open knows, and
+  // the card that names the reason and clears the slot has to be reachable from
+  // here too, or the slot prints the wire's own vocabulary at the person.
+  if (surface?.kind === "failed") {
+    return <SlotBuildFailed appId={appId} slotId={slotId} onChanged={onChanged} />;
+  }
   if (!surface) {
     if (error && !isLoading) return <SlotLoadFailed reason={error} onRetry={() => void refresh()} />;
     return <SlotGhost label="Loading app…" loading appId={appId} />;
@@ -448,7 +455,7 @@ export function VendoSlot({ id, label, description, appId: appIdProp, pin, onAut
   const mounted = appId
     // `reload` remounts the app, so Refresh is a real round trip through
     // get+open — and the wait is the shape-true skeleton, not a frozen view.
-    ? <MountedApp key={reload} appId={appId} onParked={parked} />
+    ? <MountedApp key={reload} appId={appId} slotId={id} onChanged={() => void discovery.refresh()} onParked={parked} />
     : <AppFrame surface={{ kind: "tree", payload: pin!.payload }} components={components} data={pin!.data} onAction={pin!.onAction} onParked={parked} />;
   const body = (
     <FluidReveal stateKey={appId ? `app:${appId}` : `pin:${id}`} initialExit={children}>

--- a/packages/ui/src/tree/frames.tsx
+++ b/packages/ui/src/tree/frames.tsx
@@ -192,6 +192,10 @@ export function AppFrame({ surface, appId, components = {}, data, onAction = una
     );
   }
 
+  if (surface.kind === "failed") {
+    return <ContainedNotice label="App unavailable" outcome="error">{surface.reason}</ContainedNotice>;
+  }
+
   const unknown = surface as { kind?: unknown };
   return (
     <ContainedNotice label="Unsupported app surface">

--- a/packages/ui/test/chrome/slot-states.test.tsx
+++ b/packages/ui/test/chrome/slot-states.test.tsx
@@ -134,6 +134,18 @@ describe("VendoSlot build states", () => {
       expect(await screen.findByText("Invoices app surface")).toBeTruthy();
     });
 
+    // The build landed, so the placement says "ready" and the app mounts — and
+    // the open answers that its screen is gone. Only the mounted surface knows,
+    // so the failed card has to be reachable from there too.
+    it("shows the failed card when a ready app's screen no longer opens", async () => {
+      const reason = "the screen no longer compiles: spending.data is undefined";
+      wire.state.deadScreens.set("app_1", reason);
+      wire.state.placements.push({ slot: "hero", appId: "app_1" });
+      slot("hero");
+      await screen.findByText(reason);
+      expect(screen.getByRole("button", { name: "Clear this slot" })).toBeTruthy();
+    });
+
     it("mounts the placed app — the http surface", async () => {
       wire.state.httpApps.set("app_1", "/frame-target.html");
       wire.state.placements.push({ slot: "hero", appId: "app_1" });

--- a/packages/ui/test/chrome/slot-states.test.tsx
+++ b/packages/ui/test/chrome/slot-states.test.tsx
@@ -146,6 +146,22 @@ describe("VendoSlot build states", () => {
       expect(screen.getByRole("button", { name: "Clear this slot" })).toBeTruthy();
     });
 
+    // A host-asserted appId is the host's own markup decision: there is no
+    // placement row to clear, and discovery is stood down, so the card's writes
+    // would land on the wire and change nothing on screen. The reason is still
+    // said — in the notice the frame renders for every one of its callers.
+    it("a host-asserted app says why, without a clear that could never land", async () => {
+      const reason = "the screen no longer compiles: spending.data is undefined";
+      wire.state.deadScreens.set("app_1", reason);
+      render(
+        <VendoProvider client={client}>
+          <VendoSlot id="hero" appId="app_1"><span>Original hero</span></VendoSlot>
+        </VendoProvider>,
+      );
+      await screen.findByText(reason);
+      expect(screen.queryByRole("button", { name: "Clear this slot" })).toBeNull();
+    });
+
     it("mounts the placed app — the http surface", async () => {
       wire.state.httpApps.set("app_1", "/frame-target.html");
       wire.state.placements.push({ slot: "hero", appId: "app_1" });

--- a/packages/ui/test/tree/frames.test.tsx
+++ b/packages/ui/test/tree/frames.test.tsx
@@ -226,6 +226,13 @@ describe("AppFrame", () => {
     render(<AppFrame surface={{ kind: "spatial" } as never} />);
     expect(screen.getByRole("note", { name: /unsupported app surface/i }).textContent).toContain("spatial");
   });
+
+  it("says why a failed app will not render, never its discriminant", () => {
+    const reason = "the screen no longer compiles: spending.data is undefined";
+    render(<AppFrame surface={{ kind: "failed", reason }} />);
+    expect(screen.getByRole("note", { name: /app unavailable/i }).textContent).toContain(reason);
+    expect(screen.queryByText(/unsupported app surface/i)).toBeNull();
+  });
 });
 
 describe("PinMount", () => {

--- a/packages/ui/test/wire-server.ts
+++ b/packages/ui/test/wire-server.ts
@@ -342,6 +342,11 @@ export async function createWireServer(options: WireServerOptions = {}) {
      *  screen, and "not ready yet" is the build window's pending, never a
      *  failure (persistence/open.ts, wire/apps.ts). */
     pendingScreens: new Map<string, number>(),
+    /** An app whose build LANDED and whose screen no longer opens (app id →
+     *  reason): the placement is honestly "ready" and `open` still answers
+     *  {kind:"failed"} — a stale app whose screen stopped compiling, which is
+     *  the only state that reaches a mounted surface (wire/apps.ts). */
+    deadScreens: new Map<string, string>(),
     /** What `GET /apps/:id/grants` answers, by app id — the ✦ share toggle's
      *  one round trip. An UNSEEDED app answers the empty truth (no level, no
      *  grants, no memberships), so every other suite's ✦ menu stays exactly the
@@ -1320,6 +1325,8 @@ export async function createWireServer(options: WireServerOptions = {}) {
               ? json(response, { kind: "pending" })
               : wireError(response, "not-found", `app ${id} has no screen yet`, 404);
           }
+          const dead = state.deadScreens.get(id);
+          if (dead !== undefined) return json(response, { kind: "failed", reason: dead });
           // A served (rung-4) app answers with its machine url; everything else
           // is a tree. Both must mount in a slot.
           const served = state.httpApps.get(id);


### PR DESCRIPTION
## What broke

#1537 gave a broken app's `open` a well-formed `{kind:"failed", reason}` (`packages/vendo/src/wire/apps.ts:173-175`) where a bare 400 used to be — the right call: an agent had retried one identical 400 for 7.7 minutes. But no renderer consumes the new kind, so it fell through to `AppFrame`'s catch-all and printed the wire's own discriminant on Maple's logged-in dashboard:

> Unsupported app surface "failed".

The slot path was hit too. A placement's `status` is build-time truth — the build landed, so it says `ready` — and only the `open` knows the screen has since stopped compiling. So `VendoSlot` took the mounted path and never reached `SlotBuildFailed`, the card that already knows how to say this. Pre-#1537 the 400 landed in `useApp`'s error and the slot soft-degraded to `SlotLoadFailed`; #1537 turned that soft degrade into an internal string on a host's most public surface.

## The fix — both consumers read the kind

- `packages/ui/src/tree/frames.tsx:195` — a `failed` case ahead of the catch-all, in the same `ContainedNotice` every other in-surface failure in this file uses. Closes the hole for every `AppFrame` caller (chat embeds, `Remixable`, the demo-bank apps page).
- `packages/ui/src/chrome/vendo-slot.tsx:206` — a mounted app whose surface is `failed` hands off to the existing `SlotBuildFailed`: the reason, and "Clear this slot" as the way back to the host's own markup.

No new visual design — both arms reuse components that already shipped. Placement `status` is untouched; it reports the build honestly, and the consumer side is where this belonged.

## Tests (red first)

Both new tests failed with the DOM literally rendering `Unsupported app surface "failed".` before the fix:

- `AppFrame > says why a failed app will not render, never its discriminant`
- `VendoSlot build states > ready > shows the failed card when a ready app's screen no longer opens`

The fixture could not express the regression — its only failed-app knob also flips the placement to `failed`, so it could never produce the real shape of "placement ready, open failed". `wire-server.ts` gains one additive `deadScreens` map for exactly that state, so the slot test reads it over the real wire like every other state in that file.

## Gate

`pnpm build` pass · `pnpm typecheck` pass (44/44) · `pnpm lint` pass · `pnpm test:affected` — `@vendoai/ui` 1490/1490 green, plus demo-bank, integration fixtures, corpus, genbench and the examples all green.

`@vendoai/vendo` showed 12 red files in the 1h02m concurrent run. Re-run in isolation on this branch, 10 of the 12 pass; the 2 left are the known worktree-layout red (`ENOENT … /Cool%20Code/…` — a `docs-site` scandir and an `mkdtemp`, neither touching UI). The other 9 were 30s/60s timeouts under load, the documented full-suite-on-a-laptop failure mode.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows the reason for a failed app surface instead of treating "failed" as unknown. Previously, `AppFrame` rendered “Unsupported app surface 'failed'”; now it shows “App unavailable” with the server-provided reason. In slots, a failed surface routes to the build-failed card only when the app comes from a placement; host-asserted apps show the reason without a clear action.

- `AppFrame`: handles `surface.kind === "failed"` via `ContainedNotice` and displays the failure reason.
- `VendoSlot`: `MountedApp` renders `SlotBuildFailed` only when a placement is present; otherwise the frame shows the reason and no “Clear this slot.”
- Tests/wire: add coverage for both flows; `wire-server.ts` adds a `deadScreens` map to simulate “ready placement, open failed.”
- Release: changeset for `@vendoai/ui` (patch). No visual redesign or migration.

<sup>Written for commit 66e00d5e495debff3249ac368420ff153e41a906. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1552?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

