### PR TITLE
ci(release): a push to main is the release — no version PR, no second queue trip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,19 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
+      # The same GitHub-cache-backed turbo remote cache ci.yml fills, so `build`
+      # and `typecheck` below replay whatever has already been built for this
+      # exact commit instead of recompiling it.
+      #
+      # How much that is depends on a race, honestly: the tag names the version
+      # commit, and main's own CI run on that commit starts seconds before this
+      # one, so the two build in parallel and this job replays only the tasks CI
+      # finished first. What is NOT a race is a second run at the same tag — a
+      # re-run after a flaky publish reads back its own tag-scoped cache and is
+      # pure replay. (GitHub scopes cache writes to the current ref and lets any
+      # ref read the default branch's, which is what makes both directions work.)
+      - name: Turbo remote cache (GitHub-cache backed)
+        uses: rharkor/caching-for-turbo@2238fae6eb9a9936f92356f54cb3660200d105e7 # v2.5.1
       - run: pnpm install --frozen-lockfile
       # BUILD + TYPECHECK, not the full gate. This workflow only ever runs at a
       # tag, and that tag's tree already merged through main's required checks

--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -1,23 +1,33 @@
 name: Version Packages
 
-# Keeps a "chore: version packages" PR open on main whenever there are
-# pending changesets. Releasing = merge that PR; the post-merge run of this
-# workflow pushes the `v<version>` tag and then dispatches release.yml at that
-# tag, which does the publish. Merging the version PR is the deliberate act.
+# Releasing is a push to main with pending changesets, and nothing else. This
+# workflow consumes them in place: `changeset version` runs HERE, the result is
+# committed straight to main, tagged, and release.yml is dispatched at that tag
+# to publish. There is no "Version Packages" PR any more. That PR cost a second
+# ~15-minute trip through the merge queue to re-prove a diff that is only
+# CHANGELOGs and version fields, on a tree whose real changes had already
+# passed every required check on the way in.
 #
-# The dispatch is the whole automation. GitHub never triggers a workflow from
-# anything pushed with the default GITHUB_TOKEN, so the tag push alone publishes
-# nothing — v0.23.0 is tagged and published nothing. `workflow_dispatch` is the
-# documented exception GITHUB_TOKEN may trigger, and dispatching release.yml
-# keeps it the top-level workflow of its run, which is what npm's trusted
-# publisher config names for every @vendoai package (npm validates the calling
-# workflow's filename, so `workflow_call` would break OIDC publishing).
+# Pushing to main directly is granted, not stolen: main's merge-queue ruleset
+# and its branch protection both give the repository-admin role an always
+# bypass, and RELEASE_PAT is yousefh409's. GITHUB_TOKEN is not an admin, so
+# without that secret the push below is refused and nothing releases.
 #
-# RELEASE_PAT (optional repo secret): GitHub also never triggers workflows from
-# the version PR's own commits, so without this secret the version PR gets no
-# checks until someone closes and reopens it. Publishing no longer depends on
-# it. Fine-grained PAT scoped to this repo only — Contents: read+write, Pull
-# requests: read+write — stored as the secret RELEASE_PAT.
+# The version commit goes up under a real credential, so it triggers this
+# workflow again. That run finds no changesets left, sees the tag it would push
+# already on the remote, and exits green having done nothing. That path is
+# load-bearing twice over: it is what keeps the loop from eating itself, and —
+# because it decides on the remote's tags rather than on what this run did — it
+# is also how a release interrupted between its commit and its tag gets
+# finished by the next push to main instead of vanishing.
+#
+# The dispatch is the whole publish automation. GitHub never triggers a workflow
+# from anything pushed with the default GITHUB_TOKEN, so the tag push alone
+# publishes nothing — v0.23.0 is tagged and published nothing. `workflow_dispatch`
+# is the documented exception GITHUB_TOKEN may trigger, and dispatching
+# release.yml keeps it the top-level workflow of its run, which is what npm's
+# trusted publisher config names for every @vendoai package (npm validates the
+# calling workflow's filename, so `workflow_call` would break OIDC publishing).
 
 on:
   push:
