### PR TITLE
ci(release): the version PR merges itself, the publish gate stops re-proving CI, and the bump reaches the checker

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,6 +144,20 @@ jobs:
                   (dep) => dep.replace(/\d+\.\d+\.\d+/, version)));
             ' "$version" "$dir/package.json"
           done
+          # Fail closed on whatever the rewrite could not reach. That regex only
+          # moves EXACT pins, so a range (`^0.36.1`), a `pnpm.overrides` entry or
+          # anything else added to these files later would be skipped in silence
+          # while the PR still went out claiming it covered all three projects —
+          # the same shape of miss as vendo-web#608, one layer up. Every pin is
+          # exact today, so this is quiet until the day it is not.
+          for dir in . apps/console apps/console/checker; do
+            missed=$(grep -oE '"@vendoai/[^"]+": "[^"]+"' "$dir/package.json" \
+              | grep -v '^"@vendoai/telemetry"' | grep -vF ": \"$version\"") || true
+            if [ -n "$missed" ]; then
+              echo "::error::$dir/package.json still holds @vendoai deps the bump could not rewrite, so this release is only half applied: $missed"
+              exit 1
+            fi
+          done
           if git diff --quiet; then
             echo "vendo-web is already on $version"
             exit 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
   push:
     tags: ["v*"]
   # Dry run by default: manually dispatch to prove the publish end-to-end WITHOUT
-  # publishing. Runs the exact gate stack + `pnpm -r publish --dry-run`.
+  # publishing. Runs the same gate + `pnpm -r publish --dry-run`.
   workflow_dispatch:
     inputs:
       publish:
@@ -34,22 +34,6 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    # Same Postgres leg as the `ci` gate: @vendoai/store's postgres-gate test
-    # requires POSTGRES_URL in CI so the PostgreSQL backend suite really runs.
-    services:
-      postgres:
-        image: postgres:16
-        env:
-          POSTGRES_USER: vendo
-          POSTGRES_PASSWORD: vendo
-          POSTGRES_DB: vendo_test
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd "pg_isready -U vendo"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
@@ -62,18 +46,15 @@ jobs:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      # BUILD + TYPECHECK, not the full gate. This workflow only ever runs at a
+      # tag, and that tag's tree already merged through main's required checks
+      # (ci, integration, conformance, audit) — re-running the suite here proved
+      # nothing a second time and put ~38 minutes between "merge the version PR"
+      # and "it is on npm". Build stays because the tarballs are its output;
+      # typecheck stays because it is seconds and it reads the .d.ts files the
+      # build emits, which are what users actually compile against.
       - run: pnpm build
-      # `pnpm test` now includes the UI smoke pack (`turbo run test:ui`), a real
-      # Chromium run — so the release gate needs the browser the CI browser job
-      # installs too.
-      - run: pnpm --filter @vendoai/ui exec playwright install --with-deps chromium
-      - run: pnpm test
-        env:
-          POSTGRES_URL: postgres://vendo:vendo@localhost:5432/vendo_test
-      # Parity with the `ci` gate — a release must never publish something that
-      # would have failed CI. typecheck + lint were previously missing here.
       - run: pnpm typecheck
-      - run: pnpm lint
 
       # Dry run (workflow_dispatch): prove the publish resolves + packs without
       # touching the registry. --provenance is dropped here (no tag/release to
@@ -135,34 +116,49 @@ jobs:
             exit 0
           fi
           version=$(node -p "require('./packages/vendo/package.json').version")
-          branch="chore/bump-vendoai-$version"
+          # The branch prefix is a contract: vendo-web's vendoai-bump-merge
+          # workflow only ever merges `vendoai-bump/*`.
+          branch="vendoai-bump/v$version"
           git clone --depth=1 "https://x-access-token:$GH_TOKEN@github.com/runvendo/vendo-web.git" /tmp/vendo-web
           cd /tmp/vendo-web
-          # Rewritten in place so the file's own formatting survives; catches
+          # THREE pnpm projects, not one. The repo root (marketing site) and
+          # apps/console are the obvious two; apps/console/checker is an
+          # isolated workspace nested INSIDE the console, with its own manifest
+          # and its own lockfile, so no install in the console can ever reach
+          # it. Bumping the first two and leaving it behind is what stranded
+          # the checker on 0.34.0 for two releases (vendo-web#608).
+          #
+          # Rewritten in place so each file's own formatting survives; catches
           # both `dependencies` and `pnpm.overrides`. @vendoai/telemetry is
           # deliberately excluded: it is outside this repo's changesets `fixed`
           # group and versions on its own, so it must never ride the lockstep
           # bump. (It is a `file:` reference today, which the semver pattern
           # skips anyway — the name is excluded so that holds if it is ever
           # published as a version.)
