### PR TITLE
fix(apps): the ✦ mint stops reverting the props the courier just delivered

### DIFF
--- a/.changeset/seed-writes-take-their-turn.md
+++ b/.changeset/seed-writes-take-their-turn.md
@@ -1,0 +1,23 @@
+---
+"@vendoai/apps": patch
+---
+
+A ✦ remix stops silently reverting the live props the courier just delivered.
+The remix would quietly go back to showing the values captured the day
+`vendo sync` ran, while the host's own component beside it showed today's — with
+nothing refused and nothing logged.
+
+The ✦ door twice read the app row and then put a whole document computed over
+that read: putting the mint's name back after the port's paint renamed the app,
+and marking a failed build over the row as it stands. Neither read-modify-write
+took a turn on the row, so the courier — which writes `seed.props` whenever the
+host re-renders, and re-renders all the way through a mint — could land its write
+between one of those reads and its put, and the put carried the pre-courier
+document straight back over it.
+
+Both now take the same turn on the row every other writer takes, read included,
+so the courier's write lands strictly before or strictly after them and never
+inside one. The save's assertion is untouched and stays strict: a genuine
+concurrent edit is still refused exactly as before. The courier's boundary is
+untouched too — the allowlist is still the captured baseline's own declared prop
+names, applied before anything is stored.

