### PR TITLE
chore: scratch — red proof for changeset-required, do not merge

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -88,3 +88,5 @@ export type {
 export type { CommitResult, WorkspaceFs } from "./workspace.js";
 export { WORKSPACE_INLINE_MAX_BYTES, appRootPath } from "./workspace.js";
 export type { AppMount } from "./workspace.js";
+
+// scratch: proving changeset-required can go red. Do not merge.


### PR DESCRIPTION
Throwaway. Touches `packages/core/src/index.ts` with no changeset so `changeset-required` goes red. Closed as soon as the check reports.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a no-op comment to `packages/core/src/index.ts` to intentionally trigger the `changeset-required` check by modifying a package without a changeset. Validates the changeset policy; no runtime or build behavior changes.

- Do not merge; close once `changeset-required` turns red.
- Comment-only change in core; no tests or docs needed.

<sup>Written for commit 1b0637e0a7ffbebe3891386ef16f1fe111394bf9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1577?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

