### PR TITLE
fix(guard,vendo,ui): the card an MCP-door approval settles on says the person's yes landed, not that it expired

### DIFF
--- a/.changeset/door-approval-consumed.md
+++ b/.changeset/door-approval-consumed.md
@@ -1,0 +1,35 @@
+---
+"@vendoai/guard": patch
+"@vendoai/vendo": patch
+"@vendoai/ui": patch
+---
+
+An approval card for a call parked at the MCP door no longer reads "expired" on
+the approval the person just granted.
+
+The door parks through the plain guard-bound registry, so — unlike the in-process
+tool pack — nothing records a parked call and nothing resumes one: approving
+GRANTS the call, and the outside agent's own retry runs it, exactly as the door's
+refusal sentence says ("resolve it there, then retry"). `GET /approvals/:id` knew
+only about the two lanes that DO leave a record, so the moment a door approval
+left the guard's pending queue every read fell through to not-found — which
+`<VendoApprovalEmbed>` renders as "Expired — no longer waiting for approval",
+in red, on a call that was about to run and then did. Deny and the TTL sweep hit
+the same hole; all three answered "expired".
+
+The wire now falls back to the guard's own row for an approval no lane recorded,
+so the status it reports tells the four cases apart at the server rather than
+leaving the card to guess:
+
+- approved, and the retry has spent it — `executed`, the card's "Approved — ran"
+- approved, not spent yet — `pending`, so the card holds its working beat and its
+  poll through the gap instead of settling on a receipt for something that has
+  not happened
+- denied by a person — `declined`
+- denied by the TTL sweep, or a yes taken back — `expired` / `declined`
+
+`VendoGuard.approvals.get` reports the three markers this needs beside the status
+(`consumedAt`, `voidedAt`, `deniedBy`), each optional so an implementation that
+returns only the original two fields still satisfies it. `outcome` is now optional
+on the `executed` resolution: nothing server-side ran a door-parked call, so its
+receipt can honestly say that it ran and nothing more.

--- a/docs-site/existing-agent/embeds.mdx
+++ b/docs-site/existing-agent/embeds.mdx
@@ -102,6 +102,8 @@ A guarded call that needs approval does not throw and does not stall your turn. 
 
 When the person approves in the card, the wire runs the parked call and the card resolves in place. Deny throws it away.
 
+A call parked at the [MCP door](/outside-agents/your-own-agent) is the one exception: approving there grants the call, and the outside agent's own retry of it is what runs it. The card waits through that gap on its working beat, then settles on "Approved — ran" once the retry spends the approval.
+
 <Frame>
   <img
     src="/images/existing-agents/embed-approval.png"