@@ -25,7 +35,6 @@ on:
 
 permissions:
   contents: write
-  pull-requests: write
   # Dispatching release.yml is an Actions write.
   actions: write
 
@@ -37,9 +46,9 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
-          # The PAT has to be here too, not just on the action: changesets/action
-          # pushes the version branch with a plain `git push`, so it uses the
-          # credentials checkout persists.
+          # The PAT belongs here, not only in a step env: the version commit
+          # goes up with a plain `git push`, which uses the credentials
+          # checkout persists.
           token: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
@@ -47,14 +56,20 @@ jobs:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - id: changesets
-        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
-        with:
-          version: pnpm changeset:version
-          commit: "chore: version packages"
-          title: "chore: version packages"
-        env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
+
+      # The `versioned` output gates the two steps below, so a push with no
+      # pending changesets — an ordinary commit, or the version commit's own
+      # push event — falls through to the tag step having changed nothing.
+      - name: Version the pending changesets
+        id: version
+        run: |
+          set -euo pipefail
+          if [ -z "$(find .changeset -name '*.md' ! -name README.md)" ]; then
+            echo "no pending changesets"
+            exit 0
+          fi
+          pnpm changeset:version
+          echo "versioned=true" >>"$GITHUB_OUTPUT"
 
       # THE 0.x CEILING — deliberate, not a bug. Vendo does not ship 1.0.0 until
       # Yousef says so, and lifting this ceiling is his call alone: delete this
@@ -63,88 +78,72 @@ jobs:
       # A major is not a one-package event here. All 13 packages are a single
       # changesets `fixed` group, so ONE `major` changeset drags every one of
       # them to 1.0.0 — that is exactly what happened on 2026-08-15, when four
-      # majors put 1.0.0 on all 13 in the version PR and the numbers had to be
-      # walked back by hand. So this does not look for a literal "1.0.0" in a
-      # changeset; it reads the versions the bot actually wrote on its branch —
-      # the same numbers a human reads off the version PR — and fails if any of
-      # them left 0.x. Downgrade the changeset to `minor` and this goes green.
+      # majors put 1.0.0 on all 13 and the numbers had to be walked back by
+      # hand. So this does not look for a literal "1.0.0" in a changeset; it
+      # reads the versions `changeset version` just wrote. It runs before the
+      # commit, so the runner's working tree is the only copy that has ever held
+      # them: failing here leaves main untouched and there is nothing to undo.
+      # Downgrade the changeset to `minor` and this goes green.
       - name: Guard the 0.x ceiling
-        if: steps.changesets.outputs.hasChangesets == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
-          PR: ${{ steps.changesets.outputs.pullRequestNumber }}
+        if: steps.version.outputs.versioned == 'true'
         run: |
           set -euo pipefail
-          git fetch origin changeset-release/main
           crossed=""