-          node -e '
-            const fs = require("fs");
-            fs.writeFileSync("package.json", fs.readFileSync("package.json", "utf8")
-              .replace(/"@vendoai\/(?!telemetry")[a-z-]+": "\d+\.\d+\.\d+"/g,
-                (dep) => dep.replace(/\d+\.\d+\.\d+/, process.argv[1])));
-          ' "$version"
+          for dir in . apps/console apps/console/checker; do
+            node -e '
+              const fs = require("fs");
+              const [version, file] = process.argv.slice(1);
+              fs.writeFileSync(file, fs.readFileSync(file, "utf8")
+                .replace(/"@vendoai\/(?!telemetry")[a-z-]+": "\d+\.\d+\.\d+"/g,
+                  (dep) => dep.replace(/\d+\.\d+\.\d+/, version)));
+            ' "$version" "$dir/package.json"
+          done
           if git diff --quiet; then
             echo "vendo-web is already on $version"
             exit 0
           fi
           # pnpm 9 is what vendo-web's own CI installs with, and it runs
           # --frozen-lockfile: a lockfile written by this repo's pnpm 11 would
-          # fail there. Without this refresh the PR is red on arrival.
-          npx --yes pnpm@9 install --lockfile-only --ignore-scripts
+          # fail there. Without this refresh the PR is red on arrival. One
+          # install per project — each owns a separate lockfile.
+          for dir in . apps/console apps/console/checker; do
+            npx --yes pnpm@9 install --lockfile-only --ignore-scripts --dir "$dir"
+          done
           git -c user.name='github-actions[bot]' \
               -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
               commit -am "chore: bump @vendoai/* to $version"
           git push origin "HEAD:refs/heads/$branch"
           gh pr create --head "$branch" \
             --title "chore: bump @vendoai/* to $version" \
-            --body "Automated by runvendo/vendo's release workflow for v$version. \`@vendoai/telemetry\` is outside the release group and is left alone."
+            --body "Automated by runvendo/vendo's release workflow for v$version. Covers all three pnpm projects — the root site, \`apps/console\` and the isolated \`apps/console/checker\` workspace — with each lockfile regenerated. \`@vendoai/telemetry\` is outside the release group and is left alone."

--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -86,6 +86,31 @@ jobs:
             exit 1
           fi
 
