### PR TITLE
fix(actions): resolve local OpenAPI Path Item references

### DIFF
--- a/packages/actions/src/openapi-document.ts
+++ b/packages/actions/src/openapi-document.ts
@@ -152,7 +152,7 @@ export function extractOpenApiDocument(
   const tools: Array<ExtractedTool & { binding: OpenApiBinding }> = [];
 
   for (const [route, rawPathItem] of Object.entries(paths)) {
-    const pathItem = jsonObject(rawPathItem);
+    const pathItem = jsonObject(resolveRefs(document, rawPathItem));
     for (const lowerMethod of METHODS) {
       const rawOperation = pathItem[lowerMethod];
       if (rawOperation === null || typeof rawOperation !== "object" || Array.isArray(rawOperation)) continue;

--- a/packages/actions/tests/sync/openapi.test.ts
+++ b/packages/actions/tests/sync/openapi.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import type { RunContext } from "@vendoai/core";
 import type { OpenApiBinding, RouteBinding } from "../../src/formats.js";
+import { extractOpenApiDocument } from "../../src/openapi-document.js";
 import { createActions } from "../../src/runtime/registry.js";
 import { runExtractors } from "../../src/sync/extractors.js";
 import { openApiMountPath } from "../../src/sync/openapi.js";
@@ -67,6 +68,31 @@ describe("openApiMountPath", () => {
     ["a trailing slash on the mount point", [{ url: "/cadence/" }], "/cadence"],
   ])("reads %s as %j", async (_label, servers, expected) => {
     expect(await mountOf(servers)).toBe(expected);
+  });
+});
+
+describe("OpenAPI Path Item references", () => {
+  it("extracts operations and parameters from a local referenced Path Item", () => {
+    expect(extractOpenApiDocument({
+      openapi: "3.1.0",
+      info: { title: "Referenced paths", version: "1.0.0" },
+      components: {
+        pathItems: {
+          pets: {
+            parameters: [{ name: "limit", in: "query", schema: { type: "integer" } }],
+            get: { operationId: "listPets", responses: {} },
+          },
+        },
+      },
+      paths: { "/pets": { $ref: "#/components/pathItems/pets" } },
+    })).toMatchObject([{
+      name: "host_listPets",
+      inputSchema: {
+        type: "object",
+        properties: { limit: { type: "integer" } },
+      },
+      binding: { method: "GET", path: "/pets", operationId: "listPets" },
+    }]);
   });
 });
 


### PR DESCRIPTION
  ## What
  
  Resolve local JSON Pointers (`$ref`) on root OpenAPI Path Items before extracting operations from them.
  
  ## Why
  
 OpenAPI 3.1 allows `paths` entries to reference reusable Path Items in `components/pathItems`.
  
 Vendo already resolves `$ref` for parameters and schemas, but was missing the root Path Item. As a result, referenced routes produced no tools.
  
  ## Verification
  
  - [x] `pnpm build && pnpm test && pnpm typecheck && pnpm lint` green
  - [x] **Added a regression test** to `openapi.test.ts` proving that operations and parameters hidden inside a local `$ref` Path Item are now successfully extracted into tool bindings.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve local `$ref` on OpenAPI Path Items in `paths` before extracting operations, so routes that reference `components/pathItems` now produce tools. Previously, only parameter and schema `$ref` were resolved and referenced Path Items yielded no tools.

- Updates `extractOpenApiDocument` to resolve local JSON Pointer references for Path Items before reading operations.
- Adds a regression test that verifies operations and parameters inside a locally referenced Path Item are extracted into tool bindings.

<sup>Written for commit 40a095b73354ace50c9d2c6ee8cc8db4f8bc3988. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