-          for f in $(git ls-tree -r --name-only FETCH_HEAD | grep -E '^packages/[^/]+/package\.json$'); do
-            read -r name version <<<"$(git show "FETCH_HEAD:$f" | jq -r '.name + " " + .version')"
+          for f in packages/*/package.json; do
+            read -r name version <<<"$(jq -r '.name + " " + .version' "$f")"
             case "$version" in
               0.*) ;;
               *) crossed="$crossed $name@$version" ;;
             esac
           done
           if [ -n "$crossed" ]; then
-            # Disarm before failing. Failing this step stops the arming step
-            # below from running, but it cannot un-arm a PR that was already
-            # armed on an earlier, still-0.x push — and that PR would carry
-            # 1.0.0 into main by itself the moment its checks went green.
-            # Disarming an unarmed PR is already a clean no-op, so `|| true` is
-            # here for one reason: nothing gh does may swallow the error below.
-            gh pr merge "$PR" --disable-auto || true
             echo "::error::proposed versions left 0.x —$crossed. Vendo stays below 1.0.0 until Yousef lifts the ceiling; use a minor changeset."
             exit 1
           fi
 
-      # Arm GitHub's native auto-merge so the version PR merges itself the
-      # moment ci/integration/conformance/audit are green — main runs a merge
-      # queue (ruleset merge-queue-main, SQUASH), so this enqueues rather than
-      # merges directly. It sits AFTER the 0.x guard on purpose: a version PR
-      # that crossed the ceiling must never be armed.
+      # THE CHANGESET RACE, in its only remaining form: a changeset-carrying
+      # commit landing on main while this job runs. The push then is not a
+      # fast-forward and git refuses it — which is the whole guard. Do not
+      # force, and do not retry in-run: a retry would version on top of a tree
+      # this job never checked out. Nothing needs repairing by hand either. The
+      # commit that won the race triggers this workflow itself, and that run
+      # versions every pending changeset, this one's included, under the next
+      # number.
       #
-      # RELEASE_PAT, not GITHUB_TOKEN, and this step is worthless without it —
-      # for both halves of the same rule. Without the PAT the version PR gets no
-      # checks at all (see the header), so required checks never report and
-      # auto-merge would wait forever; and the merge it eventually performs is
-      # attributed to whoever armed it, so a GITHUB_TOKEN merge would land on
-      # main without re-triggering this workflow — no tag, no publish.
-      - name: Arm auto-merge on the version PR
-        if: steps.changesets.outputs.pullRequestNumber != ''
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
-          PR: ${{ steps.changesets.outputs.pullRequestNumber }}
+      # `git add -A`, not `commit -a`: a package's first CHANGELOG.md is
+      # untracked, and `-a` would leave it out of the release it documents.
+      - name: Commit the version to main
+        if: steps.version.outputs.versioned == 'true'
         run: |
-          if [ -z "$GH_TOKEN" ]; then
-            echo "::notice::RELEASE_PAT is not set — PR #$PR stays a manual merge"
-            exit 0
+          set -euo pipefail
+          git add -A
+          git -c user.name='github-actions[bot]' \
+              -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
+              commit -m "chore: version packages"
+          if ! git push origin HEAD:main; then
+            echo "::error::main moved while this release was being versioned, so the version commit is not a fast-forward and was NOT pushed. Nothing to repair: the next push to main releases these changesets."
+            exit 1
           fi
-          # Re-arming an armed PR is a no-op, so this is safe on every push.
-          gh pr merge "$PR" --auto --squash
 
-      # THE CHANGESET RACE: a changeset-carrying PR landed in the gap between
-      # this version PR being cut and it merging, so the tag step below sees
-      # those leftover changesets and skips — a green run that released nothing
-      # (phantom 0.31.0 on 2026-08-19, run 32250259707). Every other skip is a
-      # healthy no-op; this one loses a release, so it has to be loud. Nothing to
-      # repair by hand: the version PR the step above just re-opened ships this
-      # one's changelog too, under the next number.
-      - name: Fail a swallowed release
-        # Quoted because the commit subject it matches contains a colon.
-        if: "steps.changesets.outputs.hasChangesets == 'true' && startsWith(github.event.head_commit.message, 'chore: version packages')"
-        run: |
-          echo "::error::Release skipped: changesets landed after this version PR was cut. Nothing was published — merge the next Version Packages PR to release."
-          exit 1
-
-      # No changesets left = this push is the version PR landing (or an ordinary
-      # commit after a release, where the tag already exists and this no-ops), so
-      # package.json already holds the released version. `changeset tag` is
-      # deliberately not used: in a workspace it writes one `<pkg>@<version>` tag
-      # per package, and release.yml — like every release so far — is keyed on
-      # the single lockstep `v<version>`. packages/vendo is the version of record
-      # (scripts/sync-version-constants.mjs reads the same file).
+      # UNGATED, and the remote's tags are what it decides on — not whether this
+      # run versioned anything. That is what makes every push to main a retry of
+      # a half-finished release: a run that pushed the version commit and then
+      # died before tagging has consumed its changesets, so nothing would ever
+      # release that version again, silently. Now the next push finds
+      # `v<version>` missing and finishes the job. If instead the tag went up and
+      # only the dispatch below failed, that run is red with the tag already in
+      # place, and the one-line repair is `gh workflow run release.yml --ref
+      # <tag> -f publish=true`.
+      #
+      # The existing-tag skip is also the correct answer for an ordinary commit
+      # (tag already pushed, nothing to do) and for any release that leaves the
+      # umbrella version alone. `changeset tag` is deliberately not used to name
+      # it: in a workspace it writes one `<pkg>@<version>` tag per package, and
+      # release.yml — like every release so far — is keyed on the single lockstep
+      # `v<version>`. packages/vendo is the version of record
+      # (sync-version-constants.mjs reads the same file).
       - name: Push the release tag
         id: tag
-        if: steps.changesets.outputs.hasChangesets == 'false'
         env:
           # The built-in token, spelled out, because the checkout above persists
           # RELEASE_PAT and a plain `git push origin` would inherit it. A real
@@ -157,14 +156,14 @@ jobs:
         run: |
           set -euo pipefail
           tag="v$(node -p "require('./packages/vendo/package.json').version")"
-          # Second half of the 0.x ceiling above: that guard fails the version
-          # PR, this one refuses to tag or publish a 1.0.0 that got past it.
+          # Second half of the 0.x ceiling above: that guard keeps a 1.0.0 off
+          # main, this one refuses to tag or publish one that got past it.
           case "$tag" in
             v0.*) ;;
             *) echo "::error::$tag left 0.x — Yousef lifts the ceiling, not a release run."; exit 1 ;;
           esac
           if git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null 2>&1; then
-            echo "$tag already exists — nothing to release"
+            echo "$tag is already tagged — nothing to release"
             exit 0
           fi
           git tag "$tag"
@@ -174,11 +173,12 @@ jobs:
 
       # The tag push above used GITHUB_TOKEN, so release.yml's `push: tags`
       # trigger did NOT fire (by GitHub's design) — dispatching it here is what
-      # turns a merged version PR into a published release. `--ref "$tag"` pins
-      # the publish to the exact commit that was tagged, not to whatever main
-      # has drifted to.
+      # turns a versioned main into a published release. `--ref "$TAG"` pins the
+      # publish to the exact commit that was tagged, not to whatever main has
+      # drifted to.
       - name: Publish the tag
         if: steps.tag.outputs.tag != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh workflow run release.yml --ref "${{ steps.tag.outputs.tag }}" -f publish=true
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: gh workflow run release.yml --ref "$TAG" -f publish=true


### PR DESCRIPTION
Two cuts to the release pipeline, in one PR. Both are the approved amendment to the pipeline that shipped on 2026-08-21.

## Cut 1 — the Version PR is gone; main is versioned in place

Before: push to main with pending changesets → open/update a "Version Packages" PR → arm auto-merge → wait for the merge queue → the post-merge push run tags and dispatches. That is ~15 minutes of queue to re-prove a diff that is only CHANGELOGs and `version` fields, on a tree whose real changes already passed `ci`, `integration`, `conformance` and `audit` on the way in.

After: the same push run does it all. `changeset version` runs on the runner, the 0.x guard reads the versions it just wrote, the result is committed straight to main, tagged, and `release.yml` is dispatched. One run, ~1 minute to the tag.

The direct push is granted, not stolen — main's `merge-queue-main` ruleset and its branch protection both give the repository-admin role an always-bypass, and `RELEASE_PAT` is `yousefh409`'s:

```
$ gh api repos/runvendo/vendo/rulesets/20905426
  bypass_actors: [{ actor_type: RepositoryRole, actor_id: 5, bypass_mode: always }]
  current_user_can_bypass: always
$ gh api repos/runvendo/vendo/branches/main/protection
  enforce_admins: false
```

`GITHUB_TOKEN` is not an admin, so without that secret the push is simply refused and nothing releases.

### Guards

**The 0.x ceiling survives, in a better place.** It now reads the versions `changeset version` just wrote in the runner's working tree — *before* anything is committed or pushed. Failing it leaves main untouched, so the old "disarm auto-merge before failing" dance is gone; there is nothing left to disarm. The second-half `v0.` check in the tag step stays (Yousef's word is required to remove it).

**The swallowed-release race becomes a push race.** A changeset-carrying commit landing on main mid-job makes the version push a non-fast-forward, and git refuses it. That failure is the guard: `::error::`, no force, no in-run retry. Nothing to repair by hand — the commit that won the race triggers this workflow itself, and that run releases these changesets under the next number.

**Self-heal (reviewer P2, greptile + cubic).** The tag step is *ungated* and decides on the remote's tags, not on whether this run versioned anything, so every push to main is a retry of a half-finished release. A run that pushed its version commit and then died before tagging has consumed its changesets — without this, nothing would ever release that version again and the loss would be silent. Now the next push finds `v<version>` missing and finishes the job. The same probe correctly no-ops on an ordinary commit, and correctly skips any release that leaves the umbrella version alone. Not covered, and said so in the step's comment: if the tag went up and only the *dispatch* failed, that run is red with the tag in place and the repair is `gh workflow run release.yml --ref <tag> -f publish=true` — auto-healing that would mean re-dispatching into a possibly-live publish, i.e. the #1585 collision.

**Loop safety.** The version commit goes up under a real credential, so it triggers this workflow again. That run finds no pending changesets, emits no `tag` output, and every step below is skipped: a green no-op. The commit subject keeps the `chore: version packages` prefix, so history reads exactly as it did.

**The publish interlock from #1585 is untouched.** The tag is still pushed with `GITHUB_TOKEN` through an explicit `TAG_PUSH_URL` (so `release.yml`'s `push: tags` cannot fire), and the explicit `gh workflow run release.yml` dispatch is still the single publish trigger.

### Deleted, not commented out

- the `changesets/action` step (PR mode)
- the "Arm auto-merge on the version PR" step, and the `pull-requests: write` permission it needed
- the "Fail a swallowed release" step — that race is now the non-fast-forward push
- the `gh pr merge --disable-auto` disarm inside the 0.x guard

Net: **-11 lines** on `version-packages.yml`.

## Cut 3 — warm the release build off the shared turbo cache

`release.yml` now runs the same `rharkor/caching-for-turbo` step `ci.yml` uses in five places, so `pnpm build` and `pnpm typecheck` replay instead of recompiling. No turbo outputs were touched, so the hard-link truncation trap is not in play.

Local proof that both commands are fully cacheable:

```
$ pnpm build      # cold
 Tasks: 22 successful, 22 total   Cached: 0 cached, 22 total   Time: 37.729s
$ pnpm build      # again
 Tasks: 22 successful, 22 total   Cached: 22 cached, 22 total  Time: 238ms >>> FULL TURBO

$ pnpm typecheck  # again
 Tasks: 44 successful, 44 total   Cached: 44 cached, 44 total  Time: 230ms >>> FULL TURBO
```

**Honest about the size of this win.** A version bump rewrites every publishable `package.json`, and `build` `dependsOn: ["^build"]`, so the bump invalidates almost the whole graph — measured on this branch, only **5 of 32** build tasks keep their hash across a `changeset version` (`context-e2e`, `existing-agents-e2e`, `install-seam`, `test-kit`, `@vendoai/telemetry` — the leaves with no `@vendoai` dependency). So the previous main CI run cannot pre-warm this. The warm source is main's *own* CI run on the version commit, which starts seconds before the release run and builds in parallel — this job replays only the tasks that run finished first. What is not a race: a **re-run at the same tag** (the flaky-publish path) is pure replay off its own tag-scoped cache. The comment in the file says exactly this rather than promising the ~6→~2 min.

## Proof

- `actionlint` exit 0 on both touched workflows (the four pre-existing `SC2086` infos in `ci.yml` are untouched and deliberate — `$CONE` must word-split).
- `pnpm build`, `pnpm typecheck`, `pnpm lint` green locally. `pnpm changeset status --since=origin/main` reports no packages to bump, so `changeset-required` passes on a workflow-only diff.
- **Dry runs of the new steps**, against this worktree with synthetic changesets (main at `0.37.0`):
  - **ordinary push, no changesets** → `no pending changesets`, then `v0.37.0 is already tagged — nothing to release`. Empty `$GITHUB_OUTPUT`, dispatch skipped, clean tree.
  - **self-heal** (umbrella `0.36.99` on main, zero changesets, no `v0.36.99` on origin) → version step no-ops, tag step resumes: `WOULD: git tag v0.36.99 …`, `GITHUB_OUTPUT=[tag=v0.36.99]`. The release is recovered by the next push.
  - **telemetry-only changeset** → telemetry `0.5.0 -> 0.5.1` **and umbrella `0.37.0 -> 0.38.0`**. `@vendoai/vendo` depends on `@vendoai/telemetry: workspace:*` and `updateInternalDependencies: "patch"` bumps that dependent, which is in the `fixed` group. Fresh tag, no collision — this refutes cubic's P1.
  - **one `minor` changeset** → `tag=v0.38.0`; `git add -A` stages exactly the 13 `package.json` + 13 `CHANGELOG.md` + `packages/vendo/src/cli/shared.ts` + `packages/core/src/version.ts`, and the tracked changesets as deletions. Nothing else.
  - **a `major` changeset** → `changeset version` produces 1.0.0 across the fixed group and the guard fails first:
    ```
    ::error::proposed versions left 0.x — @vendoai/actions@1.0.0 @vendoai/agents@1.0.0 … vendoai@1.0.0.
    Vendo stays below 1.0.0 until Yousef lifts the ceiling; use a minor changeset.
    ```
    exit 1, before the commit step. Main would never have been touched.

## What this PR cannot prove

Two things, and only the next organic release proves either:

1. **The direct push to main actually lands.** The bypass is verified by API above, but no CI job can rehearse `RELEASE_PAT` pushing to a protected `main` — the first real release is the first time that push runs.
2. **The end-to-end timing.** The ~15 min → ~1 min claim for cut 1 and the size of cut 3's cache win are both measured only when a real release goes through.

Everything else — the guards, the no-op path, the commit contents, the tag/dispatch interlock — is exercised above.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make a push to `main` the release. Before: a push opened/updated a “Version Packages” PR, waited for the merge queue, then tagged and dispatched. Now: the same push versions in place, commits to `main`, tags, and dispatches `release.yml`, removing the second queue trip and cutting tag time from ~15 minutes to ~1 minute.

- Enforce the 0.x ceiling before the commit; the tag step still refuses `v1.0.0+`. Failures leave `main` untouched.
- Replace `changesets/action` with an in-job `pnpm changeset:version`; if no changesets, skip. The version commit uses a real credential; a changeset race becomes a non-fast-forward push that fails without force or retry.
- Loop safety and recovery: the tag step is ungated and decides from the remote. It tags the lockstep `v<version>` from `packages/vendo/package.json` only when missing, so retriggers no-op and any release interrupted after the commit finishes on the next push.
- Publish interlock unchanged: push the tag with `GITHUB_TOKEN` (so `push: tags` does not fire) and dispatch `release.yml` via `gh workflow run --ref <tag>`.
- Warm release builds: `release.yml` adds `rharkor/caching-for-turbo@v2.5.1` so `pnpm build`/`pnpm typecheck` replay from the shared cache; re-runs at the same tag are pure replay.
- Rollout: set `RELEASE_PAT` (fine‑grained PAT for this repo; Contents read/write, Actions dispatch) so the version commit can bypass protections and land on `main`. Without it, the push is refused and nothing releases.
- Removed: the “Version Packages” PR path and `pull-requests: write`.

<sup>Written for commit b863d8a00c9de2dc04615494ba0b4d81d78be477. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


