### PR TITLE
ci: the ai@7 lane splits seven ways, and a package change without a changeset stops merging green

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,13 @@ concurrency:
 # turbo remote cache so the fan-out does not multiply the build:
 #   cone              computes the affected cone once, for everything below
 #   typecheck-lint    the non-test half
+#   changeset-required a PR that changes a publishable package carries a changeset
 #   test-shards       9 intra-package vitest shards for the big three
 #                     (vendo x4, store x3, ui x2 — 40 of the 55 serial minutes)
 #   test-rest         every other package, one job, one turbo run
 #   ai-dual           the same suites against the OTHER AI SDK major (ai@7),
-#                     which is the only thing that can prove the peer range
+#                     which is the only thing that can prove the peer range,
+#                     sharded the same way (vendo x4, ui x2, rest)
 #   coverage-merge    merges the shards' blob reports and enforces the
 #                     per-package coverage floors (they cannot be enforced on a
 #                     single shard — see the comment on that job)
@@ -213,6 +215,40 @@ jobs:
       # in the cone — still gets linted.
       - run: pnpm turbo run lint:packages
       - run: pnpm turbo run lint $CONE
+
+  # #1570 was a fix that changed a package, merged green, and released nothing:
+  # a changeset is the only thing that turns a merge into a version, and nothing
+  # was checking for one. `changeset status` is the enforcer rather than path
+  # matching, because it asks changesets itself — it knows which packages are
+  # publishable (private fixtures and examples do not count, verified), and its
+  # own `pnpm changeset --empty` is the escape hatch for a change that ships
+  # nothing.
+  #
+  # Skipped exactly where a changeset cannot be expected: the version PR, which
+  # CONSUMES them (`heavy`), and a push to main, where `base` is empty because
+  # there is no branch point left to diff against. It inherits the cone's
+  # fail-open with that same `base` — a broken probe steps this check aside
+  # rather than blocking on a diff it cannot compute.
+  changeset-required:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: cone
+    if: needs.cone.outputs.heavy == 'true' && needs.cone.outputs.base != ''
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0 # changeset status diffs against the base branch
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      # Via env, not inline ${{ }}: a base branch name is allowed to contain
+      # shell metacharacters — same reason as the cone job's resolve step.
+      - env:
+          BASE: ${{ needs.cone.outputs.base }}
+        run: pnpm changeset status --since="$BASE"
 
   # The big three, split file-wise inside each package. Coverage is collected
   # per shard as a BLOB report and merged in coverage-merge; the per-shard runs
@@ -431,27 +467,37 @@ jobs:
   # v7 pairing and runs the same suites against it, which is the only way the
   # two live majors can disagree in front of anyone.
   #
+  # SHARDED like test-shards, because unsharded it was the whole PR run's
+  # critical path: 31 minutes against every other job's <=9 (main run
+  # 32394860278), of which the serial test phase was 27m30s and @vendoai/vendo
+  # alone was 1171s, ui 377s. Same split as the v6 lane — vendo x4, ui x2 — with
+  # everything else in one `rest` leg, whose own long pole is @vendoai/agents at
+  # 320s. `pnpm test:ai7` is still the one-shot a laptop runs; the three halves
+  # of it are unrolled below so the last one can shard.
+  #
   # It BUILDS first on purpose: every package compiles with tsc, so a v7 type
-  # break fails here before a single test runs. `store` is the one package with
+  # break fails here before a single test runs. The shard legs build only their
+  # own closure; `rest` keeps the UNFILTERED build, so examples/ and fixtures/
+  # are still type-checked against v7 somewhere. `store` is the one package with
   # no `ai` peer at all and three shards' worth of PGlite boots, so it is the one
   # negation; the rest is `./packages/*`, expressed that way so a new package
   # joins this lane the day it is created.
   #
   # NOT cached: the flipped lockfile hashes differently from every other job's,