--- a/packages/apps/src/server/remix/seed-surface.ts
+++ b/packages/apps/src/server/remix/seed-surface.ts
@@ -200,13 +200,20 @@ const seedFrom = async (
     // act and nothing asked for a new name, so the mint's name goes back before
     // the instruction runs. Skipped when they already agree, for the reason
     // `authoredScreen` skips an unchanged save: a write that changes nothing.
-    const painted = await deps.requireOwned(minted.id, ctx);
-    if (painted.name !== minted.name) {
-      await deps.engine.put(
-        APPS_COLLECTION,
-        appRecordInput({ ...painted, name: minted.name }, ctx.principal.subject, false, "seed"),
-      );
-    }
+    //
+    // READ AND WRITE TAKE A TURN ON THE ROW (`onAppRow`), because this put
+    // carries the WHOLE document it read: a courier landing in the window
+    // between them was carried straight back off, and the remix silently stopped
+    // following the host page — nothing refused, nothing logged.
+    await onAppRow(minted.id, async () => {
+      const painted = await deps.requireOwned(minted.id, ctx);
+      if (painted.name !== minted.name) {
+        await deps.engine.put(
+          APPS_COLLECTION,
+          appRecordInput({ ...painted, name: minted.name }, ctx.principal.subject, false, "seed"),
+        );
+      }
+    });
     // A concurrent write to this row — the ✦ door landing a RACING gesture's
     // wish is the common one, and seeding the port first widened that window —
     // is not a failed build: the row moved, so run the instruction once more
@@ -241,12 +248,16 @@ const seedFrom = async (
   // Over the row as it stands NOW, never over the pre-seed copy above: the port
   // painted through the floor and the floor STORED it, so marking the failure on
   // the older document would quietly revert the app's screen back out of it.
-  const failed: AppDocument = {
-    ...await deps.requireOwned(minted.id, ctx),
-    buildFailed: { reason, retryable: true, at: new Date().toISOString(), prompt: input.instruction },
-  };
-  await deps.engine.put(APPS_COLLECTION, appRecordInput(failed, ctx.principal.subject, false, "seed"));
-  return failed;
+  // Reading it inside a turn (`onAppRow`) is the same "NOW" one step finer — a
+  // courier landing between this read and its put would be reverted by it.
+  return onAppRow(minted.id, async () => {
+    const failed: AppDocument = {
+      ...await deps.requireOwned(minted.id, ctx),
+      buildFailed: { reason, retryable: true, at: new Date().toISOString(), prompt: input.instruction },
+    };
+    await deps.engine.put(APPS_COLLECTION, appRecordInput(failed, ctx.principal.subject, false, "seed"));
+    return failed;
+  });
 };
 
 /**

--- a/packages/apps/tests/remix-seed-lost-update.test.ts
+++ b/packages/apps/tests/remix-seed-lost-update.test.ts
@@ -1,0 +1,178 @@
+/**
+ * THE ✦ MINT MUST NOT REVERT THE PROPS THE COURIER JUST DELIVERED.
+ *
+ * `seedFrom` twice reads the app row and then puts a WHOLE document computed
+ * over that read — putting the mint's name back after the port's paint renamed
+ * the app (`remix/seed-surface.ts`), and marking a failed build over the row as
+ * it stands. Neither read-modify-write took a turn on the row, so the courier —
+ * which writes `seed.props` whenever the host re-renders, and re-renders all the
+ * way through a mint — could land its write BETWEEN one of those reads and its
+ * put, and the put would carry the pre-courier document back over it.
+ *
+ * That is a LOST UPDATE, not the mint failure #1565 fixed: nothing is refused
+ * and nothing is logged. The remix simply stops following the host page and goes
+ * back to showing the values captured the day `vendo sync` ran, which is the one
+ * promise the courier exists to keep.
+ *
+ * DETERMINISTIC, NOT PROBABILISTIC. A read of the app row is held open, the
+ * courier is run to completion against the parked row, and only then is the
+ * reader let go — the same shape `remix-courier-race.test.ts` uses for the
+ * adjacent race. Rather than hunt for the two reads by name, the mint is first
+ * run once to count the reads it takes, and then re-run parked at every one of
+ * them in turn: the courier lands in every window the mint has, so a blind put
+ * added here later is caught the day it is written. Same interleaving every run.
+ *
+ * NEITHER SIDE IS STUBBED. The mint is the real ✦ door, the courier is the real
+ * `seed.props` door the wrapper POSTs to, and both write the real store.
+ */
+import type { RunContext, StoreAdapter, ToolRegistry } from "@vendoai/core";
+import { type AppDocument, type SeedBaseline } from "../src/contract/index.js";
+import { describe, expect, it } from "vitest";
+import { createApps } from "../src/server/index.js";
+import { guardFixture } from "../src/server/testing/guard-fixture.js";
+import { memoryStore } from "../src/server/testing/memory-store.js";
+import { FIXTURE_SCREEN } from "../src/server/testing/screen-document.js";
+
+const SLOT = "net-worth-card";
+
+/** What the host's page is really rendering, and the decoy riding beside it. The
+ *  baseline declares `valueCents` and nothing else, so ordering the writers must
+ *  not buy the decoy a way in. */
+const LIVE_CENTS = 14_292_930;
+const DECOY = "must-not-cross";
+
+const ctx: RunContext = {
+  principal: { kind: "user", subject: "u1" },
+  venue: "app",
+  presence: "present",
+  sessionId: "s1",
+};
+
+const tools: ToolRegistry = {
+  async descriptors() { return []; },
+  async execute() { return { status: "error", error: { code: "not-found", message: "missing" } }; },
+};
+
+const baseline: SeedBaseline = {
+  slot: SLOT,
+  source: "export default function NetWorthCard() {\n  return <strong>$1.2M</strong>;\n}",
+  hash: "sha256:maple-base",
+  exportable: false,
+  capturedAt: "2026-07-14T12:00:00.000Z",
+  sampleProps: { valueCents: 120_000_000 },
+  ported: { source: FIXTURE_SCREEN, tools: [], holes: [] },
+};
+
+const deferred = (): { promise: Promise<void>; settle: () => void } => {
+  let settle!: () => void;
+  const promise = new Promise<void>((resolve) => { settle = resolve; });
+  return { promise, settle };
+};
+
+/**
+ * A runtime whose app-row reads can be held open, one chosen read at a time.
+ *
+ * No screen agent is wired, so the instruction the ✦ carries cannot be built and
+ * the mint takes its failure-marker path — which is the shortest run that passes
+ * through BOTH of the puts under test, the paint's name restore and the marker
+ * itself.
+ */
+const stand = (parkAt = 0) => {
+  const store = memoryStore();
+  const arrived = deferred();
+  const held = deferred();
+  let reads = 0;
+  let appId: string | undefined;
+  const wrapped: StoreAdapter = {
+    ...store,
+    records: (collection: string) => {
+      const records = store.records(collection);
+      if (collection !== "vendo_apps") return records;
+      return {
+        ...records,
+        async get(id: string) {
+          const record = await records.get(id);
+          appId ??= id;
+          reads += 1;
+          if (reads === parkAt) {
+            arrived.settle();
+            await held.promise;
+          }
+          return record;
+        },
+      };
+    },
+  };
+  return {
+    runtime: createApps({
+      store: wrapped,
+      guard: guardFixture(),
+      tools,
+      catalog: [],
+      seedBaselines: [baseline],
+    }),
+    store,
+    reads: () => reads,
+    /** The row the mint just created, learned from the first read of it. */
+    appId: () => appId as AppDocument["id"],
+    /** Resolves once a reader is parked on read `parkAt`. */
+    reached: arrived.promise,
+    /** Lets that reader carry on. */
+    release: held.settle,
+  };
+};
+
+/** Every chance the event loop can give the courier to land its write while a
+ *  read is parked. Its read-modify-write is a handful of turns against an
+ *  in-memory store, so this is orders of magnitude more room than it needs. Not
+ *  a wall-clock budget and not a poll: once the writers are ordered the courier
+ *  simply waits here instead, which is the behaviour under test. */
+const drain = async (): Promise<void> => {
+  for (let turn = 0; turn < 20; turn += 1) await new Promise((resolve) => { setImmediate(resolve); });
+};
+
+const docOf = async (
+  store: ReturnType<typeof memoryStore>,
+  appId: string,
+): Promise<AppDocument | undefined> => {
+  const record = await store.records("vendo_apps").get(appId);
+  return (record?.data as { doc?: AppDocument } | null)?.doc;
+};
+
+describe("the live-props courier against a ✦ mint already in flight", () => {
+  it("keeps the props it delivered, wherever in the mint they land", async () => {
+    // How many reads of the app row one mint takes — counted rather than
+    // assumed, so the sweep below covers every window this door really has.
+    const counting = stand();
+    await counting.runtime.seed.from({ component: SLOT, instruction: "make it blue" }, ctx);
+    const reads = counting.reads();
+    expect(reads).toBeGreaterThan(0);
+
+    for (let at = 1; at <= reads; at += 1) {
+      const { runtime, store, appId, reached, release } = stand(at);
+      const minting = runtime.seed.from({ component: SLOT, instruction: "make it blue" }, ctx);
+      await reached;
+
+      // The wrapper's courier, arriving exactly where it does in life: somewhere
+      // inside the build of the row discovery has just found.
+      const couriered = runtime.seed.props(
+        { appId: appId(), props: { valueCents: LIVE_CENTS, secretToken: DECOY } },
+        ctx,
+      );
+      await drain();
+      release();
+      await minting;
+      await couriered;
+
+      // THE DEFECT: a put computed over the pre-courier read carried the old
+      // document back over the row, and the remix silently went back to the
+      // baseline's captured values with nothing refused and nothing logged.
+      const stored = await docOf(store, appId());
+      expect(stored?.seed?.props, `courier parked at read ${at} of ${reads}`)
+        .toEqual({ valueCents: LIVE_CENTS });
+      // The allowlist is the captured baseline's declared names, before and
+      // after: the decoy is dropped at the door and never reaches the row.
+      expect(JSON.stringify(stored)).not.toContain(DECOY);
+    }
+  }, 60_000);
+});


### PR DESCRIPTION
A remix would silently stop following the host page and go back to showing the
values captured the day `vendo sync` ran — with nothing refused and nothing
logged anywhere. The one promise the live-props courier exists to keep is the one
that broke.

## The defect

`seedFrom` twice read the app row and then put a **whole document computed over
that read**:

- `remix/seed-surface.ts:203-208` — putting the mint's name back after the port's
  paint renamed the app to the screen's own export.
- `remix/seed-surface.ts:245-248` — marking a failed build over the row as it
  stands.

Neither read-modify-write took a turn on the row. The courier writes `seed.props`
whenever the host re-renders, and the `<Remixable>` wrapper re-renders all the way
through a mint — so its write could land between one of those reads and its put,
and the put carried the pre-courier document straight back over it.

This is a **lost update**, not the mint failure #1565 fixed: the courier's write
succeeds and is then quietly undone. Confirmed from source before building — the
store call sequence was instrumented, and the two windows are
`GET seed-surface.ts:203 → PUT :205` and `GET :245 → PUT :248`, both outside any
turn.

## The fix

Both writes take the same turn every other writer takes (`onAppRow`,
`persistence.ts`), read included. Ordering, not retrying — a retry hides a race
instead of removing it, and turns a reproducible bug into a rare mystery. The
wraps are tight around the read+put pairs only: `seedScreen` and `edit()` take
that turn internally, so wrapping wider would deadlock.

Net change is 13 lines of source.

## What is untouched

- **The save's CAS assertion stays strict.** `doors/write-surface.ts` is not in
  this diff; `assertCurrent` at :105 is byte-identical, and `authored.test.ts`
  (19 tests) still passes.
- **The courier's security properties.** Allowlist is still the target's own
  declared prop names, applied before anything is stored;
  `packages/vendo/tests/remix-live-props.seam.test.ts` still proves the decoy
  `secretToken` is filtered on both the fork and on-change paths (2/2).

## Proof — deterministic, not probabilistic

The mint is run once to count the reads it takes, then re-run parked at **every
one of them in turn**, with the courier run to completion against the parked row
before the reader is let go. Same interleaving every run; real ✦ door, real
courier door, real store, nothing stubbed. Sweeping rather than naming the two
reads means a blind put added here later is caught the day it is written.

Each turn is independently load-bearing:

| state | result |
|---|---|
| both turns reverted | RED — `courier parked at read 4 of 9: expected undefined to deeply equal { valueCents: 14292930 }` |
| name-restore turn reverted only | RED — `courier parked at read 4 of 9` |
| buildFailed turn reverted only | RED — `courier parked at read 9 of 9` |
| both turns in place | GREEN |

Local gate on the touched scope: build, typecheck, lint all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the ✦ mint from reverting live props the courier just delivered. Previously `seedFrom` read the app row and PUT the whole document without a turn, so a `seed.props` write landing between the read and PUT was lost; now both read+PUT paths run under `onAppRow`, so writes are strictly ordered and props persist.

- Scope: wraps only the name-restore path and the failure-marker path in `seedFrom`; avoids deadlock with `seedScreen` and `edit()` which take turns internally.
- Concurrency: uses ordering via `onAppRow`; no retries added; CAS assertion remains strict and unchanged; prop allowlist remains unchanged.
- Tests: adds `remix-seed-lost-update.test.ts`, a deterministic test that parks each read, verifies couriered props are kept, and confirms decoys are filtered.
- Rollout: patch release to `@vendoai/apps`; no migrations or config changes.

<sup>Written for commit 46ad4a22588cf327005564b02df3d0be8af0feee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1567?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

