### PR TITLE
fix(repo,vendo): the repo's spawns find their tools on Windows

### DIFF
--- a/.changeset/the-cli-install-stops-warning-about-itself.md
+++ b/.changeset/the-cli-install-stops-warning-about-itself.md
@@ -1,0 +1,17 @@
+---
+"@vendoai/vendo": patch
+---
+
+The Windows install no longer prints a deprecation warning about our own spawn.
+Package managers are `.cmd` shims there, so the install has to go through the
+platform shell — but it was passing an args array alongside `shell: true`, and
+that pair is DEP0190. Node 24 prints it by default, onto the CLI's own stderr,
+so `vendo` interrupted its install with a security warning about itself. Windows
+now gets the whole line as one command string; nothing changes on any other
+platform.
+
+The quoting the warning was complaining about is still there and still needed —
+`cmd.exe` reads a bare `^` (as in `ai@^6`) as an escape character outside double
+quotes, and unquoted that spec reaches npm as a different, pinned `ai@6`. It has
+just moved into `installSpawnPlan`, which takes its platform as an argument so
+the Windows shape can be asserted from an ubuntu-only CI.

--- a/corpus/harness/src/ai/matrix.ts
+++ b/corpus/harness/src/ai/matrix.ts
@@ -271,12 +271,19 @@ function resolveAgentSdk(sdkDir: string): string | null {
   }
 }
 
