### PR TITLE
fix(apps): the live-props courier waits its turn, so the ✦ mint stops failing

### DIFF
--- a/.changeset/courier-waits-its-turn.md
+++ b/.changeset/courier-waits-its-turn.md
@@ -1,0 +1,24 @@
+---
+"@vendoai/apps": patch
+---
+
+The live-props courier waits its turn on the app row, so a ✦ remix stops failing
+to mint. One tap in three died with `app changed under this save`, at the moment
+a person first creates a remix.
+
+A save asserts the row is still byte-identical to the baseline it computed over
+and refuses otherwise, because a document computed over a stale row would revert
+the edit that landed there. That assertion cannot tell an edit from a write that
+is not one — and the courier is not one: it writes `seed.props` whenever the host
+re-renders, mints no version, and the `<Remixable>` wrapper starts couriering the
+moment discovery finds the freshly minted row, which is squarely inside the
+build. Landing inside a save's baseline-read→put window refused that save, and the
+mint reported the refusal as a failed build.
+
+The two writers take a turn on the row now, read included, so the courier's write
+lands strictly before or strictly after a save and never inside one. The save's
+assertion is untouched and stays strict: a genuine concurrent edit is still
+refused exactly as before, and a writer that does not come through the door is
+still caught. The courier's boundary is untouched too — the allowlist is still
+the captured baseline's own declared prop names, applied before anything is
+stored.

--- a/packages/apps/src/server/doors/write-surface.ts
+++ b/packages/apps/src/server/doors/write-surface.ts
@@ -26,7 +26,7 @@ import { rungFor } from "../persistence/edit-journal.js";
 import { findingLine } from "./build-messages.js";
 import { generationDependencies } from "../runtime/generation-context.js";
 import type { AppData } from "../../contract/index.js";
-import { APPS_COLLECTION, appRecordInput, rowFromRecord } from "../persistence/persistence.js";
+import { APPS_COLLECTION, appRecordInput, onAppRow, rowFromRecord } from "../persistence/persistence.js";
 import type { AppsRuntimeContext } from "../runtime/runtime-context.js";
 import type { AppsRuntime, EditResult, VersionEntry } from "../runtime/types.js";
 
