### PR TITLE
chore: scratch — float-path proof for the ai-dual nightly, do not merge

### DIFF
--- a/.github/workflows/ai-dual-nightly.yml
+++ b/.github/workflows/ai-dual-nightly.yml
@@ -22,6 +22,8 @@ on:
     # today, rather than one nobody can install yet.
     - cron: "0 8 * * *"
   workflow_dispatch:
+  # SCRATCH ONLY — proving the float path pre-merge. Do not merge.
+  pull_request:
 
 permissions:
   contents: read


### PR DESCRIPTION
Throwaway. Adds a temporary `pull_request:` trigger to `ai-dual-nightly.yml` so the float path (`float: true` → newest ai@7) actually runs pre-merge — `workflow_dispatch` is not registered until the workflow lands on the default branch. Closed once it reports.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs the ai-dual nightly float path on PRs so we can verify against the newest `ai@7` before merge. Previously it ran only on the cron and via `workflow_dispatch` after landing on default; now PRs to this branch also trigger it.

- Scratch change for proof only; do not merge. Close after the job reports and remove the `pull_request` trigger.
- CI-only impact: adds a PR job to this workflow; no product/runtime changes.
- Supports Linear ENG-105 by enabling pre-merge e2e/verification against the latest AI build.

<sup>Written for commit 676b49d1a934692995b908ed28e3adb42c3b4516. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

