### PR TITLE
chore(apps): backfill the changeset #1570 shipped without

### DIFF
--- a/.changeset/remix-reaches-no-automation-door.md
+++ b/.changeset/remix-reaches-no-automation-door.md
@@ -1,0 +1,21 @@
+---
+"@vendoai/apps": patch
+---
+
+A remix's ✦ door stops authoring automations nobody asked for. Asking the ✦ on
+Maple's net-worth card for a caption that reads "Tracked monthly" used to open
+`vendo_make`'s compound arm, author a schedule 2 mints in 3, and repaint the
+remix as an automation board behind an "Allow all 34 & enable" consent wall —
+because the arm only sniffs the person's own words for a recurrence word, and a
+caption is not a schedule.
+
+A remix is the ✦ on one of the host's own components, and what it may do is
+edit that component, read its data, and call its declared actions — authoring
+an automation was never on that list. The compound arm no longer opens on a row
+that carries a `seed`, the same marker that already means "this is a remix", so
+neither the mint nor any later app-scoped wish can reach the automation door.
+The ask is never dropped in silence: the receipt says where schedules live, and
+that check sits ahead of the failed-build gate, since a failure is the loudest
+way to lose an ask. Reading the row now also fails closed — only `null` means
+"no row"; an unresolved read no longer gets treated as "not a remix". An
+ordinary app's compound ask still arms exactly as it did.


### PR DESCRIPTION
PR #1570 ("fix(apps): a remix reaches no automation door, so a caption stops raising a consent wall") merged to main without a `.changeset/*.md` file, so the release pipeline has no record of it and it will never publish.

This adds the missing patch changeset for `@vendoai/apps`, describing the fix in #1570's own words.

Not a code change — no source touched, changeset file only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backfills the missing patch changeset for `@vendoai/apps` so the remix automation fix can be published. The earlier fix merged without a `.changeset` entry, so the release pipeline would not release it.

- Adds `.changeset/remix-reaches-no-automation-door.md` with a patch bump and summary of the behavior fix.
- No source changes; behavior unchanged in this PR. Next release will publish a patch for `@vendoai/apps`.

<sup>Written for commit ae30e4f53cb1dc758dca58166dfbe6200b387393. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

