### PR TITLE
fix(ui): a failed card keeps its headline and its ways out, in whatever box the host sized

### DIFF
--- a/.changeset/failed-card-keeps-its-headline.md
+++ b/.changeset/failed-card-keeps-its-headline.md
@@ -1,0 +1,16 @@
+---
+"@vendoai/ui": patch
+---
+
+A failed slot keeps its headline and its ways out, in whatever box the host sized.
+The other slot CTAs are three words over a skeleton, so the overlay carrying them
+is positioned absolutely and contributes no height. A failure carries a classified
+build reason — real prose — and that overlay is centred, so in a rail-width or
+host-sized slot the ghost's `overflow: hidden` sliced "This view didn't build" off
+the top and "Try again" / "Clear this slot" off the bottom, leaving a bare
+developer sentence with no title and no way out. The DOM held all of it, so
+`toBeVisible()` had been calling it visible for as long as the card has existed.
+
+The failure card stacks in flow now, on the same grid cell as the skeleton, so it
+grows to its own content instead of being clipped by it; the reason also stops
+bleeding past the card's padding. Every other slot state is untouched.

--- a/packages/ui/e2e/slot-failed-legible.spec.ts
+++ b/packages/ui/e2e/slot-failed-legible.spec.ts
@@ -18,7 +18,12 @@ import { openScenario, screenshotPath } from "./helpers.js";
 test("a failed card keeps its headline and its ways out in a host-sized slot", async ({ page }) => {
   await openScenario(page, "slot-states");
   const slot = page.locator('[data-vendo-slot="slot-failed"]');
-  await expect(slot.getByRole("alert")).toBeVisible();
+  // The card paints TWICE: the headline and "Clear this slot" at once, then the
+  // classified reason and "Try again" when the one detail read answers. Both the
+  // clip and the measurement below are about the settled card — the first paint
+  // carries the short generic line, which fits — so anchor on the only thing
+  // that read puts on screen, and let the suite's own expect budget do the wait.
+  await expect(slot.getByRole("button", { name: "Try again" })).toBeVisible();
 
   // A host that lets a rail-width slot size itself — the reason then wraps to
   // more lines than the card is tall, which is the whole of the bug.

--- a/packages/ui/e2e/slot-failed-legible.spec.ts
+++ b/packages/ui/e2e/slot-failed-legible.spec.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "@playwright/test";
+import { openScenario, screenshotPath } from "./helpers.js";
+
+/**
+ * A failed slot has to say what happened AT REST, in whatever box the host gave
+ * it — `--fl-slot-min-h` is the knob chrome-css ships for a host to size its own
+ * slot, and a classified build reason is real prose, so the two together are the
+ * ordinary case rather than the extreme one.
+ *
+ * The card that failed this was the one already covered: `.fl-slot-cta` is
+ * absolutely positioned, so it contributes NO height, and the ghost's
+ * `overflow: hidden` then sliced the headline off the top and the ways out off
+ * the bottom, leaving a bare paragraph nobody could act on. `toBeVisible()`
+ * cannot see that — Playwright calls a clipped element visible — so this asks
+ * the only question that settles it: is each part painted inside the box that
+ * clips it?
+ */
+test("a failed card keeps its headline and its ways out in a host-sized slot", async ({ page }) => {
+  await openScenario(page, "slot-states");
+  const slot = page.locator('[data-vendo-slot="slot-failed"]');
+  await expect(slot.getByRole("alert")).toBeVisible();
+
+  // A host that lets a rail-width slot size itself — the reason then wraps to
+  // more lines than the card is tall, which is the whole of the bug.
+  await page.addStyleTag({
+    content: '[data-vendo-slot="slot-failed"] { max-width: 320px; --fl-slot-min-h: 0; }',
+  });
+
+  const painted = await slot.evaluate(node => {
+    const card = node.querySelector(".fl-slot-ghost")!.getBoundingClientRect();
+    const inside = (el: Element) => {
+      const box = el.getBoundingClientRect();
+      return box.top >= card.top - 0.5 && box.bottom <= card.bottom + 0.5;
+    };
+    return {
+      headline: inside(node.querySelector(".fl-slot-cta-label")!),
+      actions: [...node.querySelectorAll("button")].map(button => [button.textContent!.trim(), inside(button)]),
+    };
+  });
+
+  expect(painted.headline, "the headline is clipped out of the card").toBe(true);
+  expect(painted.actions, "a way out is clipped out of the card")
+    .toEqual([["Try again", true], ["Clear this slot", true]]);
+
+  await slot.screenshot({ path: screenshotPath("slot-failed-short"), animations: "disabled" });
+});

--- a/packages/ui/src/chrome/chrome-css.ts
+++ b/packages/ui/src/chrome/chrome-css.ts
@@ -1378,6 +1378,17 @@ html[data-vendo-dock] {
 .fl-slot-ghost:hover .fl-slot-cta { background: color-mix(in srgb, var(--vendo-bg) 16%, transparent); }
 .fl-slot-cta svg { margin-bottom: 2px; opacity: .85; }
 .fl-slot-cta small { font-weight: 400; font-size: 11.5px; color: var(--vendo-fg-muted); }
+/* A failure has to read AT REST, in whatever box the host sized. The other CTAs
+   are three words over a skeleton, but a failure carries a classified reason —
+   real prose — and an absolutely-positioned overlay contributes no height, so
+   the ghost's overflow:hidden sliced the headline off the top and the ways out
+   off the bottom and left a paragraph nobody could act on. Stacked in flow (the
+   .fl-boot-labels idiom) the card grows to its own content instead. */
+.fl-slot-ghost:has(> .fl-slot-cta[role="alert"]) { display: grid; }
+.fl-slot-ghost:has(> .fl-slot-cta[role="alert"]) > * { grid-area: 1 / 1; }
+/* relative, not static: the skeleton's blur makes it a stacking context, so an
+   out-of-layer card would sit UNDER it and hand it the button presses. */
+.fl-slot-cta[role="alert"] { position: relative; }
 
 /* ---- empty-state invitation ----
    Accent-washed surface carrying real copy, up to three concrete suggestion


### PR DESCRIPTION
## What a person saw

A placed app whose screen won't open renders the failed card from `SlotBuildFailed`
(`packages/ui/src/chrome/vendo-slot.tsx:174-190`) — headline, reason, and two ways
out. On a live Maple dashboard it painted as a bare developer sentence: no title,
no buttons. All three were in the DOM; only the middle one was on screen.

## Judged first

The nit came in as "the headline and the actions are hover-revealed". They are not
— there is no hover-gating anywhere in slot chrome. `.fl-slot-ghost:hover` only
changes border colour, shadow and a background tint, and `.fl-slot-cta-label`,
`.fl-invite-btn` and `.fl-invite-own` have no opacity or visibility rule at all.
So this is the "fix it directly" branch, not the "exempt the failure state" one.

The real cause is geometry. `.fl-slot-cta` is `position: absolute; inset: 0` with
`justify-content: center`, which is right for the states it was designed for —
three words over a skeleton. It contributes **no height**. A failure carries a
classified build reason, which is real prose, so as soon as that overlay is taller
than the slot it overflows at *both* ends and the ghost's `overflow: hidden` takes
the headline off the top and both buttons off the bottom, leaving exactly the
middle: the paragraph. The reason also had no max-width, so it ran past the card's
own padding.

## The fix

Three declarations, using the `.fl-boot-labels` grid-stacking idiom already in this
file. The alert card stacks on the same grid cell as the skeleton instead of
floating over it, so the card grows to its own content:

```css
.fl-slot-ghost:has(> .fl-slot-cta[role="alert"]) { display: grid; }
.fl-slot-ghost:has(> .fl-slot-cta[role="alert"]) > * { grid-area: 1 / 1; }
.fl-slot-cta[role="alert"] { position: relative; }
```

`relative` rather than `static` is load-bearing: the skeleton's `filter: blur(.3px)`
makes it a stacking context, so an out-of-layer card sits *under* it and hands it
the button presses (caught by the existing "clearing a failed slot" spec). Being in
flow also puts the prose in the ghost's content box, so it stops bleeding past the
padding. `role="alert"` scopes this to the two failure states — `SlotBuildFailed`
and `SlotLoadFailed` — and every other slot state is byte-identical.

## Proof

`e2e/slot-states.spec.ts:52` has asserted `toBeVisible()` on both buttons since the
card existed, and passed the whole time — Playwright calls a clipped element
visible. The new spec asks the only question that settles it: is each part painted
inside the box that clips it?

Red before the fix, green after, on a production build of the harness:

| | |
|---|---|
| before | headline sliced in half, `Clear this slot` cut off |
| after | headline + full reason + both buttons, card grown to fit |

Screenshots (Maple's exact 570px column and its exact 60-component-list reason,
driven through the real read path): `/tmp/failed-card-verify/before-short.png`,
`/tmp/failed-card-verify/after-short.png`. Harness capture at rail width:
`packages/ui/e2e/screenshots/slot-failed-short.png`.

Browser suites re-run on a fresh production build: `slot-failed-legible`,
`slot-states`, `slot-hint`, `screenshots` — 18 passed, 1 skipped.

## Gate

`pnpm build` green · `pnpm typecheck` green · `pnpm lint` green ·
`pnpm test:affected` — `@vendoai/ui` 161 files / 1501 tests green; 3 reds in
`@vendoai/vendo` (`your-agent-docs.docs.test.ts` ×2, `cli/init-mcp.test.ts` ×1)
reproduce identically on clean main with this branch stashed, so they are the known
environment reds, not this change. One `accessibility.spec.ts` red
(`thread-citations` axe) likewise reproduces on clean main.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the failure card’s headline and actions visible in any host-sized slot. Previously the absolute CTA overlay was clipped by the ghost container, hiding the headline and buttons; now the alert CTA stacks in flow so the card grows to its content without changing other slot states.

- CSS: In `packages/ui/src/chrome/chrome-css.ts`, stack `.fl-slot-cta[role="alert"]` in-flow via `.fl-slot-ghost:has(...)`, layer all children to the same grid cell, and set the alert CTA to `position: relative` so it sits above the blurred skeleton; scope is failure states only.
- Tests: Add `packages/ui/e2e/slot-failed-legible.spec.ts` to assert the headline and both actions render inside the card under rail-width constraints; the spec waits for the settled card before measuring to avoid `toBeVisible()` false positives.
- Release: Patch for `@vendoai/ui`. Supports ENG-86 (Dashboard refresh) by keeping failure states legible at rest in dashboard surfaces.

<sup>Written for commit 1747f71085f6f3b94886f0f09b92d8a8ae284fdf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1557?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

