### PR TITLE
ci(ai-dual): the merge lanes stand on a pinned ai@7, and a nightly takes the newest one instead

### DIFF
--- a/.github/workflows/ai-dual-nightly.yml
+++ b/.github/workflows/ai-dual-nightly.yml
@@ -1,0 +1,33 @@
+name: ai-dual nightly
+
+# The lane that FLOATS. ci.yml calls the same seven legs against the PINNED
+# pairing in scripts/pin-ai-major-7.mjs, so that an upstream publish can no
+# longer red every open branch at whatever hour it clears pnpm's 24h quarantine
+# — which is exactly what ai@7.0.70 did on 2026-08-20, failing PRs and
+# merge_group alike until #1584. This workflow resolves the NEWEST ai@7 every
+# morning instead, on main, so the drift is found here.
+#
+# Red here IS the notification — same as a red main, there is no pager. The fix
+# is a deliberate PR: read the version off the run's "Resolved AI SDK versions"
+# step, fix the break or move the pin, land it with a green run behind it.
+#
+# It provides no required check and never runs on a PR, so it cannot block a
+# merge: `ci`, `integration`, `conformance` and `audit` all live in ci.yml and
+# none of them needs this workflow.
+on:
+  schedule:
+    # 08:00 UTC daily. pnpm quarantines anything published in the last 24h, so
+    # this hour is chosen to sit AFTER the previous evening's npm publishes have
+    # become eligible — a red then names a version that is actually resolvable
+    # today, rather than one nobody can install yet.
+    - cron: "0 8 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  ai-dual:
+    uses: ./.github/workflows/ai-dual.yml
+    with:
+      float: true

