### PR TITLE
fix(harnesses): the box holds the model behind its own write, so the next tool call stops racing the sync

### DIFF
--- a/packages/harnesses/box/turn-routes.mjs
+++ b/packages/harnesses/box/turn-routes.mjs
@@ -45,6 +45,14 @@ import path from "node:path";
 
 const RUNNER = "/opt/vendo-box/claude-turn.mjs";
 const MAX_POLL_WAIT_MS = 25_000;
+/**
+ * How long a write may wait for the host to say it synced. The ack rides the
+ * host's next poll, which its own `wrote` event has already woken, so it
+ * normally lands in milliseconds. This is the bound for a host that stopped
+ * polling ALTOGETHER, where hanging the build forever would be worse than the
+ * race it prevents: past it the turn proceeds exactly as it did before.
+ */
+const SYNC_ACK_WAIT_MS = MAX_POLL_WAIT_MS;
 /** Finished messages stay pollable for a little while (a host retrying its last
  *  poll), then go. A session box lives for many messages, and every message's
  *  event buffer kept forever is a slow leak in a long-lived box. */
@@ -162,11 +170,51 @@ export const createSessionRoutes = (options = {}) => {
     wake(current);
   };
 
-  /** The host asked for a mid-turn hot sync; it polls for this and syncs. */
-  const onFileWritten = (written) => {
+  /**
+   * The host's poll CURSOR doubles as its sync ack: `box.ts` advances it only
+   * after collecting the events it just read and committing them, so a cursor
+   * past a `wrote` event means that write has landed in the store.
+   */
+  const ackSync = (state, cursor) => {
+    if (cursor <= state.acked) return;
+    state.acked = cursor;
+    wake(state);
+  };
+
+  /** Park until the host has synced every event below `through`, or the bound. */
+  const syncedThrough = async (state, through) => {
+    const deadline = Date.now() + SYNC_ACK_WAIT_MS;
+    while (state.acked < through) {
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) return;
+      await new Promise((resolve) => {
+        const timer = setTimeout(resolve, remaining);
+        // A write nobody is coming back for must not be the reason this process
+        // stays alive — the supervisor's own server is.
+        timer.unref?.();
+        state.waiters.push(() => { clearTimeout(timer); resolve(); });
+      });
+    }
+  };
+
+  /**
+   * The host asked for a mid-turn hot sync; it polls for this and syncs.
+   *
+   * AWAITED, and that is the whole point of it. The model's next tool call goes
+   * STRAIGHT to the host's MCP door, overtaking a sync that travels the long way
+   * round — box event → host poll → collect → commit. A hook that returned here
+   * let `validate` ask about a store that had never seen the file, measured live
+   * as "app not found: app_…" on an appId that validated seconds later. The
+   * engine awaits its PostToolUse hooks, so waiting here is what holds the model
+   * behind its own write.
+   */
+  const onFileWritten = async (written) => {
     if (current === undefined) return;
-    current.events.push({ type: "wrote", ...(typeof written === "string" ? { path: written } : {}) });
-    wake(current);
+    const state = current;
+    const through = state.events.length + 1;
+    state.events.push({ type: "wrote", ...(typeof written === "string" ? { path: written } : {}) });
+    wake(state);
+    await syncedThrough(state, through);
   };
 
   const openSession = async (payload) => {
@@ -197,7 +245,7 @@ export const createSessionRoutes = (options = {}) => {
 
   const startMessage = async (payload) => {
     const messageId = `msg_${randomUUID()}`;
-    const state = { events: [], waiters: [], done: false };
+    const state = { events: [], waiters: [], done: false, acked: 0 };
     messages.set(messageId, state);
     for (const stale of [...messages.keys()].slice(0, -MESSAGES_RETAINED)) messages.delete(stale);
     current = state;
@@ -390,6 +438,7 @@ export const createSessionRoutes = (options = {}) => {
 
       if (match[2] === "poll") {
         const cursor = Number.isInteger(payload?.cursor) ? payload.cursor : 0;
+        ackSync(state, cursor);
         return { status: 200, body: await poll(state, cursor, payload?.waitMs) };
       }
       if (match[2] === "steer") {
@@ -408,6 +457,9 @@ export const createSessionRoutes = (options = {}) => {
       }
       // The user hit stop. The SESSION survives — only this turn is cut short,
       // which is the whole reason a live session interrupts instead of aborting.
+      // Any write still parked on a sync ack is released first: the host has
+      // stopped polling this message, so the ack it waits for is never coming.
+      ackSync(state, state.events.length);
       await session?.interrupt().catch(() => undefined);
       return { status: 200, body: { ok: true } };
     },

--- a/packages/harnesses/box/turn-routes.mjs
+++ b/packages/harnesses/box/turn-routes.mjs
@@ -175,18 +175,38 @@ export const createSessionRoutes = (options = {}) => {
    * after collecting the events it just read and committing them, so a cursor
    * past a `wrote` event means that write has landed in the store.
    */
-  const ackSync = (state, cursor) => {
-    if (cursor <= state.acked) return;
-    state.acked = cursor;
+  const ackSync = (state, cursor, failure) => {
+    // CLAMPED to what this box actually SERVED. The cursor is the host's own
+    // count coming home, so on its own it proves nothing: a poll claiming 999
+    // would release every parked write with no collect behind it. The box acks
+    // only events it handed out, which is the part the protocol guarantees.
+    const acked = Math.min(cursor, state.served);
+    if (acked <= state.acked) return;
+    state.acked = acked;
+    state.syncFailure = typeof failure === "string" && failure !== "" ? failure : undefined;
     wake(state);
   };
 
-  /** Park until the host has synced every event below `through`, or the bound. */
+  /** This turn is over — let go of every parked write. No ack is coming, and a
+   *  turn cut short has no next tool call left to warn. */
+  const releaseWrites = (state) => {
+    state.acked = state.events.length;
+    state.syncFailure = undefined;
+    wake(state);
+  };
+
+  /**
+   * Park until the host has synced every event below `through`.
+   *
+   * THROWS rather than resolving when the sync did not happen — a barrier that
+   * releases on a failed sync is the original race back again, minus the
+   * evidence. The caller says so to the model in band.
+   */
   const syncedThrough = async (state, through) => {
     const deadline = Date.now() + SYNC_ACK_WAIT_MS;
     while (state.acked < through) {
       const remaining = deadline - Date.now();
-      if (remaining <= 0) return;
+      if (remaining <= 0) throw new Error("the host did not confirm the workspace sync in time");
       await new Promise((resolve) => {
         const timer = setTimeout(resolve, remaining);
         // A write nobody is coming back for must not be the reason this process
@@ -195,6 +215,7 @@ export const createSessionRoutes = (options = {}) => {
         state.waiters.push(() => { clearTimeout(timer); resolve(); });
       });
     }
+    if (state.syncFailure !== undefined) throw new Error(state.syncFailure);
   };
 
   /**
@@ -245,7 +266,7 @@ export const createSessionRoutes = (options = {}) => {
 
   const startMessage = async (payload) => {
     const messageId = `msg_${randomUUID()}`;
-    const state = { events: [], waiters: [], done: false, acked: 0 };
+    const state = { events: [], waiters: [], done: false, acked: 0, served: 0 };
     messages.set(messageId, state);
     for (const stale of [...messages.keys()].slice(0, -MESSAGES_RETAINED)) messages.delete(stale);
     current = state;
@@ -305,6 +326,8 @@ export const createSessionRoutes = (options = {}) => {
     for (;;) {
       const fresh = state.events.slice(cursor);
       if (fresh.length > 0 || state.done) {
+        // What the box has actually HANDED OUT — the ceiling on any later ack.
+        state.served = state.events.length;
         return { events: fresh, cursor: cursor + fresh.length, done: state.done };
       }
       const remaining = deadline - Date.now();
@@ -438,7 +461,7 @@ export const createSessionRoutes = (options = {}) => {
 
       if (match[2] === "poll") {
         const cursor = Number.isInteger(payload?.cursor) ? payload.cursor : 0;
-        ackSync(state, cursor);
+        ackSync(state, cursor, payload?.syncError);
         return { status: 200, body: await poll(state, cursor, payload?.waitMs) };
       }
       if (match[2] === "steer") {
@@ -459,7 +482,7 @@ export const createSessionRoutes = (options = {}) => {
       // which is the whole reason a live session interrupts instead of aborting.
       // Any write still parked on a sync ack is released first: the host has
       // stopped polling this message, so the ack it waits for is never coming.
-      ackSync(state, state.events.length);
+      releaseWrites(state);
       await session?.interrupt().catch(() => undefined);
       return { status: 200, body: { ok: true } };
     },

--- a/packages/harnesses/src/claude-code/box.ts
+++ b/packages/harnesses/src/claude-code/box.ts
@@ -324,6 +324,10 @@ export async function boxMachine(options: BoxMachineOptions): Promise<SessionMac
       const budgetMs = options.messageBudgetMs ?? MESSAGE_BUDGET_MS;
       const deadline = Date.now() + budgetMs;
       let cursor = 0;
+      /** A hot sync that FAILED, owed to the box on the next poll. The ack and its
+       *  failure travel the same way, so a parked write learns the sync did not
+       *  happen instead of waiting out its whole bound and proceeding as if it had. */
+      let syncError: string | undefined;
 
       // Interrupt the TURN, not the conversation — and do it the moment Stop is
       // pressed. The door parks a poll for POLL_WAIT_MS when the box has nothing
@@ -356,14 +360,23 @@ export async function boxMachine(options: BoxMachineOptions): Promise<SessionMac
               `the turn outran its ${budgetMs}ms message budget`,
             );
           }
-          const polled = await request(`/session/${messageId}/poll`, { cursor, waitMs: POLL_WAIT_MS });
+          const polled = await request(`/session/${messageId}/poll`, {
+            cursor,
+            waitMs: POLL_WAIT_MS,
+            ...(syncError === undefined ? {} : { syncError }),
+          });
+          syncError = undefined;
           for (const event of Array.isArray(polled["events"]) ? polled["events"] : []) {
             const named = event as { type?: unknown; path?: unknown };
             // `wrote` is the native PostToolUse hook coming home. It is NOT a
             // HarnessEvent — it is the signal that replaced the 1.2s file-watch
             // timer, so it goes to the hot-sync callback and never to the user.
             if (named.type === "wrote") {
-              await message.onFileWritten?.(typeof named.path === "string" ? named.path : undefined);
+              try {
+                await message.onFileWritten?.(typeof named.path === "string" ? named.path : undefined);
+              } catch (error) {
+                syncError = error instanceof Error ? error.message : String(error);
+              }
               continue;
             }
             message.emit(event as never);

--- a/packages/harnesses/src/claude-code/box.ts
+++ b/packages/harnesses/src/claude-code/box.ts
@@ -363,7 +363,7 @@ export async function boxMachine(options: BoxMachineOptions): Promise<SessionMac
             // HarnessEvent — it is the signal that replaced the 1.2s file-watch
             // timer, so it goes to the hot-sync callback and never to the user.
             if (named.type === "wrote") {
-              message.onFileWritten?.(typeof named.path === "string" ? named.path : undefined);
+              await message.onFileWritten?.(typeof named.path === "string" ? named.path : undefined);
               continue;
             }
             message.emit(event as never);

--- a/packages/harnesses/src/claude-code/claude-turn.ts
+++ b/packages/harnesses/src/claude-code/claude-turn.ts
@@ -179,7 +179,7 @@ interface ClaudeSessionInput {
    * naming a path (`Bash`), which the host answers with one narrow
    * collect-by-shape rather than a whole-tree read.
    */
-  onFileWritten?: (path: string | undefined) => void;
+  onFileWritten?: (path: string | undefined) => void | Promise<void>;
   /**
    * The host's own MCP door, and a credential for the turn in flight.
    *
@@ -490,7 +490,7 @@ export function createClaudeSession(input: ClaudeSessionInput): ClaudeSession {
   const onPostToolUse = async (raw: unknown): Promise<Record<string, unknown>> => {
     const hook = raw as { tool_input?: { file_path?: unknown } };
     const written = hook.tool_input?.file_path;
-    input.onFileWritten?.(typeof written === "string" ? written : undefined);
+    await input.onFileWritten?.(typeof written === "string" ? written : undefined);
     // This hook OBSERVES. Permission is the box and the door; a hook that
     // returned a decision here would be a permission system smuggled back in.
     return {};

--- a/packages/harnesses/src/claude-code/claude-turn.ts
+++ b/packages/harnesses/src/claude-code/claude-turn.ts
@@ -490,7 +490,17 @@ export function createClaudeSession(input: ClaudeSessionInput): ClaudeSession {
   const onPostToolUse = async (raw: unknown): Promise<Record<string, unknown>> => {
     const hook = raw as { tool_input?: { file_path?: unknown } };
     const written = hook.tool_input?.file_path;
-    await input.onFileWritten?.(typeof written === "string" ? written : undefined);
+    try {
+      await input.onFileWritten?.(typeof written === "string" ? written : undefined);
+    } catch (error) {
+      // The write did NOT reach the workspace, and the model is about to ask the
+      // host about a file that is not there — it would read "app not found" as
+      // its own app being broken and set about "fixing" working code. So it is
+      // told the real reason, in band. Still not a decision: nothing is blocked
+      // and the turn carries on.
+      const why = error instanceof Error ? error.message : String(error);
+      return { systemMessage: `That file has not reached the workspace (${why}). Tools that read it may not see it yet.` };
+    }
     // This hook OBSERVES. Permission is the box and the door; a hook that
     // returned a decision here would be a permission system smuggled back in.
     return {};

--- a/packages/harnesses/src/claude-code/index.ts
+++ b/packages/harnesses/src/claude-code/index.ts
@@ -694,9 +694,13 @@ export function claudeCode(
           for (const path of await checkout.syncHot(hot)) landed.add(path);
         };
 
+        /** The barrier the write hook awaits. It must NOT resolve unless the write
+         *  actually reached the store: a swallowed failure here puts the model
+         *  back to racing its own write, silently, which is the worse half of the
+         *  bug this barrier exists for. The caller says so in band. */
         const syncHotNow = async (): Promise<void> => {
           if (finished) return;
-          await serialize(syncHot).catch(() => undefined);
+          await serialize(syncHot);
         };
 
         // `Turn.skills` finally reaches this harness. Before cc-native the pack

--- a/packages/harnesses/src/claude-code/index.ts
+++ b/packages/harnesses/src/claude-code/index.ts
@@ -694,9 +694,9 @@ export function claudeCode(
           for (const path of await checkout.syncHot(hot)) landed.add(path);
         };
 
-        const syncHotNow = (): void => {
+        const syncHotNow = async (): Promise<void> => {
           if (finished) return;
-          void serialize(syncHot).catch(() => undefined);
+          await serialize(syncHot).catch(() => undefined);
         };
 
         // `Turn.skills` finally reaches this harness. Before cc-native the pack

--- a/packages/harnesses/src/claude-code/machine.ts
+++ b/packages/harnesses/src/claude-code/machine.ts
@@ -76,7 +76,7 @@ export interface SessionMessage extends SessionOpen {
   emit: (event: ClaudeTurnEvent) => void;
   /** A file the turn wrote, from the SDK's native PostToolUse hook. `undefined`
    *  means a write whose path we cannot know (`Bash`). */
-  onFileWritten?: (path: string | undefined) => void;
+  onFileWritten?: (path: string | undefined) => void | Promise<void>;
   signal?: AbortSignal;
 }
 

--- a/packages/harnesses/src/materialize.ts
+++ b/packages/harnesses/src/materialize.ts
@@ -254,8 +254,13 @@ export async function checkoutWorkspace(
     if (staged.size === 0 && removed.length === 0) return [];
     const result = await workspace.commit();
     // A conflict means nothing landed (§3.2): the checkout's view of the store is
-    // unchanged, so the next sync retries the same diff.
-    if (result.status !== "ok") return [];
+    // unchanged, so the next sync retries the same diff. SAID OUT LOUD, because
+    // answering `[]` made "nothing landed" and "there was nothing to land"
+    // indistinguishable — which is how the mid-turn barrier came to acknowledge
+    // a write that never reached the store. Every caller already catches.
+    if (result.status !== "ok") {
+      throw new Error(`the workspace changed underneath this sync: ${result.paths.join(", ")}`);
+    }
     for (const [path, hash] of staged) hashes.set(path, hash);
     for (const path of removed) hashes.delete(path);
     // `removed` are paths that WERE in the checkout, so their rows existed and

--- a/packages/harnesses/tests/claude-code/sync-before-next-tool.test.ts
+++ b/packages/harnesses/tests/claude-code/sync-before-next-tool.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Read-your-own-write, PostToolUse hook to STORE — the whole chain, no stub in it.
+ *
+ * A build writes a screen file and its NEXT tool call goes to the host's MCP door:
+ * `validate`, `open`, `data_put`. That call must not be able to overtake the
+ * workspace sync the write triggered, or the door answers about a store that has
+ * never seen the file — observed live as `validate` failing "app not found:
+ * app_…" on an appId that validated `{"ok":true}` seconds later, which is a red
+ * "couldn't finish" step in the user's chat on every app build.
+ *
+ * Same chain as `beats-wire.test.ts`, for the same reason: a fake box that
+ * SCRIPTS the session cannot disagree with the loop about when the loop's hook
+ * returns, so it could never catch this.
+ *
+ *   scripted SDK, firing the REAL registered PostToolUse hook and awaiting it
+ *     → the REAL `createClaudeSession` loop (`src/claude-code/claude-turn.ts`)
+ *     → the REAL box door (`packages/harnesses/box/turn-routes.mjs`)
+ *     → the REAL `box.ts` poll loop
+ *     → the REAL `claude-code/index.ts` hot sync
+ *     → the REAL workspace commit
+ *
+ * The box's collect is deliberately SLOW. The window is a host→box round trip on
+ * a real network, and a test that wins the race only by being fast proves nothing
+ * about the one that lost it in production.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, expect, test } from "vitest";
+import type { ThreadId } from "@vendoai/core";
+import { createSessionRoutes } from "../../box/turn-routes.mjs";
+import { createClaudeSession } from "../../src/claude-code/claude-turn.js";
+import { createHarnessRuntime } from "../../src/runtime.js";
+import {
+  boundRegistry,
+  ctx,
+  readSse,
+  testAppsHooks,
+  testGuard,
+  testSkills,
+  testTranscript,
+  testWorkspace,
+  unusedModels,
+  userMessage,
+} from "../../src/test-doubles.test-util.js";
+import { claudeCode } from "../../src/claude-code/index.js";
+import {
+  disposeSessionMachines,
+  type SandboxAdapterLike,
+  type SandboxMachineLike,
+} from "../../src/claude-code/box.js";
+import { disposeLocalSessions, localMachine } from "../../src/claude-code/local.js";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+const SCREEN = "/user/apps/app_1/app.tsx";
+/** Long enough that losing the race is a certainty rather than a coin toss. */
+const COLLECT_MS = 200;
+
+const roots: string[] = [];
+afterEach(async () => {
+  await disposeSessionMachines();
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+type PostToolUseHook = (raw: Record<string, unknown>) => Promise<unknown>;
+
+/** The engine's OWN registered `PostToolUse` hook, invoked and awaited exactly
+ *  as the engine invokes it — awaiting it is the behaviour under test. */
+async function firePostToolUse(options: Record<string, unknown>, file: string): Promise<void> {
+  const hooks = options["hooks"] as { PostToolUse?: Array<{ hooks?: PostToolUseHook[] }> } | undefined;
+  const hook = hooks?.PostToolUse?.[0]?.hooks?.[0];
+  expect(typeof hook).toBe("function");
+  await hook!({
+    hook_event_name: "PostToolUse",
+    tool_name: "Write",
+    tool_input: { file_path: file },
+    tool_response: {},
+    tool_use_id: "tu_1",
+  });
+}
+
+/**
+ * One turn, as the engine runs it: write the file, fire the hook, then make the
+ * tool call the model would make next.
+ */
+function sdkWritingThenCalling(root: string, nextToolCall: () => void) {
+  return {
+    query: ({ prompt, options }: { prompt: unknown; options: Record<string, unknown> }) => ({
+      async *[Symbol.asyncIterator]() {
+        yield { type: "system", subtype: "init", session_id: "sess_row", model: "claude-test" };
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        for await (const _message of prompt as AsyncIterable<unknown>) {
+          const file = path.join(root, SCREEN.slice(1));
+          mkdirSync(path.dirname(file), { recursive: true });
+          writeFileSync(file, "screen v2");
+          yield {
+            type: "assistant",
+            message: { content: [{ type: "tool_use", name: "Write", input: { file_path: file } }] },
+          };
+          await firePostToolUse(options, file);
+          nextToolCall();
+          yield {
+            type: "result",
+            subtype: "success",
+            session_id: "sess_row",
+            usage: { input_tokens: 9, output_tokens: 4 },
+          };
+        }
+      },
+    }),
+  };
+}
+
+/** A box that speaks the REAL control-port protocol, running the REAL SDK loop. */
+function boxRunningTheRealLoop(root: string, sdk: unknown): SandboxAdapterLike {
+  return {
+    async create() {
+      const routes = createSessionRoutes({
+        root,
+        // A created machine boots with no token; the first hello claims it.
+        token: "",
+        env: {},
+        openSession: (input: Record<string, unknown>) =>
+          createClaudeSession({ ...input, sdk } as never),
+      }) as {
+        handle: (method: string, pathname: string, headers: Record<string, string>, payload: unknown)
+          => Promise<{ status: number; body: unknown }>;
+      };
+      return {
+        id: "box_row",
+        async destroy() { /* the root is reaped in afterEach */ },
+        async request(req) {
+          // The host→box hop the race is actually run across.
+          if (req.path === "/session/collect") {
+            await new Promise((resolve) => setTimeout(resolve, COLLECT_MS));
+          }
+          const payload = req.body === undefined
+            ? {}
+            : JSON.parse(typeof req.body === "string" ? req.body : decoder.decode(req.body)) as unknown;
+          const answer = await routes.handle(
+            req.method,
+            req.path,
+            (req.headers ?? {}) as Record<string, string>,
+            payload,
+          );
+          return { status: answer.status, headers: {}, body: encoder.encode(JSON.stringify(answer.body)) };
+        },
+      } as SandboxMachineLike;
+    },
+    async destroy() { /* teardown by ref */ },
+  };
+}
+
+test("the tool call after a write reaches a store that already holds the write", async () => {
+  const root = mkdtempSync(path.join(tmpdir(), "vendo-row-"));
+  roots.push(root);
+  const workspace = testWorkspace({ [SCREEN]: "screen v1" });
+  /** What the store held at the moment the model's next tool call went out. */
+  let landedBeforeNextCall: boolean | undefined;
+  const sandbox = boxRunningTheRealLoop(root, sdkWritingThenCalling(root, () => {
+    landedBeforeNextCall = workspace.commits.some((commit) => commit.changed.includes(SCREEN));
+  }));
+
+  const guard = testGuard();
+  const runtime = createHarnessRuntime({
+    tools: boundRegistry({}, guard),
+    guard,
+    skills: testSkills([]),
+    transcript: testTranscript(),
+  });
+  await readSse(await runtime.run({
+    harness: claudeCode({ sandbox, ...testAppsHooks() }) as never,
+    threadId: "thr_read_your_own_write" as ThreadId,
+    messages: [userMessage("m1", "build me a spending screen")],
+    ctx: ctx(),
+    workspace,
+    models: unusedModels(),
+    interactive: true,
+  }));
+
+  expect(landedBeforeNextCall).toBe(true);
+});
+
+test("machine: \"local\" holds the model behind its own write too — the rungs are identical", async () => {
+  // The local rung has no poll and no ack: the host's sync IS the callback the
+  // loop awaits (`local.ts` hands it straight through). So a sync that takes
+  // time must delay the model's next call, with nothing stubbed between them.
+  const order: string[] = [];
+  const sdk = {
+    query: ({ prompt, options }: { prompt: unknown; options: Record<string, unknown> }) => ({
+      async *[Symbol.asyncIterator]() {
+        yield { type: "system", subtype: "init", session_id: "sess_local_row", model: "claude-test" };
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        for await (const _message of prompt as AsyncIterable<unknown>) {
+          await firePostToolUse(options, SCREEN);
+          order.push("next tool call");
+          yield { type: "result", subtype: "success", session_id: "sess_local_row", usage: {} };
+        }
+      },
+    }),
+  };
+
+  const machine = await localMachine({
+    threadId: `thr_local_row_${Math.random().toString(36).slice(2)}`,
+    env: {},
+    openSession: ((input: Record<string, unknown>) =>
+      createClaudeSession({ ...input, sdk } as never)) as never,
+  });
+  await machine.send({
+    prompt: "build me a spending screen",
+    emit: () => undefined,
+    onFileWritten: async () => {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      order.push("sync");
+    },
+  });
+
+  expect(order).toEqual(["sync", "next tool call"]);
+  await disposeLocalSessions();
+});

--- a/packages/harnesses/tests/claude-code/sync-before-next-tool.test.ts
+++ b/packages/harnesses/tests/claude-code/sync-before-next-tool.test.ts
@@ -40,6 +40,7 @@ import {
   testSkills,
   testTranscript,
   testWorkspace,
+  type TestWorkspace,
   unusedModels,
   userMessage,
 } from "../../src/test-doubles.test-util.js";
@@ -68,24 +69,27 @@ type PostToolUseHook = (raw: Record<string, unknown>) => Promise<unknown>;
 
 /** The engine's OWN registered `PostToolUse` hook, invoked and awaited exactly
  *  as the engine invokes it — awaiting it is the behaviour under test. */
-async function firePostToolUse(options: Record<string, unknown>, file: string): Promise<void> {
+async function firePostToolUse(
+  options: Record<string, unknown>,
+  file: string,
+): Promise<Record<string, unknown>> {
   const hooks = options["hooks"] as { PostToolUse?: Array<{ hooks?: PostToolUseHook[] }> } | undefined;
   const hook = hooks?.PostToolUse?.[0]?.hooks?.[0];
   expect(typeof hook).toBe("function");
-  await hook!({
+  return await hook!({
     hook_event_name: "PostToolUse",
     tool_name: "Write",
     tool_input: { file_path: file },
     tool_response: {},
     tool_use_id: "tu_1",
-  });
+  }) as Record<string, unknown>;
 }
 
 /**
  * One turn, as the engine runs it: write the file, fire the hook, then make the
  * tool call the model would make next.
  */
-function sdkWritingThenCalling(root: string, nextToolCall: () => void) {
+function sdkWritingThenCalling(root: string, nextToolCall: (hookOutput: Record<string, unknown>) => void) {
   return {
     query: ({ prompt, options }: { prompt: unknown; options: Record<string, unknown> }) => ({
       async *[Symbol.asyncIterator]() {
@@ -99,8 +103,7 @@ function sdkWritingThenCalling(root: string, nextToolCall: () => void) {
             type: "assistant",
             message: { content: [{ type: "tool_use", name: "Write", input: { file_path: file } }] },
           };
-          await firePostToolUse(options, file);
-          nextToolCall();
+          nextToolCall(await firePostToolUse(options, file));
           yield {
             type: "result",
             subtype: "success",
@@ -153,6 +156,26 @@ function boxRunningTheRealLoop(root: string, sdk: unknown): SandboxAdapterLike {
   };
 }
 
+/** One real turn, all the way through the runtime. */
+async function runTurn(sandbox: SandboxAdapterLike, workspace: TestWorkspace, thread: string): Promise<void> {
+  const guard = testGuard();
+  const runtime = createHarnessRuntime({
+    tools: boundRegistry({}, guard),
+    guard,
+    skills: testSkills([]),
+    transcript: testTranscript(),
+  });
+  await readSse(await runtime.run({
+    harness: claudeCode({ sandbox, ...testAppsHooks() }) as never,
+    threadId: thread as ThreadId,
+    messages: [userMessage("m1", "build me a spending screen")],
+    ctx: ctx(),
+    workspace,
+    models: unusedModels(),
+    interactive: true,
+  }));
+}
+
 test("the tool call after a write reaches a store that already holds the write", async () => {
   const root = mkdtempSync(path.join(tmpdir(), "vendo-row-"));
   roots.push(root);
@@ -163,24 +186,82 @@ test("the tool call after a write reaches a store that already holds the write",
     landedBeforeNextCall = workspace.commits.some((commit) => commit.changed.includes(SCREEN));
   }));
 
-  const guard = testGuard();
-  const runtime = createHarnessRuntime({
-    tools: boundRegistry({}, guard),
-    guard,
-    skills: testSkills([]),
-    transcript: testTranscript(),
-  });
-  await readSse(await runtime.run({
-    harness: claudeCode({ sandbox, ...testAppsHooks() }) as never,
-    threadId: "thr_read_your_own_write" as ThreadId,
-    messages: [userMessage("m1", "build me a spending screen")],
-    ctx: ctx(),
-    workspace,
-    models: unusedModels(),
-    interactive: true,
-  }));
+  await runTurn(sandbox, workspace, "thr_read_your_own_write");
 
   expect(landedBeforeNextCall).toBe(true);
+});
+
+test("a hot sync that CONFLICTS tells the model, instead of acking a write that never landed", async () => {
+  // The barrier's failure mode matters more than its happy path: releasing on a
+  // sync that did NOT happen is the original race back again, minus the
+  // evidence. A conflict is the honest version of that — the commit is refused,
+  // nothing lands, and `syncHot` used to answer `[]` exactly as it does for an
+  // empty diff.
+  const root = mkdtempSync(path.join(tmpdir(), "vendo-row-conflict-"));
+  roots.push(root);
+  const workspace = testWorkspace({ [SCREEN]: "screen v1" });
+  workspace.conflictOn = [SCREEN];
+  let told: unknown;
+  let landedBeforeNextCall: boolean | undefined;
+  const sandbox = boxRunningTheRealLoop(root, sdkWritingThenCalling(root, (hookOutput) => {
+    told = hookOutput["systemMessage"];
+    landedBeforeNextCall = workspace.commits.some((commit) => commit.changed.includes(SCREEN));
+  }));
+
+  await runTurn(sandbox, workspace, "thr_read_your_own_write_conflict");
+
+  // Nothing landed — which is precisely why the model has to hear about it.
+  expect(landedBeforeNextCall).toBe(false);
+  expect(told).toMatch(/has not reached the workspace/);
+});
+
+test("an inflated poll cursor does not release a parked write", async () => {
+  // The cursor is the HOST's own count coming home. Taken on trust it is not an
+  // ack at all: a poll can claim any number and walk every parked write past a
+  // sync that never ran.
+  const root = mkdtempSync(path.join(tmpdir(), "vendo-row-cursor-"));
+  roots.push(root);
+  const auth = { "x-vendo-box-token": "tok" };
+  let released: string | undefined;
+  const routes = createSessionRoutes({
+    root,
+    token: "tok",
+    env: {},
+    openSession: (input: Record<string, unknown>) => ({
+      async send() {
+        const wrote = input["onFileWritten"] as (path: string) => Promise<void>;
+        await wrote(`${root}/user/apps/app_1/app.tsx`).then(
+          () => { released = "resolved"; },
+          () => { released = "threw"; },
+        );
+      },
+      steer: () => false,
+      async interrupt() { /* nothing to stop */ },
+      async end() { /* nothing to close */ },
+    }),
+  }) as {
+    handle: (method: string, pathname: string, headers: Record<string, string>, payload: unknown)
+      => Promise<{ status: number; body: Record<string, unknown> }>;
+  };
+
+  const started = await routes.handle("POST", "/session/message", auth, { prompt: "build it" });
+  const messageId = String(started.body["messageId"]);
+  // A poll that claims to have consumed 999 events when the box has served none.
+  const bogus = await routes.handle("POST", `/session/${messageId}/poll`, auth, { cursor: 999, waitMs: 0 });
+  expect(bogus.body["events"]).toEqual([]);
+  // Drained before asserting, or "still parked" would just mean "has not got
+  // round to it yet" and the assertion would hold with no clamp at all.
+  await new Promise((resolve) => setImmediate(resolve));
+  expect(released).toBeUndefined();
+
+  // The honest sequence still releases it: one poll is served the event, the
+  // next carries the cursor back as the ack.
+  const served = await routes.handle("POST", `/session/${messageId}/poll`, auth, { cursor: 0, waitMs: 0 });
+  expect(served.body["events"]).toEqual([{ type: "wrote", path: `${root}/user/apps/app_1/app.tsx` }]);
+  await routes.handle("POST", `/session/${messageId}/poll`, auth, { cursor: 1, waitMs: 0 });
+  // The park unwinds through the session's own continuation, not the poll's.
+  await new Promise((resolve) => setImmediate(resolve));
+  expect(released).toBe("resolved");
 });
 
 test("machine: \"local\" holds the model behind its own write too — the rungs are identical", async () => {


### PR DESCRIPTION
## The bug

A read-your-own-write race. The boxed agent writes a screen file and its **next**
tool call goes straight to the host's MCP door, while the sync that carries the
write travels the long way round — box event → host poll → collect → commit. The
door call kept winning, so `validate` asked about a store that had never seen the
file: `app not found: app_…` on an appId that validated `{"ok":true}` seconds
later. That is the red "couldn't finish" step users saw on every app build.

## The fix

The write hook is awaited end to end.

- `claude-turn.ts:182` widens `onFileWritten` to `=> void | Promise<void>`, and
  `:493` awaits it. The engine already awaits its `PostToolUse` hooks, so on
  `machine: "local"` — where that callback *is* the host's sync — this alone
  holds the model behind its own write.
- `index.ts:697` `syncHotNow` now returns the real `serialize(syncHot)` promise
  instead of firing and forgetting, so there is something to await.
- `box.ts:366` awaits the sync inside the poll loop, before advancing `cursor`.

The box needed one more rung, because in there the callback only appends a
`wrote` event to the poll buffer — awaiting it awaited nothing. **The host's poll
cursor is already the ack**: `box.ts` advances it only after collecting and
committing what it just read, so a cursor past a `wrote` event means that write
has landed. `turn-routes.mjs` now parks the hook until such a poll arrives
(`ackSync` / `syncedThrough`). No new route, no extra round trip.

Bound: `SYNC_ACK_WAIT_MS = MAX_POLL_WAIT_MS` (25s), the file's own budget
constant. The ack normally lands in milliseconds — the `wrote` event itself wakes
the parked poll — so this only covers a host that stopped polling altogether,
where hanging the build forever is worse than the race it prevents. Released
early on interrupt, since no ack is coming then, and the timer is `unref`ed so a
parked write never keeps the box's process alive.

## Tests

New seam test, `tests/claude-code/sync-before-next-tool.test.ts`, covering both
rungs with nothing stubbed between them — a scripted SDK firing the **real**
registered `PostToolUse` hook → real `createClaudeSession` → real box door → real
`box.ts` poll loop → real `index.ts` hot sync → real store commit. The box's
collect is deliberately slowed, because a test that wins the race only by being
fast proves nothing about the one that lost it in production.

Red → green was verified in both directions: both cases fail without the
`await`, and the box case still failed with the `await` alone until the cursor
ack landed.

## ⚠️ Rebake required after merge

`claude-turn.ts` and `turn-routes.mjs` are both copied into the box image
(`packages/apps/box/build-template.mjs`), so **the Cloud `vendo-box` template
must be rebaked after this merges** or boxes keep running the racing pair.
`claude-turn.ts` still imports nothing — that property is preserved.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the read-your-own-write race in the boxed Claude Code harness. The next tool call now waits for the workspace sync: previously it could overtake the sync and hit a stale store; now the write hook is awaited until the host acks the sync or reports failure, and the model is told when a sync fails.

- `packages/harnesses/src/claude-code/claude-turn.ts`: widen `onFileWritten` to `() => void | Promise<void>` and await it; on rejection, return a short system message warning the model that the file has not reached the workspace.
- `packages/harnesses/src/claude-code/index.ts`: make `syncHotNow` return and await the real serialized sync promise; do not swallow failures so a failed sync propagates.
- `packages/harnesses/src/materialize.ts`: throw on commit conflict instead of returning `[]`, so callers can distinguish “nothing landed” from “nothing to land.”
- `packages/harnesses/src/claude-code/box.ts`: await `message.onFileWritten`; if it throws, capture the error and send it back on the next poll as `syncError`.
- `packages/harnesses/box/turn-routes.mjs`: treat the host poll cursor as the sync ack but clamp it to what the box actually served; park `onFileWritten` until acked or `SYNC_ACK_WAIT_MS = MAX_POLL_WAIT_MS` (25s); release on interrupt; propagate a failed sync back to the parked write and throw; `unref` the timer.
- `packages/harnesses/src/claude-code/machine.ts`: update `onFileWritten` type to allow a Promise.
- Tests: add end-to-end seam tests verifying ordering for boxed and local machines, conflict reporting to the model, and that an inflated poll cursor cannot release a parked write.

- Rollout
  - Rebake required: rebuild the Cloud `vendo-box` template so boxes pick up the updated `claude-turn.ts` and `turn-routes.mjs`.
  - If you implement `onFileWritten`, it may now return a Promise and will be awaited; rejection surfaces as a model-visible warning, and long-running work delays the next tool call.

<sup>Written for commit dcf0fafcf26f82fce6ed08c8d14c824d38d738a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1555?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

