### PR TITLE
fix(core,apps,vendo): a remix's wish list records what landed, and a follow-up edit changes the port

### DIFF
--- a/.changeset/remix-wish-integrity.md
+++ b/.changeset/remix-wish-integrity.md
@@ -1,0 +1,29 @@
+---
+"@vendoai/core": patch
+"@vendoai/apps": patch
+"@vendoai/vendo": patch
+---
+
+A remix's wish list records what the person GOT, and a follow-up edit changes the
+port instead of replacing it.
+
+One follow-up ask on Maple was refused three times and left four entries on
+`seed.wishes` — a list every Update replays in order, so one ask became four
+edits the person never made. The front door recorded the ask whether or not the
+change landed, which is right for `memory.asks` (the next editor wants to read
+"asked for X, then asked for X again, narrower") and wrong for the replay list
+beside it. `AppsRuntime.remember` now takes `landed`, and only a change that
+reached the screen becomes a wish. The ask itself is still recorded either way,
+the list is still ordered and never trimmed, and an inapplicable wish still lands
+on `seed.unapplied` and is still said out loud.
+
+The fourth attempt then abandoned the ported source and rewrote the app out of
+the host's catalog, losing the first wish's edit. The port reaches the model
+through `startingSource`, which was filled from the CHECKOUT — and the checkout
+only ever fills an EMPTY workspace. So once the first edit's save had landed a
+file, every later edit of that remix arrived with no code at all in front of it
+(the loop has no file hand and cannot read the workspace itself), and an ask with
+nothing to change is answered out of the catalog. The stored screen is now read
+for every edit of a remix, not only the first; it is still never written over a
+file a save left behind. A port that genuinely cannot take an edit now fails
+through the one channel there is, rather than succeeding as a different app.

