### PR TITLE
fix(store): a corrupt pglite install has four faces, and the retry knows all four

### DIFF
--- a/.changeset/pglite-boot-retry-signatures.md
+++ b/.changeset/pglite-boot-retry-signatures.md
@@ -1,0 +1,17 @@
+---
+"@vendoai/store": patch
+---
+
+The PGlite boot retry now knows all four faces of a half-written install.
+`could not load library "/pglite/lib/postgresql/plpgsql.so"` and initdb's
+`input file ".../postgres.bki" does not belong to PostgreSQL 18.3` are the same
+corrupt `@electric-sql/pglite` bundle that already produced `Invalid FS bundle
+size` and `PGlite failed to initialize properly` — a `.so` that dlopen cannot
+read and a leftover input file from another version, instead of a short read —
+but neither matched, so they fell through with no recovery path. Between them
+they killed six CI runs on 2026-08-19, each on a different random test in
+`packages/agents`.
+
+All four share the one delayed retry. The library signature is pinned to the
+bundle's own `/pglite/…` path, so a host extension that fails to load still
+raises on the first attempt.

--- a/packages/store/src/db.ts
+++ b/packages/store/src/db.ts
@@ -271,8 +271,17 @@ async function releaseSharedPglite(dataDir: string, entry: SharedPglite): Promis
     ~300 in `packages/agents` on two unrelated branches). Both are signatures of a
     boot that never started, so a second attempt is free of side effects — unlike
     `Aborted()`, which means a half-opened data dir and belongs to the stale-lock
-    heal below, not here. */
-const TRANSIENT_BOOT = /Invalid FS bundle size|failed to initialize properly/;
+    heal below, not here.
+
+    Two more faces of the same half-written install (CI 2026-08-19, three runs
+    each): a `.so` inside the bundle that dlopen cannot read
+    (`could not load library "/pglite/lib/postgresql/plpgsql.so"`), and an initdb
+    input file left behind from another version
+    (`postgres.bki` … `does not belong to PostgreSQL 18.3`). Both are the bundle
+    reading back wrong rather than a data dir half-opened, so they belong here
+    with the other two. */
+const TRANSIENT_BOOT =
+  /Invalid FS bundle size|failed to initialize properly|could not load library "\/pglite\/[^"]*\.so"|does not belong to PostgreSQL/;
 
 async function createPgliteRetryingTransientBoot(dataDir: string): Promise<PGlite> {
   try {

--- a/packages/store/tests/db.fs-bundle-retry.test.ts
+++ b/packages/store/tests/db.fs-bundle-retry.test.ts
@@ -15,6 +15,14 @@ const { createDb } = await import("../src/db.js");
 
 const truncatedBundle = () => new Error("Invalid FS bundle size: 3030528 !== 6293225");
 const initFailure = () => new Error("PGlite failed to initialize properly");
+const unloadableLibrary = () =>
+  new Error(
+    'error: could not load library "/pglite/lib/postgresql/plpgsql.so": Could not load dynamic lib: /pglite/lib/postgresql/plpgsql.so',
+  );
+const mixedVersionBundle = () =>
+  new Error(
+    'INITDB failed to initialize: initdb: error: input file "/pglite/share/postgresql/postgres.bki" does not belong to PostgreSQL 18.3initdb: hint: Specify the correct path using the option -L.',
+  );
 const fakePglite = () => ({
   query: vi.fn(async () => ({ rows: [{ ok: 1 }] })),
   close: vi.fn(async () => {}),
@@ -79,11 +87,48 @@ describe("PGlite transient boot retry", () => {
     await db.close();
   });
 
+  // The same half-written install wearing two other faces (CI 2026-08-19): a
+  // `.so` in the bundle that dlopen cannot read, and an initdb input file left
+  // over from another version. Both hit `packages/agents` on a random test.
+  it("heals a bundle library that fails to load, with one retry", async () => {
+    pgliteCreate.mockRejectedValueOnce(unloadableLibrary()).mockResolvedValueOnce(fakePglite());
+
+    const db = createDb({ dataDir: "memory://boot-library-heals" });
+    await expect(db.query("select 1")).resolves.toEqual({ rows: [{ ok: 1 }] });
+
+    expect(pgliteCreate).toHaveBeenCalledTimes(2);
+    await db.close();
+  });
+
+  it("heals a version-mixed initdb input file, with one retry", async () => {
+    pgliteCreate.mockRejectedValueOnce(mixedVersionBundle()).mockResolvedValueOnce(fakePglite());
+
+    const db = createDb({ dataDir: "memory://boot-bki-heals" });
+    await expect(db.query("select 1")).resolves.toEqual({ rows: [{ ok: 1 }] });
+
+    expect(pgliteCreate).toHaveBeenCalledTimes(2);
+    await db.close();
+  });
+
   it("propagates an unrelated boot failure unchanged, without retrying", async () => {
     pgliteCreate.mockRejectedValue(new Error("boot blip"));
 
     const db = createDb({ dataDir: "memory://fs-bundle-unrelated" });
     await expect(db.query("select 1")).rejects.toThrow("boot blip");
+
+    expect(pgliteCreate).toHaveBeenCalledTimes(1);
+    await db.close();
+  });
+
+  // The library signature is pinned to the bundle's own path: a host extension
+  // that fails to load is the host's problem, and retrying it just doubles it.
+  it("propagates a failed load of a library outside the bundle, without retrying", async () => {
+    pgliteCreate.mockRejectedValue(
+      new Error('could not load library "/usr/lib/postgresql/vector.so"'),
+    );
+
+    const db = createDb({ dataDir: "memory://boot-host-library" });
+    await expect(db.query("select 1")).rejects.toThrow("/usr/lib/postgresql/vector.so");
 
     expect(pgliteCreate).toHaveBeenCalledTimes(1);
     await db.close();


### PR DESCRIPTION
Two more PGlite boot failures now match `TRANSIENT_BOOT`: `could not load library "/pglite/lib/postgresql/plpgsql.so"` and initdb's `input file ".../postgres.bki" does not belong to PostgreSQL 18.3`.

Both are the same half-written `@electric-sql/pglite` install that already produced `Invalid FS bundle size` and `PGlite failed to initialize properly` — a `.so` dlopen cannot read and a leftover input file from another version, instead of a short read — so they belong on the same one delayed retry. They fell through with no recovery path and killed six CI runs on 2026-08-19, each on a different random test in `packages/agents`.

The heal now covers all four observed faces. The library signature is pinned to the bundle's own `/pglite/…` path so a host extension that fails to load still raises on the first attempt; three tests accompany the fix (two heal cases, one tightness guard), and both new heal tests were confirmed red against the old regex.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Heals all four signatures of a corrupt `@electric-sql/pglite` install by treating them as transient boot failures and retrying once. Previously only “Invalid FS bundle size” and “PGlite failed to initialize properly” retried; now “could not load library "/pglite/... .so"” and “postgres.bki … does not belong to PostgreSQL 18.3” also retry, reducing CI flakes.

- Review notes:
  - Extends TRANSIENT_BOOT regex with two patterns; the `.so` match is pinned to the bundle path (`/pglite/...`) so host extensions still fail fast.
  - Adds two heal tests and a guard test to ensure non-bundle library errors do not retry.
  - No behavior change for `Aborted()`; it remains handled by the stale-lock path.
  - Publishes a patch to `@vendoai/store`; no migrations or config changes required.

<sup>Written for commit cb3977bd550de1460cf64c49dca9f8a6139139ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1559?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

