### PR TITLE
ci(release): one tag, one publish — the tag push goes back to the token whose pushes stay silent

### DIFF
--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -145,6 +145,15 @@ jobs:
       - name: Push the release tag
         id: tag
         if: steps.changesets.outputs.hasChangesets == 'false'
+        env:
+          # The built-in token, spelled out, because the checkout above persists
+          # RELEASE_PAT and a plain `git push origin` would inherit it. A real
+          # credential's tag push DOES fire release.yml's `push: tags` trigger,
+          # so the tag and the dispatch below both started a publish and the two
+          # runs collided on npm (2026-08-21: dispatch 32437362971 lost to push
+          # 32437364008). GITHUB_TOKEN's silence is the interlock that makes the
+          # dispatch the single trigger — it is load-bearing, not incidental.
+          TAG_PUSH_URL: https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
         run: |
           set -euo pipefail
           tag="v$(node -p "require('./packages/vendo/package.json').version")"
@@ -159,7 +168,7 @@ jobs:
             exit 0
           fi
           git tag "$tag"
-          git push origin "refs/tags/$tag"
+          git push "$TAG_PUSH_URL" "refs/tags/$tag"
           echo "pushed $tag -> $(git rev-parse HEAD)"
           echo "tag=$tag" >>"$GITHUB_OUTPUT"
 


### PR DESCRIPTION
v0.36.2 published twice-over: two `Release` runs raced at the same tag and one lost on npm.

| run | event | outcome |
| --- | --- | --- |
| [32437364008](https://github.com/runvendo/vendo/actions/runs/32437364008) | `push` (tag `v0.36.2`) | success — this one published |
| [32437362971](https://github.com/runvendo/vendo/actions/runs/32437362971) | `workflow_dispatch` | **failure** at `npm publish`, versions already on the registry |

The run actors name the culprit outright:

- push run 32437364008 — `actor: yousefh409`, i.e. **RELEASE_PAT**
- dispatch run 32437362971 — `actor: github-actions[bot]`, i.e. GITHUB_TOKEN

## What actually broke

Nothing in `release.yml`. Its `on:` is unchanged and correct — `push: tags` plus a dispatch — and the whole design rests on one property, stated in its own comment: *"a GITHUB_TOKEN tag push can never fire the `push: tags` trigger above, and a dispatch can."* That is the interlock. The dispatch is meant to be the only trigger, and GITHUB_TOKEN's silence is what guarantees it.

Arming auto-merge put `RELEASE_PAT` into this workflow, and `actions/checkout` persists it. `git push origin` inherits persisted credentials, so the tag went up under a **real** credential — which does fire `push: tags`. Both triggers ran. The comment three lines below the push, "The tag push above used GITHUB_TOKEN, so release.yml's `push: tags` trigger did NOT fire," had quietly become false.

## The fix

Name the token instead of inheriting one:

```yaml
env:
  TAG_PUSH_URL: https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
```
```bash
git push "$TAG_PUSH_URL" "refs/tags/$tag"
```

One line changed, one `env:` added. Everything else — `changesets/action`, both guards, the auto-merge arming, the dispatch — keeps `RELEASE_PAT`, which they need. The `git ls-remote` probe above still rides the persisted credential; it only reads.

## Why not delete the `push: tags` trigger instead

That is the other way to get one trigger, and it is not smaller. It would need edits in two files, and it would make a hand-pushed tag publish **nothing, silently** — the exact failure this workflow's header memorialises (`v0.23.0` tagged and published nothing). Restoring the token restores the design the comments already describe, and leaves the manual tag path working for a human.

## Gate

- `actionlint` exit 0 on both release workflows.
- `pnpm test:affected` — no tasks (workflow-only diff). `pnpm typecheck` — 44/44.

Goes through the merge queue; not merging it myself.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops double publishes by pushing release tags with `GITHUB_TOKEN` instead of inheriting `RELEASE_PAT`. Previously the tag push used a real PAT and triggered `push: tags` alongside the `workflow_dispatch`; now the tag push is silent, so only the dispatch publishes.

- Changes: in `.github/workflows/version-packages.yml`, add `TAG_PUSH_URL` using `secrets.GITHUB_TOKEN` and push tags via that URL; replace `git push origin` with `git push "$TAG_PUSH_URL"`.
- Keeps `RELEASE_PAT` for `changesets`, auto-merge, and the dispatch; the existing `git ls-remote` read stays on the persisted credential.
- Leaves the `push: tags` trigger intact so a human-pushed tag still publishes; we do not remove it to avoid silent no-publish on manual tags.
- No new secrets, migrations, or application code changes.

<sup>Written for commit 596525b2d6b0653f9fc238b73ab6762d8e2fe47e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1585?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


