### PR TITLE
fix(ui): a remix repaints when its build lands, instead of waiting for F5

### DIFF
--- a/.changeset/remix-repaints-after-a-build.md
+++ b/.changeset/remix-repaints-after-a-build.md
@@ -1,0 +1,17 @@
+---
+"@vendoai/ui": patch
+---
+
+A remix repaints when its build lands, instead of holding the pre-edit port
+until the person presses F5. A remix's screen is written long after its row
+exists: the seed paints the ported host component first and rebuilds it into the
+person's wish tens of seconds later, and every edit the chat runs does the same
+again. `useApp` re-reads only while `open` is still answering pending, so the
+surface settled on whichever screen happened to be servable first — the port —
+and then never looked again. The agent said "it's replaced the original on your
+page" over a card still painting the original.
+
+`<Remixable>` now re-reads on what a build leaves on the app document — the code
+it saved and whether it is still saving — off the discovery poll the wrapper
+already runs. No request of its own, and no cadence: an app nobody is building
+is an app nothing re-reads.

--- a/packages/ui/src/chrome/remixable.tsx
+++ b/packages/ui/src/chrome/remixable.tsx
@@ -101,6 +101,14 @@ function serializableProps(children: ReactNode): Record<string, Json> {
 
 const NO_APPS: AppDocument[] = [];
 
+/** What a BUILD writing this app leaves on its document: the code it saved, and
+ *  whether it is still saving (`AppDocument.source` / `.building`). Nothing else
+ *  on the document moves per read, so a mark that changes means a build landed —
+ *  and a settled mark means there is nothing to re-read. */
+function buildMark(app: AppDocument | undefined): string {
+  return `${app?.building ?? ""}|${Object.values(app?.source ?? {}).map(file => file.hash).join()}`;
+}
+
 /** Remix discovery: the user's remix for this component is the app whose `seed`
  *  names it (provenance — the 2026-08-02 provenance/placement split). An
  *  in-place remix needs no placement: its location IS the wrapper it replaced,
@@ -118,14 +126,15 @@ function useRemixFork(slot: string | null) {
     [client, slot],
   );
   const { data, refresh } = useResource(list, NO_APPS, { pollMs: slot === null ? 0 : DISCOVERY_POLL_MS });
-  const appId = data.filter(app => app.seed?.component === slot).at(-1)?.id;
-  return { appId, refresh };
+  const fork = data.filter(app => app.seed?.component === slot).at(-1);
+  return { appId: fork?.id, build: buildMark(fork), refresh };
 }
 
-function RemixedFork({ appId, slot, review, liveProps, original, onReverted }: {
+function RemixedFork({ appId, slot, review, build, liveProps, original, onReverted }: {
   appId: string;
   slot: string;
   review: boolean;
+  build: string;
   liveProps: Record<string, Json>;
   original: ReactNode;
   onReverted(): Promise<void>;
@@ -137,6 +146,20 @@ function RemixedFork({ appId, slot, review, liveProps, original, onReverted }: {
   // below rather than the fork's own boundary: it must outlive a fork that
   // unmounts (a revert) while a decision is still in flight.
   const approval = useApprovalModal();
+
+  // THE BUILD THAT LANDS LATE. A remix's screen is rebuilt long after its row
+  // exists: the seed paints the ported original first and turns it into the
+  // wish seconds later, and every edit the chat runs does the same again.
+  // `useApp` re-reads only while the answer is still pending, so a surface that
+  // settled on the port kept painting it until the person reloaded the page.
+  // The mark rides the discovery poll the wrapper already runs — no request of
+  // its own, and nothing to re-read once the app stops being built.
+  const built = useRef(build);
+  useEffect(() => {
+    if (build === built.current) return;
+    built.current = build;
+    void refresh();
+  }, [build, refresh]);
 
   useEffect(() => {
     if (!isLoading && error !== undefined && developmentMode()) {
@@ -280,7 +303,7 @@ export function Remixable({ review = false, children }: RemixableProps) {
   useEffect(() => () => window.clearTimeout(grace.current), []);
 
   const slot = slotOf(children);
-  const { appId, refresh } = useRemixFork(slot);
+  const { appId, build, refresh } = useRemixFork(slot);
 
   useEffect(() => {
     if (slot === null && developmentMode()) {
@@ -347,6 +370,7 @@ export function Remixable({ review = false, children }: RemixableProps) {
           appId={appId}
           slot={slot}
           review={review}
+          build={build}
           liveProps={serializableProps(children)}
           original={children}
           onReverted={refresh}

--- a/packages/ui/test/chrome/remixable.test.tsx
+++ b/packages/ui/test/chrome/remixable.test.tsx
@@ -301,6 +301,44 @@ describe("Remixable — one door into the chat, one ✦ menu on the remix", () =
     await waitFor(() => expect(opens().length).toBeGreaterThan(before));
   });
 
+  // A BUILD THAT LANDS AFTER THE MOUNT SETTLED. The seed paints the ported
+  // original first and rebuilds it into the wish seconds later, and every later
+  // edit the chat runs does the same — so the screen this surface first opened
+  // is routinely not the screen the person asked for. `useApp` re-reads only
+  // while the answer is pending, so the settled surface kept painting the
+  // pre-edit port and the person had to press F5 (2026-08-20 cold walk). The
+  // wrapper watches what a build writes onto the document — the code it saved,
+  // and whether it is still saving — off the discovery poll it already runs.
+  it("repaints when a build lands after the surface settled, with no reload", async () => {
+    const forked = await seedRemix();
+    // A plain tree, because what the surface PAINTS is the assertion here: a
+    // real remix's jailed island renders as the containment notice in jsdom.
+    const screenOf = (text: string) => ({
+      formatVersion: "vendo-genui/v2",
+      root: "root",
+      nodes: [{ id: "root", component: "Text", props: { text } }],
+    });
+    wire.state.surfaces.set(forked.id, screenOf("The ported original"));
+    mount();
+    await waitFor(() => expect(screen.getByText("The ported original")).toBeTruthy());
+
+    // The chat's edit lands: the build saved a new screen onto the same app.
+    wire.state.surfaces.set(forked.id, screenOf("The remix the wish asked for"));
+    wire.state.apps.find(app => app.id === forked.id)!.source = {
+      "app.tsx": { hash: `sha256:${"b".repeat(64)}`, bytes: 12 },
+    };
+    await waitFor(
+      () => expect(screen.getByText("The remix the wish asked for")).toBeTruthy(),
+      { timeout: 20_000 },
+    );
+
+    // And then it STOPS. A surface that re-reads on a cadence of its own would
+    // cost every host page a request forever; this one re-reads on a build.
+    const settled = opens().length;
+    await new Promise(resolve => setTimeout(resolve, 12_000));
+    expect(opens().length).toBe(settled);
+  }, 45_000);
+
   // The point of the wish list: the host ships a new version, and "Update"
   // replays every wish onto it. The menu item read "Update" while doing nothing
   // but re-read the same screen, and `client.apps.reseed` had no caller at all —


### PR DESCRIPTION
## The defect

A remix does not repaint after an edit. The user has to press F5. Reproduced in a
production browser on Maple against Vendo Cloud: the agent says *"Done — it's
replaced the original on your page"* over a card still painting the original.

## Root cause

A remix's screen is written long after its row exists. `seedFrom`
(`packages/apps/src/server/remix/seed-surface.ts`) puts the row down, paints the
ported host component through the checks floor, and only then runs the person's
wish through the edit door — so `open` answers a servable tree (the **port**)
tens of seconds before it answers the remix. Measured second by second on Maple:

| t | what the wire says |
|---|---|
| +9s | the app row appears |
| +13s | `open` → `tree` — the **port**; the surface mounts and settles |
| +28s | `source` rewritten, `building` set — the wish's build starts |
| +43s | `building` cleared — the wish's screen is servable |
| +142s | the page is still painting the port |

`useApp`'s loop re-polls only while `open` answers `{kind:"pending"}`
(`packages/ui/src/hooks/use-app.ts:71-86`); once it settles, nothing re-reads it.
`RemixedFork`'s only later `refresh()` is the courier's, which fires on a prop
change, not on a build. Every later edit the chat runs has the same shape, so
this is not only the seed's race.

## The fix

`<Remixable>` already polls `apps.list()` for discovery, and the app document
carries what a build leaves behind — the source it saved (`source`) and whether
it is still saving (`building`). The wrapper reads that mark off the poll it
already runs and re-reads the app when it moves.

**No unbounded poll.** No request of its own, and no cadence: nothing on the
document moves per read, so an app nobody is building is an app nothing
re-reads. The regression test pins that by holding the `/open` count flat across
two discovery ticks after the repaint.

## Proof

- **Regression test** — `repaints when a build lands after the surface settled,
  with no reload`. Revert the fix and it fails (`Unable to find an element with
  the text: The remix the wish asked for` after 20s); restore it and it passes.
- **Real browser, fresh production build** (`next start` on `examples/demo-bank`,
  never reused, never a dev server), driven once by script. The same script on
  the two builds:
  - before: `repaintedWithoutReload=false` — surface stuck on `TOTAL BALANCE`,
    F5 needed to reveal `NET WORTH`
  - after: `repaintedWithoutReload=true` — surface flips to `NET WORTH` in place
  - and the full ✦ cold walk through the chat: `wishRepaintedWithoutReload=true`,
    `navigations=1`
  - locators asserted before use (1 wrapper, 1 `[data-maple-net-worth]`, 0
    `[data-vendo-surface]`), so no negative assertion runs against a zero-match
    locator.
- **Gate** — build ✓, `@vendoai/ui` 161 files / 1502 tests ✓, typecheck ✓,
  dependency-guard + portability-gate + blocking eslint ✓.

## Not this PR

The second chat turn in the cold walk failed *server-side* — `vendo_make` came
back with "That update failed", the wish was appended but no new screen was
built, so `open` was unchanged and the wrapper was right not to repaint. That is
a separate defect in the edit path, left to the lane that owns it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remix surfaces now repaint automatically when their build finishes, instead of requiring a manual reload. Previously the surface stayed on the pre-edit port; now `<Remixable>` detects a build landing via the app document and triggers a single refresh so the remix renders in place.

- Review notes
  - Watches a “build mark” on the app document (`source` hashes + `building`) from the existing `apps.list()` discovery poll and calls `refresh()` only when the mark changes. No new polling cadence or extra requests.
  - Changes are isolated to `packages/ui/src/chrome/remixable.tsx` in `@vendoai/ui`; adds a regression test in `packages/ui/test/chrome/remixable.test.tsx` asserting repaint without reload and no ongoing re-reads.
  - No API changes and no migration required.

<sup>Written for commit 008c1fb9497ca26fd7c6d4c94a2cc9cbfe47ff38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1564?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

