### PR TITLE
fix(harnesses,vendo): a workspace the box never received is not the user deleting everything

### DIFF
--- a/.changeset/materialize-loss-guard.md
+++ b/.changeset/materialize-loss-guard.md
@@ -1,0 +1,30 @@
+---
+"@vendoai/harnesses": patch
+"@vendoai/vendo": patch
+---
+
+A workspace upload the box never received no longer reads as the user deleting
+everything.
+
+The `claudeCode()` turn puts the workspace on the box before the model runs, and
+that upload was the one unguarded network call in the turn. When it died before
+the box applied it — a refused connect, a dead socket, a first chunk that never
+landed — the turn's `finally` still read the box's disk back, the box answered
+honestly that it held nothing, and the sync-back read "nothing here" as "the user
+deleted everything" and erased the whole workspace from the store. The failed
+READ was already guarded ("an EMPTY read is not the same fact as the user deleted
+everything"); this was the same fact from the other end, and it had no guard.
+
+Now the turn tracks whether the box actually holds the checkout, and syncs back
+only if it does. A machine that never received the workspace makes no statement
+about it: the store keeps what it had and the next turn recovers on a fresh box,
+exactly as a machine that died mid-turn already did.
+
+Two things that made it hard to survive and hard to diagnose are fixed with it.
+The workspace calls — the upload and the turn-end read, both of which are the
+same twice — are now sent again once if the transport drops, so a blip no longer
+costs the turn. And a Cloud sandbox that cannot be reached now says so: the
+adapter turns the transport fault into a named `sandbox-unavailable` failure
+carrying the cause, and the runtime's operator log prints that cause alongside
+the message. The observed failure used to reach the log as undici's bare
+`fetch failed` — three words naming neither Vendo nor the call.

--- a/.changeset/materialize-loss-guard.md
+++ b/.changeset/materialize-loss-guard.md
@@ -39,6 +39,14 @@ holds. That report is also how a box whose supervisor RESTARTED — same machine
 same token, empty disk — stops passing as the box that holds the conversation:
 the host reads its own generation back before it treats an empty disk as news.
 
+**The box image must be rebaked for the generation to take effect** — half of it
+lives in the machine image, beside the supervisor. A host on this version against
+an older image is safe but unprotected: the box ignores the generation it is sent
+and reports none, and an absent report is tolerated on purpose, so the seam
+behaves exactly as it did before rather than refusing every sync-back until the
+rebake lands. Such a turn now logs `harnesses.claude-code-box-no-generation`, so
+the unprotected window is visible while it is open.
+
 And the retry itself now knows what a retry is for. It replayed everything,
 including answers — a meter refusal, a rejected key, a machine the provider had
 destroyed — and threw the first error away to say the second one twice. Only a

--- a/.changeset/materialize-loss-guard.md
+++ b/.changeset/materialize-loss-guard.md
@@ -25,6 +25,22 @@ The workspace calls — the upload and the turn-end read, both of which are the
 same twice — are now sent again once if the transport drops, so a blip no longer
 costs the turn. And a Cloud sandbox that cannot be reached now says so: the
 adapter turns the transport fault into a named `sandbox-unavailable` failure
-carrying the cause, and the runtime's operator log prints that cause alongside
-the message. The observed failure used to reach the log as undici's bare
-`fetch failed` — three words naming neither Vendo nor the call.
+carrying the cause, and the runtime's operator log prints the ROOT of that cause
+chain alongside the message. The observed failure used to reach the log as
+undici's bare `fetch failed` — three words naming neither Vendo nor the call.
+
+The retry is what made the rest necessary. Aborting a request cancels this host's
+leg of it and nothing else, so a chunk this host gave up on can still land after
+its own replay — and the first chunk of an upload carries the reset that empties
+the box's root. Every materialize now mints a GENERATION and carries it on each
+chunk: the box refuses a generation it has already moved past, empties the root
+once per generation instead of once per request, and reports the generation it
+holds. That report is also how a box whose supervisor RESTARTED — same machine,
+same token, empty disk — stops passing as the box that holds the conversation:
+the host reads its own generation back before it treats an empty disk as news.
+
+And the retry itself now knows what a retry is for. It replayed everything,
+including answers — a meter refusal, a rejected key, a machine the provider had
+destroyed — and threw the first error away to say the second one twice. Only a
+call that DROPPED may be sent again, only while the box is still waiting for it,
+and the attempt that failed is logged rather than discarded.

--- a/packages/harnesses/box/turn-routes.mjs
+++ b/packages/harnesses/box/turn-routes.mjs
@@ -136,6 +136,23 @@ export const createSessionRoutes = (options = {}) => {
   // "Not logged in"), so the credential arrives with the first message.
   let sdkEnv = { ...(options.env ?? process.env) };
 
+  /**
+   * The materialize GENERATION this disk holds. The host mints one per
+   * materialize and carries it on every chunk; the box refuses anything from a
+   * generation it has already moved past, and echoes what it holds on `hello`
+   * and `collect` so the host can tell that the disk it is reading is the disk
+   * it wrote.
+   *
+   * A host leg that times out does NOT cancel the console→box hop behind it, so
+   * chunk 0 of a dead attempt can still be travelling while its replay and every
+   * chunk after it have landed. Without a generation that late arrival resets the
+   * root and the turn reads a truncated disk — which the host's sync-back then
+   * commits as deletions.
+   *
+   * Zero is a box that has been given nothing, which is also what a RESTARTED
+   * supervisor reports: same box, same token, empty disk.
+   */
+  let epoch = 0;
   /** The live session, the id to resume on reopen, and the brief it was OPENED
    *  with — the SDK fixes `systemPrompt` at open, so this is the only record of
    *  what the session is actually thinking with. */
@@ -370,7 +387,7 @@ export const createSessionRoutes = (options = {}) => {
           }
           sdkEnv = { ...sdkEnv, ...next };
         }
-        return { status: 200, body: { ok: true } };
+        return { status: 200, body: { ok: true, epoch } };
       }
 
       // Every other route needs the CURRENT token, always.
@@ -379,7 +396,16 @@ export const createSessionRoutes = (options = {}) => {
       }
 
       if (pathname === "/session/workspace") {
-        if (payload?.reset === true) {
+        const at = typeof payload?.epoch === "number" ? payload.epoch : undefined;
+        if (at !== undefined && at < epoch) {
+          return { status: 409, body: { error: `workspace generation ${at} is stale; this box holds ${epoch}` } };
+        }
+        // The reset belongs to the GENERATION, not to the request. Chunk 0 is the
+        // one call the host may send twice — a dropped transport carries no
+        // answer — and a second wipe would take the chunks that landed between
+        // the two attempts. A caller that names no generation gets the old
+        // behaviour: every reset empties the root.
+        if (payload?.reset === true && at !== epoch) {
           // Empty the root's CONTENTS, never the root itself: the sandbox runs
           // as a non-root user and cannot recreate a directory directly under
           // `/` (measured 2026-08-01 — every materialize answered 500).
@@ -388,6 +414,7 @@ export const createSessionRoutes = (options = {}) => {
             rmSync(path.join(root, entry), { recursive: true, force: true });
           }
         }
+        if (at !== undefined) epoch = at;
         for (const file of Array.isArray(payload?.files) ? payload.files : []) {
           if (typeof file?.path !== "string" || typeof file?.base64 !== "string") continue;
           const target = toDisk(root, file.path);
@@ -441,7 +468,10 @@ export const createSessionRoutes = (options = {}) => {
             }
           }
         }
-        return { status: 200, body: { files } };
+        // The generation goes home with the files: an empty read from a box that
+        // holds nothing is only news about the store if it is the same disk the
+        // host materialized.
+        return { status: 200, body: { files, epoch } };
       }
 
       if (pathname === "/session/message") {

--- a/packages/harnesses/box/turn-routes.mjs
+++ b/packages/harnesses/box/turn-routes.mjs
@@ -51,6 +51,13 @@ const MAX_POLL_WAIT_MS = 25_000;
  * normally lands in milliseconds. This is the bound for a host that stopped
  * polling ALTOGETHER, where hanging the build forever would be worse than the
  * race it prevents: past it the turn proceeds exactly as it did before.
+ *
+ * The host's replay window (`WORKSPACE_RETRY_WINDOW_MS`, `src/claude-code/box.ts`)
+ * is deliberately this same number: past it the host would be landing a write the
+ * model has already been told did not land. It cannot be imported from here —
+ * this module ships inside the machine image and stays dependency-free — so
+ * `tests/claude-code/box-sync-window.test.ts` reads both files and holds them
+ * equal instead.
  */
 const SYNC_ACK_WAIT_MS = MAX_POLL_WAIT_MS;
 /** Finished messages stay pollable for a little while (a host retrying its last

--- a/packages/harnesses/src/claude-code/box.ts
+++ b/packages/harnesses/src/claude-code/box.ts
@@ -80,10 +80,29 @@ const POLL_WAIT_MS = 10_000;
  * `box/turn-routes.mjs`) waiting for this host to say the sync landed, and then
  * tells the model it did not. A replay that starts after that window is
  * answering a question nobody is waiting on any more, over a model that has
- * already been told the opposite. It bounds the SECOND attempt only: the first
- * one runs on the adapter's own timeout, which this seam does not own.
+ * already been told the opposite — so the replay is refused past the window, and
+ * cut loose the moment it reaches it. The FIRST attempt still runs on the
+ * adapter's own timeout, which this seam does not own.
+ *
+ * The twin of `SYNC_ACK_WAIT_MS` in `box/turn-routes.mjs`, which cannot import it:
+ * that module ships inside the machine image and stays dependency-free. The two
+ * literals are held equal by `tests/claude-code/box-sync-window.test.ts`, which
+ * reads both files — drift between them is a red test, not a silent race.
  */
 const WORKSPACE_RETRY_WINDOW_MS = 25_000;
+
+/** Rejects when the window closes. The call underneath cannot be CANCELLED from
+ *  here — this seam takes no signal — but it can stop being waited on, and what
+ *  it may still do late is bounded: a materialize chunk is refused by its
+ *  generation or rewrites its own bytes, and a collect is a read nobody reads. */
+const expire = (ms: number, path: string): Promise<never> =>
+  new Promise((_resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new VendoError("sandbox-unavailable", `box ${path} did not answer inside the ${WORKSPACE_RETRY_WINDOW_MS}ms sync window`)),
+      ms,
+    );
+    timer.unref?.();
+  });
 
 /**
  * A fault that carries NO answer — the connection died, so whether the box
@@ -371,14 +390,18 @@ export async function boxMachine(options: BoxMachineOptions): Promise<SessionMac
         // someone is still waiting for it. Replaying everything replayed the
         // answers too — a meter refusal, a rejected key, a machine the provider
         // destroyed — and threw the first error away to say the second one twice.
-        if (!repeatable || !dropped(error) || Date.now() - started >= WORKSPACE_RETRY_WINDOW_MS) throw error;
+        const left = WORKSPACE_RETRY_WINDOW_MS - (Date.now() - started);
+        if (!repeatable || !dropped(error) || left <= 0) throw error;
         log({
           code: "harnesses.claude-code-box-retried",
           level: "warn",
           message: `[vendo] claude-code: box ${path} dropped its connection; sending it again`,
           data: { error },
         });
-        return call();
+        // What is LEFT of the window, not a fresh one: a first attempt that died
+        // at 24s leaves a second one a second, or the pair outlasts the wait the
+        // box has already given up on and holds the turn for the adapter's timeout.
+        return Promise.race([call(), expire(left, path)]);
       })
       // `hello` reads a transport fault as "the box did not answer" and moves on;
       // a call somebody is waiting on has to SAY so, in this file's own voice —

--- a/packages/harnesses/src/claude-code/box.ts
+++ b/packages/harnesses/src/claude-code/box.ts
@@ -242,7 +242,16 @@ export async function boxMachine(options: BoxMachineOptions): Promise<SessionMac
     }).catch(() => ({ status: 0, json: undefined }));
     if (status !== 200) return undefined;
     const epoch = (json as { epoch?: unknown } | undefined)?.epoch;
-    return typeof epoch === "number" ? { epoch } : {};
+    if (typeof epoch === "number") return { epoch };
+    // Tolerated, and therefore said out loud: for the length of the rollout every
+    // guard below reads "no generation" as "nothing to disagree with" and passes,
+    // so an unprotected turn is otherwise indistinguishable from a protected one.
+    log({
+      code: "harnesses.claude-code-box-no-generation",
+      level: "warn",
+      message: "[vendo] claude-code: the box reports no workspace generation — its image predates the guard, so nothing this turn reads back is checked against what it wrote. Rebake the box image.",
+    });
+    return {};
   };
 
   const bootBox = async (): Promise<BoxEntry> => {

--- a/packages/harnesses/src/claude-code/box.ts
+++ b/packages/harnesses/src/claude-code/box.ts
@@ -35,7 +35,7 @@
  * resumes on the same session) and worse for cost (a parked write holds a
  * sandbox for up to 90s). Recorded in the lane's close note as a deviation.
  */
