### PR TITLE
fix(vendo): `vendo sync`'s impact probe finds a wire mounted under a path prefix

### DIFF
--- a/.changeset/sync-impact-finds-a-mounted-wire.md
+++ b/.changeset/sync-impact-finds-a-mounted-wire.md
@@ -1,0 +1,20 @@
+---
+"@vendoai/vendo": patch
+---
+
+`vendo sync` now finds the wire on a host that is mounted under a path prefix.
+
+The blast-radius probe — the one that answers "what does changing this tool
+break?" — addressed the dev server at `<base>/api/vendo`, and with no
+`VENDO_BASE_URL` in the environment that base was a bare
+`http://localhost:3000`. On a host served under a prefix (Maple runs at
+`/maple`, so its wire answers at `/maple/api/vendo`) the request landed on a
+path the router never matched, and the probe reported the 404 it caused as
+`impact unknown — dev server not reachable`. Every mounted host got that same
+wrong diagnosis on every sync, with a running server the whole time.
+
+With no base URL configured the probe now reads the prefix off the OpenAPI
+spec's relative server mount — the only other place it is written down, already
+how the prefix reaches host tool calls, and the value `vendo doctor` holds
+`VENDO_BASE_URL` to agreement with (E-CFG-003). A host with no prefix, or one
+whose `VENDO_BASE_URL` is set, is addressed exactly as before.