-  # so this is a cold run by construction. That is also why it is one job rather
-  # than a second shard matrix.
+  # so every leg is a cold run by construction. Parallelism is the entire win
+  # here; there is no cache to chase.
   #
   # `test` only, never `test:ui` — no browser runs in CI (2026-08-06: headless
   # mis-resolves :focus-visible and light-dark()), and an SDK major is not a
   # pixel question anyway. The Playwright suite stays the local pre-PR gate it
   # is for the v6 lane.
   ai-dual:
+    name: ai-dual (${{ matrix.name }})
     runs-on: ubuntu-latest
-    # Longer than test-rest's 25 because this is ONE cold runner doing what the
-    # shards and test-rest split between ten: no remote cache to restore from,
-    # and the big packages are not sharded here. A timeout is a hang detector,
-    # and ~20 minutes of real work needs a ceiling above it, not at it.
-    timeout-minutes: 45
+    # ~10 minutes of real work on the longest leg (install ~40s, build <=2m30s,
+    # tests <=6m). A timeout is a hang detector, so the ceiling sits well above
+    # that rather than at it.
+    timeout-minutes: 25
     needs: cone
     # Same reasoning as the shards' RUN gate: the version PR puts every package
     # in the cone and there is nothing here for it to prove.
@@ -459,11 +505,27 @@ jobs:
     env:
       # Both halves, at job level: this job invokes turbo directly, so it does
       # not inherit the root scripts' caps, and a max-only cap makes Tinypool
-      # throw before a single test runs.
+      # throw before a single test runs. Stays at 2 rather than test-shards' 4:
+      # `rest` runs turbo across many packages, which is the outer layer the cap
+      # exists to stop multiplying, and a cold v7 tree is the heaviest install
+      # in the file.
       VITEST_MIN_FORKS: "1"
       VITEST_MAX_FORKS: "2"
       VITEST_MIN_THREADS: "1"
       VITEST_MAX_THREADS: "2"
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { name: vendo-1, build: "--filter=@vendoai/vendo", test: "--filter=@vendoai/vendo exec vitest run --shard=1/4" }
+          - { name: vendo-2, build: "--filter=@vendoai/vendo", test: "--filter=@vendoai/vendo exec vitest run --shard=2/4" }
+          - { name: vendo-3, build: "--filter=@vendoai/vendo", test: "--filter=@vendoai/vendo exec vitest run --shard=3/4" }
+          - { name: vendo-4, build: "--filter=@vendoai/vendo", test: "--filter=@vendoai/vendo exec vitest run --shard=4/4" }
+          - { name: ui-1, build: "--filter=@vendoai/ui", test: "--filter=@vendoai/ui exec vitest run --shard=1/2" }
+          - { name: ui-2, build: "--filter=@vendoai/ui", test: "--filter=@vendoai/ui exec vitest run --shard=2/2" }
+          # No build filter = the whole tree; this is the leg that carries the
+          # type-break guarantee above.
+          - { name: rest, build: "", test: "turbo run test --continue --concurrency=2 '--filter=./packages/*' '--filter=!@vendoai/store' '--filter=!@vendoai/vendo' '--filter=!@vendoai/ui'" }
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
@@ -471,9 +533,10 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
-      # One command, the same one a laptop runs: pin -> install -> build -> test.
-      - name: Build and test against ai@7
-        run: pnpm test:ai7
+      - run: node scripts/pin-ai-major-7.mjs
+      - run: pnpm install --no-frozen-lockfile
+      - run: pnpm turbo run build ${{ matrix.build }}
+      - run: pnpm ${{ matrix.test }}
 
   # The per-package coverage floors (vendo 78 / store 84 / ui 90, each in the
   # package's vitest config) live HERE, because a floor is only meaningful
@@ -549,7 +612,7 @@ jobs:
   # cone-only CI and no PR ever passing again, in either direction.
   ci:
     runs-on: ubuntu-latest
-    needs: [cone, typecheck-lint, test-shards, test-rest, ai-dual, coverage-merge]
+    needs: [cone, typecheck-lint, changeset-required, test-shards, test-rest, ai-dual, coverage-merge]
     if: always()
     steps:
       - name: All lanes green (skipped counts as success)


### PR DESCRIPTION
Two changes to `.github/workflows/ci.yml`, both aimed at merges that lie.