-import { log, VENDO_DEV_PORT, VENDO_DEV_PORT_ENV, VendoError, WARM_THREAD_PREFIX } from "@vendoai/core";
+import { isVendoError, log, VENDO_DEV_PORT, VENDO_DEV_PORT_ENV, VendoError, WARM_THREAD_PREFIX } from "@vendoai/core";
 import type { CheckoutFile, SyncFile, TreeState } from "../materialize.js";
 import { emptyTree } from "../materialize.js";
 import { MESSAGE_BUDGET_MS, type SessionMachine, type SessionMessage } from "./machine.js";
@@ -300,8 +300,29 @@ export async function boxMachine(options: BoxMachineOptions): Promise<SessionMac
     message: `[vendo] claude-code: box ready by ${served} in ${Date.now() - startedAt}ms`,
   });
 
-  const request = async (path: string, body?: unknown): Promise<Record<string, unknown>> => {
-    const { status, json } = await control(box.machine, box.token, path, body);
+  /**
+   * `repeatable` is the caller's promise that this call is the same twice — the
+   * workspace seam is (the same bytes to the same path; a read), a call that
+   * starts work is not. Only those may be replayed, because a transport fault
+   * carries no answer: whether the box applied the call is exactly what we do
+   * not know. The replay is instant — what died was a connection, not a quota.
+   */
+  const request = async (
+    path: string,
+    body?: unknown,
+    repeatable = false,
+  ): Promise<Record<string, unknown>> => {
+    const call = (): Promise<{ status: number; json: unknown }> =>
+      control(box.machine, box.token, path, body);
+    const { status, json } = await (repeatable ? call().catch(call) : call())
+      // `hello` reads a transport fault as "the box did not answer" and moves on;
+      // a call somebody is waiting on has to SAY so, in this file's own voice —
+      // undici's bare `TypeError: fetch failed` names neither the box nor Vendo.
+      // An adapter that already named its own failure keeps its sentence.
+      .catch((cause: unknown) => {
+        if (isVendoError(cause)) throw cause;
+        throw new VendoError("sandbox-unavailable", `box ${path} could not be reached`, { cause });
+      });
     if (status !== 200 && status !== 202) {
       // Carry the box's own sentence: a bare status turns every box problem
       // into a guessing game on the host side.
@@ -344,13 +365,13 @@ export async function boxMachine(options: BoxMachineOptions): Promise<SessionMac
             readOnly: file.readOnly,
             base64: Buffer.from(file.bytes).toString("base64"),
           })),
-        });
+        }, true);
       }