+/** npm is a `.cmd` shim on Windows and Node has refused to exec one without a
+ *  shell since CVE-2024-27980, so a bare spawn ENOENTs and the SDK provision
+ *  fails before npm ever starts. Windows takes the whole line as ONE string —
+ *  an args array alongside `shell: true` is DEP0190 and warns on every run. The
+ *  spec is quoted because cmd.exe reads `^` (as in `@^1.2`) as an escape
+ *  character outside double quotes; the same reasoning as provider-deps.ts. */
 function npmInstallAgentSdk(sdkDir: string): Promise<void> {
   return new Promise((resolve, reject) => {
-    const child = spawn("npm", ["install", "--no-audit", "--no-fund", `${AGENT_SDK_PACKAGE}@${AGENT_SDK_VERSION}`], {
-      cwd: sdkDir,
-      stdio: ["ignore", "ignore", "pipe"],
-    });
+    const spec = `${AGENT_SDK_PACKAGE}@${AGENT_SDK_VERSION}`;
+    const stdio: ["ignore", "ignore", "pipe"] = ["ignore", "ignore", "pipe"];
+    const child = process.platform === "win32"
+      ? spawn(`npm install --no-audit --no-fund "${spec}"`, { cwd: sdkDir, stdio, shell: true })
+      : spawn("npm", ["install", "--no-audit", "--no-fund", spec], { cwd: sdkDir, stdio });
     let stderr = "";
     child.stderr.setEncoding("utf8");
     child.stderr.on("data", (chunk: string) => { stderr += chunk; });

--- a/examples/demo-bank/tests/vendo/away-drill.test.ts
+++ b/examples/demo-bank/tests/vendo/away-drill.test.ts
@@ -369,7 +369,12 @@ beforeAll(async () => {
     MAPLE_DIST_DIR: ".next-away-drill",
   };
   delete (env as Record<string, string | undefined>).NODE_ENV; // vitest's "test" would leak into next dev
-  const spawned = spawn(join(appDir, "node_modules", ".bin", "next"), ["dev", "-p", String(port)], {
+  // Not the `.bin` entry: it is an extensionless script on POSIX and a
+  // `.cmd`/`.ps1` pair on Windows, where Node has refused to exec either without
+  // a shell since CVE-2024-27980 — the bare spawn ENOENTs and the drill never
+  // starts. Next ships its real entry as plain JS; run that on this same Node.
+  const nextEntry = join(appDir, "node_modules", "next", "dist", "bin", "next");
+  const spawned = spawn(process.execPath, [nextEntry, "dev", "-p", String(port)], {
     cwd: appDir,
     env,
     stdio: ["pipe", "pipe", "pipe"],

--- a/fixtures/automations-e2e/src/global-setup.ts
+++ b/fixtures/automations-e2e/src/global-setup.ts
@@ -9,7 +9,12 @@ import { join } from "node:path";
 import type { TestProject } from "vitest/node";
 
 const fixtureDir = fileURLToPath(new URL("../../host-app/", import.meta.url));
-const nextBin = join(fixtureDir, "node_modules", ".bin", "next");
+// `node_modules/.bin/next` is an extensionless shell script on POSIX and a
+// `.cmd`/`.ps1` pair on Windows, where Node has refused to exec either without
+// a shell since CVE-2024-27980 — the bare spawn ENOENTs and the fixture never
+// comes up. Next ships its real entry as plain JS, so run that on this same
+// Node: no shell, no quoting, one code path on both platforms.
+const nextBin = join(fixtureDir, "node_modules", "next", "dist", "bin", "next");
 
 let child: ChildProcessWithoutNullStreams | undefined;
 let serverOutput = "";
@@ -48,7 +53,7 @@ async function waitForFixture(baseUrl: string): Promise<void> {
 export default async function setup(project: TestProject): Promise<() => Promise<void>> {
   const port = await freePort();
   const baseUrl = `http://127.0.0.1:${port}`;
-  child = spawn(nextBin, ["dev", "-p", String(port)], {
+  child = spawn(process.execPath, [nextBin, "dev", "-p", String(port)], {
     cwd: fixtureDir,
     // Own dist dir → own dev-server lock; the actions fixture e2e may be
     // booting the same host app concurrently under turbo. Nested under .next

--- a/fixtures/install-seam/src/stranger.ts
+++ b/fixtures/install-seam/src/stranger.ts
@@ -265,9 +265,13 @@ export async function bootStranger(artifactsDir: string): Promise<{ stranger: St
     await writeLog("init.log", init.output);
 
     // Assertion 3: the app compiles WITH what init generated.
+    // Not the `.bin` entry: it is an extensionless script on POSIX and a
+    // `.cmd`/`.ps1` pair on Windows, where Node has refused to exec either
+    // without a shell since CVE-2024-27980. TypeScript ships its real entry as
+    // plain JS, so run that on this same Node — no shell, no quoting.
     const typecheck = await run(
-      path.join(scaffoldDir, "node_modules/.bin/tsc"),
-      ["--noEmit"],
+      process.execPath,
+      [path.join(scaffoldDir, "node_modules/typescript/bin/tsc"), "--noEmit"],
       { cwd: scaffoldDir, env },
     );
     await writeLog("typecheck.log", typecheck.output);

--- a/fixtures/integration-browser/e2e/harness/backends.ts
+++ b/fixtures/integration-browser/e2e/harness/backends.ts
@@ -50,7 +50,12 @@ import { createControllableModel, expandTurn, type TurnSpec } from "./model.ts";
 const WIRE_BASE = "/api/vendo";
 const CONTROL_BASE = "/__test";
 const hostDir = fileURLToPath(new URL("../../../host-app/", import.meta.url));
-const nextBin = join(hostDir, "node_modules", ".bin", "next");
+// `node_modules/.bin/next` is an extensionless shell script on POSIX and a
+// `.cmd`/`.ps1` pair on Windows, where Node has refused to exec either without
+// a shell since CVE-2024-27980 — the bare spawn ENOENTs and the fixture never
+// comes up. Next ships its real entry as plain JS, so run that on this same
+// Node: no shell, no quoting, one code path on both platforms.
+const nextBin = join(hostDir, "node_modules", "next", "dist", "bin", "next");
 
 async function freePort(): Promise<number> {
   const probe = createNetServer();
@@ -79,7 +84,7 @@ export async function startBackends(): Promise<Backends> {
   const hostPort = await freePort();
   const hostBaseUrl = `http://127.0.0.1:${hostPort}`;
   let hostOutput = "";
-  const host: ChildProcessWithoutNullStreams = spawn(nextBin, ["dev", "-p", String(hostPort)], {
+  const host: ChildProcessWithoutNullStreams = spawn(process.execPath, [nextBin, "dev", "-p", String(hostPort)], {
     cwd: hostDir,
     env: { ...process.env, NEXT_TELEMETRY_DISABLED: "1", FIXTURE_DIST_DIR: ".next/integration-browser" },
     stdio: ["pipe", "pipe", "pipe"],

--- a/fixtures/integration/src/global-setup.ts
+++ b/fixtures/integration/src/global-setup.ts
@@ -14,7 +14,12 @@ import { join } from "node:path";
 import type { TestProject } from "vitest/node";
 
 const fixtureDir = fileURLToPath(new URL("../../host-app/", import.meta.url));
-const nextBin = join(fixtureDir, "node_modules", ".bin", "next");
+// `node_modules/.bin/next` is an extensionless shell script on POSIX and a
+// `.cmd`/`.ps1` pair on Windows, where Node has refused to exec either without
+// a shell since CVE-2024-27980 — the bare spawn ENOENTs and the fixture never
+// comes up. Next ships its real entry as plain JS, so run that on this same
+// Node: no shell, no quoting, one code path on both platforms.
+const nextBin = join(fixtureDir, "node_modules", "next", "dist", "bin", "next");
 
 let child: ChildProcessWithoutNullStreams | undefined;
 let serverOutput = "";
@@ -53,7 +58,7 @@ async function waitForFixture(baseUrl: string): Promise<void> {
 export default async function setup(project: TestProject): Promise<() => Promise<void>> {
   const port = await freePort();
   const baseUrl = `http://127.0.0.1:${port}`;
-  child = spawn(nextBin, ["dev", "-p", String(port)], {
+  child = spawn(process.execPath, [nextBin, "dev", "-p", String(port)], {
     cwd: fixtureDir,
     // Own dist dir → own dev-server lock; sibling e2e suites may boot the same
     // host app concurrently under turbo. Nested under .next so scanner/gitignore

--- a/fixtures/mcp-e2e/src/global-setup.ts
+++ b/fixtures/mcp-e2e/src/global-setup.ts
@@ -6,7 +6,12 @@ import { fileURLToPath } from "node:url";
 import type { TestProject } from "vitest/node";
 
 const fixtureDir = fileURLToPath(new URL("../../host-app/", import.meta.url));
-const nextBin = join(fixtureDir, "node_modules", ".bin", "next");
+// `node_modules/.bin/next` is an extensionless shell script on POSIX and a
+// `.cmd`/`.ps1` pair on Windows, where Node has refused to exec either without
+// a shell since CVE-2024-27980 — the bare spawn ENOENTs and the fixture never
+// comes up. Next ships its real entry as plain JS, so run that on this same
+// Node: no shell, no quoting, one code path on both platforms.
+const nextBin = join(fixtureDir, "node_modules", "next", "dist", "bin", "next");
 
 let child: ChildProcessWithoutNullStreams | undefined;
 let serverOutput = "";
@@ -80,7 +85,7 @@ async function waitForFixture(baseUrl: string): Promise<void> {
 export default async function setup(project: TestProject): Promise<() => Promise<void>> {
   const port = await freePort();
   const baseUrl = `http://127.0.0.1:${port}`;
-  child = spawn(nextBin, ["dev", "-p", String(port)], {
+  child = spawn(process.execPath, [nextBin, "dev", "-p", String(port)], {
     cwd: fixtureDir,
     env: { ...process.env, NEXT_TELEMETRY_DISABLED: "1", FIXTURE_DIST_DIR: ".next/mcp-e2e" },
     stdio: ["pipe", "pipe", "pipe"],

--- a/fixtures/redteam/src/global-setup.ts
+++ b/fixtures/redteam/src/global-setup.ts
@@ -9,7 +9,12 @@ import { join } from "node:path";
 import type { TestProject } from "vitest/node";
 
 const fixtureDir = fileURLToPath(new URL("../../host-app/", import.meta.url));
-const nextBin = join(fixtureDir, "node_modules", ".bin", "next");
+// `node_modules/.bin/next` is an extensionless shell script on POSIX and a
+// `.cmd`/`.ps1` pair on Windows, where Node has refused to exec either without
+// a shell since CVE-2024-27980 — the bare spawn ENOENTs and the fixture never
+// comes up. Next ships its real entry as plain JS, so run that on this same
+// Node: no shell, no quoting, one code path on both platforms.
+const nextBin = join(fixtureDir, "node_modules", "next", "dist", "bin", "next");
 
 let child: ChildProcessWithoutNullStreams | undefined;
 let serverOutput = "";
@@ -48,7 +53,7 @@ async function waitForFixture(baseUrl: string): Promise<void> {
 export default async function setup(project: TestProject): Promise<() => Promise<void>> {
   const port = await freePort();
   const baseUrl = `http://127.0.0.1:${port}`;
-  child = spawn(nextBin, ["dev", "-p", String(port)], {
+  child = spawn(process.execPath, [nextBin, "dev", "-p", String(port)], {
     cwd: fixtureDir,
     // Own dist dir → own dev-server lock; the actions and automations fixture
     // e2e suites may be booting the same host app concurrently under turbo.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test:ai7": "node scripts/pin-ai-major-7.mjs && pnpm install --no-frozen-lockfile && pnpm build && VITEST_MIN_FORKS=1 VITEST_MAX_FORKS=2 VITEST_MIN_THREADS=1 VITEST_MAX_THREADS=2 turbo run test --continue --concurrency=2 '--filter=./packages/*' '--filter=!@vendoai/store'",
     "conformance": "turbo run conformance --filter=@vendoai/core --filter=@vendoai/store --filter=@vendoai/vendo",
     "typecheck": "turbo run typecheck",
-    "lint": "node scripts/dependency-guard.mjs && node scripts/portability-gate.mjs && turbo run lint:packages lint",
+    "lint": "node scripts/dependency-guard.mjs && node scripts/portability-gate.mjs && node scripts/windows-spawn-gate.mjs && turbo run lint:packages lint",
     "lint:packages": "eslint --config eslint.blocking.config.mjs --no-config-lookup packages",
     "lint:report": "node scripts/lint-report.mjs",
     "deps:guard": "node scripts/dependency-guard.mjs",
@@ -22,7 +22,8 @@
     "changeset:status": "changeset status --since=origin/main",
     "changeset:version": "changeset version && node scripts/sync-version-constants.mjs",
     "changeset:publish": "changeset publish",
-    "portability": "node scripts/portability-gate.mjs"
+    "portability": "node scripts/portability-gate.mjs",
+    "windows-spawn": "node scripts/windows-spawn-gate.mjs"
   },
   "devDependencies": {
     "@changesets/cli": "^2.31.0",

--- a/packages/actions/tests/runtime/fixture.e2e.test.ts
+++ b/packages/actions/tests/runtime/fixture.e2e.test.ts
@@ -11,7 +11,12 @@ import { vendoSync } from "../../src/sync/index.js";
 import { createActions, type ActionsRunContext } from "../../src/runtime/registry.js";
 
 const fixtureDir = fileURLToPath(new URL("../../../../fixtures/host-app/", import.meta.url));
-const nextBin = join(fixtureDir, "node_modules", ".bin", "next");
+// `node_modules/.bin/next` is an extensionless shell script on POSIX and a
+// `.cmd`/`.ps1` pair on Windows, where Node has refused to exec either without
+// a shell since CVE-2024-27980 — the bare spawn ENOENTs and the fixture never
+// comes up. Next ships its real entry as plain JS, so run that on this same
+// Node: no shell, no quoting, one code path on both platforms.
+const nextBin = join(fixtureDir, "node_modules", "next", "dist", "bin", "next");
 
 let child: ChildProcessWithoutNullStreams | undefined;
 let baseUrl = "";
@@ -91,7 +96,7 @@ async function startFixture(): Promise<void> {
   const port = await freePort();
   baseUrl = `http://127.0.0.1:${port}`;
   serverOutput = "";
-  const fixtureChild = spawn(nextBin, ["dev", "-p", String(port)], {
+  const fixtureChild = spawn(process.execPath, [nextBin, "dev", "-p", String(port)], {
     cwd: fixtureDir,
     // FIXTURE_DIST_DIR: host-app's next.config gives each concurrent consumer
     // its own dist dir (see the comment there); the previous default `.next`

--- a/packages/vendo/src/cli/provider-deps.ts
+++ b/packages/vendo/src/cli/provider-deps.ts
@@ -1,4 +1,4 @@
-import { spawn } from "node:child_process";
+import { spawn, type SpawnOptions } from "node:child_process";
 import { access, readFile } from "node:fs/promises";
 import { dirname, join, relative, resolve, sep } from "node:path";
 import type { DevCredential, EnvKeyProvider } from "../dev-creds/resolve.js";
@@ -220,16 +220,27 @@ export function installStderrTail(): string {
     through the platform shell there — a shell-less spawn ENOENTs before the
     install starts. cmd.exe treats `^` (as in ai@^6) as an escape character
     OUTSIDE double quotes, so every arg is quoted; none of ours carry quotes
-    of their own (specs, flags, relative paths). */
+    of their own (specs, flags, relative paths).
+
+    Windows takes the whole line as ONE string rather than command + args:
+    passing an array alongside `shell: true` is DEP0190, and Node prints that
+    deprecation warning to the CLI's own stderr on every install — so the user
+    saw a security warning about our spawn in the middle of `vendo` output. */
+export function installSpawnPlan(
+  command: string,
+  args: readonly string[],
+  platform: NodeJS.Platform = process.platform,
+): { command: string; args: readonly string[] | undefined; shell: boolean } {
+  if (platform !== "win32") return { command, args, shell: false };
+  return { command: [command, ...args.map((arg) => `"${arg}"`)].join(" "), args: undefined, shell: true };
+}
+
 export const defaultRunner: InstallRunner = (command, args, cwd) =>
   new Promise((resolve) => {
     stderrTail = "";
-    const windows = process.platform === "win32";
-    const child = spawn(command, windows ? args.map((arg) => `"${arg}"`) : args, {
-      cwd,
-      stdio: ["ignore", "ignore", "pipe"],
-      shell: windows,
-    });
+    const plan = installSpawnPlan(command, args);
+    const options: SpawnOptions = { cwd, stdio: ["ignore", "ignore", "pipe"], shell: plan.shell };
+    const child = plan.args ? spawn(plan.command, [...plan.args], options) : spawn(plan.command, options);
     child.stderr?.setEncoding("utf8");
     child.stderr?.on("data", (chunk: string) => {
       stderrTail = (stderrTail + chunk).slice(-STDERR_TAIL_CHARS);

--- a/packages/vendo/src/cli/provider-deps.ts
+++ b/packages/vendo/src/cli/provider-deps.ts
@@ -225,14 +225,27 @@ export function installStderrTail(): string {
     Windows takes the whole line as ONE string rather than command + args:
     passing an array alongside `shell: true` is DEP0190, and Node prints that
     deprecation warning to the CLI's own stderr on every install — so the user
-    saw a security warning about our spawn in the middle of `vendo` output. */
+    saw a security warning about our spawn in the middle of `vendo` output.
+
+    An arg carrying a `"` of its own is REFUSED rather than escaped. cmd.exe has
+    no escaping story worth trusting — the rules differ between the shell and
+    the callee's own argv parser — and this builds a command line for a shell,
+    so a wrong guess is a command injection, not a typo. Nothing calls it with
+    one (specs, flags, relative paths), which is exactly why the day something
+    does should be a loud stop rather than a quiet best effort. */
 export function installSpawnPlan(
   command: string,
   args: readonly string[],
   platform: NodeJS.Platform = process.platform,
 ): { command: string; args: readonly string[] | undefined; shell: boolean } {
   if (platform !== "win32") return { command, args, shell: false };
-  return { command: [command, ...args.map((arg) => `"${arg}"`)].join(" "), args: undefined, shell: true };
+  const quoted = args.map((arg) => {
+    if (arg.includes('"')) {
+      throw new Error(`install argument cannot be quoted safely for cmd.exe (it contains a double quote): ${arg}`);
+    }
+    return `"${arg}"`;
+  });
+  return { command: [command, ...quoted].join(" "), args: undefined, shell: true };
 }
 
 export const defaultRunner: InstallRunner = (command, args, cwd) =>

--- a/packages/vendo/tests/cli/provider-deps.test.ts
+++ b/packages/vendo/tests/cli/provider-deps.test.ts
@@ -2,7 +2,7 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { aiBelowPeerFloor, defaultRunner, ensureGeneratedImports, ensureProviderDeps, ensureVendoPackage, ensureZodFloor, installCommandFor, installStderrTail, providerModuleFor, VENDO_PACKAGE_SPEC, zodBelowAiSdkFloor, ZOD_FLOOR_SPEC } from "../../src/cli/provider-deps.js";
+import { aiBelowPeerFloor, defaultRunner, installSpawnPlan, ensureGeneratedImports, ensureProviderDeps, ensureVendoPackage, ensureZodFloor, installCommandFor, installStderrTail, providerModuleFor, VENDO_PACKAGE_SPEC, zodBelowAiSdkFloor, ZOD_FLOOR_SPEC } from "../../src/cli/provider-deps.js";
 
 // Init installs the provider module the resolved credential loads at
 // runtime (0.4.1 E2E cert finding: nothing declares @ai-sdk/*, so a fresh
@@ -766,5 +766,33 @@ describe("ensureZodFloor in a hoisted workspace (checker round 1)", () => {
       },
     });
     expect(calls).toEqual([{ command: "pnpm", args: ["add", ZOD_FLOOR_SPEC], cwd: app }]);
+  });
+});
+
+/**
+ * The Windows half of the install spawn. Package managers are `.cmd` shims
+ * there and Node has refused to exec one without a shell since CVE-2024-27980,
+ * so the spawn ENOENTs before the install starts. CI is ubuntu-only, so the
+ * platform is injected rather than observed — this is the only place the win32
+ * shape is checked at all.
+ */
+describe("installSpawnPlan", () => {
+  it("gives Windows ONE command string and a shell, never an args array", () => {
+    const plan = installSpawnPlan("pnpm", ["add", "ai@^6"], "win32");
+    expect(plan.shell).toBe(true);
+    // An args array alongside `shell: true` is DEP0190: Node 24 prints that
+    // deprecation warning by default, onto the CLI's own stderr, mid-install.
+    expect(plan.args).toBeUndefined();
+    expect(plan.command).toBe('pnpm "add" "ai@^6"');
+  });
+
+  it("quotes every arg, because cmd.exe reads a bare ^ as an escape", () => {
+    // Unquoted, `ai@^6.1` reaches npm as `ai@6.1` — a different, pinned spec.
+    expect(installSpawnPlan("npm", ["install", "ai@^6.1"], "win32").command).toContain('"ai@^6.1"');
+  });
+
+  it("leaves every other platform on the shell-less argv spawn", () => {
+    const plan = installSpawnPlan("pnpm", ["add", "ai@^6"], "linux");
+    expect(plan).toEqual({ command: "pnpm", args: ["add", "ai@^6"], shell: false });
   });
 });

--- a/packages/vendo/tests/cli/provider-deps.test.ts
+++ b/packages/vendo/tests/cli/provider-deps.test.ts
@@ -791,6 +791,15 @@ describe("installSpawnPlan", () => {
     expect(installSpawnPlan("npm", ["install", "ai@^6.1"], "win32").command).toContain('"ai@^6.1"');
   });
 
+  it("refuses an arg it cannot quote safely rather than guessing", () => {
+    // cmd.exe has no escaping story worth trusting, and this builds a line for
+    // a shell — a wrong guess is a command injection, not a typo. Nothing calls
+    // it with a quote today, which is why the day something does must be loud.
+    expect(() => installSpawnPlan("npm", ["install", 'a" & calc "'], "win32")).toThrow(/double quote/);
+    // Only Windows quotes at all, so the argv path is unaffected.
+    expect(installSpawnPlan("npm", ["install", 'a"b'], "linux").args).toEqual(["install", 'a"b']);
+  });
+
   it("leaves every other platform on the shell-less argv spawn", () => {
     const plan = installSpawnPlan("pnpm", ["add", "ai@^6"], "linux");
     expect(plan).toEqual({ command: "pnpm", args: ["add", "ai@^6"], shell: false });

--- a/scripts/dependency-guard.mjs
+++ b/scripts/dependency-guard.mjs
@@ -314,7 +314,12 @@ const IMPORT_RE =
  * `<parent>/*` glob. Anything else throws, because a silently unscanned directory
  * is the defect above. */
 function workspacePackageDirs() {
-  const yaml = readFileSync(join(ROOT, "pnpm-workspace.yaml"), "utf8");
+  // Normalized, because a Windows checkout (core.autocrlf=true, the git default
+  // there) hands every line back with a trailing \r. The entry pattern below
+  // ends at `["']?$`, which cannot consume it — so `pnpm lint` died on its very
+  // first step with `unreadable workspace entry: - "packages/*"`, an error about
+  // the workspace file rather than about the platform.
+  const yaml = readFileSync(join(ROOT, "pnpm-workspace.yaml"), "utf8").replace(/\r\n/g, "\n");
   const list = /^packages:[^\S\n]*\n((?:[^\S\n]+-[^\n]*\n)+)/m.exec(yaml)?.[1];
   if (!list) throw new Error("dependency-guard: no `packages:` list in pnpm-workspace.yaml");
   const dirs = [];

--- a/scripts/dependency-guard.mjs
+++ b/scripts/dependency-guard.mjs
@@ -314,12 +314,7 @@ const IMPORT_RE =
  * `<parent>/*` glob. Anything else throws, because a silently unscanned directory
  * is the defect above. */
 function workspacePackageDirs() {
-  // Normalized, because a Windows checkout (core.autocrlf=true, the git default
-  // there) hands every line back with a trailing \r. The entry pattern below
-  // ends at `["']?$`, which cannot consume it — so `pnpm lint` died on its very
-  // first step with `unreadable workspace entry: - "packages/*"`, an error about
-  // the workspace file rather than about the platform.
-  const yaml = readFileSync(join(ROOT, "pnpm-workspace.yaml"), "utf8").replace(/\r\n/g, "\n");
+  const yaml = readFileSync(join(ROOT, "pnpm-workspace.yaml"), "utf8");
   const list = /^packages:[^\S\n]*\n((?:[^\S\n]+-[^\n]*\n)+)/m.exec(yaml)?.[1];
   if (!list) throw new Error("dependency-guard: no `packages:` list in pnpm-workspace.yaml");
   const dirs = [];

--- a/scripts/windows-spawn-gate.mjs
+++ b/scripts/windows-spawn-gate.mjs
@@ -23,10 +23,13 @@
  *      `typescript/bin/tsc`): no shell, no quoting, one code path on both
  *      platforms. See fixtures/integration/src/global-setup.ts.
  *
- *  The check is per FILE, not per line, because a correct fix keeps the POSIX
- *  spawn verbatim in the else branch — a line-level scan would flag the fix it
- *  is asking for. A file that spawns one of these and never names `win32` has
- *  not been through this; a file that does is taken at its word.
+ *  The check is not per LINE, because a correct fix keeps the POSIX spawn
+ *  verbatim in its else branch — a line-level scan would flag the very shape it
+ *  is asking for. It is not per FILE either: a long file can carry a `win32`
+ *  for something unrelated (a path separator, a temp dir) and that would vouch
+ *  for an unguarded spawn hundreds of lines away. So each hazard is judged in
+ *  its own NEIGHBOURHOOD — `win32` has to appear within PROXIMITY_CHARS of the
+ *  spawn itself, which is where the branch that fixes it would be.
  *
  *  Run: node scripts/windows-spawn-gate.mjs  (wired into `pnpm lint`). */
 import { readFile, readdir } from "node:fs/promises";
@@ -52,16 +55,34 @@ const ALLOWED = new Map([
   ],
 ]);
 
-const PACKAGE_MANAGER_SPAWN = /spawn(?:Sync)?\s*\(\s*["'](?:npm|pnpm|npx|yarn|bun)["']\s*,\s*\[/;
-const DOT_BIN_PATH = /["']node_modules["']\s*,\s*["']\.bin["']|node_modules\/\.bin\//;
+const PACKAGE_MANAGER_SPAWN = /spawn(?:Sync)?\s*\(\s*["'](?:npm|pnpm|npx|yarn|bun)["']\s*,\s*\[/g;
+const DOT_BIN_PATH = /["']node_modules["']\s*,\s*["']\.bin["']|node_modules\/\.bin\//g;
 const ANY_SPAWN = /\bspawn(?:Sync)?\s*\(/;
 const HAS_PLATFORM_BRANCH = /win32/;
 
+/** How far from a hazard the platform branch may sit and still be believed.
+ *  Generous — a `const WINDOWS = …` at the top of a helper and the spawn it
+ *  guards are usually a few lines apart, and the fixes in this repo run to a
+ *  paragraph of comment — but far short of vouching for a whole file. */
+const PROXIMITY_CHARS = 1_200;
+
+/** Is there a `win32` close enough to this hazard to be about it? */
+function guarded(code, index) {
+  return HAS_PLATFORM_BRANCH.test(code.slice(Math.max(0, index - PROXIMITY_CHARS), index + PROXIMITY_CHARS));
+}
+
 /** Comments carry the explanation of the very patterns banned here, so they are
  *  removed before matching — otherwise every correct fix flags itself. Strings
- *  are left alone: a path built in a string IS the hazard. */
+ *  are left alone: a path built in a string IS the hazard.
+ *
+ *  Blanked rather than deleted, so every offset and line number below still
+ *  points at the real file — a gate that reports the wrong line sends whoever
+ *  hit it to the wrong place. */
 function stripComments(source) {
-  return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/(^|[^:])\/\/[^\n]*/g, "$1");
+  const blank = (text) => text.replace(/[^\n]/g, " ");
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, blank)
+    .replace(/(^|[^:])(\/\/[^\n]*)/g, (_, before, comment) => before + blank(comment));
 }
 
 async function* sourceFiles(dir) {
@@ -88,19 +109,24 @@ for (const tree of SCANNED) {
     if (rel === "scripts/windows-spawn-gate.mjs" || ALLOWED.has(rel)) continue;
     scanned += 1;
     const code = stripComments(await readFile(file, "utf8"));
-    if (HAS_PLATFORM_BRANCH.test(code)) continue;
-    if (PACKAGE_MANAGER_SPAWN.test(code)) {
-      failures.push([rel, 'spawns a package manager with no `win32` branch — it is a .cmd shim there and ENOENTs without a shell. Give Windows ONE command string with `shell: true`.']);
-    }
-    if (DOT_BIN_PATH.test(code) && ANY_SPAWN.test(code)) {
-      failures.push([rel, "spawns a node_modules/.bin/* entry — extensionless on POSIX, a .cmd/.ps1 pair on Windows. Spawn process.execPath against the tool's real JS entry instead."]);
+    const spawns = ANY_SPAWN.test(code);
+    for (const [pattern, applies, message] of [
+      [PACKAGE_MANAGER_SPAWN, true, "spawns a package manager with no `win32` branch beside it — it is a .cmd shim there and ENOENTs without a shell. Give Windows ONE command string with `shell: true`."],
+      [DOT_BIN_PATH, spawns, "spawns a node_modules/.bin/* entry — extensionless on POSIX, a .cmd/.ps1 pair on Windows. Spawn process.execPath against the tool's real JS entry instead."],
+    ]) {
+      if (!applies) continue;
+      pattern.lastIndex = 0;
+      for (let match = pattern.exec(code); match !== null; match = pattern.exec(code)) {
+        if (guarded(code, match.index)) continue;
+        failures.push([`${rel}:${code.slice(0, match.index).split("\n").length}`, message]);
+      }
     }
   }
 }
 
 for (const [file, message] of failures) console.error(`windows-spawn-gate: ${file} — ${message}`);
 if (failures.length > 0) {
-  console.error(`\nwindows-spawn-gate: ${failures.length} file${failures.length === 1 ? "" : "s"} of ${scanned} scanned.`);
+  console.error(`\nwindows-spawn-gate: ${failures.length} hazard${failures.length === 1 ? "" : "s"} across ${scanned} files scanned.`);
   process.exit(1);
 }
 console.log(`windows-spawn-gate: ok (${scanned} files, ${ALLOWED.size} documented exception${ALLOWED.size === 1 ? "" : "s"})`);

--- a/scripts/windows-spawn-gate.mjs
+++ b/scripts/windows-spawn-gate.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+/** Windows spawn gate — the enforcement half of "the repo runs on Windows".
+ *
+ *  Node has refused to exec a `.cmd`/`.bat` file without a shell since the fix
+ *  for CVE-2024-27980 (Node 18.20.2 / 20.12.2 / 21.7.3). On Windows every
+ *  package manager and every `node_modules/.bin/*` entry IS one of those shims,
+ *  so `spawn("pnpm", …)` and `spawn(join(dir, "node_modules/.bin/next"), …)`
+ *  fail with ENOENT before the child ever starts. That is not a Windows edge
+ *  case in the product — it is the test suite, the fixtures and the box template
+ *  refusing to run at all on a Windows checkout.
+ *
+ *  CI is ubuntu-only (every `runs-on:` in .github/workflows), which is exactly
+ *  why this is a gate and not a test: nothing that runs on a green PR can
+ *  observe the bug. This scan runs on Linux and fails there.
+ *
+ *  The two fixes it enforces:
+ *    - a package manager → branch on the platform and give Windows ONE command
+ *      STRING with `shell: true`. Not command + args array: that combination is
+ *      DEP0190, and Node 24 prints the deprecation warning by default — a
+ *      security warning about our own spawn, in the middle of `vendo` output.
+ *    - a `node_modules/.bin/<tool>` entry → do not run the shim at all. Spawn
+ *      `process.execPath` against the tool's real JS entry (`next/dist/bin/next`,
+ *      `typescript/bin/tsc`): no shell, no quoting, one code path on both
+ *      platforms. See fixtures/integration/src/global-setup.ts.
+ *
+ *  The check is per FILE, not per line, because a correct fix keeps the POSIX
+ *  spawn verbatim in the else branch — a line-level scan would flag the fix it
+ *  is asking for. A file that spawns one of these and never names `win32` has
+ *  not been through this; a file that does is taken at its word.
+ *
+ *  Run: node scripts/windows-spawn-gate.mjs  (wired into `pnpm lint`). */
+import { readFile, readdir } from "node:fs/promises";
+import { dirname, join, relative, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+
+/** Where source that has to run on a contributor's machine lives. */
+const SCANNED = ["packages", "fixtures", "corpus", "examples", "scripts", "genbench"];
+
+const SKIP_DIRS = new Set(["node_modules", "dist", "build", ".next", ".turbo", "coverage", ".vendo"]);
+
+/** Known and deliberate, each with the reason it is not simply fixed. Kept as
+ *  an explicit list rather than a narrower scan so that skipping something
+ *  stays visible in review. */
+const ALLOWED = new Map([
+  [
+    "genbench/src/codex.ts",
+    "codex is a NATIVE binary published through npm — it has no JS entry to run on process.execPath, " +
+      "so the shim is the only entry point and the fix is a different one. genbench is an on-demand " +
+      "benchmark, never part of `pnpm test`.",
+  ],
+]);
+
+const PACKAGE_MANAGER_SPAWN = /spawn(?:Sync)?\s*\(\s*["'](?:npm|pnpm|npx|yarn|bun)["']\s*,\s*\[/;
+const DOT_BIN_PATH = /["']node_modules["']\s*,\s*["']\.bin["']|node_modules\/\.bin\//;
+const ANY_SPAWN = /\bspawn(?:Sync)?\s*\(/;
+const HAS_PLATFORM_BRANCH = /win32/;
+
+/** Comments carry the explanation of the very patterns banned here, so they are
+ *  removed before matching — otherwise every correct fix flags itself. Strings
+ *  are left alone: a path built in a string IS the hazard. */
+function stripComments(source) {
+  return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/(^|[^:])\/\/[^\n]*/g, "$1");
+}
+
+async function* sourceFiles(dir) {
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return; // an optional tree (fixtures a shallow clone skipped) is not a failure
+  }
+  for (const entry of entries) {
+    if (entry.name.startsWith(".") || SKIP_DIRS.has(entry.name)) continue;
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) yield* sourceFiles(path);
+    else if (/\.(ts|tsx|mts|js|mjs|cjs)$/.test(entry.name)) yield path;
+  }
+}
+
+const failures = [];
+let scanned = 0;
+
+for (const tree of SCANNED) {
+  for await (const file of sourceFiles(join(root, tree))) {
+    const rel = relative(root, file).split(sep).join("/");
+    if (rel === "scripts/windows-spawn-gate.mjs" || ALLOWED.has(rel)) continue;
+    scanned += 1;
+    const code = stripComments(await readFile(file, "utf8"));
+    if (HAS_PLATFORM_BRANCH.test(code)) continue;
+    if (PACKAGE_MANAGER_SPAWN.test(code)) {
+      failures.push([rel, 'spawns a package manager with no `win32` branch — it is a .cmd shim there and ENOENTs without a shell. Give Windows ONE command string with `shell: true`.']);
+    }
+    if (DOT_BIN_PATH.test(code) && ANY_SPAWN.test(code)) {
+      failures.push([rel, "spawns a node_modules/.bin/* entry — extensionless on POSIX, a .cmd/.ps1 pair on Windows. Spawn process.execPath against the tool's real JS entry instead."]);
+    }
+  }
+}
+
+for (const [file, message] of failures) console.error(`windows-spawn-gate: ${file} — ${message}`);
+if (failures.length > 0) {
+  console.error(`\nwindows-spawn-gate: ${failures.length} file${failures.length === 1 ? "" : "s"} of ${scanned} scanned.`);
+  process.exit(1);
+}
+console.log(`windows-spawn-gate: ok (${scanned} files, ${ALLOWED.size} documented exception${ALLOWED.size === 1 ? "" : "s"})`);


### PR DESCRIPTION
## What

Node has refused to exec a `.cmd`/`.bat` without a shell since the fix for CVE-2024-27980. On Windows every package manager and every `node_modules/.bin/*` entry **is** one of those shims, so `spawn("npm", …)` and `spawn(<…>/.bin/next, …)` ENOENT before the child ever starts. 9 sites across `packages/`, `fixtures/`, `corpus/` and `examples/`.

Two fixes, applied by kind:

- **a package manager** → branch on the platform and hand Windows ONE command string with `shell: true`. Not command + args: that combination is DEP0190, and Node 24 prints the warning by default. Args are quoted because `cmd.exe` reads a bare `^` (as in `ai@^6`) as an escape — the reasoning `provider-deps.ts` already carried.
- **a `node_modules/.bin/<tool>` entry** → don't run the shim at all. Spawn `process.execPath` against the tool's real JS entry (`next/dist/bin/next`, `typescript/bin/tsc`): no shell, no quoting, one code path on both platforms. The repo already did this at `fixtures/existing-agents-e2e/src/journey.ts:202`; this makes it the rule.

## Why

CI is ubuntu-only — every `runs-on:` in `.github/workflows`. Nothing that runs on a green PR can observe any of this. Measured on a Windows checkout of this branch:

| | before | after |
|---|---|---|
| `spawn(node_modules/.bin/next, …)` | `ERROR ENOENT` | `ok Next.js v16.2.11` (via `process.execPath` + `next/dist/bin/next`) |
| `vendo` install, on a user's screen | `[DEP0190] DeprecationWarning: …security vulnerabilities…` | *(nothing)* |

The second one is the one that reaches users: the CLI printed a Node security-deprecation warning about its own spawn, in the middle of its own output, on every install.

**Rebased onto #1623.** This branch originally carried 13 sites. #1623 deleted `packages/box-template` outright and rewrote `packages/apps/box/build-template.mjs` so it no longer spawns at all — which retires 4 of them, along with the `taskkill` teardown fix that belonged to the deleted `box-template.test.ts`. Those are gone from the diff rather than carried forward; the hazard they covered no longer exists. The gate re-run on the merged tree is green, so #1623's replacement box machinery did not reintroduce it.

**On `pnpm lint`.** It dies on step 1 on Windows too — `dependency-guard.mjs` cannot parse a CRLF `pnpm-workspace.yaml`. I hit it here and fixed it before finding that **#1447 already carries that fix** (ENG-430, bug 3), in a better form: it splits on `/\r?\n/` rather than rewriting the file first. Backed out rather than shipping a second, colliding fix — `pnpm lint` on Windows is #1447's to unblock. The gate added here runs standalone, so nothing in this PR waits on it.

## Verification

- `packages/vendo` `tests/cli/provider-deps.test.ts` — **50/50**, including 4 new, re-run after the rebase. `installSpawnPlan` takes its platform as an argument, so the win32 shape is asserted **on ubuntu** — the only place in the repo it is checked at all.
- `node scripts/windows-spawn-gate.mjs` — ok, 2214 files, 1 documented exception. **Proved non-vacuous twice**: once by reintroducing a plain hazard, and once by probing the exact false negative review named — an unrelated `win32` near the top of a file and an unguarded spawn at the bottom, which the original file-level check passed and the neighbourhood check catches at the right line.
- `tsc --noEmit` clean on all six fixtures, `corpus/harness`, `packages/actions`, and on `provider-deps.ts`. The remaining errors in `packages/vendo` are stale-dist `has no exported member` ones, identical on an unmodified tree (checked with `git stash`).

### The gate

`scripts/windows-spawn-gate.mjs`, wired into `pnpm lint` beside the portability gate. It judges each hazard by its **neighbourhood**: not per line, because a correct fix keeps the POSIX spawn verbatim in its else branch and a line-level scan flags the very shape it is asking for; and not per file, because one `win32` mentioned for a path separator would vouch for an unguarded spawn hundreds of lines away. `win32` has to appear within 1200 characters of the spawn, which is where the branch that fixes it would be. Comments are stripped (blanked, so line numbers survive) for the same reason. `genbench/src/codex.ts` is a named exception carrying its reason (codex is a native binary published through npm; it has no JS entry to run on `process.execPath`), kept as an explicit list so that skipping something stays visible in review.

**From review (`fa26e790`).** Two gaps Greptile named, both real, both closed. `installSpawnPlan` now **refuses** an arg carrying a `"` of its own instead of wrapping it and hoping — cmd.exe has no escaping story worth trusting, and this builds a line for a shell, so a wrong guess is a command injection rather than a typo. And the gate judged per FILE, which let any `win32` anywhere vouch for every spawn in it; each hazard is now judged within 1200 characters of itself. Comments are blanked rather than deleted when stripped, so the reported `file:line` still points at the real line.

### Not in scope

15 `corpus/harness` failures, **pre-existing and unchanged** — verified by running the suite with and without this branch's one change to that package: 15 failed / 174 passed both times. Those tests write extensionless shell scripts as fake `npm`/`pnpm` binaries, which `cmd.exe` cannot run. That is the test doubles, not the product's spawns, and it wants its own change.

- [x] `pnpm lint` — `windows-spawn-gate` green standalone. `dependency-guard` needs #1447 to run on Windows at all; `portability-gate` reads built output and needs `pnpm build` first. Both left to CI.
- [ ] Screenshots attached (if UI-affecting) — n/a