--- a/packages/guard/src/guard.ts
+++ b/packages/guard/src/guard.ts
@@ -48,6 +48,7 @@ import {
 } from "@vendoai/core";
 import { PolicyResolver, resolvePolicyConfig, ruleMatches } from "./policy.js";
 import type {
+  ApprovalReading,
   CreateGuardConfig,
   Judge,
   PolicyConfigObject,
@@ -547,10 +548,7 @@ class GuardImplementation implements VendoGuard {
     parkedCallTtlMs: DEFAULT_PARKED_CALL_TTL_MS,
     pending: (principal: Principal): Promise<ApprovalRequest[]> =>
       this.#pendingApprovals(principal),
-    get: (
-      id: ApprovalId,
-      principal: Principal,
-    ): Promise<{ request: ApprovalRequest; status: ApprovalRecordData["status"] } | undefined> =>
+    get: (id: ApprovalId, principal: Principal): Promise<ApprovalReading | undefined> =>
       this.#getApproval(id, principal),
     decide: (
       ids: ApprovalId | ApprovalId[],
@@ -2249,12 +2247,18 @@ class GuardImplementation implements VendoGuard {
   async #getApproval(
     id: ApprovalId,
     principal: Principal,
-  ): Promise<{ request: ApprovalRequest; status: ApprovalRecordData["status"] } | undefined> {
+  ): Promise<ApprovalReading | undefined> {
     const record = await this.#engine.get(APPROVALS_COLLECTION, id);
     if (record === null) return undefined;
     const data = approvalData(record);
     if (data.request.ctx.principal.subject !== principal.subject) return undefined;
-    return { request: data.request, status: data.status };
+    return {
+      request: data.request,
+      status: data.status,
+      ...(data.consumedAt === undefined ? {} : { consumedAt: data.consumedAt }),
+      ...(data.voidedAt === undefined ? {} : { voidedAt: data.voidedAt }),
+      ...(data.deniedBy === undefined ? {} : { deniedBy: data.deniedBy }),
+    };
   }
 
   async #pendingApprovals(principal: Principal): Promise<ApprovalRequest[]> {

--- a/packages/guard/src/index.ts
+++ b/packages/guard/src/index.ts
@@ -33,6 +33,7 @@ export { parseOrgPolicyFile } from "./org-policy.js";
 // package.
 export type { GuardLike } from "@vendoai/core";
 export type {
+  ApprovalReading,
   GuardRules,
   Judge,
   PolicyConfig,

--- a/packages/guard/src/types.ts
+++ b/packages/guard/src/types.ts
@@ -107,6 +107,26 @@ export interface Judge {
   }): Promise<{ action: "run" | "ask" | "block"; rationale: string }>;
 }
 
+/**
+ * ONE approval as {@link VendoGuard.approvals.get} answers it.
+ *
+ * The three markers beside the status separate receipts a status alone cannot:
+ * an approved call that RAN from one still waiting on its caller to retry, and
+ * a person's no from the sweep's. Each is optional so an implementation that
+ * knows only the two original fields still satisfies the method; absent means
+ * the row carries no such marker.
+ */
+export interface ApprovalReading {
+  request: ApprovalRequest;
+  status: "pending" | "approved" | "denied";
+  /** When the yes was spent by the call it authorized. */
+  consumedAt?: IsoDateTime;
+  /** When the decision was taken back (`revoke`): it no longer stands. */
+  voidedAt?: IsoDateTime;
+  /** Who said no. Absent reads as `system` (rows predating the field). */
+  deniedBy?: "human" | "system";
+}
+
 export interface VendoGuard extends Guard {
   bind(tools: ToolRegistry): ToolRegistry;
 
@@ -147,10 +167,7 @@ export interface VendoGuard extends Guard {
      *  Optional for the reason `sweepExpiredApprovals` is — `VendoGuard` is a
      *  published interface and an implementation written before this method
      *  must keep compiling; every guard this package builds has it. */
-    get?(
-      id: ApprovalId,
-      principal: Principal,
-    ): Promise<{ request: ApprovalRequest; status: "pending" | "approved" | "denied" } | undefined>;
+    get?(id: ApprovalId, principal: Principal): Promise<ApprovalReading | undefined>;
     decide(
       ids: ApprovalId | ApprovalId[],
       decision: ApprovalDecision,

--- a/packages/ui/src/chrome/embeds.tsx
+++ b/packages/ui/src/chrome/embeds.tsx
@@ -135,7 +135,11 @@ function ResolvedApprovalCard({ summary, ok, line, detail }: {
   );
 }
 
-function executedCard(summary: string, outcome: ToolOutcome): ReactNode {
+function executedCard(summary: string, outcome: ToolOutcome | undefined): ReactNode {
+  // A call parked at the MCP door runs in the outside agent's own retry, not
+  // server-side, so its receipt carries no result to show — only that the yes
+  // was spent by the call it authorized.
+  if (outcome === undefined) return <ResolvedApprovalCard summary={summary} ok line="Approved — ran" />;
   if (outcome.status === "ok") {
     // The result reads as the shell's ONE body — field rows, never the raw JSON
     // dump this used to print at an end user (spec §16.2). `resultRows`, not

--- a/packages/ui/src/tree/renderer.tsx
+++ b/packages/ui/src/tree/renderer.tsx
@@ -952,7 +952,10 @@ function StatefulTreeView({
   // forever. That one boots fresh. A tree with no query plan (a plain action tree)
   // has nothing to re-read; its notice still settles.
   useParkedApprovals(parked, (nodeId, resolution) => {
-    const settled: ToolOutcome = resolution.state === "executed" ? resolution.outcome : {
+    // An executed answer that carries no outcome ran somewhere this screen
+    // cannot see (the MCP door's lane): it moved the data, so the re-read below
+    // still runs, but there is no notice to leave.
+    const settled: ToolOutcome | undefined = resolution.state === "executed" ? resolution.outcome : {
       status: "blocked",
       reason: resolution.state === "expired"
         ? "This needed approval and nobody answered in time — nothing was sent."
@@ -963,7 +966,9 @@ function StatefulTreeView({
     // ok read clears this very slot.
     setOutcomes((current) => ({ ...current, [nodeId]: undefined }));
     void screen.refresh(nodeId, resolution.state !== "executed").then(() => {
-      if (settled.status !== "ok") setOutcomes((current) => ({ ...current, [nodeId]: settled }));
+      if (settled !== undefined && settled.status !== "ok") {
+        setOutcomes((current) => ({ ...current, [nodeId]: settled }));
+      }
     });
   });
   // The served paint until a handler moves the screen, and the screen's own tree

--- a/packages/ui/src/wire-types.ts
+++ b/packages/ui/src/wire-types.ts
@@ -141,11 +141,14 @@ export interface EnableResult {
  *  renders them with the existing failed vocabulary, never a blank).
  *  Mirrors the umbrella's `ByoApprovalResolution`. */
 export type ApprovalResolution =
-  // The request is absent only for an in-app parked press read during the
-  // resume window: still undecided, but the ask itself is gone (the umbrella's
-  // ByoApprovalResolution says why). Surfaces keep waiting on it.
+  // The request is absent where the ask is gone but the answer is not in yet —
+  // an in-app parked press during the resume window, or a door-parked call
+  // whose yes is in and whose caller has not retried (the umbrella's
+  // ByoApprovalResolution says why). Surfaces keep waiting on it. The outcome
+  // is absent for that same door lane: nothing server-side ran the call, so
+  // "it ran" is all its receipt can say.
   | { state: "pending"; request?: ApprovalRequest }
-  | { state: "executed"; outcome: ToolOutcome }
+  | { state: "executed"; outcome?: ToolOutcome }
   | { state: "declined" }
   | { state: "expired" };
 

--- a/packages/ui/test/embeds.test.tsx
+++ b/packages/ui/test/embeds.test.tsx
@@ -150,6 +150,32 @@ describe("existing-agents embeds", () => {
       }
     });
 
+    /** A call parked at the MCP DOOR runs in the outside agent's own retry, not
+     *  server-side, so its executed receipt carries no outcome to show. It is
+     *  still a call that RAN — the one thing this card must never call it is
+     *  expired (observed live 2026-08-23, on the approval the user had just
+     *  granted). */
+    it("renders the approved receipt for an executed answer that carries no outcome", async () => {
+      wire.state.approvals = [];
+      wire.state.approvalResolutions.set("apr_1", { state: "executed" });
+      mount(<VendoApprovalEmbed refValue={approvalRef} />);
+      await waitFor(() => expect(screen.getByText("Approved — ran")).toBeDefined());
+      expect(document.querySelector(".fl-approval-sub--failed")).toBeNull();
+      expect(document.body.textContent).not.toMatch(/expired/i);
+    });
+
+    /** The window between the press and the outside agent's retry: the yes is
+     *  in, so the ask is gone, but nothing has run. The card keeps its working
+     *  beat and its poll instead of settling on any receipt at all. */
+    it("keeps working, with no ask to re-answer, for a decided approval whose call has not run yet", async () => {
+      wire.state.approvals = [];
+      wire.state.approvalResolutions.set("apr_1", { state: "pending" });
+      const { container } = mount(<VendoApprovalEmbed refValue={approvalRef} />);
+      await waitFor(() => expect(container.querySelector(".fl-beat-working")).not.toBeNull());
+      expect(screen.queryByRole("button", { name: "Approve" })).toBeNull();
+      expect(document.body.textContent).not.toMatch(/expired/i);
+    });
+
     it("renders expired for a TTL-swept approval", async () => {
       wire.state.approvals = [];
       wire.state.approvalResolutions.set("apr_1", { state: "expired" });

--- a/packages/vendo/src/byo-approvals.ts
+++ b/packages/vendo/src/byo-approvals.ts
@@ -73,13 +73,17 @@ interface ParkedByoCall {
  *  the full request while pending (the consent card shows real inputs), the
  *  executed outcome after resume.
  *
- *  The request is absent in exactly one case: an IN-APP parked press read
- *  during the resume window, where the answer is "not decided yet" and the ask
- *  itself is no longer anywhere to be had (that lane persists the call, not the
- *  request). Surfaces treat it as still-working and keep polling. */
+ *  The request is absent where the answer is "not decided yet" but the ask
+ *  itself is no longer anywhere to be had: an IN-APP parked press read during
+ *  the resume window (that lane persists the call, not the request), and a
+ *  DOOR-parked call whose yes is in but whose caller has not retried it yet.
+ *  Surfaces treat both as still-working and keep polling.
+ *
+ *  The outcome is absent for the same door lane: nothing here runs that call,
+ *  so once it has run all this seam can honestly say is that it did. */
 export type ByoApprovalResolution =
   | { state: "pending"; request?: ApprovalRequest }
-  | { state: "executed"; outcome: ToolOutcome }
+  | { state: "executed"; outcome?: ToolOutcome }
   | { state: "declined" }
   | { state: "expired" };
 
@@ -284,6 +288,33 @@ export function createByoApprovals({ guard, tools, ops }: ByoApprovalsConfig): B
         const data = stillParked?.data as Pick<ParkedByoCall, "owner" | "request"> | undefined;
         if (data?.owner !== principal.subject) continue;
         return { state: "pending", ...(data.request === undefined ? {} : { request: data.request }) };
+      }
+      // The THIRD lane: a call parked at the MCP door. `compose-mcp` hands the
+      // door the plain bound registry, so nothing was ever parked here and
+      // nothing here resumes it — approving GRANTS the call and the outside
+      // agent retries it itself ("resolve it there, then retry", door.ts). So
+      // the guard's own row is the only witness left, and without it every
+      // decided door approval fell through to the not-found below, which
+      // <VendoApprovalEmbed> renders as "Expired" on the very approval the
+      // person just granted.
+      const decided = await guard.approvals.get?.(approvalId, principal);
+      if (decided !== undefined) {
+        if (decided.status === "pending") return { state: "pending", request: decided.request };
+        // Only a person's no is a decline; the TTL sweep's and the abandonment
+        // path's are expiries, and a row too old to carry the field reads as
+        // the sweep's (the fail-safe direction — "ask again", never a no
+        // nobody said).
+        if (decided.status === "denied") {
+          return { state: decided.deniedBy === "human" ? "declined" : "expired" };
+        }
+        // Approved. The yes is spent by the call it authorizes, so `consumedAt`
+        // is what tells "it ran" from "it is about to": until then the card
+        // keeps its working beat and its poll rather than settling on a receipt
+        // for something that has not happened.
+        if (decided.consumedAt !== undefined) return { state: "executed" };
+        // A yes taken back (`DELETE /approvals/:id`) can never be spent — the
+        // same nothing-ran receipt a no leaves.
+        return decided.voidedAt === undefined ? { state: "pending" } : { state: "declined" };
       }
       throw new VendoError("not-found", `Approval ${approvalId} was not found`);
     },

--- a/packages/vendo/tests/byo-approvals.e2e.test.ts
+++ b/packages/vendo/tests/byo-approvals.e2e.test.ts
@@ -255,7 +255,10 @@ describe.sequential("existing-agents — parked BYO guarded calls", () => {
     const resolved = await byo.read(parked.approvalId, principal);
     expect(resolved.state).toBe("executed");
     if (resolved.state !== "executed") throw new Error("expected executed");
-    expect(resolved.outcome.status).toBe("error");
+    // Optional on the type since the MCP door's lane records a yes with no
+    // outcome to carry; THIS lane runs the call itself, so it always has one —
+    // an absent outcome fails the assertion rather than reading as a pass.
+    expect(resolved.outcome?.status).toBe("error");
   });
 
   it("answers pending, never not-found, to a read that lands mid-resume", async () => {

--- a/packages/vendo/tests/mcp-approval-resolution.e2e.test.ts
+++ b/packages/vendo/tests/mcp-approval-resolution.e2e.test.ts
@@ -1,0 +1,189 @@
+/**
+ * THE SEAM for a call parked at the MCP DOOR: the door parks it, the WIRE's
+ * `GET /approvals/:id` answers for it, and the outside agent retries on the
+ * SAME session. Nothing between them is stubbed — `vendo.handler` is both the
+ * door and the wire, and the guard, the store and the tool are real.
+ *
+ * The door parks through the plain guard-bound registry (`compose-mcp` passes
+ * `boundTools`, not the BYO parking registry), so no parked-call record exists
+ * for the resume subscriber to find: approving GRANTS the call, it never
+ * executes it — the door's own refusal line says "resolve it there, then
+ * retry". `read` therefore had nothing left to answer with once the approval
+ * left the pending queue and threw not-found, which `<VendoApprovalEmbed>`
+ * renders as "Expired — no longer waiting for approval" on the very approval
+ * the person had just granted (observed live 2026-08-23).
+ */
+import type { ApprovalRequest, ToolDescriptor, ToolRegistry } from "@vendoai/core";
+import type { LanguageModel } from "ai";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  openDoor,
+  principal,
+  runCleanups,
+  SUBJECT,
+  tempStore,
+  type DoorSession,
+} from "../src/mcp-door.test-util.js";
+import { createVendo, type Vendo } from "../src/server.js";
+
+afterEach(runCleanups);
+
+const KEY = "vsk_0123456789abcdef0123456789abcdef0123456789abcdef";
+const BASE = "https://host.test";
+const WIRE = `${BASE}/api/vendo`;
+const TODO_TOOL = "host_todos_create";
+const ARGS = { title: "Buy milk" };
+
+/** The observed host tool: ONE write the `cautious` policy parks, counting
+ *  every execution so "ran exactly once" is measured, not assumed. */
+function todoHost(): { tools: ToolRegistry; created: string[] } {
+  const created: string[] = [];
+  const descriptor: ToolDescriptor = {
+    name: TODO_TOOL,
+    title: "Add a todo",
+    description: "Add a todo for the signed-in customer",
+    inputSchema: { type: "object", properties: { title: { type: "string" } }, required: ["title"] },
+    risk: "write",
+  };
+  return {
+    created,
+    tools: {
+      async descriptors() {
+        return [descriptor];
+      },
+      async execute(call) {
+        created.push((call.args as { title: string }).title);
+        return { status: "ok", output: { added: true } };
+      },
+    },
+  };
+}
+
+interface Host {
+  vendo: Vendo;
+  created: string[];
+  door: DoorSession;
+}
+
+async function host(clock?: () => number): Promise<Host> {
+  const store = await tempStore();
+  const app = todoHost();
+  const vendo = createVendo({
+    models: { default: {} as LanguageModel },
+    principal: async () => principal,
+    store,
+    guard: { policy: "cautious", approvals: { parkedCallTtlMs: 10_000 } },
+    ...(clock === undefined ? {} : { sweep: { intervalMs: 1, now: clock } }),
+    mcp: { serviceAuth: { keys: [KEY] }, baseUrl: BASE },
+    oauth: {
+      async session() {
+        return { subject: SUBJECT };
+      },
+      async principal(subject: string) {
+        return { kind: "user", subject };
+      },
+    },
+  } as Parameters<typeof createVendo>[0]);
+  vendo.actions.add(app.tools);
+  await store.ensureSchema();
+  // ONE kept-alive session, exactly as a host's own agent loop holds it: the
+  // park and the retry both ride it, which is what makes the replay id stable.
+  const door = await openDoor(vendo, await vendo.tokenFor(SUBJECT));
+  return { vendo, created: app.created, door };
+}
+
+/** The parked call's approval id, off the typed envelope the door returns —
+ *  the same field `<VendoApprovalEmbed>` is handed. */
+async function park(door: DoorSession): Promise<string> {
+  const parked = await door.callTool(TODO_TOOL, ARGS);
+  const ref = parked.structuredContent as { kind?: string; approvalId?: string } | undefined;
+  expect(ref?.kind).toBe("vendo/approval-ref@1");
+  expect(typeof ref?.approvalId).toBe("string");
+  return ref!.approvalId!;
+}
+
+type Resolution = { state: string; request?: ApprovalRequest };
+
+/** What the embed's poll sees, over the real wire. */
+async function poll(vendo: Vendo, approvalId: string): Promise<Resolution & { status: number }> {
+  const response = await vendo.handler(new Request(`${WIRE}/approvals/${approvalId}`));
+  const body = response.ok ? ((await response.json()) as Resolution) : { state: "not-found" };
+  return { ...body, status: response.status };
+}
+
+async function decide(vendo: Vendo, approvalId: string, approve: boolean): Promise<void> {
+  const decided = await vendo.handler(new Request(`${WIRE}/approvals/decide`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ ids: [approvalId], decision: { approve } }),
+  }));
+  if (!decided.ok) throw new Error(`decide failed ${decided.status}: ${await decided.text()}`);
+}
+
+describe.sequential("a call parked at the MCP door, read over the wire", () => {
+  it("reads approved-then-ran, never expired, and the retry runs it exactly once", async () => {
+    const { vendo, created, door } = await host();
+
+    const approvalId = await park(door);
+    expect(created).toEqual([]);
+
+    // 1. The card's first poll: the ask itself, so the consent card has inputs.
+    const pending = await poll(vendo, approvalId);
+    expect(pending.state).toBe("pending");
+    expect(pending.request?.call.tool).toBe(TODO_TOOL);
+
+    // 2. The user presses Approve.
+    await decide(vendo, approvalId, true);
+    // Approving GRANTS the parked door call; it does not execute it. Were it
+    // both, the retry below would be a second write of the same todo.
+    expect(created).toEqual([]);
+
+    // 3. The poll straight after the press. It must never read "expired" — the
+    //    yes stands, so the card keeps its working beat and its poll.
+    const granted = await poll(vendo, approvalId);
+    expect(granted.status).toBe(200);
+    expect(granted.state).toBe("pending");
+    // No ask to re-show: it is decided, so the card must not offer the buttons
+    // a second time.
+    expect(granted.request).toBeUndefined();
+
+    // 4. The agent retries on the SAME session, and the call finally runs.
+    const ran = await door.callTool(TODO_TOOL, ARGS);
+    expect(ran.isError).toBeFalsy();
+    expect(created).toEqual([ARGS.title]);
+
+    // 5. The card settles on the executed receipt — "Approved — ran".
+    expect(await poll(vendo, approvalId)).toMatchObject({ state: "executed", status: 200 });
+
+    // The yes was single-use: an identical third call parks anew rather than
+    // riding a spent approval.
+    const again = await door.callTool(TODO_TOOL, ARGS);
+    expect((again.structuredContent as { kind?: string } | undefined)?.kind).toBe("vendo/approval-ref@1");
+    expect(created).toEqual([ARGS.title]);
+  });
+
+  it("reads a refused door call as declined, not expired", async () => {
+    const { vendo, created, door } = await host();
+    const approvalId = await park(door);
+
+    await decide(vendo, approvalId, false);
+
+    expect(await poll(vendo, approvalId)).toMatchObject({ state: "declined", status: 200 });
+    expect(created).toEqual([]);
+  });
+
+  it("still reads a door call nobody answered as expired once the TTL sweep denies it", async () => {
+    let at = Date.now();
+    const { vendo, created, door } = await host(() => at);
+    const approvalId = await park(door);
+
+    // Past the TTL: the next request's amortized sweep denies it, with SYSTEM
+    // provenance — the one denial that is not a person saying no. Re-anchored
+    // on the real clock because the park lands after this test's first read.
+    at = Date.now() + 11_000;
+    expect((await vendo.handler(new Request(`${WIRE}/status`))).status).toBe(200);
+
+    expect(await poll(vendo, approvalId)).toMatchObject({ state: "expired", status: 200 });
+    expect(created).toEqual([]);
+  });
+});


### PR DESCRIPTION
## The bug, observed live (2026-08-23, real browser, real app)

A host with an MCP door (`createVendo({ auth: authJs(), mcp: true })`). The host's own agent loop holds one kept-alive MCP session on a `tokenFor` badge. `host_todos_create` parked for approval and the chat rendered `<VendoApprovalEmbed>`.

1. Card renders pending. Correct.
2. User clicks **Approve** → the card flips to red "✕ Expired — no longer waiting for approval". **Wrong** — the approval was granted.
3. User re-asks, the agent retries the same tool on the same session, it runs ("Added ✅"). The grant was real; only the card lied.

## Root cause

`compose-mcp.ts` hands the door `boundTools` — the plain guard-bound registry, not `byoApprovals.registry`. So the door's parked calls leave **no** record in either lane that `GET /approvals/:id` knows about (`vendo_parked_call`, `vendo_parked_action`), and no `onApprovalDecision` subscriber matches one.

`byoApprovals.read` looked in exactly three places — the terminal outcome row, the guard's *pending* queue, the two parked-call drawers — and threw `not-found` past all three. A decided door approval matches none of them, and `<VendoApprovalEmbed>` maps `not-found` → `{ state: "expired" }`. Deny and the TTL sweep fell into the same hole; **all three** answered "expired".

## Does approving EXECUTE the parked MCP call, or only grant it?

**Grant-only. There was no double-write.** Pinned by assertion, not opinion, in `tests/mcp-approval-resolution.e2e.test.ts`: after `POST /approvals/decide {approve:true}` the counting tool has run **zero** times; it runs exactly once on the client's retry, and an identical third call parks anew because the yes is single-use. This matches the door's own refusal sentence — "resolve it there, then retry" — and `docs-site/outside-agents/your-own-agent.mdx`, which already documented it correctly.

## The fix — at the server, where the distinction lives

The wire now falls back to the **guard's own approval row** for an approval no lane recorded, so the status it reports tells the four cases apart rather than leaving the card to guess:

| guard row | resolution | card |
| --- | --- | --- |
| approved, `consumedAt` set (the retry spent it) | `executed` | "Approved — ran" |
| approved, not spent yet | `pending`, no request | working beat, poll stays armed |
| denied, `deniedBy: "human"` | `declined` | "Declined — nothing ran" |
| denied by the sweep (`system`/absent) | `expired` | "Expired" |
| approved then taken back (`voidedAt`) | `declined` | "Declined — nothing ran" |

The un-spent-yes case is deliberately **not** terminal: between the press and the agent's retry nothing has run, so the card holds its beat and its poll and settles on "Approved — ran" the moment the retry lands. Settling early would trade one lie for a smaller one.

Supporting changes, all minimal:

- `VendoGuard.approvals.get` reports the three markers this needs beside the status (`consumedAt`, `voidedAt`, `deniedBy`), each **optional** so an implementation returning only the original two fields still satisfies the interface. Shape named as the exported `ApprovalReading`.
- `outcome` is now optional on the `executed` resolution (umbrella + the `@vendoai/ui` mirror): nothing server-side ran a door-parked call, so its receipt can honestly say it ran and nothing more. `executedCard` renders that as plain "Approved — ran"; the screen renderer treats it as a data-moving answer with no notice to leave.
- One clarifying paragraph in `docs-site/existing-agent/embeds.mdx`, whose "the wire runs the parked call" line was true only of the in-process lane.

## Tests at the seam

`packages/vendo/tests/mcp-approval-resolution.e2e.test.ts` — real door, real wire, real guard, real store, nothing stubbed on either side. `vendo.handler` is both the door and the wire. Drives the exact observed sequence: park over MCP → poll (pending, with the ask) → approve over the wire → **assert nothing executed** → poll (never "expired", never 404) → retry on the same session → assert it ran exactly once → poll (`executed`) → identical third call parks anew. Plus the deny and TTL-sweep arms.

`packages/ui/test/embeds.test.tsx` — the outcome-less executed receipt renders "Approved — ran" and never the word "expired"; the decided-but-not-yet-run answer keeps the working beat with no ask to re-answer.

### Prove-it-can-fail

Confirmed by reverting and watching red, then restoring:

- Server fix removed from `byo-approvals.ts` → all **3** seam tests fail (`404` / `state: "not-found"` where `200` + `pending`/`declined`/`expired` is expected).
- `executedCard`'s no-outcome branch removed → the new UI test fails.
- Honest caveat: the second UI test (working beat for a decided-but-unrun approval) stayed green under the revert. It pins pre-existing embed behaviour that the server fix now routes into — a regression pin, not a new-behaviour test.

## Gate

`pnpm build` ✅ · `pnpm typecheck` ✅ · `pnpm lint` ✅ (0 errors) · `@vendoai/guard` 362/362 ✅ · `@vendoai/ui` 1513/1513 ✅ · `@vendoai/vendo` 2755 passed, **3 failed** — all three are the documented `Cool%20Code` space-in-path worktree gotcha (`ENOENT … /Users/yousefh/Desktop/Cool%20Code/…` in `your-agent-docs.docs.test.ts` and `cli/init-mcp.test.ts`), unrelated to this change. Relying on CI for those.

Changeset: patch on guard, vendo, ui.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the MCP door approval card so it never shows “Expired” right after a user approves. Previously, reads fell through to not-found after a decision, so the card showed “Expired”; now the wire resolves from the guard’s row and the UI shows “Approved — ran” after the retry or keeps working until the retry spends the approval.

- Server: `GET /approvals/:id` falls back to `guard.approvals.get` for door-parked calls and maps outcomes: approved+consumed → executed; approved+not consumed → pending (no request); denied by human → declined; sweep/voided → expired/declined.
- Guard (`@vendoai/guard`): adds `ApprovalReading` and returns optional `consumedAt`, `voidedAt`, `deniedBy` from `approvals.get`; fully backward compatible.
- UI (`@vendoai/ui`): executed receipts may have no outcome; render “Approved — ran”. When approved but not yet retried, keep the working beat and do not re-show buttons.
- Types: `executed` outcome is optional in `ByoApprovalResolution` and UI `ApprovalResolution`.
- Docs: clarify that MCP door approvals grant only; the outside agent’s retry runs the call.
- Tests: add end-to-end seam test for the door lane and UI tests to pin the new receipts.

Bold rollout notes:
- If you consume `GET /approvals/:id` directly, handle `executed` responses that omit `outcome`.
- Custom guard implementations do not need changes. To enable precise mapping for the door lane, optionally include `consumedAt`, `voidedAt`, and `deniedBy` in `approvals.get`.

<sup>Written for commit c26e446697a03ed807c14192fb81eaa6f196bee3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

