### PR TITLE
feat(ui): useVendoChat takes the host's fetch

### DIFF
--- a/.changeset/chat-host-fetch.md
+++ b/.changeset/chat-host-fetch.md
@@ -1,0 +1,21 @@
+---
+"@vendoai/ui": patch
+---
+
+`useVendoChat` takes a `fetch`, so a header-authenticated host can use it.
+
+The hook called `globalThis.fetch` directly on all three of its routes — the
+turn, the transcript read-back a reload does, and the approval decision on the
+permission wire. That works when the session is a cookie, because the browser
+attaches it without being asked. It cannot work when the session is a bearer
+token: nothing in `UseVendoChatOptions` reached the request, so there was no
+way to put an `Authorization` header on it, and every route answered 401.
+
+`fetch` is now an option. Unset, it is `globalThis.fetch` and nothing changes.
+Set, every request the conversation makes goes through it — which is the point:
+a hook that authenticated the send but not the read-back would leave a host
+with a conversation that half-works, and the half that fails is the one that
+restores a parked approval after a reload.
+
+It is read through a ref, so a token that changes between renders is picked up
+on the next request rather than pinned by the transport's first build.

--- a/packages/ui/src/use-vendo-chat.ts
+++ b/packages/ui/src/use-vendo-chat.ts
@@ -12,7 +12,7 @@
  * is read back from the server, which is what makes `interruptions` survive a
  * reload without this hook owning a byte of browser storage.
  */