-      if (files.length === 0) await request("/session/workspace", { reset: true, files: [] });
+      if (files.length === 0) await request("/session/workspace", { reset: true, files: [] }, true);
     },
 
     async collect(paths) {
-      const answer = await request("/session/collect", paths === undefined ? {} : { paths });
+      const answer = await request("/session/collect", paths === undefined ? {} : { paths }, true);
       const files = Array.isArray(answer["files"]) ? answer["files"] : [];
       return files.flatMap((raw): SyncFile[] => {
         const entryFile = raw as { path?: unknown; base64?: unknown };

--- a/packages/harnesses/src/claude-code/box.ts
+++ b/packages/harnesses/src/claude-code/box.ts
@@ -73,6 +73,29 @@ const CONTROL_PORT = 8811;
 export const BOX_IDLE_TTL_MS = 5 * 60_000;
 /** The box holds each poll open this long before answering empty. */
 const POLL_WAIT_MS = 10_000;
+/**
+ * How long the workspace seam may still be trying.
+ *
+ * The box parks the model behind its own write for `SYNC_ACK_WAIT_MS` (25s,
+ * `box/turn-routes.mjs`) waiting for this host to say the sync landed, and then
+ * tells the model it did not. A replay that starts after that window is
+ * answering a question nobody is waiting on any more, over a model that has
+ * already been told the opposite. It bounds the SECOND attempt only: the first
+ * one runs on the adapter's own timeout, which this seam does not own.
+ */
+const WORKSPACE_RETRY_WINDOW_MS = 25_000;
+
+/**
+ * A fault that carries NO answer — the connection died, so whether the box
+ * applied the call is exactly what we do not know, which is the only state a
+ * replay can improve. The adapters mark it by hanging the reason on
+ * `detail.cause` (`cloudSandbox`'s `send`); an answer they merely disliked —
+ * 401, 402, 429, a destroyed machine — carries none. An unclassified throw from
+ * a BYO adapter is transport by default: raw is what a dead socket looks like.
+ */
+const dropped = (error: unknown): boolean =>
+  !isVendoError(error)
+  || (error.code === "sandbox-unavailable" && (error.detail as { cause?: unknown } | undefined)?.cause !== undefined);
 
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
@@ -89,6 +112,11 @@ interface BoxEntry {
   reopen: boolean;
   /** What this box's disk holds — the sync-back baseline, per conversation. */
   tree: TreeState;
+  /** The materialize GENERATION this host has minted for this box, counted up
+   *  before each upload so a replay always outranks the attempt it replaces.
+   *  The box reports what it holds (`hello`, `collect`); a box reporting less
+   *  than this is not holding the disk this host wrote. */
+  epoch: number;
   idle?: ReturnType<typeof setTimeout>;
 }
 
@@ -200,13 +228,21 @@ export async function boxMachine(options: BoxMachineOptions): Promise<SessionMac
    * CLAUDE_CONFIG_DIR is deliberately unset: the SDK's default lives under $HOME,
    * and `/workspace` is the materialized copy — parking the native session there
    * would put machine state inside the user's files.
+   *
+   * The answer carries the box's own materialize generation, which is how a
+   * RESTARTED supervisor is told from the box it is wearing the name of: same
+   * machine, same token, empty disk, generation back at zero. `undefined` is a
+   * box that did not answer at all; an answer with no generation is a box image
+   * that predates it and can therefore say nothing wrong about it.
    */
-  const hello = async (machine: SandboxMachineLike, token: string): Promise<boolean> => {
-    const { status } = await control(machine, token, "/session/hello", {
+  const hello = async (machine: SandboxMachineLike, token: string): Promise<{ epoch?: number } | undefined> => {
+    const { status, json } = await control(machine, token, "/session/hello", {
       token,
       env: options.env,
     }).catch(() => ({ status: 0, json: undefined }));
-    return status === 200;
+    if (status !== 200) return undefined;
+    const epoch = (json as { epoch?: unknown } | undefined)?.epoch;
+    return typeof epoch === "number" ? { epoch } : {};
   };
 
   const bootBox = async (): Promise<BoxEntry> => {
@@ -225,14 +261,14 @@ export async function boxMachine(options: BoxMachineOptions): Promise<SessionMac
       },
       allowedDomains: [...options.allowedDomains],
     });
-    if (!await hello(machine, token)) {
+    if (await hello(machine, token) === undefined) {
       await machine.destroy().catch(() => undefined);
       throw new VendoError(
         "sandbox-unavailable",
         "the workspace machine refused the session handshake",
       );
     }
-    const fresh: BoxEntry = { machine, token, warm: false, reopen: false, tree: emptyTree() };
+    const fresh: BoxEntry = { machine, token, warm: false, reopen: false, tree: emptyTree(), epoch: 0 };
     boxes.set(key, fresh);
     return fresh;
   };
@@ -255,11 +291,16 @@ export async function boxMachine(options: BoxMachineOptions): Promise<SessionMac
     if (held === undefined) return undefined;
     if (exclusive) boxes.delete(at);
     disarmIdle(held);
-    if (await hello(held.machine, held.token)) return held;
+    // A box that answers is not yet a box that still HOLDS what we put on it: a
+    // restarted supervisor answers every route with an empty disk, and `warm` is
+    // our memory of it rather than its state. The generation it reports is the
+    // one thing it cannot be wrong about.
+    const greeted = await hello(held.machine, held.token);
+    if (greeted !== undefined && (greeted.epoch ?? held.epoch) >= held.epoch) return held;
     log({
       code: "harnesses.claude-code-box-stale",
       level: "error",
-      message: "[vendo] claude-code: the box stopped answering; starting fresh",
+      message: `[vendo] claude-code: the box ${greeted === undefined ? "stopped answering" : "no longer holds the workspace"}; starting fresh`,
     });
     boxes.delete(at);
     await held.machine.destroy().catch(() => undefined);
@@ -314,13 +355,30 @@ export async function boxMachine(options: BoxMachineOptions): Promise<SessionMac
   ): Promise<Record<string, unknown>> => {
     const call = (): Promise<{ status: number; json: unknown }> =>
       control(box.machine, box.token, path, body);
-    const { status, json } = await (repeatable ? call().catch(call) : call())
+    const started = Date.now();
+    const { status, json } = await call()
+      .catch((error: unknown) => {
+        // A DROPPED call is the only one worth sending again, and only while
+        // someone is still waiting for it. Replaying everything replayed the
+        // answers too — a meter refusal, a rejected key, a machine the provider
+        // destroyed — and threw the first error away to say the second one twice.
+        if (!repeatable || !dropped(error) || Date.now() - started >= WORKSPACE_RETRY_WINDOW_MS) throw error;
+        log({
+          code: "harnesses.claude-code-box-retried",
+          level: "warn",
+          message: `[vendo] claude-code: box ${path} dropped its connection; sending it again`,
+          data: { error },
+        });
+        return call();
+      })
       // `hello` reads a transport fault as "the box did not answer" and moves on;
       // a call somebody is waiting on has to SAY so, in this file's own voice —
       // undici's bare `TypeError: fetch failed` names neither the box nor Vendo.
-      // An adapter that already named its own failure keeps its sentence.
+      // An adapter that already named its own failure keeps its SENTENCE (the
+      // wire gate shows some of them to a user verbatim) and gains the route it
+      // died on, which the bare rethrow dropped.
       .catch((cause: unknown) => {
-        if (isVendoError(cause)) throw cause;
+        if (isVendoError(cause)) throw new VendoError(cause.code, cause.message, { path, cause });
         throw new VendoError("sandbox-unavailable", `box ${path} could not be reached`, { cause });
       });
     if (status !== 200 && status !== 202) {
@@ -353,12 +411,21 @@ export async function boxMachine(options: BoxMachineOptions): Promise<SessionMac
     },
 
     async materialize(files: readonly CheckoutFile[]) {
+      // Minted BEFORE the first chunk and carried on every one of them, because
+      // a host leg that timed out does not cancel the console→box hop behind it:
+      // a dead attempt's chunk 0 can land after its replay and after the chunks
+      // that followed. The box refuses a generation it has moved past and resets
+      // once per generation rather than once per request, so the replay rewrites
+      // its own bytes instead of wiping the ones behind it. Counted up even when
+      // the upload fails, so the next attempt always outranks the stalled one.
+      const epoch = (box.epoch += 1);
       // Chunked by COUNT, which bounds the typical upload body — not a hard
       // byte bound: one large file still travels alone in its chunk, and a
       // BYO files adapter can hold files the proxy may refuse.
       const CHUNK = 24;
       for (let at = 0; at < files.length; at += CHUNK) {
         await request("/session/workspace", {
+          epoch,
           reset: at === 0,
           files: files.slice(at, at + CHUNK).map((file) => ({
             path: file.path,
@@ -367,11 +434,23 @@ export async function boxMachine(options: BoxMachineOptions): Promise<SessionMac
           })),
         }, true);
       }
-      if (files.length === 0) await request("/session/workspace", { reset: true, files: [] }, true);
+      if (files.length === 0) await request("/session/workspace", { epoch, reset: true, files: [] }, true);
     },
 
     async collect(paths) {
       const answer = await request("/session/collect", paths === undefined ? {} : { paths }, true);
+      // The disk this reads has to be the disk this host wrote. A supervisor that
+      // restarted under the same name answers every route holding nothing, and an
+      // empty read is what the sync-back turns into deleting the workspace. A box
+      // image that predates the generation reports none — it can say nothing about
+      // it, and nothing wrong about it either.
+      const held = answer["epoch"];
+      if (typeof held === "number" && held !== box.epoch) {
+        throw new VendoError(
+          "sandbox-unavailable",
+          `box holds workspace generation ${held}, not the ${box.epoch} this turn put there`,
+        );
+      }
       const files = Array.isArray(answer["files"]) ? answer["files"] : [];
       return files.flatMap((raw): SyncFile[] => {
         const entryFile = raw as { path?: unknown; base64?: unknown };

--- a/packages/harnesses/src/claude-code/index.ts
+++ b/packages/harnesses/src/claude-code/index.ts
@@ -833,6 +833,13 @@ export function claudeCode(
         let collected: SyncFile[] | undefined;
         try {
           if (materialized) collected = await machine.collect();
+          else {
+            log({
+              code: "harnesses.claude-code-workspace-not-materialized",
+              level: "error",
+              message: "[vendo] claude-code: the box never received the workspace; nothing is synced back",
+            });
+          }
         } catch (error) {
           log({
             code: "harnesses.claude-code-workspace-read-failed",

--- a/packages/harnesses/src/claude-code/index.ts
+++ b/packages/harnesses/src/claude-code/index.ts
@@ -670,13 +670,20 @@ export function claudeCode(
       const stale = truncated(state, turn.messages.length);
       let sessionId = machine.carriesSession && !stale ? state.sessionId : undefined;
       let finished = false;
+      /** Whether the box's disk is KNOWN to hold this checkout — a warm one
+       *  already does, a fresh one only once materialize lands. What the
+       *  sync-back below needs before it may read the disk as a statement. */
+      let materialized = machine.carriesSession;
 
       try {
         // ONLY on a machine that is not already carrying this conversation. A warm
         // box's disk IS the working copy: re-materializing between messages would
         // reset the tree the live session is holding open, which is the one thing
         // "one box per conversation" exists to prevent.
-        if (!machine.carriesSession) await machine.materialize(checkout.files);
+        if (!machine.carriesSession) {
+          await machine.materialize(checkout.files);
+          materialized = true;
+        }
 
         /** Every hot path this turn actually LANDED in the store — what the
          *  validate gate below checks. Accumulated from the syncs' own answers
@@ -816,9 +823,16 @@ export function claudeCode(
         // other would erase the workspace on every dead box. No read, no sync:
         // the store keeps what it had and the next turn recovers on a fresh
         // machine, which is exactly what the kill-mid-turn law asks for.
+        //
+        // A machine that never RECEIVED the workspace is that same fact from the
+        // other end, and the more dangerous one: the box answers the read
+        // honestly, and its honest answer is an empty tree. Read as a sync-back
+        // it deletes every baseline path — the whole workspace — on a materialize
+        // that died before it landed. No disk of ours, nothing it holds or lacks
+        // is news about the store.
         let collected: SyncFile[] | undefined;
         try {
-          collected = await machine.collect();
+          if (materialized) collected = await machine.collect();
         } catch (error) {
           log({
             code: "harnesses.claude-code-workspace-read-failed",

--- a/packages/harnesses/src/runtime.ts
+++ b/packages/harnesses/src/runtime.ts
@@ -282,6 +282,28 @@ export function addUsage(totals: UsageTotals | undefined, event: Extract<Harness
  */
 const HARNESS_FAILED = "Something went wrong on my side, so I stopped.";
 
+/** One hop down a failure: a VendoError carries its reason on `detail` (the
+ *  class takes no ErrorOptions), everything else on `cause`. */
+const causeOf = (error: unknown): unknown =>
+  isVendoError(error)
+    ? (error.detail as { cause?: unknown } | undefined)?.cause
+    : (error as { cause?: unknown } | undefined)?.cause;
+
+/**
+ * The BOTTOM of that chain — the only link that says anything.
+ *
+ * A dead socket reaches the operator wrapped twice over: the box names the route
+ * it died on, the adapter names the console, and undici's `fetch failed` sits on
+ * top of the one word (ECONNREFUSED, ECONNRESET) that tells them apart. One hop
+ * down printed the wrapper again. Bounded because a cause chain is other
+ * people's data and may point back at itself.
+ */
+const rootCause = (error: unknown): unknown => {
+  let deepest = causeOf(error);
+  for (let hop = 0; hop < 8 && causeOf(deepest) !== undefined; hop += 1) deepest = causeOf(deepest);
+  return deepest;
+};
+
 export function createHarnessRuntime(deps: HarnessRuntimeDeps): HarnessRuntime {
   const harnessState = deps.harnessState ?? memoryHarnessStateStore();
 
@@ -676,12 +698,8 @@ export function createHarnessRuntime(deps: HarnessRuntimeDeps): HarnessRuntime {
             // …and the cause with it. A transport fault's whole message is
             // "fetch failed"; everything that tells a refused connect from a
             // dropped socket is underneath. Kept as TEXT, because this detail is
-            // structured and a host's own sink may serialize it. A VendoError
-            // carries the reason on `detail` (the class takes no ErrorOptions),
-            // a native throw on `cause`.
-            const under = isVendoError(error)
-              ? (error.detail as { cause?: unknown } | undefined)?.cause
-              : (error as { cause?: unknown } | undefined)?.cause;
+            // structured and a host's own sink may serialize it.
+            const under = rootCause(error);
             log({
               code: "harnesses.runtime-run-failed",
               level: "error",

--- a/packages/harnesses/src/runtime.ts
+++ b/packages/harnesses/src/runtime.ts
@@ -673,6 +673,15 @@ export function createHarnessRuntime(deps: HarnessRuntimeDeps): HarnessRuntime {
             // A harness that throws is a bug in the thinker, not in the user's
             // day. The real error goes to the operator's terminal; the user gets
             // a plain sentence, and NOTHING of the internals travels.
+            // …and the cause with it. A transport fault's whole message is
+            // "fetch failed"; everything that tells a refused connect from a
+            // dropped socket is underneath. Kept as TEXT, because this detail is
+            // structured and a host's own sink may serialize it. A VendoError
+            // carries the reason on `detail` (the class takes no ErrorOptions),
+            // a native throw on `cause`.
+            const under = isVendoError(error)
+              ? (error.detail as { cause?: unknown } | undefined)?.cause
+              : (error as { cause?: unknown } | undefined)?.cause;
             log({
               code: "harnesses.runtime-run-failed",
               level: "error",
@@ -682,6 +691,7 @@ export function createHarnessRuntime(deps: HarnessRuntimeDeps): HarnessRuntime {
                   harness: input.harness.name,
                   threadId: input.threadId,
                   error: error instanceof Error ? error.message : String(error),
+                  ...(under === undefined ? {} : { cause: String(under) }),
                 },
               },
             });

--- a/packages/harnesses/tests/claude-code/box-generation-rollout.test.ts
+++ b/packages/harnesses/tests/claude-code/box-generation-rollout.test.ts
@@ -1,0 +1,51 @@
+/**
+ * The generation guard spans a wire, and the two sides ship separately: the host
+ * half rides `@vendoai/harnesses`, the box half is baked into the machine image.
+ * A host on this version against an image that predates it FAILS OPEN by design —
+ * hello reports no generation, `adopt` has nothing to disagree with, and collect's
+ * check does not apply — because a box that cannot speak about its generation
+ * cannot be wrong about it, and refusing every sync-back until the rebake lands
+ * would be the worse failure by far.
+ *
+ * Which leaves an unprotected turn looking exactly like a protected one. It says
+ * so instead.
+ */
+import { setLogger, type VendoLogEvent } from "@vendoai/core";
+import { afterEach, expect, test } from "vitest";
+import { boxMachine, disposeSessionMachines, type SandboxAdapterLike } from "../../src/claude-code/box.js";
+
+const encoder = new TextEncoder();
+
+afterEach(async () => {
+  setLogger(undefined);
+  await disposeSessionMachines();
+});
+
+/** A box from before the generation: it answers everything, and reports none. */
+const unversionedBox = (): SandboxAdapterLike => ({
+  create: async () => ({
+    id: "box_old_image",
+    async request(req) {
+      const body = req.path === "/session/collect" ? { files: [] } : { ok: true };
+      return { status: 200, headers: {}, body: encoder.encode(JSON.stringify(body)) };
+    },
+    files: { read: async () => new Uint8Array(), write: async () => undefined, list: async () => [] },
+    url: async () => "https://box_old_image.fake-provider.test",
+    destroy: async () => undefined,
+  }),
+  destroy: async () => undefined,
+});
+
+test("a box whose image predates the generation says so, and is still believed", async () => {
+  const lines: VendoLogEvent[] = [];
+  setLogger((event) => lines.push(event));
+
+  const machine = await boxMachine({ sandbox: unversionedBox(), threadId: "thr_old", env: {}, allowedDomains: [] });
+  await machine.materialize([{ path: "/user/a.tsx", bytes: encoder.encode("<App/>"), readOnly: false }]);
+
+  expect(lines.find((line) => line.code === "harnesses.claude-code-box-no-generation")?.message)
+    .toMatch(/Rebake the box image/);
+  // Fails OPEN, deliberately: the read still counts, exactly as it did before the
+  // guard existed. The line above is the only difference.
+  expect(await machine.collect()).toEqual([]);
+});

--- a/packages/harnesses/tests/claude-code/box-retry-classification.test.ts
+++ b/packages/harnesses/tests/claude-code/box-retry-classification.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Which failures the workspace seam may send again — and for how long.
+ *
+ * The retry took `call().catch(call)`, which replays EVERYTHING: a meter refusal,
+ * a rejected key, a machine the provider destroyed. Those are answers, not dropped
+ * connections; asking twice gets the same one, a second later, with the first
+ * error thrown away. Only a fault that carries no answer is worth repeating,
+ * because whether the box applied the call is exactly what is unknown.
+ *
+ * And only while somebody is waiting. The box parks the model behind its own write
+ * for 25s (`SYNC_ACK_WAIT_MS`) and then tells it the sync failed — so a second
+ * attempt that starts after that window contradicts what the model has already
+ * been told.
+ */
+import { VendoError } from "@vendoai/core";
+import { afterEach, expect, test, vi } from "vitest";
+import { boxMachine, disposeSessionMachines, type SandboxAdapterLike, type SandboxMachineLike } from "../../src/claude-code/box.js";
+
+const encoder = new TextEncoder();
+const CHECKOUT = [{ path: "/user/apps/app_1/app.tsx", bytes: new TextEncoder().encode("<App/>"), readOnly: false }];
+
+afterEach(async () => {
+  vi.useRealTimers();
+  await disposeSessionMachines();
+});
+
+/** A box whose control port answers hello and then fails every workspace call
+ *  with `fault`, counting the attempts. */
+function boxThatFails(fault: () => unknown): { sandbox: SandboxAdapterLike; attempts: () => number } {
+  let attempts = 0;
+  const machine: SandboxMachineLike = {
+    id: "box_faulty",
+    async request(req) {
+      if (req.path === "/session/workspace") {
+        attempts += 1;
+        throw fault();
+      }
+      return { status: 200, headers: {}, body: encoder.encode(JSON.stringify({ ok: true })) };
+    },
+    files: { read: async () => new Uint8Array(), write: async () => undefined, list: async () => [] },
+    url: async () => "https://box_faulty.fake-provider.test",
+    destroy: async () => undefined,
+  };
+  return { sandbox: { create: async () => machine, destroy: async () => undefined }, attempts: () => attempts };
+}
+
+test("a refusal the console ANSWERED is not asked again", async () => {
+  const { sandbox, attempts } = boxThatFails(() =>
+    new VendoError("cloud-required", "Vendo Cloud: this month's build meter is exhausted"));
+  const machine = await boxMachine({ sandbox, threadId: "thr_meter", env: {}, allowedDomains: [] });
+
+  const thrown = await machine.materialize(CHECKOUT).catch((error: unknown) => error);
+
+  expect(attempts()).toBe(1);
+  // The console's own sentence survives the seam — the wire gate shows it to the
+  // user verbatim — and gains the route it died on.
+  expect((thrown as VendoError).code).toBe("cloud-required");
+  expect((thrown as VendoError).message).toMatch(/meter is exhausted/);
+  expect((thrown as VendoError).detail).toMatchObject({ path: "/session/workspace" });
+});
+
+test("a dropped connection is asked again", async () => {
+  const { sandbox, attempts } = boxThatFails(() =>
+    new VendoError("sandbox-unavailable", "Vendo Cloud sandbox could not be reached", {
+      path: "/request",
+      cause: Object.assign(new TypeError("fetch failed"), { cause: new Error("ECONNRESET") }),
+    }));
+  const machine = await boxMachine({ sandbox, threadId: "thr_drop", env: {}, allowedDomains: [] });
+
+  await machine.materialize(CHECKOUT).catch(() => undefined);
+
+  expect(attempts()).toBe(2);
+});
+
+test("a drop nobody is waiting for any more is not asked again", async () => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  const { sandbox, attempts } = boxThatFails(() => {
+    // The attempt outlived the box's own sync-ack window: the model has already
+    // been told this write did not land.
+    vi.advanceTimersByTime(30_000);
+    return new VendoError("sandbox-unavailable", "Vendo Cloud sandbox could not be reached", {
+      path: "/request",
+      cause: new TypeError("fetch failed"),
+    });
+  });
+  const machine = await boxMachine({ sandbox, threadId: "thr_slow", env: {}, allowedDomains: [] });
+
+  await machine.materialize(CHECKOUT).catch(() => undefined);
+
+  expect(attempts()).toBe(1);
+});

--- a/packages/harnesses/tests/claude-code/box-sync-window.test.ts
+++ b/packages/harnesses/tests/claude-code/box-sync-window.test.ts
@@ -1,0 +1,85 @@
+/**
+ * The 25 seconds the box waits, and the 25 seconds the host is allowed to keep
+ * trying — one number living in two files that cannot import each other.
+ *
+ * `box/turn-routes.mjs` parks the model behind its own write for
+ * `SYNC_ACK_WAIT_MS` and then tells it the sync failed. Past that moment the host
+ * is landing a write the model has been told did not land, so the replay window
+ * is the same number by necessity. The box module ships inside the machine image
+ * and stays dependency-free, so it cannot export the constant — which leaves two
+ * literals free to drift apart silently, each still looking right on its own page.
+ * They are held together here instead.
+ *
+ * And the window has to bound the whole retry, not just its start: a first attempt
+ * that dies at 24s used to hand the second one the adapter's full timeout, five
+ * minutes of holding a hot sync open on a barrier the box released long ago.
+ */
+import { VendoError } from "@vendoai/core";
+import { readFileSync } from "node:fs";
+import { afterEach, expect, test, vi } from "vitest";
+import { boxMachine, disposeSessionMachines, type SandboxAdapterLike } from "../../src/claude-code/box.js";
+
+const encoder = new TextEncoder();
+const CHECKOUT = [{ path: "/user/a.tsx", bytes: encoder.encode("<App/>"), readOnly: false }];
+
+afterEach(async () => {
+  vi.useRealTimers();
+  await disposeSessionMachines();
+});
+
+const sourceOf = (relative: string): string =>
+  readFileSync(new URL(relative, import.meta.url), "utf8");
+
+/** The literal a `const NAME = 25_000;` line carries, as a number. */
+const constantIn = (source: string, name: string): number | undefined => {
+  const found = new RegExp(`const ${name} = ([\\d_]+);`).exec(source)?.[1];
+  return found === undefined ? undefined : Number(found.replaceAll("_", ""));
+};
+
+test("the host's replay window is the box's own sync-ack wait", () => {
+  const host = sourceOf("../../src/claude-code/box.ts");
+  const box = sourceOf("../../box/turn-routes.mjs");
+
+  // `SYNC_ACK_WAIT_MS` is defined as `MAX_POLL_WAIT_MS`, so the alias has to hold
+  // too — the coupling can drift through either name.
+  expect(box).toMatch(/const SYNC_ACK_WAIT_MS = MAX_POLL_WAIT_MS;/);
+  expect(constantIn(host, "WORKSPACE_RETRY_WINDOW_MS")).toBe(constantIn(box, "MAX_POLL_WAIT_MS"));
+});
+
+test("a replay does not outlive the window the box already gave up on", async () => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  let attempts = 0;
+  const sandbox: SandboxAdapterLike = {
+    create: async () => ({
+      id: "box_hang",
+      async request(req) {
+        if (req.path !== "/session/workspace") {
+          return { status: 200, headers: {}, body: encoder.encode(JSON.stringify({ ok: true, epoch: 0 })) };
+        }
+        attempts += 1;
+        if (attempts === 1) {
+          throw new VendoError("sandbox-unavailable", "Vendo Cloud sandbox could not be reached", {
+            path: "/request",
+            cause: new TypeError("fetch failed"),
+          });
+        }
+        // The replay reaches a console that accepts the connection and then says
+        // nothing — the adapter would sit here for its own five minutes.
+        return await new Promise(() => { /* never answers */ });
+      },
+      files: { read: async () => new Uint8Array(), write: async () => undefined, list: async () => [] },
+      url: async () => "https://box_hang.fake-provider.test",
+      destroy: async () => undefined,
+    }),
+    destroy: async () => undefined,
+  };
+
+  const machine = await boxMachine({ sandbox, threadId: "thr_hang", env: {}, allowedDomains: [] });
+  const materializing = machine.materialize(CHECKOUT).catch((error: unknown) => error);
+  await vi.advanceTimersByTimeAsync(30_000);
+  const thrown = await materializing;
+
+  expect(attempts).toBe(2);
+  expect((thrown as VendoError).code).toBe("sandbox-unavailable");
+  expect((thrown as VendoError).message).toMatch(/sync window/);
+});

--- a/packages/harnesses/tests/claude-code/materialize-generation.test.ts
+++ b/packages/harnesses/tests/claude-code/materialize-generation.test.ts
@@ -1,0 +1,222 @@
+/**
+ * The retry that saved the upload made the upload replayable — and a replay is
+ * only safe if the box can tell it from a ghost.
+ *
+ * `AbortSignal.timeout` aborts the HOST's leg of a call and nothing else: the
+ * console→box hop behind it keeps going. So chunk 0 of an attempt this host gave
+ * up on can still land — after its own replay, after the chunks that followed it,
+ * even after the model started writing — and chunk 0 carries `reset`, which empties
+ * the root. The turn then reads a truncated disk and the sync-back commits the
+ * difference as deletions.
+ *
+ * The same fact wearing a different hat: a box whose supervisor RESTARTED answers
+ * hello, answers collect, and holds nothing. `carriesSession` is this host's
+ * memory of a machine, never the machine's own state.
+ *
+ * So every materialize mints a GENERATION and carries it on every chunk. The box
+ * refuses a generation it has moved past, resets once per generation rather than
+ * once per request, and reports what it holds — which is how the host knows the
+ * disk it is reading is the disk it wrote.
+ */
+import { setLogger, type HarnessEvent, type Turn, type VendoLogEvent } from "@vendoai/core";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, expect, test } from "vitest";
+import { createSessionRoutes } from "../../box/turn-routes.mjs";
+import { boxMachine, disposeSessionMachines, type SandboxAdapterLike, type SandboxMachineLike } from "../../src/claude-code/box.js";
+import { claudeCode } from "../../src/claude-code/index.js";
+import { createTurnState } from "../../src/harness-state.js";
+import { testWorkspace, unusedModels, userMessage } from "../../src/test-doubles.test-util.js";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+const SCREEN = "/user/apps/app_1/app.tsx";
+
+const roots: string[] = [];
+afterEach(async () => {
+  setLogger(undefined);
+  await disposeSessionMachines();
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+interface Door {
+  handle(method: string, pathname: string, headers: Record<string, string>, payload: unknown):
+    Promise<{ status: number; body: unknown }>;
+}
+
+const newRoot = (): string => {
+  const root = mkdtempSync(path.join(tmpdir(), "vendo-generation-"));
+  roots.push(root);
+  return root;
+};
+
+/** The real box door on a real disk, already claimed by one hello. */
+const openDoor = async (root: string): Promise<Door> => {
+  const door = createSessionRoutes({ root, token: "", env: {} }) as Door;
+  await door.handle("POST", "/session/hello", {}, { token: "bxt_test" });
+  return door;
+};
+
+const upload = async (door: Door, payload: unknown): Promise<{ status: number; body: unknown }> =>
+  await door.handle("POST", "/session/workspace", { "x-vendo-box-token": "bxt_test" }, payload);
+
+const wireFile = (at: string, text: string): unknown =>
+  ({ path: at, base64: Buffer.from(text).toString("base64") });
+
+const onDisk = (root: string, at: string): string => readFileSync(path.join(root, at.replace(/^\/+/, "")), "utf8");
+
+test("a chunk from a materialize the box has moved past cannot wipe the one that replaced it", async () => {
+  const root = newRoot();
+  const door = await openDoor(root);
+
+  await upload(door, { epoch: 1, reset: true, files: [wireFile("/user/first.txt", "one")] });
+  await upload(door, { epoch: 2, reset: true, files: [wireFile("/user/second.txt", "two")] });
+  // Attempt 1 of generation 1, arriving now: this host stopped waiting for it
+  // minutes ago and nothing ever cancelled the hop.
+  const late = await upload(door, { epoch: 1, reset: true, files: [wireFile("/user/first.txt", "one")] });
+
+  expect(late.status).toBe(409);
+  expect(onDisk(root, "/user/second.txt")).toBe("two");
+  expect(existsSync(path.join(root, "user/first.txt"))).toBe(false);
+});
+
+test("a first chunk sent twice does not take the chunks that landed behind it", async () => {
+  const root = newRoot();
+  const door = await openDoor(root);
+
+  await upload(door, { epoch: 1, reset: true, files: [wireFile("/user/first.txt", "one")] });
+  await upload(door, { epoch: 1, files: [wireFile("/user/second.txt", "two")] });
+  // The replay the transport retry sends: the same bytes to the same path, which
+  // is the promise `repeatable` makes — and it must stay true of the whole disk.
+  await upload(door, { epoch: 1, reset: true, files: [wireFile("/user/first.txt", "one")] });
+
+  expect(onDisk(root, "/user/first.txt")).toBe("one");
+  expect(onDisk(root, "/user/second.txt")).toBe("two");
+});
+
+test("a box whose supervisor restarted is not the box that holds the workspace", async () => {
+  // One real door per machine, each on its own disk — a box the provider hands
+  // over boots with no token, and the first hello claims it.
+  const doors = new Map<string, Door>();
+  const boot = (id: string): Door => {
+    const door = createSessionRoutes({ root: newRoot(), token: "", env: {} }) as Door;
+    doors.set(id, door);
+    return door;
+  };
+  let created = 0;
+  const sandbox: SandboxAdapterLike = {
+    async create() {
+      created += 1;
+      const id = `box_restart_${created}`;
+      boot(id);
+      return {
+        id,
+        async request(req) {
+          const payload = req.body === undefined
+            ? {}
+            : JSON.parse(typeof req.body === "string" ? req.body : decoder.decode(req.body));
+          const door = doors.get(id) as Door;
+          const reply = await door.handle(req.method, req.path, (req.headers ?? {}) as Record<string, string>, payload);
+          return { status: reply.status, headers: {}, body: encoder.encode(JSON.stringify(reply.body)) };
+        },
+        files: { read: async () => new Uint8Array(), write: async () => undefined, list: async () => [] },
+        url: async () => "https://box_restart.fake-provider.test",
+        destroy: async () => undefined,
+      } satisfies SandboxMachineLike;
+    },
+    async destroy() { /* no machine to reap by ref */ },
+  };
+
+  const machine = await boxMachine({ sandbox, threadId: "thr_restart", env: {}, allowedDomains: [] });
+  await machine.materialize([{ path: SCREEN, bytes: encoder.encode("<App/>"), readOnly: false }]);
+
+  // The supervisor comes back: a fresh process on an empty disk holding no token
+  // of its own — the provider does not hand create-time env to a template's start
+  // command, so the next hello simply claims it again, exactly as the first one
+  // did. Answering is all a box has to do to be believed.
+  boot("box_restart_1");
+  const lines: VendoLogEvent[] = [];
+  setLogger((event) => lines.push(event));
+
+  const next = await boxMachine({ sandbox, threadId: "thr_restart", env: {}, allowedDomains: [] });
+
+  expect(created).toBe(2);
+  expect(next.carriesSession).toBe(false);
+  expect(lines.find((line) => line.code === "harnesses.claude-code-box-stale")?.message)
+    .toMatch(/no longer holds the workspace/);
+});
+
+/** A box that takes the workspace, answers one message, and then reads back as a
+ *  machine that never got it — the restart, from the store's side. */
+function boxThatForgetsMidTurn(): SandboxAdapterLike {
+  const machine: SandboxMachineLike = {
+    id: "box_amnesiac",
+    async request(req) {
+      const body = (payload: unknown): { status: number; headers: Record<string, string>; body: Uint8Array } =>
+        ({ status: 200, headers: {}, body: encoder.encode(JSON.stringify(payload)) });
+      if (req.path === "/session/message") return body({ messageId: "msg_1" });
+      if (req.path.endsWith("/poll")) return body({ events: [{ type: "text", delta: "done" }], cursor: 1, done: true });
+      // Generation zero: everything this host put here is gone.
+      if (req.path === "/session/collect") return body({ files: [], epoch: 0 });
+      return body({ ok: true, epoch: 0 });
+    },
+    files: { read: async () => new Uint8Array(), write: async () => undefined, list: async () => [] },
+    url: async () => "https://box_amnesiac.fake-provider.test",
+    destroy: async () => undefined,
+  };
+  return { create: async () => machine, destroy: async () => undefined };
+}
+
+function turnOver(workspace: ReturnType<typeof testWorkspace>): Turn<never> {
+  return {
+    threadId: "thr_forget",
+    messages: [userMessage("m1", "make me a dashboard")],
+    tools: { list: async () => [], call: async () => ({ status: "ok" as const, output: {} }) },
+    skills: { list: async () => [], load: async () => "" },
+    workspace,
+    models: unusedModels(),
+    state: createTurnState(undefined),
+    options: {} as never,
+    signal: new AbortController().signal,
+    interactive: true,
+    system: "PRODUCT BRIEF",
+  } as unknown as Turn<never>;
+}
+
+test("a box that forgot the workspace mid-turn does not get to delete it", async () => {
+  const workspace = testWorkspace({ [SCREEN]: "<App/>" });
+  const harness = claudeCode({ sandbox: boxThatForgetsMidTurn() });
+  const seen: HarnessEvent[] = [];
+
+  for await (const event of harness.run(turnOver(workspace) as never)) seen.push(event);
+
+  expect(await workspace.readFile(SCREEN)).toBe("<App/>");
+  expect(workspace.commits).toEqual([]);
+});
+
+test("the turn says out loud that nothing was synced back", async () => {
+  const lines: VendoLogEvent[] = [];
+  setLogger((event) => lines.push(event));
+  const lost: SandboxAdapterLike = {
+    create: async () => ({
+      id: "box_lost",
+      async request(req) {
+        if (req.path === "/session/workspace") throw new TypeError("fetch failed");
+        return { status: 200, headers: {}, body: encoder.encode(JSON.stringify({ ok: true })) };
+      },
+      files: { read: async () => new Uint8Array(), write: async () => undefined, list: async () => [] },
+      url: async () => "https://box_lost.fake-provider.test",
+      destroy: async () => undefined,
+    }),
+    destroy: async () => undefined,
+  };
+  const harness = claudeCode({ sandbox: lost });
+
+  const events: HarnessEvent[] = [];
+  await (async () => {
+    for await (const event of harness.run(turnOver(testWorkspace({ [SCREEN]: "<App/>" })) as never)) events.push(event);
+  })().catch(() => undefined);
+
+  expect(lines.map((line) => line.code)).toContain("harnesses.claude-code-workspace-not-materialized");
+});

--- a/packages/harnesses/tests/claude-code/materialize-loss-guard.test.ts
+++ b/packages/harnesses/tests/claude-code/materialize-loss-guard.test.ts
@@ -1,0 +1,144 @@
+/**
+ * The workspace upload is the one network call a turn makes before the model
+ * runs, and until now it was the one with nothing behind it.
+ *
+ * When it dies BEFORE the box applies it — a refused connect, a dead socket, a
+ * first chunk that never lands — the box is left holding an empty disk. The
+ * turn's `finally` then reads that disk back honestly, and the sync-back reads
+ * "nothing here" as "the user deleted everything" and erases the baseline from
+ * the store. The failed-READ half of that seam is already guarded ("an EMPTY
+ * read is not the same fact as the user deleted everything"); this is the same
+ * fact from the other end, and it had no guard and no test.
+ *
+ * Observed live once on a warm-probe turn, as a bare `TypeError: fetch failed`.
+ */
+import { VendoError, type HarnessEvent, type Turn } from "@vendoai/core";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, expect, test } from "vitest";
+import { createSessionRoutes } from "../../box/turn-routes.mjs";
+import { boxMachine, disposeSessionMachines, type SandboxAdapterLike, type SandboxMachineLike } from "../../src/claude-code/box.js";
+import { claudeCode } from "../../src/claude-code/index.js";
+import { createTurnState } from "../../src/harness-state.js";
+import { testWorkspace, unusedModels, userMessage } from "../../src/test-doubles.test-util.js";
+
+const encoder = new TextEncoder();
+const SCREEN = "/user/apps/app_1/app.tsx";
+
+const boxRoots: string[] = [];
+afterEach(async () => {
+  await disposeSessionMachines();
+  for (const root of boxRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+/** What undici hands back for a connection that died: three words, and the real
+ *  reason only on the cause. */
+const fetchFailed = (): Error =>
+  Object.assign(new TypeError("fetch failed"), { cause: new Error("ECONNRESET") });
+
+const answer = (body: unknown): { status: number; headers: Record<string, string>; body: Uint8Array } =>
+  ({ status: 200, headers: {}, body: encoder.encode(JSON.stringify(body)) });
+
+/**
+ * A box that greets, is asked to take the workspace, and never gets it — and
+ * then answers the turn-end read HONESTLY, because from its side the disk really
+ * is empty. That honesty is what makes the sync-back dangerous.
+ */
+function boxThatNeverReceivesTheWorkspace(): SandboxAdapterLike {
+  const machine: SandboxMachineLike = {
+    id: "box_lost",
+    async request(req) {
+      if (req.path === "/session/workspace") throw fetchFailed();
+      if (req.path === "/session/collect") return answer({ files: [] });
+      return answer({ ok: true });
+    },
+    files: { read: async () => new Uint8Array(), write: async () => undefined, list: async () => [] },
+    url: async () => "https://box_lost.fake-provider.test",
+    destroy: async () => undefined,
+  };
+  return { create: async () => machine, destroy: async () => undefined };
+}
+
+function turnOver(workspace: ReturnType<typeof testWorkspace>): Turn<never> {
+  return {
+    threadId: "thr_loss",
+    messages: [userMessage("m1", "make me a dashboard")],
+    tools: { list: async () => [], call: async () => ({ status: "ok" as const, output: {} }) },
+    skills: { list: async () => [], load: async () => "" },
+    workspace,
+    models: unusedModels(),
+    state: createTurnState(undefined),
+    options: {} as never,
+    signal: new AbortController().signal,
+    interactive: true,
+    system: "PRODUCT BRIEF",
+  } as unknown as Turn<never>;
+}
+
+const drain = async (workspace: ReturnType<typeof testWorkspace>): Promise<unknown> => {
+  const harness = claudeCode({ sandbox: boxThatNeverReceivesTheWorkspace() });
+  const events: HarnessEvent[] = [];
+  return await (async () => {
+    for await (const event of harness.run(turnOver(workspace) as never)) events.push(event);
+  })().catch((thrown: unknown) => thrown);
+};
+
+test("a workspace the box never received is not the user deleting everything", async () => {
+  const workspace = testWorkspace({ [SCREEN]: "<App/>" });
+
+  await drain(workspace);
+
+  expect(await workspace.readFile(SCREEN)).toBe("<App/>");
+  // Nothing was written back at all: a turn whose box never held the workspace
+  // has no statement to make about it.
+  expect(workspace.commits).toEqual([]);
+});
+
+test("a box that cannot be reached says so, instead of three words from undici", async () => {
+  const thrown = await drain(testWorkspace({ [SCREEN]: "<App/>" }));
+
+  expect(thrown).toBeInstanceOf(VendoError);
+  expect((thrown as VendoError).code).toBe("sandbox-unavailable");
+  expect((thrown as VendoError).detail).toMatchObject({ cause: expect.any(TypeError) });
+});
+
+test("a workspace upload that dies on the transport is sent again", async () => {
+  const root = mkdtempSync(path.join(tmpdir(), "vendo-materialize-retry-"));
+  boxRoots.push(root);
+  const routes = createSessionRoutes({ root, token: "", env: {} }) as {
+    handle: (method: string, pathname: string, headers: Record<string, string>, payload: unknown)
+      => Promise<{ status: number; body: unknown }>;
+  };
+  let dropped = 0;
+  const sandbox: SandboxAdapterLike = {
+    async create() {
+      return {
+        id: "box_blip",
+        async request(req) {
+          // Once, on the leg that carries the files — the shape observed live,
+          // where the box had applied the POST and only the answer died.
+          if (req.path === "/session/workspace" && dropped === 0) {
+            dropped += 1;
+            throw fetchFailed();
+          }
+          const payload = req.body === undefined
+            ? {}
+            : JSON.parse(typeof req.body === "string" ? req.body : new TextDecoder().decode(req.body));
+          const reply = await routes.handle(req.method, req.path, (req.headers ?? {}) as Record<string, string>, payload);
+          return { status: reply.status, headers: {}, body: encoder.encode(JSON.stringify(reply.body)) };
+        },
+        files: { read: async () => new Uint8Array(), write: async () => undefined, list: async () => [] },
+        url: async () => "https://box_blip.fake-provider.test",
+        destroy: async () => undefined,
+      };
+    },
+    async destroy() { /* no machine to reap by ref */ },
+  };
+
+  const machine = await boxMachine({ sandbox, threadId: "thr_blip", env: {}, allowedDomains: [] });
+  await machine.materialize([{ path: SCREEN, bytes: encoder.encode("<App/>"), readOnly: false }]);
+
+  expect(dropped).toBe(1);
+  expect(readFileSync(path.join(root, SCREEN.replace(/^\/+/, "")), "utf8")).toBe("<App/>");
+});

--- a/packages/harnesses/tests/claude-code/materialize-loss-guard.test.ts
+++ b/packages/harnesses/tests/claude-code/materialize-loss-guard.test.ts
@@ -116,8 +116,13 @@ test("a workspace upload that dies on the transport is sent again", async () => 
       return {
         id: "box_blip",
         async request(req) {
-          // Once, on the leg that carries the files — the shape observed live,
-          // where the box had applied the POST and only the answer died.
+          // Once, on the leg that carries the files, and BEFORE the box sees it:
+          // the upload never applied, which is the half of the live failure that
+          // costs the turn. The other half — applied, and only the answer died —
+          // is where a replay can do damage rather than just cost a round trip,
+          // and it is proved against the real door in
+          // `materialize-generation.test.ts` ("a first chunk sent twice does not
+          // take the chunks that landed behind it").
           if (req.path === "/session/workspace" && dropped === 0) {
             dropped += 1;
             throw fetchFailed();

--- a/packages/harnesses/tests/runtime-deep-cause.test.ts
+++ b/packages/harnesses/tests/runtime-deep-cause.test.ts
@@ -1,0 +1,70 @@
+/**
+ * The cause the operator needs is at the BOTTOM of the chain, not one hop down.
+ *
+ * A dead socket on the workspace seam arrives wrapped twice: `box.ts` names the
+ * route it died on, `cloudSandbox` names the console it could not reach, and
+ * undici's `fetch failed` sits on top of the one word — ECONNREFUSED, ECONNRESET —
+ * that tells a refused connect from a dropped socket. Printing one hop down printed
+ * a wrapper, which is the same three words the log already had.
+ */
+import { VendoError, setLogger, type ThreadId, type VendoLogEvent } from "@vendoai/core";
+import { afterEach, expect, test } from "vitest";
+import { defineHarness } from "../src/define.js";
+import { memoryHarnessStateStore } from "../src/harness-state.js";
+import { createHarnessRuntime } from "../src/runtime.js";
+import {
+  boundRegistry,
+  ctx,
+  readSse,
+  testGuard,
+  testSkills,
+  testTranscript,
+  testWorkspace,
+  unusedModels,
+  userMessage,
+} from "../src/test-doubles.test-util.js";
+
+afterEach(() => {
+  setLogger(undefined);
+});
+
+test("the operator's line names the ROOT cause, not the wrapper above it", async () => {
+  const lines: VendoLogEvent[] = [];
+  setLogger((event) => lines.push(event));
+  const guard = testGuard();
+  const runtime = createHarnessRuntime({
+    tools: boundRegistry({}, guard),
+    guard,
+    skills: testSkills([]),
+    transcript: testTranscript(),
+    harnessState: memoryHarnessStateStore(),
+  });
+  const harness = defineHarness({
+    name: "wrapped-socket",
+    async *run() {
+      yield { type: "text", delta: "starting" };
+      // Exactly the chain the workspace seam builds: the box's route, the
+      // adapter's sentence, undici's three words, the reason.
+      throw new VendoError("sandbox-unavailable", "box /session/workspace could not be reached", {
+        path: "/session/workspace",
+        cause: new VendoError("sandbox-unavailable", "Vendo Cloud sandbox could not be reached", {
+          path: "/request",
+          cause: Object.assign(new TypeError("fetch failed"), { cause: new Error("ECONNREFUSED") }),
+        }),
+      });
+    },
+  });
+
+  await readSse(await runtime.run({
+    harness,
+    threadId: "thr_1" as ThreadId,
+    messages: [userMessage("m1", "hello")],
+    ctx: ctx(),
+    workspace: testWorkspace(),
+    models: unusedModels(),
+    interactive: true,
+  }));
+
+  const failure = lines.find((line) => line.code === "harnesses.runtime-run-failed");
+  expect(failure?.data?.["detail"]).toMatchObject({ cause: "Error: ECONNREFUSED" });
+});

--- a/packages/harnesses/tests/runtime-error-cause.test.ts
+++ b/packages/harnesses/tests/runtime-error-cause.test.ts
@@ -1,0 +1,63 @@
+/**
+ * "The real error goes to the operator's terminal" — which it did not, for the
+ * one failure that needs it most. A dead connection reaches this seam as undici's
+ * bare `TypeError: fetch failed`, whose entire message is those three words; the
+ * reason lives on the cause, and the log kept only the message. An operator got
+ * "fetch failed" and no way to tell a refused connect from a dropped socket.
+ */
+import { setLogger, type ThreadId, type VendoLogEvent } from "@vendoai/core";
+import { afterEach, expect, test } from "vitest";
+import { defineHarness } from "../src/define.js";
+import { memoryHarnessStateStore } from "../src/harness-state.js";
+import { createHarnessRuntime } from "../src/runtime.js";
+import {
+  boundRegistry,
+  ctx,
+  readSse,
+  testGuard,
+  testSkills,
+  testTranscript,
+  testWorkspace,
+  unusedModels,
+  userMessage,
+} from "../src/test-doubles.test-util.js";
+
+afterEach(() => {
+  setLogger(undefined);
+});
+
+test("the operator's line names the cause under a bare transport failure", async () => {
+  const lines: VendoLogEvent[] = [];
+  setLogger((event) => lines.push(event));
+  const guard = testGuard();
+  const runtime = createHarnessRuntime({
+    tools: boundRegistry({}, guard),
+    guard,
+    skills: testSkills([]),
+    transcript: testTranscript(),
+    harnessState: memoryHarnessStateStore(),
+  });
+  const harness = defineHarness({
+    name: "dead-socket",
+    async *run() {
+      yield { type: "text", delta: "starting" };
+      throw Object.assign(new TypeError("fetch failed"), { cause: new Error("ECONNRESET") });
+    },
+  });
+
+  await readSse(await runtime.run({
+    harness,
+    threadId: "thr_1" as ThreadId,
+    messages: [userMessage("m1", "hello")],
+    ctx: ctx(),
+    workspace: testWorkspace(),
+    models: unusedModels(),
+    interactive: true,
+  }));
+
+  const failure = lines.find((line) => line.code === "harnesses.runtime-run-failed");
+  expect(failure?.data?.["detail"]).toMatchObject({
+    error: "fetch failed",
+    cause: "Error: ECONNRESET",
+  });
+});

--- a/packages/vendo/src/sandbox.ts
+++ b/packages/vendo/src/sandbox.ts
@@ -281,18 +281,33 @@ export function cloudSandbox(options: CloudSandboxOptions): SandboxAdapter {
   const fetchImpl = options.fetch ?? keepAliveFetch;
 
   const send = async (path: string, init: RequestInit = {}): Promise<Response> => {
-    const response = await fetchImpl(`${base}${CLOUD_SANDBOX_PATH}${path}`, {
-      ...init,
-      headers: {
-        authorization: `Bearer ${options.apiKey}`,
-        accept: "application/json",
-        // Interaction model: key-authed Cloud requests carry the deployment
-        // identity; the console meters usage from real traffic.
-        ...(await deploymentIdentityHeaders()),
-        ...init.headers,
-      },
-      signal: AbortSignal.timeout(timeoutMs),
-    });
+    let response: Response;
+    try {
+      response = await fetchImpl(`${base}${CLOUD_SANDBOX_PATH}${path}`, {
+        ...init,
+        headers: {
+          authorization: `Bearer ${options.apiKey}`,
+          accept: "application/json",
+          // Interaction model: key-authed Cloud requests carry the deployment
+          // identity; the console meters usage from real traffic.
+          ...(await deploymentIdentityHeaders()),
+          ...init.headers,
+        },
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+    } catch (cause) {
+      // Every console ANSWER this adapter dislikes is already named below; a
+      // console it never REACHED was not. undici's throw for a dead connection
+      // is `TypeError: fetch failed` and nothing else — the reason rides only on
+      // the cause, so raw it reaches a caller, and the log seam above it, as
+      // three words naming neither Vendo nor the call. The route stays on
+      // `detail`: this message is one the wire gate shows a user verbatim.
+      throw new VendoError(
+        "sandbox-unavailable",
+        "Vendo Cloud sandbox could not be reached",
+        { path, cause },
+      );
+    }
     if (!response.ok) await raiseSandboxError(response);
     return response;
   };

--- a/packages/vendo/tests/sandbox-transport.test.ts
+++ b/packages/vendo/tests/sandbox-transport.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Every console ANSWER this adapter dislikes already becomes a named VendoError
+ * (raiseSandboxError). A console it never reached did not: `fetchImpl` threw,
+ * and undici's throw for a dead connection is a bare `TypeError: fetch failed`
+ * whose only detail is on the cause. Raw, it reaches a caller as three words
+ * that name neither Vendo nor the call, and the log seam above drops the cause.
+ */
+import { VendoError } from "@vendoai/core";
+import { expect, test } from "vitest";
+import { cloudSandbox } from "../src/sandbox.js";
+
+test("a console this adapter cannot reach is a named failure that keeps the cause", async () => {
+  const cause = new Error("ECONNRESET");
+  const adapter = cloudSandbox({
+    apiKey: "vnd_secret",
+    baseUrl: "https://cloud.test",
+    fetch: (async () => {
+      throw Object.assign(new TypeError("fetch failed"), { cause });
+    }) as unknown as typeof fetch,
+  });
+
+  const thrown = await adapter.create({ env: {} }).catch((error: unknown) => error);
+
+  expect(thrown).toBeInstanceOf(VendoError);
+  expect((thrown as VendoError).code).toBe("sandbox-unavailable");
+  expect((thrown as VendoError).message).toMatch(/Vendo Cloud sandbox/);
+  // The whole chain, so an operator can tell a refused connect from a dead
+  // socket: undici's three words on top, the real reason underneath.
+  const detail = (thrown as VendoError).detail as { cause: Error };
+  expect(detail.cause).toBeInstanceOf(TypeError);
+  expect(detail.cause.cause).toBe(cause);
+});


### PR DESCRIPTION
## The bug

`claudeCode()` puts the workspace on the box before the model runs
(`packages/harnesses/src/claude-code/index.ts:679` → `box.ts` → `POST /session/workspace`),
and that upload was the one **unguarded network call** in the turn: no retry, no
error classification, and a transport fault surfaced as undici's bare
`TypeError: fetch failed`.

The dangerous half is what happened next. If the POST died **before** the box
applied it, the generator's `finally` still ran `collect()`, the box honestly
reported an **empty tree**, and `syncAll` — which deletes missing paths — read
that as *the user deleted everything* and erased every baseline path from the
store.

The failed-**READ** was already guarded (`index.ts`: "an EMPTY read is not the
same fact as the user deleted everything"). This is the same fact from the other
end, and it had **no guard and no test**. Observed live once on a warm-probe turn.

The red test proves it: before the fix, the store file is gone —
`ENOENT: no such file or directory, open '/user/apps/app_1/app.tsx'`.

## The three fixes

**1. Loss guard.** The turn tracks whether the box actually holds the checkout
(`materialized`), and reads its disk back only if it does. A machine that never
received the workspace makes no statement about it: the store keeps what it had
and the next turn recovers on a fresh box — the same outcome the kill-mid-turn
law already produces.

**2. One idempotent transport retry**, on the workspace seam only. `box.ts`'s
`request()` takes a `repeatable` flag — the caller's promise that the call is
the same twice — and the upload and the turn-end read set it. A transport fault
carries no answer, so those are exactly the calls that may be replayed; the
replay is instant, because what died was a connection, not a quota.

> **Deviation from the brief, deliberately.** The brief asked for this in
> `cloudSandbox`'s `send()`. Reading the call sites, a blanket retry there is
> **not** safe: `send` also serves create (`POST ""`), `/resume`, `/snapshot`
> and `/exec` — replaying those leaks a machine or an artifact, or runs a
> command twice — and its `/{id}/request` proxy carries *arbitrary* inner
> requests including `/session/message`, which would start a second model turn.
> `hostedStore`'s retry is only safe because it carries an `Idempotency-Key`;
> the console's sandbox routes have none. Idempotency is knowable only at
> `box.ts`, which names its own routes, so the retry lives there.
> `hosted-store.ts` is untouched.

**3. Attributable errors.** `cloudSandbox` converts a thrown `fetch` into
`VendoError("sandbox-unavailable", …, { path, cause })` — the cause on `detail`,
not in the message, because the wire gate shows that message to a user verbatim.
`box.ts`'s `request()` is unified with `hello()`'s convention: a transport fault
means the box did not answer, and now says so in this file's voice (an adapter
that already named its own failure keeps its sentence). The runtime's operator
log prints the cause alongside the message — it previously kept only
`error.message`, which for a dead socket is the three words `fetch failed`.

## Tests — red first, every one

| # | Test | Red before |
|---|---|---|
| 1 | store's baseline survives an upload the box never received | `ENOENT` — the file was **deleted** |
| 2 | an unreachable box throws a named `VendoError` | `expected TypeError: fetch failed to be an instance of VendoError` |
| 3 | an upload that dies on the transport is sent again | `TypeError: fetch failed` |
| 4 | the operator's log names the cause | detail had `error` only, no `cause` |
| 5 | `cloudSandbox` names an unreachable console, cause and all | `expected TypeError: fetch failed to be an instance of VendoError` |

Test 1 drives the **real** `claudeCode()` harness and the **real** checkout/sync
path against a real in-memory store — no stub on the receiving side. Test 3
drives the **real** box door (`turn-routes.mjs`) behind a transport shim that
drops one leg, and asserts the bytes reached the box's real disk.

No existing test was modified.

## Gate

- `pnpm build` — 22/22
- `pnpm typecheck` — 44/44
- `pnpm lint` — 0 errors
- `packages/harnesses` full suite — **592 passed**, 7 skipped
- `packages/vendo` — 2764 passed; 4 pre-existing env failures (`Cool%20Code`
  ENOENT — this worktree's path contains a space), none in touched files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents workspace data loss in `claudeCode()` and makes the upload seam safe to replay. Previously a dropped pre-run `/session/workspace` upload caused `collect()` to read an empty tree that `syncAll` treated as “user deleted everything”; now we only collect after a successful materialize and each materialize carries a generation so late chunks can’t wipe newer files.

- Loss guard: track `materialized`; skip `collect()` and log when the box never received the checkout.
- Generation/epoch: host increments per materialize and sends it on every chunk; box refuses stale generations (409), resets once per generation, and echoes the held epoch on `hello`/`collect`; `adopt()` rejects a box that reports a lower epoch; `collect()` validates epoch to catch a restarted or wrong box.
- Scoped retry: add `request(path, body, repeatable)` and set `repeatable=true` only for `/session/workspace` and `/session/collect`; retry only dropped connections and only within what remains of a 25s window; cut the replay off at the window’s edge; log the first failed attempt; tests enforce the host’s window equals the box’s `SYNC_ACK_WAIT_MS`.
- Error attribution: convert undici transport throws into `VendoError("sandbox-unavailable", { cause })` in both the box adapter and `@vendoai/vendo`; include the route on `detail`; runtime logs the root cause (e.g., ECONNRESET) instead of the “fetch failed” wrapper.
- Tests: added coverage for loss guard, generation handling, rollout behavior, remaining-window retry, and operator log causes; no existing tests changed.
- Scope: changes limited to `@vendoai/harnesses` and `@vendoai/vendo`; no caller API changes.

**Rollout**
- Rebake the box image to pick up `turn-routes.mjs` generation logic. A new host against an old image is safe but unprotected (epoch absent) and logs `harnesses.claude-code-box-no-generation` once per turn.

<sup>Written for commit 8116a4db5ca8d36a9872d953c0c8dfb694c4eeef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1558?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

---

## Round 2 — what an independent risk check found in the fix itself

The guard held up, but the **retry** it shipped with made the upload replayable,
and a replay is only safe if the box can tell it from a ghost.

**1. The replay was not idempotent (HIGH).** `AbortSignal.timeout` aborts the
HOST's leg of a call and nothing else — the console→box hop keeps going. So
chunk 0 of an attempt this host gave up on can land *after* its replay, after the
chunks behind it, even after `send` — and chunk 0 carries `reset`, which empties
the root. Every materialize now mints a **generation** and carries it on each
chunk: the box refuses a generation it has moved past (409), empties the root
**once per generation** rather than once per request, and echoes what it holds on
`hello` and `collect`. The echo is what lets the host know the disk it is reading
is the disk it wrote.

**2. Retry classification.** `call().catch(call)` replayed everything — 402, 401,
429, a machine the provider destroyed — and discarded attempt 1's error to say
attempt 2's. Only a fault that carries **no answer** is replayed now (the adapters
mark it by hanging the reason on `detail.cause`), and attempt 1 is logged.

**3. The restarted container.** `carriesSession` is host memory; a restarted
supervisor answers hello holding nothing. `adopt()` now refuses a box that greets
but reports a lower generation, and `collect()` refuses a disk that is not the one
this turn wrote.

**4. Attribution.** The operator's line prints the **root** of the cause chain
(`ECONNRESET`), not the `fetch failed` wrapper one hop above it; a box error keeps
the adapter's own sentence — the wire gate shows some of those to a user verbatim
— and gains the route it died on, on `detail`.

**5.** The `materialized === false` skip now says so in the log.

**6. Budget alignment.** The box parks the model behind its own write for
`SYNC_ACK_WAIT_MS` (25s) and then tells it the sync failed; the replay is bounded
to that window, so a second attempt never lands under a model that has been told
the opposite. The *first* attempt still runs on the adapter's own timeout, which
this seam does not own.

### Round-2 tests — red first, every one

| Test | Red before |
|---|---|
| a chunk from a materialize the box has moved past cannot wipe the one that replaced it | `expected 200 to be 409` |
| a first chunk sent twice does not take the chunks that landed behind it | `ENOENT` — the replay's reset deleted it |
| a box whose supervisor restarted is not the box that holds the workspace | `expected 1 to be 2` — the corpse was handed back |
| a box that forgot the workspace mid-turn does not get to delete it | `ENOENT` — **the store file was deleted** |
| the turn says out loud that nothing was synced back | log had `box-ready` only |
| the operator's line names the ROOT cause | detail carried the wrapper, not `ECONNREFUSED` |
| a refusal the console ANSWERED is not asked again | `expected 2 to be 1` |
| a drop nobody is waiting for any more is not asked again | `expected 2 to be 1` |

`a dropped connection is asked again` is green both before and after — it is the
guard that the classification did not break the retry it is narrowing.

No existing test was modified.

> ⚠️ **REBAKE THE BOX IMAGE.** `box/turn-routes.mjs` ships inside the machine
> image (`packages/apps/box/build-template.mjs` stages it beside the supervisor),
> and the generation lives on both sides of that wire. A host on this version
> against an **old** image is safe but unprotected: the box ignores the generation
> it is sent and reports none, and an absent report is tolerated deliberately —
> a box that cannot speak about its generation cannot be wrong about it either, so
> the seam behaves exactly as it does today rather than refusing every sync-back
> until the rebake lands.

### Gate (round 2)

- `pnpm build` — 22/22
- `pnpm test:affected` — 34/34 tasks, 6m30s (`@vendoai/harnesses` 62 files passed, 3 skipped)
- `pnpm typecheck` — 44/44
- `pnpm lint` — 0 errors


### Known bounded residual — stale bytes, never a wipe

The generation closes the *destructive* half of a late attempt-1 (it can no longer
empty the root, and it can no longer be mistaken for the disk this turn wrote).
One remainder stays open, deliberately, and is worth naming so it is discoverable:

A chunk of a stalled attempt-1 that lands **after `send()`** carries the same
generation as the replay that succeeded, so the box accepts it and rewrites the
files in that chunk — **at most 24, with the turn's own baseline bytes** — over
edits the model has since made to them. Bounded, silent, and much narrower than
what it replaced: no deletion, no truncation, no reset, and only for files the
model happened to edit inside the same window a chunk was stalled in.

**The fix shape when it is worth building:** a per-generation *applied-chunk set*
on the box — each chunk carries its index, the box records which indices it has
applied for the current generation, and a chunk whose index is already recorded is
acknowledged without being written. That makes the upload idempotent per chunk
rather than per generation, which is the last step of the same idea. Not built
here: it costs box-side state on a seam that just changed, and the destructive
failure is already gone.

### Rollout observability

Against an un-rebaked image the guard fails open silently — hello reports no
generation, `adopt` has nothing to disagree with, collect's check does not apply.
An unprotected turn now logs `harnesses.claude-code-box-no-generation` once, so the
window is visible while it is open. The rebake requirement is in the changeset too.