## `ai-dual` shards (31 min → ~10)

`ai-dual` was the long pole of every PR run: **1863s** on main run 32394860278, against `<=540s` for every other job. One cold runner re-ran the big packages unsharded against ai@7 — `@vendoai/vendo` alone was 1171s of a 27m30s serial test phase, `@vendoai/ui` 377s.

It is now a 7-leg matrix mirroring `test-shards`: **vendo x4, ui x2, and one `rest` leg** for everything else (its own long pole is `@vendoai/agents` at 320s). `store` stays the single negation — it has no `ai` peer and three shards' worth of PGlite boots, unchanged from before.

Load-bearing bits kept intact:

- the `heavy` cone gate is byte-for-byte the same, so the version PR still skips it
- `VITEST_MIN_FORKS/MAX_FORKS` **and** `VITEST_MIN_THREADS/MAX_THREADS` are set at job level on every leg, both halves — a max-only cap makes Tinypool throw before a test runs. They stay at 2 rather than `test-shards`' 4: the `rest` leg has the outer turbo layer the cap exists to stop multiplying
- timeout drops 45 → 25, still a hang detector well above the ~10 min the longest leg does, never at it
- the `rest` leg keeps the **unfiltered** build, so a v7 type break in `examples/` or `fixtures/` still fails before a test runs — the shard legs build only their own closure
- no cache chasing: the ai@7 pin rewrites the lockfile, so every leg is cold by construction. Parallelism is the whole win
- the `ci` aggregate needs no arithmetic change for this — GitHub rolls a matrix into one `needs` result, and `ci` already treats success-or-skipped as green

## `changeset-required`

#1570 was a fix that changed a package, merged green, and released nothing. A changeset is the only thing that turns a merge into a version, and nothing checked for one.

The new job runs `changeset status --since=<base>` — the native enforcer, not path matching. It asks changesets itself, so it already knows which packages are publishable (verified locally: a change under `examples/demo-bank` does not trip it) and `pnpm changeset --empty` is its own escape hatch.

It skips exactly where a changeset cannot be expected: the version PR, which *consumes* changesets (`heavy`), and pushes to main, where the cone's `base` is empty. Same fail-open as the cone probe. Folded into the `ci` aggregate's needs list; the required-check name `ci` is unchanged.

## Proof

- `actionlint` clean — same four pre-existing `SC2086 $CONE` infos as `origin/main`, zero new findings
- `changeset status` behaviour verified locally against the real workspace: clean branch passes, a `packages/core` edit with no changeset exits 1, an empty changeset restores green, a private-package edit passes
- turbo dry-runs confirm the `rest` filter selects exactly today's task set minus vendo and ui, and that the shard legs' `--filter` build closures cover their deps
- a scratch PR off this branch proves `changeset-required` goes **red** on a package change with no changeset

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Splits the `ai-dual` lane into a seven-leg matrix and adds a `changeset-required` check. PR CI runs faster and package changes can’t merge without a changeset.

- Faster `ai@7` lane: `@vendoai/vendo` x4, `@vendoai/ui` x2, and one `rest` leg (excludes `@vendoai/store`). Longest leg drops from ~31 min to ~10.
- The `rest` leg keeps an unfiltered build to catch `ai@7` type breaks in `examples/` and `fixtures/`; shard legs build only their closures.
- Sets `VITEST_MIN/MAX_FORKS` and `VITEST_MIN/MAX_THREADS` to 1/2 per leg; reduces timeout 45 → 25 minutes. No cache expected (lockfile pin makes runs cold).
- Gating unchanged: still behind the `heavy` cone; rolled into the existing `ci` aggregate.

**Require changesets on package changes**

- Adds `changeset-required`: runs `pnpm changeset status --since=<base>` and fails when a publishable package changes without a changeset.
- Skips on the version PR (`heavy` false) and pushes to `main` (no base); included in `ci`’s `needs` while the required check name stays `ci`.
- Action: when a publishable package changes, include a changeset (or use `pnpm changeset --empty` if no release is intended).

<sup>Written for commit a377cbec8b5acc47edb801621bfd1234bfa85041. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