+      # Arm GitHub's native auto-merge so the version PR merges itself the
+      # moment ci/integration/conformance/audit are green — main runs a merge
+      # queue (ruleset merge-queue-main, SQUASH), so this enqueues rather than
+      # merges directly. It sits AFTER the 0.x guard on purpose: a version PR
+      # that crossed the ceiling must never be armed.
+      #
+      # RELEASE_PAT, not GITHUB_TOKEN, and this step is worthless without it —
+      # for both halves of the same rule. Without the PAT the version PR gets no
+      # checks at all (see the header), so required checks never report and
+      # auto-merge would wait forever; and the merge it eventually performs is
+      # attributed to whoever armed it, so a GITHUB_TOKEN merge would land on
+      # main without re-triggering this workflow — no tag, no publish.
+      - name: Arm auto-merge on the version PR
+        if: steps.changesets.outputs.pullRequestNumber != ''
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+          PR: ${{ steps.changesets.outputs.pullRequestNumber }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::notice::RELEASE_PAT is not set — PR #$PR stays a manual merge"
+            exit 0
+          fi
+          # Re-arming an armed PR is a no-op, so this is safe on every push.
+          gh pr merge "$PR" --auto --squash
+
       # THE CHANGESET RACE: a changeset-carrying PR landed in the gap between
       # this version PR being cut and it merging, so the tag step below sees
       # those leftover changesets and skips — a green run that released nothing

--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -70,6 +70,9 @@ jobs:
       # them left 0.x. Downgrade the changeset to `minor` and this goes green.
       - name: Guard the 0.x ceiling
         if: steps.changesets.outputs.hasChangesets == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
+          PR: ${{ steps.changesets.outputs.pullRequestNumber }}
         run: |
           set -euo pipefail
           git fetch origin changeset-release/main
@@ -82,6 +85,13 @@ jobs:
             esac
           done
           if [ -n "$crossed" ]; then
+            # Disarm before failing. Failing this step stops the arming step
+            # below from running, but it cannot un-arm a PR that was already
+            # armed on an earlier, still-0.x push — and that PR would carry
+            # 1.0.0 into main by itself the moment its checks went green.
+            # Disarming an unarmed PR is already a clean no-op, so `|| true` is
+            # here for one reason: nothing gh does may swallow the error below.
+            gh pr merge "$PR" --disable-auto || true
             echo "::error::proposed versions left 0.x —$crossed. Vendo stays below 1.0.0 until Yousef lifts the ceiling; use a minor changeset."
             exit 1
           fi


### PR DESCRIPTION
Three cuts to the release train, so "merge the version PR" stops being a human step and the tail stops taking an hour.

## 1. The version PR arms its own auto-merge

`version-packages.yml` now arms GitHub native auto-merge (squash) on the `changeset-release/main` PR. `main` runs the `merge-queue-main` ruleset (SQUASH, ALLGREEN), so this **enqueues** the PR behind the four required checks rather than merging it directly; the post-merge push then tags and dispatches the publish exactly as it does today.

Two placement facts that are load-bearing:

- The step sits **after** the 0.x ceiling guard. A version PR that crossed 1.0.0 fails that guard, the job aborts, and auto-merge is never armed.
- It uses `RELEASE_PAT`, not `GITHUB_TOKEN`, and no-ops loudly without it. Both halves of the same rule: without the PAT the version PR never gets its required checks at all (see the file header), so auto-merge would wait forever — and the merge is attributed to whoever armed it, so a `GITHUB_TOKEN` merge would land on main **without** re-triggering this workflow. No tag, no publish.

And the ceiling guard now **disarms** on its failure path (`gh pr merge --disable-auto`) before it errors. Failing the guard stops the arming step from running, but it could not un-arm a PR armed on an earlier, still-0.x push — and that PR would have carried 1.0.0 into main by itself once its checks went green. Nothing can auto-mint a 1.0 now. The guard's detection logic (fetch → loop → `case` → `if` condition) is byte-identical to main; the swallowed-release guard is untouched.

## 2. The publish gate is build + typecheck

`release.yml` was running the full suite — install, build, Chromium install, `pnpm test`, typecheck, lint — before publishing, on a Postgres service container. That is ~38 minutes re-proving what the tag already proved: this workflow only ever runs at a tag, and that tag's tree merged through `ci`, `integration`, `conformance` and `audit` on main.

Gone: the Postgres service, the Playwright install, `pnpm test`, `pnpm lint`. Kept: `pnpm build` (the tarballs are its output) and `pnpm typecheck`. The OIDC trusted-publishing block, the dependency-ordered publish loop and the tag flow are untouched.

## 3. The vendo-web bump PR reaches all three pnpm projects

The bump step rewrote **one** manifest — the repo root — and refreshed **one** lockfile. vendo-web has three pnpm projects:

| project | manifest | lockfile |
| --- | --- | --- |
| root marketing site | `package.json` | `pnpm-lock.yaml` |
| console | `apps/console/package.json` | `apps/console/pnpm-lock.yaml` |
| screen checker | `apps/console/checker/package.json` | `apps/console/checker/pnpm-lock.yaml` |

The checker is an isolated workspace nested *inside* the console (its own `pnpm-workspace.yaml`), so no console install can ever reach it — which is how it sat stranded on `0.34.0` for two releases and needed the hand-written straggler PR runvendo/vendo-web#608. All three are now rewritten and all three lockfiles regenerated with pnpm 9, the version vendo-web CI installs with.

The branch is now `vendoai-bump/v<version>` — a frozen contract with vendo-web's new `vendoai-bump-merge` workflow (runvendo/vendo-web PR pending), which squash-merges the bump once its whole check rollup is green. `@vendoai/telemetry` is still excluded; the `VENDO_WEB_PAT` skip-notice is unchanged.

## Gate

- `actionlint` clean on both changed workflows.
- `pnpm test:affected` — no tasks (workflow-only diff).
- `pnpm typecheck` — 44/44 green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automates the release train and cuts publish latency. Previously maintainers merged the version PR and the tag workflow re-ran full CI; now the version PR self-enqueues and merges safely, the publish gate is build + typecheck only, and the vendo-web bump covers all three pnpm projects and fails closed if any pin is missed.

- Version PR auto-merge: arms GitHub auto-merge (squash) after the 0.x ceiling guard; if the guard trips, we explicitly disable auto-merge so a previously armed PR can’t carry 1.0+ into main. Enqueues behind required checks on `main`. Uses `RELEASE_PAT`; without it the PR stays manual. Avoids merges that fail to retrigger tagging/publish.
- Publish gate scope: drops Postgres, Playwright install, tests, and lint. Keeps `pnpm build` (tarballs) and `pnpm typecheck`. OIDC trusted publishing, dependency-ordered publish, and tag flow are unchanged.
- vendo-web bump PR: updates `package.json` in the repo root, `apps/console`, and `apps/console/checker`; verifies all `@vendoai/*` pins (except `@vendoai/telemetry`) were rewritten and fails the run if any were missed; regenerates each project’s lockfile with `pnpm@9`. Branch: `vendoai-bump/v<version>`.
- Required actions: set `RELEASE_PAT` to enable auto-merge; `VENDO_WEB_PAT` remains required to open the vendo-web bump PR.
- Status: workflow-only changes; actionlint and `pnpm typecheck` are green. Supports ENG-55 by shortening release time for the pricing rollout.

<sup>Written for commit 61831034dda33b29e10cf58e5035ecf9ef8de535. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1578?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