--- a/packages/apps/src/server/doors/make-tool.ts
+++ b/packages/apps/src/server/doors/make-tool.ts
@@ -110,8 +110,10 @@ interface MakeCall {
   ask: string;
   /** The client parts this execution may publish, when the caller opened a stream. */
   stream: ((update: VendoViewStreamUpdate) => void) | undefined;
-  /** The ask, onto the app's memory. Best-effort, always. */
-  remember(appId: string): Promise<void>;
+  /** The ask, onto the app's memory. Best-effort, always. `landed` says the
+   *  change reached the screen, which is what makes it a remix WISH as well as
+   *  an ask — the create arms leave it off because a new app has no wish list. */
+  remember(appId: string, landed?: boolean): Promise<void>;
 }
 
 const makeNewApp = async (
@@ -281,10 +283,13 @@ const changeExistingApp = async (
 ): Promise<ToolOutcome> => {
   const appId = await resolveAppRef(runtime, app, ctx);
   const result = await runtime.edit(appId, ask, ctx);
-  // Recorded whether or not the change landed: the person DID ask this of
-  // this app, and the next editor reading "asked for X, then asked for X
-  // again, narrower" is reading the truth.
-  await remember(appId);
+  // The ASK is recorded whether or not the change landed: the person DID ask
+  // this of this app, and the next editor reading "asked for X, then asked for
+  // X again, narrower" is reading the truth. Whether it landed travels with it,
+  // because a remix's wish list is the other thing this writes and that one
+  // replays on every Update — an attempt the person never got back is not a
+  // change to replay.
+  await remember(appId, result.failure === undefined);
   // An automation this edit authored raises its own card. Published HERE, by the
   // side that knows, rather than duck-typed out of this tool's return value at
   // the bridge: the receipt carries words only.
@@ -452,8 +457,9 @@ export const runMakeTool = async (
    * Best-effort, always. There is no arrangement of a lost memory write
    * that is worse than failing a make the person can already see.
    */
-  const remember = async (appId: string): Promise<void> => {
-    await runtime.remember({ appId, ask: request }, ctx).catch((error: unknown) => {
+  const remember = async (appId: string, landed?: boolean): Promise<void> => {
+    const recorded = { appId, ask: request, ...(landed === undefined ? {} : { landed }) };
+    await runtime.remember(recorded, ctx).catch((error: unknown) => {
       log({
         code: "apps.ask-not-recorded",
         level: "warn",

--- a/packages/apps/src/server/doors/write-surface.ts
+++ b/packages/apps/src/server/doors/write-surface.ts
@@ -503,10 +503,14 @@ export const createWriteSurface = (
         memory: rememberedMemory(doc.memory, input),
         // A REMIX keeps every wish beside the memory, because the two answer
         // different questions. `memory.asks` is a capped working set for the
-        // next editor; `seed.wishes` is what a re-seed replays onto the host's
-        // new version, so a wish that fell off a cap would be an edit the person
-        // loses the next time the host ships.
-        ...(doc.seed === undefined || input.ask === undefined
+        // next editor and holds every ask, landed or not; `seed.wishes` is what
+        // a re-seed REPLAYS onto the host's new version, so it holds only the
+        // asks that reached the screen — a refused attempt is not a change the
+        // person has, and one ask refused three times used to leave four entries
+        // that every Update then replayed (live 2026-08-18). A wish that fell off
+        // a cap would be an edit the person loses the next time the host ships,
+        // which is why the list is never trimmed.
+        ...(doc.seed === undefined || input.ask === undefined || input.landed !== true
           ? {}
           : { seed: { ...doc.seed, wishes: [...doc.seed.wishes, input.ask] } }),
       }));

--- a/packages/apps/src/server/runtime/types.ts
+++ b/packages/apps/src/server/runtime/types.ts
@@ -695,13 +695,20 @@ export interface AppsRuntime {
    * one reads as a current constraint. Both are capped here (`app-memory.ts`)
    * rather than in the schema, so a stored row survives a cap that changes.
    *
+   * `landed` is the other half of an `ask` on a REMIX, and only there: the wish
+   * list replays on every Update, so only a change that reached the screen
+   * belongs on it. The ask itself is recorded either way.
+   *
    * There is deliberately no second row-write door for this. Every caller —
    * `vendo_make`'s create arms, its edit arm, the screen assembler's decisions —
    * comes through here, which is also the one place the `editor` level is
    * checked. A caller treats a rejection as a non-event: memory is never worth
    * failing a make over.
    */
-  remember(input: { appId: AppId; ask?: string; decisions?: string }, ctx: RunContext): Promise<void>;
+  remember(
+    input: { appId: AppId; ask?: string; decisions?: string; landed?: boolean },
+    ctx: RunContext,
+  ): Promise<void>;
   /**
    * The capped version log.
    *

--- a/packages/core/src/app-document.ts
+++ b/packages/core/src/app-document.ts
@@ -190,12 +190,15 @@ export const appMemorySchema = z.object({
  * never the location of record — that is a placement ROW), and `review` carries
  * the captured baseline's review kind.
  *
- * `wishes` is EVERY change the person has asked of this remix, VERBATIM and in
- * order, the ✦ gesture's own first. There are no bare forks — the gesture
- * collects the first wish before it fires — and a re-seed replays the WHOLE list
- * against the host's new baseline, so a wish missing here is an edit the person
- * silently loses. Unlike {@link AppMemory.asks}, a capped working set, this list
- * is never trimmed: it IS the remix.
+ * `wishes` is every change that LANDED on this remix, VERBATIM and in order, the
+ * ✦ gesture's own first. There are no bare forks — the gesture collects the
+ * first wish before it fires — and a re-seed replays the WHOLE list against the
+ * host's new baseline, so a wish missing here is an edit the person silently
+ * loses, and a wish here that never reached their screen is one the Update
+ * silently invents. That is why the list is what the person GOT and
+ * {@link AppMemory.asks} beside it is everything they asked: one ask refused
+ * three times is three asks and no wishes. Unlike `asks`, a capped working set,
+ * this list is never trimmed: it IS the remix.
  */
 export interface AppSeed {
   component: string;

--- a/packages/vendo/src/screen-agent.ts
+++ b/packages/vendo/src/screen-agent.ts
@@ -642,6 +642,11 @@ const judgeScreen = async (
  * guessing a host component's props, which the checks floor then refused. The
  * ask alone could never have produced anything else.
  *
+ * EVERY edit of a remix, not only the first. This was once filled from the
+ * CHECKOUT, which fills an empty workspace and so had nothing to say once the
+ * first edit's save had landed a file — leaving the second ask in exactly the
+ * position the first was rescued from, and answered the same way.
+ *
  * A message rather than a section of the brief: the brief heads a cached prefix
  * shared by every assembly, and this is one app's file.
  *
@@ -650,7 +655,8 @@ const judgeScreen = async (
  * still the ask, byte for byte.
  */
 const startingSource = (source: string | undefined): string =>
-  source === undefined ? "" : `This app already has a screen: the host's own component, ported into this dialect.
+  source === undefined ? "" : `This app already has a screen: the host's own component, ported into this
+dialect, and every change already made to it.
 It is below, and it is what the ask under it changes — edit THIS code, keep every
 part the ask does not name, and never replace it with something built from the
 catalog.
@@ -1501,11 +1507,17 @@ export function screenAssembler(deps: ScreenAssemblerDeps): ScreenAssembler {
       // save is the single landing, so a replay that never saves leaves the
       // stored screen untouched. Only a re-seed publishes one.
       let start = deps.replayFrom?.(request.appId);
-      // Otherwise the ordinary checkout, which only ever FILLS an empty
-      // workspace and can never overwrite a save.
-      if (start === undefined && !(await base.exists(checkout))) {
-        start = await deps.storedScreen?.(request.appId, ctx);
-      }
+      // Otherwise the app's own stored screen — a REMIX's and nothing else
+      // (`storedScreen`, compose-apps.ts). Read whether or not the workspace
+      // already holds a copy, because this is ALSO what goes in front of the
+      // model ({@link startingSource}) and the loop cannot read the workspace
+      // itself. Asking only when the workspace was empty meant a remix's SECOND
+      // edit arrived with no code at all in front of it, and an ask with nothing
+      // to change is answered out of the catalog — the one thing a fork exists
+      // not to do, and what a live session's fourth attempt did (2026-08-18),
+      // taking the first wish's edit with it.
+      const held = start === undefined && await base.exists(checkout);
+      start ??= await deps.storedScreen?.(request.appId, ctx);
       // Blank is not a screen — `open()` reads it the same way — and an empty
       // file would leave `edit_app` editing nothing, which is worse than none.
       //
@@ -1526,8 +1538,11 @@ export function screenAssembler(deps: ScreenAssemblerDeps): ScreenAssembler {
       // the loss happens a turn later. Proven: re-add the commit and
       // `remix-port-seed.e2e.test.ts`'s re-seed guarantee goes red on the
       // workspace half.
-      const staged = start !== undefined && start.trim() !== "" ? start : undefined;
-      if (staged !== undefined) await base.writeFile(checkout, staged);
+      //
+      // Never over a file the workspace already `held`: that one belongs to a
+      // save, and a save is newer than the row. Showing it is not writing it.
+      const starting = start !== undefined && start.trim() !== "" ? start : undefined;
+      if (starting !== undefined && !held) await base.writeFile(checkout, starting);
       /** The last SETTLED paint of this app, kept as it goes past on its way to the
        *  person's screen. It is the only place the resolved query answers exist —
        *  the seam spreads them beside the description on the final paint — so the
@@ -1580,7 +1595,7 @@ export function screenAssembler(deps: ScreenAssemblerDeps): ScreenAssembler {
           request: request.request,
           ...(request.viewport === undefined ? {} : { viewport: request.viewport }),
           ...(pack === undefined ? {} : { briefing: renderBriefingPack(pack) }),
-          ...(staged === undefined ? {} : { source: staged }),
+          ...(starting === undefined ? {} : { source: starting }),
         },
       );
       if (result.kind !== "assembled") return result;

--- a/packages/vendo/src/screen-agent.ts
+++ b/packages/vendo/src/screen-agent.ts
@@ -1541,6 +1541,15 @@ export function screenAssembler(deps: ScreenAssemblerDeps): ScreenAssembler {
       //
       // Never over a file the workspace already `held`: that one belongs to a
       // save, and a save is newer than the row. Showing it is not writing it.
+      //
+      // So a `held` run is SHOWN the row while its hands edit the workspace, and
+      // §3.2 is what makes that the right way round: a landed save wrote both, so
+      // they agree, and where they do not the ROW is the truth — it is the screen
+      // the person is actually looking at. The way they part is a save the floor
+      // refused, which reaches the workspace (`persistSource`) but never the row.
+      // Showing the workspace there would hand the model bytes the floor has
+      // already rejected; showing the row costs at most a missed `edit_app`, and
+      // a miss is reported (#1535) over a screen that still stands.
       const starting = start !== undefined && start.trim() !== "" ? start : undefined;
       if (starting !== undefined && !held) await base.writeFile(checkout, starting);
       /** The last SETTLED paint of this app, kept as it goes past on its way to the

--- a/packages/vendo/tests/remix-wish-integrity.e2e.test.ts
+++ b/packages/vendo/tests/remix-wish-integrity.e2e.test.ts
@@ -1,0 +1,304 @@
+/**
+ * THE WISH LIST IS THE REMIX — so what goes on it, and what a follow-up edit is
+ * allowed to do to the screen, are both data-integrity properties.
+ *
+ * A remix's `seed.wishes` replays in order on every Update, so anything that
+ * lands on it is an edit the person keeps forever. Two ways that went wrong in
+ * one live session (Maple, 2026-08-18): one follow-up ask was refused three
+ * times and left FOUR entries on the list, and the attempt that finally landed
+ * had abandoned the ported source and rewritten the app out of the host's
+ * catalog, losing the first wish's edit.
+ *
+ * Both are seams between the front door, the memory door and the assembly loop,
+ * so neither side is stubbed: a real PGlite store, a real `createVendo`, the
+ * real `vendo_make` tool called the way a calling agent calls it, the real
+ * checks floor, the real screen agent and the real workspace façade. Only the
+ * MODEL is scripted — what is measured is the doors.
+ *
+ * The second test scripts a SOURCE-SENSITIVE model on purpose: it edits the
+ * screen when the loop puts one in front of it and writes a catalog card when it
+ * does not, which is exactly what the live model did. That makes the assertion
+ * about the loop's own prompt, not about a mood — the run is deterministic
+ * either way, and the two outcomes are distinguishable in the stored screen.
+ *
+ * The ones that must be able to fail:
+ *  1. drop the `landed` gate in `remember` (`apps/server/doors/write-surface.ts`)
+ *     and "a follow-up that does not land" goes red with a second wish.
+ *  2. restore the `!(await base.exists(checkout))` guard around `storedScreen`
+ *     in `screenAssembler` (`vendo/src/screen-agent.ts`) and "the follow-up edits
+ *     the port" goes red: the screen loses the first wish and holds the catalog
+ *     card instead.
+ */
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SCREEN_FILE, type SeedBaseline } from "@vendoai/apps";
+import { makeReceiptSchema } from "@vendoai/apps/contract";
+import { VENDO_MAKE_TOOL, type AppId, type RunContext } from "@vendoai/core";
+import { defineHarness } from "@vendoai/harnesses";
+import { createStore, type VendoStore } from "@vendoai/store";
+import type { LanguageModel } from "ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createVendo } from "../src/server.js";
+
+const originalCwd = process.cwd();
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  process.chdir(originalCwd);
+  vi.unstubAllEnvs();
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+const ctx: RunContext = {
+  principal: { kind: "user", subject: "user_wish" },
+  venue: "app",
+  presence: "present",
+  sessionId: "session_wish",
+};
+
+/** The splitter's output for the slot: real TSX in the screen dialect. */
+const PORTED = `import { Stack, Text } from "@vendo/screen";
+
+export default function NetWorthCard() {
+  return (
+    <Stack gap={12}>
+      <Text text="Net worth at Maple" variant="heading" />
+      <Text text="$1.2M" />
+    </Stack>
+  );
+}
+`;
+
+/** In the port and in nothing else, so any regeneration loses it. */
+const PORT_ONLY = 'text="Net worth at Maple"';
+/** What the FIRST wish turns it into — the edit that must survive the second. */
+const WISH_ONE_LANDED = 'text="Net worth at Maple, mine"';
+/** What the SECOND wish turns the figure into. */
+const WISH_TWO_LANDED = 'text="$1.3M"';
+
+/**
+ * What a run with no screen in front of it writes: a card built out of the
+ * host's own catalog, guessing at a component the person never asked for. It
+ * shares not one byte with the port, so "did a catalog rewrite land" has a
+ * one-string answer.
+ */
+const CATALOG_REWRITE = `import { Stack, Text } from "@vendo/screen";
+
+export default function NetWorthCard() {
+  return (
+    <Stack gap={12}>
+      <Text text="Rebuilt from the catalog" variant="heading" />
+    </Stack>
+  );
+}
+`;
+const CATALOG_ONLY = 'text="Rebuilt from the catalog"';
+
+const FIRST_WISH = "say it is mine";
+const SECOND_WISH = "say it louder";
+
+/** The screen agent's own brief (`environmentNote`), which is how an assembly
+ *  prompt is told apart from the reviewer's. */
+const SCREEN_BRIEF_MARKER = "# In this loop";
+/** `startingSource`'s own first words — the screen the run must change. */
+const STARTING_SOURCE_MARKER = "This app already has a screen";
+
+const ZERO_USAGE = {
+  inputTokens: { total: 0, noCache: 0, cacheRead: 0, cacheWrite: 0 },
+  outputTokens: { total: 0, text: 0, reasoning: 0 },
+} as const;
+
+type Chunk = Record<string, unknown>;
+
+const call = (toolName: string, input: unknown, toolCallId: string): Chunk[] => [
+  { type: "tool-call", toolCallId, toolName, input: JSON.stringify(input) },
+  { type: "finish", usage: ZERO_USAGE, finishReason: { unified: "tool-calls", raw: undefined } },
+];
+
+const speak = (text: string): Chunk[] => [
+  { type: "text-start", id: "t1" },
+  { type: "text-delta", id: "t1", delta: text },
+  { type: "text-end", id: "t1" },
+  { type: "finish", usage: ZERO_USAGE, finishReason: { unified: "stop", raw: undefined } },
+];
+
+interface Scripted {
+  model: LanguageModel;
+  /** Every prompt the assembly loop was handed, in order — the only place "what
+   *  the loop was told" is readable. */
+  prompts: string[];
+}
+
+/** A model that plays the assembly loop's steps in order. Anything that is not
+ *  the loop — the mandatory reviewer above all — gets plain prose, which reads
+ *  as "no findings", so no repair round fires and the run stays deterministic. */
+function scripted(steps: Array<(prompt: string) => Chunk[]>): Scripted {
+  const prompts: string[] = [];
+  const remaining = [...steps];
+  const answer = (prompt: string): Chunk[] => {
+    if (!prompt.includes(SCREEN_BRIEF_MARKER)) return speak("nothing to report");
+    prompts.push(prompt);
+    const step = remaining.shift();
+    return step === undefined ? speak("nothing more to do") : step(prompt);
+  };
+  const textOf = (request: { prompt?: unknown }): string => JSON.stringify(request.prompt ?? "");
+  const model = {
+    specificationVersion: "v2",
+    provider: "vendo-remix-wish",
+    modelId: "vendo-remix-wish-v1",
+    supportedUrls: {},
+    async doStream(request: { prompt?: unknown }) {
+      const chunks = answer(textOf(request));
+      return {
+        stream: new ReadableStream({
+          start(controller) {
+            controller.enqueue({ type: "stream-start", warnings: [] });
+            for (const chunk of chunks) controller.enqueue(chunk);
+            controller.close();
+          },
+        }),
+      };
+    },
+  };
+  return { model: model as unknown as LanguageModel, prompts };
+}
+
+const baseline: SeedBaseline = {
+  slot: "NetWorthCard",
+  source: "export default function NetWorthCard() {\n  return <strong>$1.2M</strong>;\n}\n",
+  hash: "sha256:maple-net-worth-1",
+  exportable: false,
+  capturedAt: "2026-08-18T09:00:00.000Z",
+  ported: { source: PORTED, tools: [], holes: [] },
+};
+
+/**
+ * One real turn whose harness does exactly what a calling agent does: ask
+ * `vendo_make` in words, naming the host component, and keep the receipts.
+ *
+ * The ✦ and every follow-up go through that ONE door — which is the door that
+ * records the wish, so nothing below it can be reached any other way.
+ */
+async function walk(
+  asks: readonly string[],
+  steps: Array<(prompt: string) => Chunk[]>,
+) {
+  vi.stubEnv("VENDO_BASE_URL", "http://wish.test");
+  const root = await mkdtemp(join(tmpdir(), "vendo-remix-wish-"));
+  cleanups.push(async () => rm(root, { recursive: true, force: true }));
+  await mkdir(join(root, ".vendo", "remixable"), { recursive: true });
+  await writeFile(
+    join(root, ".vendo", "remixable", `${baseline.slot}.json`),
+    JSON.stringify(baseline, null, 2),
+  );
+  const store: VendoStore = createStore({ dataDir: join(root, ".data") });
+  await store.ensureSchema();
+  cleanups.push(async () => store.close());
+  const { model, prompts } = scripted(steps);
+  const receipts: Array<ReturnType<typeof makeReceiptSchema.parse>> = [];
+  const harness = defineHarness({
+    name: "wish-probe",
+    async *run(turn) {
+      for (const request of asks) {
+        const result = await turn.tools.call(VENDO_MAKE_TOOL, { request, component: baseline.slot });
+        if (result.status === "ok") receipts.push(makeReceiptSchema.parse(result.output));
+      }
+      yield { type: "text", delta: "ok" };
+    },
+  });
+  process.chdir(root);
+  const vendo = createVendo({
+    models: { default: model },
+    principal: async () => ctx.principal,
+    store,
+    harness: harness as never,
+  } as Parameters<typeof createVendo>[0]);
+  const response = await vendo.handler(new Request("http://wish.test/api/vendo/threads", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      threadId: "thr_wish",
+      message: { id: "m1", role: "user", parts: [{ type: "text", text: "remix my net worth card" }] },
+    }),
+  }));
+  expect(response.status).toBe(200);
+  await response.text();
+  return { vendo, prompts, receipts };
+}
+
+/** The app's screen as the ROW holds it — the truth both stores answer to. */
+const screenOf = async (
+  vendo: Awaited<ReturnType<typeof walk>>["vendo"],
+  appId: AppId,
+): Promise<string> => (await vendo.apps.get(appId, ctx))?.source?.[SCREEN_FILE]?.text ?? "";
+
+describe("a remix's wish list records what the person got, not what the builder tried", () => {
+  it("a follow-up edit that does not land leaves the wish list exactly as it was", async () => {
+    const walked = await walk([FIRST_WISH, SECOND_WISH], [
+      // The ✦ itself: the first wish, landed on the port.
+      () => call("edit_app", { edits: [{ find: PORT_ONLY, replace: WISH_ONE_LANDED }] }, "e1"),
+      () => speak("Tightened the heading."),
+      // The follow-up, REFUSED: the run never saves, which is the honest failure
+      // the front door reports (`this run never saved a screen`). One ask, one
+      // failure — and the wish list must not grow by it.
+      () => speak("I cannot make that change"),
+    ]);
+
+    const appId = walked.receipts[0]!.id as AppId;
+    // The failure really reached the person, through the one channel there is.
+    expect(walked.receipts[1]?.status).toBe("failed");
+
+    const stored = await walked.vendo.apps.get(appId, ctx);
+    // THE PROPERTY: one landed change, one wish. The refused attempt asked for
+    // nothing the Update should ever replay.
+    expect(stored?.seed?.wishes).toEqual([FIRST_WISH]);
+    // …and the person's screen is untouched by the attempt that failed.
+    expect(await screenOf(walked.vendo, appId)).toContain(WISH_ONE_LANDED);
+
+    // NOT WEAKENED: `memory.asks` is the next editor's working set and it still
+    // holds the ask that failed — "asked for X, then asked for X again, narrower"
+    // is the truth an editor needs, and it answers a different question from the
+    // replay list beside it.
+    expect(stored?.memory?.asks).toContain(SECOND_WISH);
+  }, 120_000);
+
+  it("the follow-up edits the PORT, so a refused edit can never become a catalog rewrite", async () => {
+    const walked = await walk([FIRST_WISH, SECOND_WISH], [
+      () => call("edit_app", { edits: [{ find: PORT_ONLY, replace: WISH_ONE_LANDED }] }, "e1"),
+      () => speak("Tightened the heading."),
+      // THE LOAD-BEARING STEP. A run handed the screen edits it; a run handed
+      // nothing has only the catalog to build from, which is what the live model
+      // did on its fourth attempt.
+      (prompt) => prompt.includes(STARTING_SOURCE_MARKER)
+        ? call("edit_app", { edits: [{ find: 'text="$1.2M"', replace: WISH_TWO_LANDED }] }, "e2")
+        : call("save_app", { content: CATALOG_REWRITE }, "c2"),
+      () => speak("Raised the figure."),
+    ]);
+
+    const appId = walked.receipts[0]!.id as AppId;
+
+    // ── What the loop was TOLD, asserted first: it is the proximate cause of
+    // everything below. The follow-up's own prompt carries the screen it must
+    // change and the line that forbids replacing it out of the catalog.
+    // The prompt is captured as JSON, so this reads the quote-free heart of the
+    // first wish's edit — a string the port carries only once it has landed.
+    const followUp = walked.prompts[2] ?? "";
+    expect(followUp).toContain(STARTING_SOURCE_MARKER);
+    expect(followUp).toContain("never replace it with something built from the");
+    expect(followUp).toContain("Net worth at Maple, mine");
+
+    // ── …and what the person is left with.
+    const screen = await screenOf(walked.vendo, appId);
+    // THE FIRST WISH SURVIVED the second.
+    expect(screen).toContain(WISH_ONE_LANDED);
+    // The second landed on the port, not beside it.
+    expect(screen).toContain(WISH_TWO_LANDED);
+    expect(screen).toContain('import { Stack, Text } from "@vendo/screen"');
+    // No from-scratch rewrite anywhere near this app.
+    expect(screen).not.toContain(CATALOG_ONLY);
+
+    // Both changes landed, so both are wishes — in the order they were asked.
+    expect((await walked.vendo.apps.get(appId, ctx))?.seed?.wishes)
+      .toEqual([FIRST_WISH, SECOND_WISH]);
+  }, 120_000);
+});

--- a/packages/vendo/tests/remix-wish-integrity.e2e.test.ts
+++ b/packages/vendo/tests/remix-wish-integrity.e2e.test.ts
@@ -280,9 +280,18 @@ describe("a remix's wish list records what the person got, not what the builder 
     // ── What the loop was TOLD, asserted first: it is the proximate cause of
     // everything below. The follow-up's own prompt carries the screen it must
     // change and the line that forbids replacing it out of the catalog.
-    // The prompt is captured as JSON, so this reads the quote-free heart of the
-    // first wish's edit — a string the port carries only once it has landed.
-    const followUp = walked.prompts[2] ?? "";
+    //
+    // Found by the ask it carries, never by index. A later drive of the FIRST
+    // ask satisfies all three assertions below — it too holds the port with the
+    // first wish applied — so a fixed index would go on passing against the
+    // wrong prompt the day the loop's drive count changes, and this test would
+    // stop pinning the thing it exists for. Only the follow-up's prompts name
+    // the second ask: the memory block is written after the edit, so the first
+    // run has never heard of it.
+    const followUp = walked.prompts.find((prompt) => prompt.includes(SECOND_WISH)) ?? "";
+    // The prompt is captured as JSON, so the third assertion reads the
+    // quote-free heart of the first wish's edit — a string the port carries only
+    // once that wish has landed.
     expect(followUp).toContain(STARTING_SOURCE_MARKER);
     expect(followUp).toContain("never replace it with something built from the");
     expect(followUp).toContain("Net worth at Maple, mine");


### PR DESCRIPTION
A cold walk on `main` found one user request leaving **four** entries on a remix's `seed.wishes` — and the attempt that finally landed had thrown the ported source away and rebuilt the app out of the host's catalog, losing the first wish.

`seed.wishes` replays in order on every **Update**, so both halves are data integrity: the list was recording what the *builder attempted*, and one of those attempts was a different app.

## Half 1 — a refused attempt became a wish

`vendo_make`'s edit arm recorded the ask whether or not the change landed (`make-tool.ts:287`), and the memory door appended it to `seed.wishes` unconditionally (`write-surface.ts:511`).

That is right for `memory.asks` — the next editor genuinely wants to read *"asked for X, then asked for X again, narrower"* — and wrong for the replay list beside it. The two answer different questions and were sharing one write.

`AppsRuntime.remember` now takes `landed`. The ask is recorded either way; only a change that reached the screen becomes a wish.

## Half 2 — a blind edit is answered out of the catalog

There is no explicit "fall back to a rewrite" branch. There is something worse: **the model was never shown the code it was supposed to edit.**

The port reaches it through `startingSource`, which is filled from the CHECKOUT — and the checkout only ever fills an **empty** workspace (`screen-agent.ts:1506`). The loop carries no file hand and `edit_app` can only replace passages the model quotes back character for character, so it cannot read the workspace itself. Once the first edit's save had landed a file, every later edit of that remix arrived with **no code at all** in front of it, and no "never replace it with something built from the catalog" line either.

An ask with nothing to change is answered out of the catalog. That is the whole fallback, and it is emergent — which is why fixing the cause makes the rewrite unreachable rather than detected. When the port genuinely cannot take an edit, `edit_app` refuses, nothing saves, and #1535's channel reports the real reason and re-arms the repair round. No second failure channel was invented.

The stored screen is now read for **every** edit of a remix, not only the first. It is still never written over a file a save left behind — showing it is not writing it.

Measured, before the fix, through the real path:

```
PROBE first-edit sees port:                       true
PROBE workspace holds app.tsx after first edit:   true
PROBE follow-up sees source:                      false
PROBE follow-up contains catalog warning:         false
```

## Proof

Two tests in `packages/vendo/tests/remix-wish-integrity.e2e.test.ts`, through a real PGlite store, a real `createVendo`, the real `vendo_make` tool called the way a calling agent calls it, the real checks floor, the real screen agent and the real workspace façade. Only the MODEL is scripted. Both failures are forced **deterministically** — a run that never saves, and a source-sensitive model that writes a catalog card exactly when the loop hands it nothing, which is what the live model did.

Each proven able to fail, reverting one fix at a time:

**1. drop the `landed` gate**
```
× a follow-up edit that does not land leaves the wish list exactly as it was
AssertionError: expected [ 'say it is mine', 'say it louder' ] to deeply equal [ 'say it is mine' ]
```

**2. restore the `!(await base.exists(checkout))` guard** — the prompt assertion goes red, and with it muted so does the outcome:
```
× the follow-up edits the PORT, so a refused edit can never become a catalog rewrite
AssertionError: expected 'import { Stack, Text } from "@vendo/s…' to contain 'text="Net worth at Maple, mine"'
+ <Text text="Rebuilt from the catalog" variant="heading" />
```
The catalog card really lands and the first wish is really gone. Restored → both green.

## Not weakened

Asserted or covered by suites re-run green: the list stays ordered and never trimmed, replays in order on Update, records an inapplicable wish on `seed.unapplied` and says it out loud, and the legacy `instruction` lift still parses pre-existing remixes. `memory.asks` still records the ask that failed — asserted in the new test, so the two halves can never quietly re-merge.

## Gate

`pnpm build` 22/22 · `pnpm typecheck` 44/44 · `pnpm lint` 0 errors · `@vendoai/apps` 1544 passed · `@vendoai/core` 813 passed · every remix/seed/memory suite in `@vendoai/vendo` green. Full suite is CI's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes remix wish integrity: `seed.wishes` now records only landed edits, and follow-ups always edit the ported screen instead of regenerating from the catalog. Previously, refused edits appended to `seed.wishes`, and later edits saw no source after the first save, causing catalog rewrites that could drop earlier wishes.

- API: `AppsRuntime.remember` adds optional `landed`. `@vendoai/apps` passes `landed: true` when an edit reaches the screen. `memory.asks` still records all asks.
- Assembly: `@vendoai/vendo` reads the stored screen for every remix edit and includes it in the prompt, even when the workspace already holds a file; it never overwrites a saved file. Catalog fallback applies only when no screen exists.
- Tests: Adds `remix-wish-integrity.e2e.test.ts` proving both invariants end-to-end. Anchors the follow-up prompt assertion on the second ask to avoid brittle index-based checks.
- Migration: No data changes. Existing remixes may still contain historic refused asks in `seed.wishes`; cleanup is optional.

<sup>Written for commit d42e566940353597b03536c50f5ffc561bb21cfb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1563?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