-import type { Decisions, Interruption, Json } from "@vendoai/core";
+import { defaultFetch, type Decisions, type Interruption, type Json } from "@vendoai/core";
 import { useChat } from "@ai-sdk/react";
 import {
   DefaultChatTransport,
@@ -36,10 +36,26 @@ export interface UseVendoChatOptions {
   /** The id the server minted, the moment it lands. Keep it where your app
    *  already keeps route state — this hook keeps nothing. */
   onThreadId?: (threadId: string) => void;
+  /** What every request this hook makes goes through; defaults to the global.
+   *  The seam a host whose session is a HEADER rather than a cookie needs —
+   *  a bearer token cannot ride along on its own, and all three of this hook's
+   *  routes (the turn, the transcript read-back, the approval decision) are
+   *  equally authenticated, so one fetch covers the conversation rather than
+   *  the send alone. */
+  fetch?: typeof fetch;
 }
 
-export function useVendoChat({ api, threadId, onThreadId }: UseVendoChatOptions) {
+export function useVendoChat({ api, threadId, onThreadId, fetch: hostFetch }: UseVendoChatOptions) {
   const base = api.replace(/\/$/, "");
+  // Read through a ref for the reason `onThreadId` is: the transport is built
+  // once per `base`, so a fetch captured in that closure would pin the first
+  // render's token forever.
+  const doFetch = useRef(hostFetch);
+  doFetch.current = hostFetch;
+  const request: typeof fetch = useCallback(
+    (input, init) => (doFetch.current ?? defaultFetch)(input, init),
+    [],
+  );
   // The live id: a ref because the transport closure reads it per request, and
   // state because the caller renders it.
   const activeThreadId = useRef(threadId);
@@ -52,7 +68,7 @@ export function useVendoChat({ api, threadId, onThreadId }: UseVendoChatOptions)
       new DefaultChatTransport<UIMessage>({
         api: `${base}/threads`,
         fetch: async (input, init) => {
-          const response = await globalThis.fetch(input, init);
+          const response = await request(input, init);
           const returned = response.headers.get(THREAD_ID_HEADER);
           if (returned !== null && returned !== activeThreadId.current) {
             activeThreadId.current = returned;
@@ -68,7 +84,7 @@ export function useVendoChat({ api, threadId, onThreadId }: UseVendoChatOptions)
           return { body: { ...(id === undefined ? {} : { threadId: id }), message } };
         },
       }),
-    [base],
+    [base, request],
   );
 
   const chat = useChat<UIMessage>({
@@ -89,8 +105,7 @@ export function useVendoChat({ api, threadId, onThreadId }: UseVendoChatOptions)
     activeThreadId.current = threadId;
     setEffectiveThreadId(threadId);
     let active = true;
-    void globalThis
-      .fetch(`${base}/threads/${encodeURIComponent(threadId)}`)
+    void request(`${base}/threads/${encodeURIComponent(threadId)}`)
       .then(response => (response.ok ? response.json() as Promise<{ messages: UIMessage[] }> : undefined))
       .then(thread => {
         if (active && thread !== undefined) setMessages(thread.messages);
@@ -99,7 +114,7 @@ export function useVendoChat({ api, threadId, onThreadId }: UseVendoChatOptions)
     return () => {
       active = false;
     };
-  }, [base, threadId, setMessages]);
+  }, [base, threadId, setMessages, request]);
 
   /** What this conversation is waiting on a person for, in the vocabulary the
    *  server speaks (`Interruption`) rather than the SDK's part shape. */
@@ -143,7 +158,7 @@ export function useVendoChat({ api, threadId, onThreadId }: UseVendoChatOptions)
         // no interruption here to answer.
         const ids = Object.entries(decisions).filter(([, decision]) => decision === verdict).map(([id]) => id);
         if (ids.length === 0) continue;
-        const response = await globalThis.fetch(`${base}/approvals/decide`, {
+        const response = await request(`${base}/approvals/decide`, {
           method: "POST",
           headers: { "content-type": "application/json" },
           body: JSON.stringify({ ids, decision: { approve } }),
@@ -155,7 +170,7 @@ export function useVendoChat({ api, threadId, onThreadId }: UseVendoChatOptions)
         if (!response.ok) throw new Error(`Vendo could not record the ${verdict} decision (${response.status}).`);
       }
     },
-    [base],
+    [base, request],
   );
 
   return {

--- a/packages/ui/test/use-vendo-chat.test.tsx
+++ b/packages/ui/test/use-vendo-chat.test.tsx
@@ -42,6 +42,9 @@ interface Mount {
   sent: Array<Record<string, unknown>>;
   /** Every approval decision the browser posted to the permission wire. */
   decided: Array<Record<string, unknown>>;
+  /** What every route actually SAW, so a host-supplied fetch can be checked
+   *  where it matters: on the wire, not at the call site. */
+  seen: Array<{ path: string; authorization: string | undefined }>;
   /** Make the permission wire refuse from here on — a 409, which is what the
    *  wire answers for an approval already decided or long expired. */
   refuse(): void;
@@ -54,11 +57,13 @@ interface Mount {
 async function serveMount(): Promise<Mount> {
   const sent: Array<Record<string, unknown>> = [];
   const decided: Array<Record<string, unknown>> = [];
+  const seen: Array<{ path: string; authorization: string | undefined }> = [];
   const thread: UIMessage[] = [];
   let refusing = false;
   const server: Server = createServer((incoming, outgoing) => {
     void (async () => {
       const url = new URL(incoming.url ?? "/", "http://127.0.0.1");
+      seen.push({ path: url.pathname, authorization: incoming.headers.authorization });
       if (incoming.method === "GET" && url.pathname.startsWith("/threads/")) {
         outgoing.writeHead(200, { "content-type": "application/json" });
         outgoing.end(JSON.stringify({ id: THREAD_ID, messages: thread }));
@@ -95,6 +100,7 @@ async function serveMount(): Promise<Mount> {
     url: `http://127.0.0.1:${(server.address() as AddressInfo).port}`,
     sent,
     decided,
+    seen,
     refuse: () => {
       refusing = true;
     },
@@ -196,6 +202,45 @@ describe("useVendoChat", () => {
     // expired. Resolved as success it reads as "the approval landed" while the
     // turn is still parked, waiting for a decision that never arrives.
     await expect(result.current.resume({ apr_1: "approve" })).rejects.toThrow(/409/);
+  });
+
+  it("sends every route through a host-supplied fetch", async () => {
+    mount.thread.push(...parked);
+    // A header-authenticated host: the token cannot ride along on its own the
+    // way a cookie does, so this is the only way its session reaches the mount.
+    const authorized: typeof globalThis.fetch = (input, init) =>
+      globalThis.fetch(input, {
+        ...init,
+        headers: { ...Object.fromEntries(new Headers(init?.headers)), authorization: "Bearer t0ken" },
+      });
+
+    const { result } = renderHook(() =>
+      useVendoChat({ api: mount.url, threadId: THREAD_ID, fetch: authorized }));
+
+    // The transcript read-back a reload does.
+    await waitFor(() => expect(result.current.interruptions).toHaveLength(1));
+    // The turn.
+    result.current.sendMessage({ text: "hello" });
+    await waitFor(() => expect(mount.sent).toHaveLength(1));
+    // The approval decision, on the permission wire.
+    await result.current.resume({ apr_1: "approve" });
+    await waitFor(() => expect(mount.decided).toHaveLength(1));
+
+    // All three, not just the send — a host whose read-back or approval went
+    // out unauthenticated has a conversation that silently half-works.
+    expect(mount.seen.map((request) => request.path)).toEqual(
+      expect.arrayContaining([`/threads/${THREAD_ID}`, "/threads", "/approvals/decide"]),
+    );
+    expect(mount.seen.every((request) => request.authorization === "Bearer t0ken")).toBe(true);
+  });
+
+  it("falls back to the global fetch when the host supplies none", async () => {
+    const { result } = renderHook(() => useVendoChat({ api: mount.url }));
+
+    result.current.sendMessage({ text: "hello" });
+
+    await waitFor(() => expect(mount.sent).toHaveLength(1));
+    expect(mount.seen.every((request) => request.authorization === undefined)).toBe(true);
   });
 
   it("points the next turn at the thread it was switched to", async () => {


### PR DESCRIPTION
## What

`useVendoChat` takes a `fetch`. Unset, it is `defaultFetch` and nothing changes.
Set, every request the conversation makes goes through it: the turn, the
transcript read-back a reload does, and the approval decision on the permission
wire.

Read through a ref rather than captured, for the same reason `onThreadId` is.
The transport is built once per `base`, so a fetch closed over at first render
would pin that render's token forever.

No API break, no new dependency, no change to any host that does not pass the
option. Changeset included (`patch`, `@vendoai/ui`).

## Why

The hook called `globalThis.fetch` directly on all three routes. That works when
the session is a cookie, because the browser attaches it without being asked.

It cannot work when the session is a bearer token. Nothing in
`UseVendoChatOptions` reached the request, so there was no way to put an
`Authorization` header on one, and every route answered 401. I hit t
the hook on a host that keeps its token in `localStorage`, and ended up copying
the hook into the app to change one line.

Related: #1256 covers the server half, where a host whose auth Vendo cannot read
is pointed at a custom principal resolver using its own auth library. This is the
browser half of the same posture. Once a host brings its own resolver, the hook
still had no way to send the credential that resolver reads.

All three routes, deliberately. Authenticating the send but not the
leaves a conversation that half-works, and the half that fails is the one
restoring a parked approval after a reload.

## Verification

Two tests in `packages/ui/test/use-vendo-chat.test.tsx`, against the
real HTTP mount rather than a stub. The mount now records the path and
`authorization` header of every request it receives, so the assertio
crossed the wire, not on what the hook was called with.

- a host-supplied fetch reaches the turn, the read-back and the approval
  decision. Confirmed failing before the change and passing after, b
  the source fix and re-running.
- with no fetch supplied, requests still go out unauthenticated as b

`@vendoai/ui` is green at 1513 tests across 161 files.

The portability gate earned its keep: my first version defaulted wit
`?? globalThis.fetch`, and the gate rejected the detached reference as an
`Illegal invocation` on Workers. Switched to `defaultFetch` from `@v

- [x] `pnpm build && pnpm test && pnpm typecheck && pnpm lint` green
- [ ] Screenshots attached (if UI-affecting) — not UI-affecting

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lets hosts authenticate `useVendoChat` requests by passing a `fetch`. Previously the hook always used the global fetch, which broke bearer-token sessions; now all requests can include headers without changing callers that rely on cookies.

- Adds `fetch?: typeof fetch` to `UseVendoChatOptions`. Defaults to `defaultFetch` from `@vendoai/core`; existing hosts see no behavior change.
- Routes all three requests (send turn, transcript read-back on reload, approval decision) through the provided fetch to avoid half-authenticated conversations.
- Reads `fetch` via a ref so token updates apply to subsequent requests; avoids pinning the first render’s token.
- Updates tests to assert the Authorization header hits the server on every route and that fallback to the global still works.
- Ships as a `patch` to `@vendoai/ui`.

<sup>Written for commit 065318f23069c689e882a6c7f55af54617a302b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