--- a/packages/vendo/src/cli/sync-flow.ts
+++ b/packages/vendo/src/cli/sync-flow.ts
@@ -620,10 +620,19 @@ async function runGradingStages(input: {
  *  it off. The spec's relative server mount is the only other place it is
  *  written down — doctor holds the two to agreement (E-CFG-003) — and it is
  *  already how the prefix reaches host tool calls. Without it the probe asks a
- *  mounted host one prefix short and reads its own 404 back as "not reachable". */
+ *  mounted host one prefix short and reads its own 404 back as "not reachable".
+ *
+ *  Total on purpose, the way doctor's own mount check is (`doctor-config-checks`):
+ *  this reads a file and parses it, it runs OUTSIDE the probe's error boundary,
+ *  and no prefix is the answer the probe already handles. A spec that will not
+ *  parse costs the run its impact line, never the sync. */
 async function declaredMount(root: string): Promise<string> {
-  const spec = await firstOpenApiSpec(root);
-  return spec === null ? "" : await openApiMountPath(spec);
+  try {
+    const spec = await firstOpenApiSpec(root);
+    return spec === null ? "" : await openApiMountPath(spec);
+  } catch {
+    return "";
+  }
 }
 
 async function probeImpact(input: {

--- a/packages/vendo/src/cli/sync-flow.ts
+++ b/packages/vendo/src/cli/sync-flow.ts
@@ -2,7 +2,7 @@ import { readFile, rm } from "node:fs/promises";
 import { join } from "node:path";
 import type { z } from "zod";
 import type { ExtractedTool } from "@vendoai/actions";
-import { vendoSync, type SyncReportWithWarnings } from "@vendoai/actions/sync";
+import { firstOpenApiSpec, openApiMountPath, vendoSync, type SyncReportWithWarnings } from "@vendoai/actions/sync";
 import type { VendoThemeFont } from "@vendoai/apps/contract";
 import type { ToolImpact } from "../sync-impact.js";
 import {
@@ -616,6 +616,16 @@ async function runGradingStages(input: {
   return { judged, themeDraft };
 }
 
+/** The deployment's path prefix, for the run that has no VENDO_BASE_URL to read
+ *  it off. The spec's relative server mount is the only other place it is
+ *  written down — doctor holds the two to agreement (E-CFG-003) — and it is
+ *  already how the prefix reaches host tool calls. Without it the probe asks a
+ *  mounted host one prefix short and reads its own 404 back as "not reachable". */
+async function declaredMount(root: string): Promise<string> {
+  const spec = await firstOpenApiSpec(root);
+  return spec === null ? "" : await openApiMountPath(spec);
+}
+
 async function probeImpact(input: {
   report: SyncReportWithWarnings;
   options: SyncFlowOptions;
@@ -626,7 +636,7 @@ async function probeImpact(input: {
   note: (message: string) => void;
 }): Promise<ToolImpact[] | null> {
   const { report, options, env, output, note } = input;
-  const base = (env.VENDO_BASE_URL ?? "http://localhost:3000").replace(/\/+$/, "");
+  const base = (env.VENDO_BASE_URL ?? `http://localhost:3000${await declaredMount(options.root)}`).replace(/\/+$/, "");
   const wireUrl = (options.url ?? env.VENDO_URL ?? `${base}/api/vendo`).replace(/\/+$/, "");
   const tools = [...new Set([
     ...report.breaking.map((breaking) => breaking.tool),

--- a/packages/vendo/tests/cli/sync-impact-mount.seam.test.ts
+++ b/packages/vendo/tests/cli/sync-impact-mount.seam.test.ts
@@ -1,0 +1,94 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createStore } from "@vendoai/store";
+import { afterEach, describe, expect, it } from "vitest";
+import { runSyncFlow } from "../../src/cli/sync-flow.js";
+import { createVendo } from "../../src/server.js";
+
+/**
+ * The seam `vendo sync` crosses to say what a changed tool would break: the
+ * CLI's impact probe on one side, the real wire's `POST /sync/impact` on the
+ * other, and between them a host mounted under a path prefix. Maple is that
+ * host — `basePath: "/maple"`, so Next strips the prefix on the way in and the
+ * wire answers at `/maple/api/vendo`.
+ *
+ * The probe addressed it one prefix short and read its own 404 back as "dev
+ * server not reachable", so every mounted host got the same wrong diagnosis.
+ * Neither side may be stubbed here: a probe that talks to a fixture of the
+ * wire, or a wire asked at an address the probe never builds, agree with each
+ * other and stay wrong together.
+ */
+
+const MOUNT = "/maple";
+
+/** The prefix has one static home the CLI can read without a server: the spec's
+ *  relative server mount, which is how it reaches host tool calls too. */
+const SPEC = `${JSON.stringify({
+  openapi: "3.1.0",
+  info: { title: "Maple", version: "1" },
+  servers: [{ url: MOUNT }],
+  paths: {},
+})}\n`;
+
+/** One changed tool, so the probe has something to ask about. */
+const CHANGED = (async () => ({
+  tools: { added: [], removed: [], changed: ["host_a"] },
+  breaking: [],
+  pins: { captured: [], drifted: [] },
+  remixableErrors: [],
+  catalog: { discovered: 0, registered: 0 },
+  components: { captured: [], drifted: [] },
+  toolSchemas: { total: 0, inputs: { known: 0, unknown: [] }, outputs: { known: 0, unknown: [] } },
+  warnings: [],
+})) as never;
+
+const cleanups: Array<() => Promise<unknown>> = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+/** The host as Next serves it under `basePath`: requests under the prefix reach
+ *  the wire with the prefix stripped, everything else never routes at all. */
+function mountedHost(handler: (request: Request) => Promise<Response>): typeof fetch {
+  return (async (input: string | URL, init?: RequestInit) => {
+    const url = new URL(String(input));
+    if (url.pathname !== MOUNT && !url.pathname.startsWith(`${MOUNT}/`)) {
+      return new Response("Not Found", { status: 404 });
+    }
+    url.pathname = url.pathname.slice(MOUNT.length);
+    return handler(new Request(url, init));
+  }) as unknown as typeof fetch;
+}
+
+describe("[sync impact] the probe reaches a wire mounted under a path prefix", () => {
+  it("reads real impact back through the real route", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vendo-sync-impact-mount-"));
+    cleanups.push(() => rm(root, { recursive: true, force: true }));
+    await mkdir(join(root, ".vendo"), { recursive: true });
+    await writeFile(join(root, "openapi.json"), SPEC, "utf8");
+
+    const store = createStore({ dataDir: join(root, ".data") });
+    cleanups.push(() => store.close());
+    const vendo = createVendo({
+      store,
+      development: true,
+      principal: async () => ({ kind: "user", subject: "dev" }),
+    });
+
+    const result = await runSyncFlow({
+      root,
+      output: { log: () => {}, error: () => {} },
+      mode: "incremental",
+      interactive: false,
+      yes: true,
+      ai: false,
+      sync: CHANGED,
+      fetchImpl: mountedHost((request) => vendo.handler(request)),
+    });
+
+    // `null` is the "impact unknown" the unreachable path returns; a row per
+    // asked-about tool is the real route's own answer, off the real store.
+    expect(result.impact).toEqual([{ tool: "host_a", apps: [], automations: [], grants: 0 }]);
+  }, 120_000);
+});

--- a/packages/vendo/tests/cli/sync-impact-mount.seam.test.ts
+++ b/packages/vendo/tests/cli/sync-impact-mount.seam.test.ts
@@ -92,3 +92,36 @@ describe("[sync impact] the probe reaches a wire mounted under a path prefix", (
     expect(result.impact).toEqual([{ tool: "host_a", apps: [], automations: [], grants: 0 }]);
   }, 120_000);
 });
+
+describe("[sync impact] a spec the prefix cannot be read from", () => {
+  /** Reading the mount is best-effort, and it happens outside the probe's own
+   *  error boundary. A spec that will not parse must cost the run its IMPACT
+   *  line and nothing else: `vendo sync` exists to write the catalog, and an
+   *  unreadable openapi.json is not a reason to abandon that. */
+  it("degrades to the root URL instead of aborting the sync", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vendo-sync-impact-badspec-"));
+    cleanups.push(() => rm(root, { recursive: true, force: true }));
+    await mkdir(join(root, ".vendo"), { recursive: true });
+    await writeFile(join(root, "openapi.json"), "{ not json at all", "utf8");
+
+    const asked: string[] = [];
+    const offline = (async (input: string | URL) => {
+      asked.push(String(input));
+      throw new Error("offline");
+    }) as unknown as typeof fetch;
+
+    const result = await runSyncFlow({
+      root,
+      output: { log: () => {}, error: () => {} },
+      mode: "incremental",
+      interactive: false,
+      yes: true,
+      ai: false,
+      sync: CHANGED,
+      fetchImpl: offline,
+    });
+
+    expect(asked).toEqual(["http://localhost:3000/api/vendo/sync/impact"]);
+    expect(result.impact).toBeNull();
+  }, 120_000);
+});


### PR DESCRIPTION
`vendo sync`'s blast-radius probe — the one that answers "what does changing
this tool break?" — could not find the wire on any host served under a path
prefix, and reported the 404 it caused as a dead server.

## The bug

`probeImpact` builds its address as `<base>/api/vendo`, where `base` is
`VENDO_BASE_URL` or, failing that, a bare `http://localhost:3000`
(`packages/vendo/src/cli/sync-flow.ts`). Nothing in that fallback knows about a
path prefix.

Maple is served at `basePath: "/maple"`, so Next strips the prefix on the way in
and the wire answers at `/maple/api/vendo`. Confirmed live:

- `POST /api/vendo/sync/impact` → **404** (the Next router never matched)
- `POST /maple/api/vendo/sync/impact` → **200**, with real impact data

The probe swallows any failure as `impact unknown — dev server not reachable`,
so a mounted host got that same wrong diagnosis on every sync — with a healthy
dev server running the whole time. The operator is told the server is down; the
truth is the CLI knocked on the wrong door.

## The fix

The deployment's path prefix has exactly one home, `VENDO_BASE_URL`, and one
static declaration: the OpenAPI spec's relative server mount. `vendo doctor`
already holds those two to agreement (`E-CFG-003`, `doctor-config-checks.ts`),
and Maple's own `base-path.ts` names the spec's server url as how the prefix
reaches out-of-browser callers.

So when no base URL is configured, the probe now reads the prefix off the spec,
via the same `firstOpenApiSpec` / `openApiMountPath` pair doctor uses. No new
flag, no trying several spellings, and no network added to `vendo doctor` —
which stays static-only.

`??` short-circuits, so a host with `VENDO_BASE_URL` set does no extra I/O and
is addressed byte-identically. `openApiDocumentMountPath` returns `""` for an
absent spec or an absolute server url, so an unprefixed host is unchanged too —
the two existing probe-address tests still pass untouched.

12 insertions, 2 deletions, one file.

## Test

`packages/vendo/tests/cli/sync-impact-mount.seam.test.ts` — a real `createVendo`
wire behind a prefix-stripping front (what `basePath` does on the way in),
driven through the real `runSyncFlow`. Neither side is stubbed: a probe talking
to a fixture of the wire, or a wire asked at an address the probe never builds,
would agree with each other and stay wrong together.

Proven red first: `expected null to deeply equal [ { tool: 'host_a', … } ]` —
`null` being the "impact unknown" the unreachable path returns. Green after the
fix, reading a real row back off the real store through the real route.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`vendo sync`’s impact probe now resolves a path prefix when `VENDO_BASE_URL` is unset and degrades safely if the OpenAPI spec is unreadable. Previously it probed `<base>/api/vendo` with a default `http://localhost:3000`, ignored the prefix, returned 404s, and could misreport “impact unknown — dev server not reachable.”

- Default base becomes `http://localhost:3000${mount}`, where `mount` comes from the OpenAPI relative server via `firstOpenApiSpec` and `openApiMountPath` (falls back to "" for absolute servers or no spec).
- If the spec cannot be read or parsed, treat `mount` as "", probe the root (`http://localhost:3000/api/vendo`), and continue the sync; impact may be `null` instead of aborting the run.
- Preserve behavior when `VENDO_BASE_URL` is set; `??` short-circuits and avoids extra I/O.
- Add seam tests for a mounted host and for an unreadable spec; add a patch changeset for `@vendoai/vendo`.

<sup>Written for commit 5d91dba4695930bfff5ccd183d449841a93d3f6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1556?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