@@ -267,7 +267,11 @@ const createAuthoredScreenDoor = (
   },
 ): AppsRuntime["authoredScreen"] => {
   const { engine, holds, buildingNow, saveAuthoredDocument } = deps;
-  return async (input, ctx) => {
+  // The BASELINE READ is inside the turn, not before it: the document below is
+  // computed over `row`, and `saveAuthoredDocument` refuses if the stored row
+  // stopped matching it. Taking the turn after the read would leave exactly the
+  // window that refusal exists to catch (`onAppRow`).
+  return async (input, ctx) => onAppRow(input.appId, async () => {
     const record = await engine.get(APPS_COLLECTION, input.appId);
     const row = record === null ? null : rowFromRecord(record);
     if (row !== null && !await holds(input.appId, ctx, "editor", record)) return;
@@ -283,7 +287,7 @@ const createAuthoredScreenDoor = (
       previous: row?.doc,
       row,
     }, ctx);
-  };
+  });
 };
 
 /**

--- a/packages/apps/src/server/persistence/persistence.ts
+++ b/packages/apps/src/server/persistence/persistence.ts
@@ -162,6 +162,41 @@ export const appRecordInput = (
   };
 };
 
+/** In-flight writers, per app row. Cleared by the last one out. */
+const rowWriters = new Map<AppId, Promise<unknown>>();
+
+/**
+ * One writer at a time on an app row — read included.
+ *
+ * A save asserts the row is still byte-identical to the baseline it computed
+ * over and REFUSES otherwise (`assertCurrent`, doors/write-surface.ts), because a
+ * document computed over a stale row would revert the edit that landed there.
+ * That assertion cannot tell an edit from a write that is not one, so the
+ * live-props courier — which writes `seed.props` whenever the host re-renders,
+ * and mints no version because the person changed nothing — killed one ✦ mint in
+ * three with `app changed under this save`.
+ *
+ * Ordering the two writers is what keeps that assertion STRICT. Loosening it
+ * instead is what would let a genuine concurrent edit be reverted, and a writer
+ * that does not come through here is still refused exactly as before.
+ *
+ * Per process, like `buildsInFlight` (doors/placement-surface.ts): it closes the
+ * window between two requests the same host serves, which is where the courier
+ * and the mint it races both live.
+ */
+export const onAppRow = async <T>(appId: AppId, write: () => Promise<T>): Promise<T> => {
+  // `then(write, write)` because a writer ahead that THREW still had its turn:
+  // the queue orders writers, it does not couple their outcomes.
+  const mine = (rowWriters.get(appId) ?? Promise.resolve()).then(write, write);
+  const queued = mine.catch(() => undefined);
+  rowWriters.set(appId, queued);
+  try {
+    return await mine;
+  } finally {
+    if (rowWriters.get(appId) === queued) rowWriters.delete(appId);
+  }
+};
+
 /** Bounded read-mutate-CAS on the app row; the store's revision receipt
  *  arbitrates racers (a row that carries no revision falls back to put). */
 export const updateAppRow = async (

--- a/packages/apps/src/server/remix/seed-surface.ts
+++ b/packages/apps/src/server/remix/seed-surface.ts
@@ -36,7 +36,7 @@ import {
   type SeedDrift,
   type SeedPort,
 } from "../../contract/index.js";
-import { APPS_COLLECTION, appRecordInput } from "../persistence/persistence.js";
+import { APPS_COLLECTION, appRecordInput, onAppRow } from "../persistence/persistence.js";
 import type { AppsRuntimeContext } from "../runtime/runtime-context.js";
 import type { AppsRuntime, SeedFromInput, VersionEntry } from "../runtime/types.js";
 
@@ -348,12 +348,18 @@ const reseed = async (
  * HERE, before it is stored, rather than being filtered at each of the places
  * that later read the seed. A baseline that captured no props declares none and
  * so admits none: never invented, exactly like the paint it feeds.
+ *
+ * READ AND WRITE TAKE A TURN ON THE ROW (`onAppRow`). Being provenance rather
+ * than an edit is exactly what makes this dangerous: it writes whenever the host
+ * re-renders, including all the way through a ✦ mint's build, and a save cannot
+ * tell this write from an edit that would revert it — so landing inside one's
+ * window refused it as `app changed under this save`, one mint in three.
  */
 const courierProps = async (
   deps: SeedSurfaceDeps,
   input: { appId: AppId; props: Record<string, Json> },
   ctx: RunContext,
-): Promise<AppDocument> => {
+): Promise<AppDocument> => onAppRow(input.appId, async () => {
   const app = await deps.requireOwned(input.appId, ctx);
   const seed = app.seed;
   if (seed === undefined) {
@@ -370,7 +376,7 @@ const courierProps = async (
   const next: AppDocument = { ...app, seed: { ...seed, props } };
   await deps.engine.put(APPS_COLLECTION, appRecordInput(next, ctx.principal.subject, false, "seed"));
   return next;
-};
+});
 
 export const createSeedSurface = (deps: SeedSurfaceDeps): AppsRuntime["seed"] => ({
   async drift(appId, ctx): Promise<SeedDrift | null> {

--- a/packages/apps/tests/remix-courier-race.test.ts
+++ b/packages/apps/tests/remix-courier-race.test.ts
@@ -1,0 +1,192 @@
+/**
+ * THE COURIER AND THE SAVE WRITE THE SAME ROW, so one of them must go second.
+ *
+ * A save asserts the row is still byte-identical to the baseline it computed
+ * over and REFUSES otherwise (`assertCurrent`, doors/write-surface.ts) —
+ * correctly, because a document computed over a stale row would revert the edit
+ * that landed there. The live-props courier writes `seed.props` onto that same
+ * row (`courierProps`, remix/seed-surface.ts), and it is not an edit at all: the
+ * person did not change their remix, their page did. So a courier that arrives
+ * inside a save's baseline-read→put window fails a save it has no quarrel with,
+ * and the ✦ mint it lands in reports `app changed under this save`.
+ *
+ * In life that is a coin toss — the wrapper couriers as soon as discovery finds
+ * the freshly minted row, which is squarely inside the build. Here it is not: the
+ * save is PARKED on its baseline read, the courier is run against the parked row,
+ * and only then is the save let go. Same interleaving every run.
+ *
+ * NEITHER SIDE IS STUBBED. The save is the real `authoredScreen` door every
+ * screen lands through, the courier is the real `seed.props` door the wrapper
+ * POSTs to, and both write the real store.
+ *
+ * The one that must be able to fail: take the ordering back off either door and
+ * the courier's write lands in the window again — the save is refused, the
+ * person's screen is the one they did not save, and the log says
+ * `app changed under this save`.
+ */
+import { engineOverAdapter, type AppId, type RunContext, type ToolRegistry } from "@vendoai/core";
+import { SCREEN_FILE, type AppDocument } from "../src/contract/index.js";
+import { describe, expect, it, vi } from "vitest";
+import { createApps, type SeedBaseline } from "../src/server/index.js";
+import { guardFixture } from "../src/server/testing/guard-fixture.js";
+import { memoryStore } from "../src/server/testing/memory-store.js";
+import { FIXTURE_SCREEN, screenDocument } from "../src/server/testing/screen-document.js";
+import { seedAppRow } from "../src/server/testing/seed-app-row.js";
+
+const APP_ID = "app_courier_race" as AppId;
+const SLOT = "NetWorthView";
+
+const ctx: RunContext = {
+  principal: { kind: "user", subject: "u1" },
+  venue: "app",
+  presence: "present",
+  sessionId: "s1",
+};
+
+const tools: ToolRegistry = {
+  async descriptors() { return []; },
+  async execute() { return { status: "error", error: { code: "not-found", message: "missing" } }; },
+};
+
+/** What the host's page is really rendering, and the decoy riding beside it. The
+ *  baseline declares `valueCents` and nothing else, so the ordering must not buy
+ *  the decoy a way in. */
+const LIVE_CENTS = 14_292_930;
+const DECOY = "must-not-cross";
+
+const baseline: SeedBaseline = {
+  slot: SLOT,
+  source: "export default function NetWorthView() { return <p>net worth</p>; }\n",
+  hash: "sha256:net-worth-view-1",
+  exportable: false,
+  capturedAt: "2026-08-18T09:00:00.000Z",
+  sampleProps: { valueCents: 5_490_715 },
+  // A baseline the splitter could not port has no remix to courier props to, so
+  // the courier refuses at the lookup before any of this is reachable.
+  ported: { source: FIXTURE_SCREEN, tools: [], holes: [] },
+};
+
+/** The screen the person saves while the courier is in the air — a different
+ *  export name, so the save is a real change rather than the no-op an unchanged
+ *  source short-circuits into. */
+const SAVED = `import { Stack, Text } from "@vendo/screen";
+
+export default function Renamed() {
+  return (
+    <Stack gap={12}>
+      <Text text="Ready" variant="heading" />
+    </Stack>
+  );
+}
+`;
+
+const deferred = (): { promise: Promise<void>; settle: () => void } => {
+  let settle!: () => void;
+  const promise = new Promise<void>((resolve) => { settle = resolve; });
+  return { promise, settle };
+};
+
+const stand = () => {
+  const store = memoryStore();
+  let parked: { reached: () => void; hold: Promise<void> } | undefined;
+  // The runtime reaches its app rows through this door, so a test can hold one
+  // read open and know exactly what is standing in the window behind it.
+  const wrapped = {
+    ...store,
+    records: (collection: string) => {
+      const records = store.records(collection);
+      if (collection !== "vendo_apps") return records;
+      return {
+        ...records,
+        async get(id: string) {
+          const record = await records.get(id);
+          if (parked !== undefined) {
+            const { reached, hold } = parked;
+            parked = undefined;
+            reached();
+            await hold;
+          }
+          return record;
+        },
+      };
+    },
+  };
+  const runtime = createApps({
+    store: wrapped,
+    guard: guardFixture(),
+    tools,
+    catalog: [],
+    seedBaselines: [baseline],
+  });
+  return {
+    runtime,
+    store,
+    /** Hold the NEXT app-row read open. `reached` resolves once a caller is
+     *  parked on it; `release` lets that caller carry on. */
+    parkNextRead: () => {
+      const arrived = deferred();
+      const held = deferred();
+      parked = { reached: arrived.settle, hold: held.promise };
+      return { reached: arrived.promise, release: held.settle };
+    },
+  };
+};
+
+/** Every chance the event loop can give the courier to land its write while the
+ *  save is parked. Its read-modify-write is a handful of turns against an
+ *  in-memory store, so this is orders of magnitude more room than it needs. Not
+ *  a wall-clock budget and not a poll: once the two writers are ordered the
+ *  courier simply waits here instead, which is the behaviour under test. */
+const drain = async (): Promise<void> => {
+  for (let turn = 0; turn < 20; turn += 1) await new Promise((resolve) => { setImmediate(resolve); });
+};
+
+const docOf = async (store: ReturnType<typeof memoryStore>): Promise<AppDocument | undefined> => {
+  const record = await store.records("vendo_apps").get(APP_ID);
+  return (record?.data as { doc?: AppDocument } | null)?.doc;
+};
+
+describe("the live-props courier against a save already in flight", () => {
+  it("lands the screen AND the props when it arrives inside the save's window", async () => {
+    const errors = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    try {
+      const { runtime, store, parkNextRead } = stand();
+      await seedAppRow(engineOverAdapter(store), {
+        ...screenDocument(APP_ID),
+        seed: { component: SLOT, baseline: baseline.hash, wishes: ["track it monthly"] },
+      }, "u1");
+
+      // The save reads the row it is about to write over, and stops there.
+      const { reached, release } = parkNextRead();
+      const saving = runtime.authoredScreen({ appId: APP_ID, name: "Renamed", source: SAVED }, ctx);
+      await reached;
+
+      // The wrapper's courier, arriving exactly where it does in life: the save
+      // has its baseline and has not yet asserted it.
+      const couriered = runtime.seed.props(
+        { appId: APP_ID, props: { valueCents: LIVE_CENTS, secretToken: DECOY } },
+        ctx,
+      );
+      await drain();
+      release();
+      await saving;
+      const answered = await couriered;
+
+      // THE DEFECT: the courier's write used to land in the window, so the save
+      // was refused and the person's screen was the one they did not save.
+      expect(errors.mock.calls.map(String).join(" ")).not.toContain("app changed under this save");
+      const stored = await docOf(store);
+      expect(stored?.source?.[SCREEN_FILE]?.text).toBe(SAVED);
+
+      // …and the provenance the courier carried is on the row too. Ordering the
+      // two writers must not cost either one of them.
+      expect(stored?.seed?.props).toEqual({ valueCents: LIVE_CENTS });
+      expect(answered.seed?.props).toEqual({ valueCents: LIVE_CENTS });
+      // The allowlist is the captured baseline's declared names, before and
+      // after: the decoy is dropped at the door and never reaches the row.
+      expect(JSON.stringify(stored)).not.toContain(DECOY);
+    } finally {
+      errors.mockRestore();
+    }
+  }, 30_000);
+});


### PR DESCRIPTION
One remix mint in three died with `app changed under this save`, at the moment a person first creates one. Introduced by #1506.

## Root cause

A save asserts the row is still byte-identical to the baseline it computed over and refuses otherwise (`assertCurrent`, `packages/apps/src/server/doors/write-surface.ts:105`) — correctly: a document computed over a stale row would revert the edit that landed there.

That assertion cannot tell an edit from a write that is not one, and the courier is not one. It writes `seed.props` whenever the host re-renders, mints no version, and the `<Remixable>` wrapper starts couriering the moment discovery finds the freshly minted row — squarely inside the build. Its blind whole-document put (`packages/apps/src/server/remix/seed-surface.ts:370-371`, new in #1506) landing inside a save's baseline-read→put window refused that save, and the mint reported the refusal as a failed build.

## The fix

Both writers take a turn on the row, **read included**, so the courier's write lands strictly before or strictly after a save and never inside one.

Serialising rather than loosening. The save's assertion is what stops a real concurrent edit being reverted, so it stays strict — a writer that does not come through the door is still refused exactly as before, which `authored.test.ts` still proves. **Not** solved by retrying the save: a retry hides the race and makes the failure rarer instead of removing it.

The alternative — moving `seed.props` off the app row into its own collection — needs a `core` allowlist entry plus version bump, a `store` drift-test mirror, a new side-row module, a reader change, and deletion cleanup, and carries the exact hazard `vendo_app_seen` hit in 0.27.0 (a collection missing from the deployed Cloud allowlist). Roughly 10× the change for the same outcome, so: serialise.

## Proof

Deterministic, not one-in-three: the save is parked on its baseline read, the courier runs against the parked row, and only then is the save let go. Same interleaving every run — real save door, real courier door, real store, nothing stubbed on either side.

- Fix reverted → **red**, with the reported sentence verbatim: `[vendo] app not saved (app_courier_race): the harness wrote it as a file but it did not land — app changed under this save: app_courier_race`
- Fix restored → **green**
- Red confirmed 5/5 consecutive runs before the fix existed

## Boundary

Untouched. The allowlist is still the captured baseline's own declared prop names, applied before anything is stored, and the decoy `secretToken` seam test (`packages/vendo/tests/remix-live-props.seam.test.ts`) still passes on both the fork and on-change paths.

## Gate

`build` ✅ · `typecheck` ✅ · `lint` ✅ (0 errors) · `test:affected` — `@vendoai/apps` 1545 passed / 0 failed (the task-level exit was the documented `Timeout calling "onTaskUpdate"` RPC artifact); `@vendoai/actions` and `demo-bank` away-drill timed out under a 4-way-concurrent 70-minute run and both pass isolated (4s and 26s against 30s/120s budgets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops ✦ remix mints from failing by serializing app-row access between saves and the live-props courier. Previously the courier could write between a save’s baseline read and put, triggering “app changed under this save”; now both take a per-app turn that includes the read.

- Adds `onAppRow` (per-app writer queue) in `persistence.ts`; orders reads and writes, independent of prior writer success.
- Wraps `authoredScreen` and `seed.props` with `onAppRow`, so the courier lands strictly before or after a save, never inside it.
- Keeps the save’s `assertCurrent` strict; off-door writers are still refused; prop allowlist unchanged.
- Adds deterministic test `packages/apps/tests/remix-courier-race.test.ts` that reproduces the race and verifies both the saved screen and filtered props persist.
- No migrations or operational changes.

<sup>Written for commit 0724e209e7632b3228278bdd0d1ba65ad6039a50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