--- a/.github/workflows/ai-dual.yml
+++ b/.github/workflows/ai-dual.yml
@@ -1,0 +1,106 @@
+name: ai-dual
+
+# The OTHER AI SDK major (#478). Every other job in ci.yml resolves ai@6 — the
+# version each package's devDependencies pin — so a peer range that claims
+# `ai >=6 <8` is a claim nothing checks. This lane pins the whole tree to the
+# v7 pairing and runs the same suites against it, which is the only way the two
+# live majors can disagree in front of anyone.
+#
+# It lives in its own file because it is called TWICE with the same seven legs:
+#
+#   ci.yml               float: false — the PINNED pairing, on every PR, merge
+#                        queue entry and push to main
+#   ai-dual-nightly.yml  float: true  — the newest ai@7, on main, on a schedule
+#
+# GitHub Actions has no YAML anchors, so "the same matrix, two versions of the
+# SDK" is either one `workflow_call` or seventy duplicated lines that drift.
+# The versions themselves are NOT here — they are the PAIRING map in
+# scripts/pin-ai-major-7.mjs, which is also what `pnpm test:ai7` runs, so a
+# laptop reproduces the pinned lane exactly.
+on:
+  workflow_call:
+    inputs:
+      float:
+        description: Resolve the NEWEST ai@7 pairing instead of the pinned one. The nightly's job.
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  # SHARDED like test-shards, because unsharded it was the whole PR run's
+  # critical path: 31 minutes against every other job's <=9 (main run
+  # 32394860278), of which the serial test phase was 27m30s and @vendoai/vendo
+  # alone was 1171s, ui 377s. Same split as the v6 lane — vendo x4, ui x2 — with
+  # everything else in one `rest` leg, whose own long pole is @vendoai/agents at
+  # 320s. `pnpm test:ai7` is still the one-shot a laptop runs; the three halves
+  # of it are unrolled below so the last one can shard.
+  #
+  # It BUILDS first on purpose: every package compiles with tsc, so a v7 type
+  # break fails here before a single test runs. The shard legs build only their
+  # own closure; `rest` keeps the UNFILTERED build, so examples/ and fixtures/
+  # are still type-checked against v7 somewhere. `store` is the one package with
+  # no `ai` peer at all and three shards' worth of PGlite boots, so it is the one
+  # negation; the rest is `./packages/*`, expressed that way so a new package
+  # joins this lane the day it is created.
+  #
+  # NOT cached: the flipped lockfile hashes differently from every other job's,
+  # so every leg is a cold run by construction. Parallelism is the entire win
+  # here; there is no cache to chase.
+  #
+  # `test` only, never `test:ui` — no browser runs in CI (2026-08-06: headless
+  # mis-resolves :focus-visible and light-dark()), and an SDK major is not a
+  # pixel question anyway. The Playwright suite stays the local pre-PR gate it
+  # is for the v6 lane.
+  ai-dual:
+    name: ai-dual (${{ matrix.name }})
+    runs-on: ubuntu-latest
+    # ~10 minutes of real work on the longest leg (install ~40s, build <=2m30s,
+    # tests <=6m). A timeout is a hang detector, so the ceiling sits well above
+    # that rather than at it.
+    timeout-minutes: 25
+    env:
+      # Both halves, at job level: this job invokes turbo directly, so it does
+      # not inherit the root scripts' caps, and a max-only cap makes Tinypool
+      # throw before a single test runs. Stays at 2 rather than test-shards' 4:
+      # `rest` runs turbo across many packages, which is the outer layer the cap
+      # exists to stop multiplying, and a cold v7 tree is the heaviest install
+      # in the file.
+      VITEST_MIN_FORKS: "1"
+      VITEST_MAX_FORKS: "2"
+      VITEST_MIN_THREADS: "1"
+      VITEST_MAX_THREADS: "2"
+      AI7_FLOAT: ${{ inputs.float }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { name: vendo-1, build: "--filter=@vendoai/vendo", test: "--filter=@vendoai/vendo exec vitest run --shard=1/4" }
+          - { name: vendo-2, build: "--filter=@vendoai/vendo", test: "--filter=@vendoai/vendo exec vitest run --shard=2/4" }
+          - { name: vendo-3, build: "--filter=@vendoai/vendo", test: "--filter=@vendoai/vendo exec vitest run --shard=3/4" }
+          - { name: vendo-4, build: "--filter=@vendoai/vendo", test: "--filter=@vendoai/vendo exec vitest run --shard=4/4" }
+          - { name: ui-1, build: "--filter=@vendoai/ui", test: "--filter=@vendoai/ui exec vitest run --shard=1/2" }
+          - { name: ui-2, build: "--filter=@vendoai/ui", test: "--filter=@vendoai/ui exec vitest run --shard=2/2" }
+          # No build filter = the whole tree; this is the leg that carries the
+          # type-break guarantee above.
+          - { name: rest, build: "", test: "turbo run test --continue --concurrency=2 '--filter=./packages/*' '--filter=!@vendoai/store' '--filter=!@vendoai/vendo' '--filter=!@vendoai/ui'" }
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: node scripts/pin-ai-major-7.mjs
+      - run: pnpm install --no-frozen-lockfile
+      # What the tree actually RESOLVED, straight out of the flipped lockfile.
+      # The nightly is why: it floats, so a red run has to name the version that
+      # broke it, and the lockfile is thrown away with the runner. #1584 was
+      # diagnosed by reconstructing npm publish times by hand — this is that
+      # answer, for free, on every leg. `provider-utils` is in the net on
+      # purpose; it was the co-conspirator in the 7.0.70 break.
+      - name: Resolved AI SDK versions
+        run: grep -oE "^  '?(ai|@ai-sdk/[a-z-]+)@[0-9.]+" pnpm-lock.yaml | tr -d " '" | sort -u
+      - run: pnpm turbo run build ${{ matrix.build }}
+      - run: pnpm ${{ matrix.test }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,9 @@ concurrency:
 #   test-rest         every other package, one job, one turbo run
 #   ai-dual           the same suites against the OTHER AI SDK major (ai@7),
 #                     which is the only thing that can prove the peer range,
-#                     sharded the same way (vendo x4, ui x2, rest)
+#                     sharded the same way (vendo x4, ui x2, rest). The matrix
+#                     itself lives in ai-dual.yml, because ai-dual-nightly.yml
+#                     runs it a second time against the newest ai@7
 #   coverage-merge    merges the shards' blob reports and enforces the
 #                     per-package coverage floors (they cannot be enforced on a
 #                     single shard — see the comment on that job)
@@ -461,82 +463,18 @@ jobs:
         if: always()
         run: stat -c '%n size=%s inode=%i links=%h mtime=%Y' node_modules/.pnpm/@electric-sql+pglite@*/node_modules/@electric-sql/pglite/dist/pglite.data
 
-  # The OTHER AI SDK major (#478). Every other job in this file resolves ai@6 —
-  # the version each package's devDependencies pin — so a peer range that claims
-  # `ai >=6 <8` is a claim nothing checks. This lane pins the whole tree to the
-  # v7 pairing and runs the same suites against it, which is the only way the
-  # two live majors can disagree in front of anyone.
-  #
-  # SHARDED like test-shards, because unsharded it was the whole PR run's
-  # critical path: 31 minutes against every other job's <=9 (main run
-  # 32394860278), of which the serial test phase was 27m30s and @vendoai/vendo
-  # alone was 1171s, ui 377s. Same split as the v6 lane — vendo x4, ui x2 — with
-  # everything else in one `rest` leg, whose own long pole is @vendoai/agents at
-  # 320s. `pnpm test:ai7` is still the one-shot a laptop runs; the three halves
-  # of it are unrolled below so the last one can shard.
-  #
-  # It BUILDS first on purpose: every package compiles with tsc, so a v7 type
-  # break fails here before a single test runs. The shard legs build only their
-  # own closure; `rest` keeps the UNFILTERED build, so examples/ and fixtures/
-  # are still type-checked against v7 somewhere. `store` is the one package with
-  # no `ai` peer at all and three shards' worth of PGlite boots, so it is the one
-  # negation; the rest is `./packages/*`, expressed that way so a new package
-  # joins this lane the day it is created.
-  #
-  # NOT cached: the flipped lockfile hashes differently from every other job's,
-  # so every leg is a cold run by construction. Parallelism is the entire win
-  # here; there is no cache to chase.
-  #
-  # `test` only, never `test:ui` — no browser runs in CI (2026-08-06: headless
-  # mis-resolves :focus-visible and light-dark()), and an SDK major is not a
-  # pixel question anyway. The Playwright suite stays the local pre-PR gate it
-  # is for the v6 lane.
+  # The OTHER AI SDK major (#478), as a reusable workflow: the same seven legs
+  # run again on a nightly schedule against the NEWEST ai@7, so the matrix and
+  # its comments live once, in ai-dual.yml. What this call gets is the PINNED
+  # pairing (scripts/pin-ai-major-7.mjs) — `float` defaults to false — because a
+  # floating range let ai@7.0.70 red every PR and merge_group entry on
+  # 2026-08-20 until #1584.
   ai-dual:
-    name: ai-dual (${{ matrix.name }})
-    runs-on: ubuntu-latest
-    # ~10 minutes of real work on the longest leg (install ~40s, build <=2m30s,
-    # tests <=6m). A timeout is a hang detector, so the ceiling sits well above
-    # that rather than at it.
-    timeout-minutes: 25
     needs: cone
     # Same reasoning as the shards' RUN gate: the version PR puts every package
     # in the cone and there is nothing here for it to prove.
     if: needs.cone.outputs.heavy == 'true'
-    env:
-      # Both halves, at job level: this job invokes turbo directly, so it does
-      # not inherit the root scripts' caps, and a max-only cap makes Tinypool
-      # throw before a single test runs. Stays at 2 rather than test-shards' 4:
-      # `rest` runs turbo across many packages, which is the outer layer the cap
-      # exists to stop multiplying, and a cold v7 tree is the heaviest install
-      # in the file.
-      VITEST_MIN_FORKS: "1"
-      VITEST_MAX_FORKS: "2"
-      VITEST_MIN_THREADS: "1"
-      VITEST_MAX_THREADS: "2"
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - { name: vendo-1, build: "--filter=@vendoai/vendo", test: "--filter=@vendoai/vendo exec vitest run --shard=1/4" }
-          - { name: vendo-2, build: "--filter=@vendoai/vendo", test: "--filter=@vendoai/vendo exec vitest run --shard=2/4" }
-          - { name: vendo-3, build: "--filter=@vendoai/vendo", test: "--filter=@vendoai/vendo exec vitest run --shard=3/4" }
-          - { name: vendo-4, build: "--filter=@vendoai/vendo", test: "--filter=@vendoai/vendo exec vitest run --shard=4/4" }
-          - { name: ui-1, build: "--filter=@vendoai/ui", test: "--filter=@vendoai/ui exec vitest run --shard=1/2" }
-          - { name: ui-2, build: "--filter=@vendoai/ui", test: "--filter=@vendoai/ui exec vitest run --shard=2/2" }
-          # No build filter = the whole tree; this is the leg that carries the
-          # type-break guarantee above.
-          - { name: rest, build: "", test: "turbo run test --continue --concurrency=2 '--filter=./packages/*' '--filter=!@vendoai/store' '--filter=!@vendoai/vendo' '--filter=!@vendoai/ui'" }
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-        with:
-          node-version: 22
-          cache: pnpm
-      - run: node scripts/pin-ai-major-7.mjs
-      - run: pnpm install --no-frozen-lockfile
-      - run: pnpm turbo run build ${{ matrix.build }}
-      - run: pnpm ${{ matrix.test }}
+    uses: ./.github/workflows/ai-dual.yml
 
   # The per-package coverage floors (vendo 78 / store 84 / ui 90, each in the
   # package's vitest config) live HERE, because a floor is only meaningful

--- a/scripts/pin-ai-major-7.mjs
+++ b/scripts/pin-ai-major-7.mjs
@@ -14,20 +14,40 @@
  */
 import { readFile, writeFile } from "node:fs/promises";
 
-/** The v7 pairing. Each `@ai-sdk/*` major is the one that ships against ai@7. */
+/**
+ * THE PIN. Each `@ai-sdk/*` major is the one that ships against ai@7, and every
+ * version here is EXACT for one reason: a floating range hands upstream the
+ * power to red every open branch at whatever hour its publish clears pnpm's 24h
+ * quarantine. Not hypothetical — `ai@7.0.70` did precisely that on 2026-08-20,
+ * failed `ai-dual` on every PR and merge_group alike, and blocked the queue
+ * until #1584.
+ *
+ * So the lanes people merge against are pinned, and the ai-dual NIGHTLY
+ * workflow is the thing that floats (AI7_FLOAT below): upstream drift gets
+ * found on a schedule, against main, where a red is a notification instead of
+ * everyone's problem. Moving a version here is therefore a deliberate PR with
+ * a green run behind it — never an accident of the clock.
+ *
+ * These six are what the lane last ran green on: main run 32525724379,
+ * 2026-08-21T20:53Z.
+ */
 const PAIRING = {
-  ai: "^7.0.0",
-  "@ai-sdk/anthropic": "^4.0.0",
-  "@ai-sdk/react": "^4.0.0",
-  "@ai-sdk/openai": "^4.0.0",
-  "@ai-sdk/google": "^4.0.0",
-  "@ai-sdk/openai-compatible": "^3.0.0",
+  ai: "7.0.71",
+  "@ai-sdk/anthropic": "4.0.40",
+  "@ai-sdk/react": "4.0.74",
+  "@ai-sdk/openai": "4.0.45",
+  "@ai-sdk/google": "4.0.48",
+  "@ai-sdk/openai-compatible": "3.0.33",
 };
 
+// The nightly floats the same pairing to the newest of each major. `^` on an
+// exact version is exactly that range, so the one flag covers all six and the
+// pinned set stays the single list to edit.
+const caret = process.env.AI7_FLOAT === "true" ? "^" : "";
 const file = new URL("../pnpm-workspace.yaml", import.meta.url);
-const pins = Object.entries(PAIRING).map(([name, range]) => `  "${name}": "${range}"`).join("\n");
+const pins = Object.entries(PAIRING).map(([name, v]) => `  "${name}": "${caret}${v}"`).join("\n");
 const manifest = await readFile(file, "utf8");
 if (!/^overrides:$/m.test(manifest)) throw new Error("pnpm-workspace.yaml has no `overrides:` block to pin into");
 await writeFile(file, manifest.replace(/^overrides:$/m, `overrides:\n${pins}`));
-console.log(`pinned the AI SDK to its v7 pairing:\n${pins}\n`);
+console.log(`${caret ? "FLOATED" : "pinned"} the AI SDK to its v7 pairing:\n${pins}\n`);
 console.log("this edit is throwaway — `git checkout pnpm-workspace.yaml pnpm-lock.yaml && pnpm install` puts the tree back on ai@6.\n");


### PR DESCRIPTION
`ai-dual` floats `ai@^7.0.0` on every PR, queue entry and push. That hands upstream a switch that reds every open branch at whatever hour a publish clears pnpm's 24h quarantine — which is not a hypothetical: `ai@7.0.70` did exactly that on 2026-08-20 and blocked the merge queue until #1584.

So: **the lanes people merge against are pinned, and a nightly floats.**

## The pin

`scripts/pin-ai-major-7.mjs` — the one obvious place, already the single declaration of the v7 pairing and already what `pnpm test:ai7` runs, so a laptop now reproduces the CI lane exactly. `PAIRING` holds exact versions instead of carets:

```
ai                        7.0.71
@ai-sdk/anthropic         4.0.40
@ai-sdk/react             4.0.74
@ai-sdk/openai            4.0.45
@ai-sdk/google            4.0.48
@ai-sdk/openai-compatible 3.0.33
```

Those six are not a guess — they are what the lane **last ran green on** (main run 32525724379, 2026-08-21T20:53Z), derived by taking each package's newest version published before that run's 24h quarantine cutoff. This PR's own `ai-dual` run re-proves them.

## The nightly

`ai-dual-nightly.yml` — `schedule` at 08:00 UTC plus `workflow_dispatch`, on main, floating. Red on it **is** the notification; no pager, same convention as a red main. It provides no required check and has no `pull_request` trigger, so it cannot block a merge — `ci`, `integration`, `conformance` and `audit` all still live in ci.yml and none of them needs it.

## Why a third file

The same seven legs now run twice, and GitHub Actions has no YAML anchors — this file already says so in the `test-shards` comment. So the matrix moved to `ai-dual.yml` as a `workflow_call` with one `float` input, and both callers are ~4 lines. ci.yml gets 82 lines lighter; nothing about the matrix, the shard split, the caps or the timeout changed.

One flag covers all six pins: `^` prefixed onto an exact version *is* the "newest of this major" range, so the pinned list stays the single thing to edit.

## Constraints held

- required-check names untouched (`ci`, `integration`, `conformance`, `audit`); `ci`'s `needs` still lists `ai-dual` and a `workflow_call` job rolls up into one `needs` result exactly like a matrix did
- the `heavy` cone gate stays on the caller job in ci.yml, unchanged
- both halves of the vitest caps still set at job level on the matrix job
- timeout still 25m against ~10m of real work
- new diagnostic step prints the **resolved** AI SDK versions from the flipped lockfile on every leg. #1584 had to be diagnosed by reconstructing npm publish times by hand; a floating nightly that goes red must name the version itself

## Note for reviewers

The ai-dual **check names** change from `ai-dual (vendo-1)` to `ai-dual / ai-dual (vendo-1)` — that is how a called workflow reports. None of them is a required check.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the `ai@7` pairing for PR and merge lanes and adds a nightly that floats to the newest `ai@7`. Previously `ai-dual` floated `ai@^7.0.0` on every run; now merge lanes use a last-known-green pin, and a scheduled run on main detects upstream drift.

- `scripts/pin-ai-major-7.mjs` now writes exact versions; set `AI7_FLOAT=true` to prefix `^` and float the same majors.
- New reusable workflow `ai-dual.yml`; `ci.yml` calls it with `float: false` (pinned), and `ai-dual-nightly.yml` calls it with `float: true` at 08:00 UTC and via `workflow_dispatch`.
- Adds a diagnostic step to print resolved `ai`/`@ai-sdk/*` versions from `pnpm-lock.yaml`.
- Required checks and gates are unchanged; the job names show as `ai-dual / ai-dual (vendo-1)` etc., none are required.
- Local runs match CI: `pnpm test:ai7` uses the same pinned pairing. If the nightly goes red, update the pins in `scripts/pin-ai-major-7.mjs` or fix the break and land with a green run.

<sup>Written for commit 10ec937fe4e6c805cb1e01d4cb71b7000ae5737a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

