### PR TITLE
ci(release): the tag push stops wearing the wrong credential, and a bump that fails says so

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,13 +113,28 @@ jobs:
           # release partway through, after earlier packages are already live.
           done < <(pnpm -r --filter './packages/*' exec node -e "const p=require('./package.json'); if (!p.private) process.stdout.write(p.name+'\n')")
 
-      # Last: open the @vendoai bump PR on vendo-web, so the console never sits
-      # on a stale release. GITHUB_TOKEN is scoped to this repo alone, so this
-      # needs its own cross-repo credential; without it the step says so and
-      # stops, and it never reddens a release that already published.
+  # Opening the @vendoai bump PR on vendo-web is its OWN job so that its
+  # failures are visible. It used to be the publish job's last step under
+  # `continue-on-error: true`, and that combination is how the console sat on a
+  # stale release for two days: v0.38.0's bump died on
+  # ERR_PNPM_NO_MATCHING_VERSION, the annotation was a warning inside a green
+  # release, and nobody had any reason to look. A separate job can go red on its
+  # own without claiming the publish failed — the publish really did succeed,
+  # and the packages really are on npm.
+  #
+  # GITHUB_TOKEN is scoped to this repo alone, so this needs its own cross-repo
+  # credential; without it the job says so and stops green, because a missing
+  # optional secret is not a failure.
+  bump-console:
+    needs: publish
+    if: github.event_name == 'push' || inputs.publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
       - name: Open the vendo-web dep bump PR
-        if: github.event_name == 'push' || inputs.publish
-        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.VENDO_WEB_PAT }}
         run: |
@@ -129,6 +144,21 @@ jobs:
             exit 0
           fi
           version=$(node -p "require('./packages/vendo/package.json').version")
+          # `npm publish` returning is not the same as the version being
+          # installable: the registry's read path lags the write by seconds to
+          # minutes, and this job starts immediately after. v0.38.0's bump asked
+          # pnpm for a version npm had not surfaced yet and died with
+          # ERR_PNPM_NO_MATCHING_VERSION. Wait for the thing we just published to
+          # actually resolve before rewriting nine files against it.
+          published=false
+          for _ in $(seq 60); do
+            if npm view "@vendoai/vendo@$version" version >/dev/null 2>&1; then published=true; break; fi
+            sleep 5
+          done
+          if [ "$published" != true ]; then
+            echo "::error::@vendoai/vendo@$version is still not resolvable 5 minutes after publish — refusing to open a bump PR pnpm cannot install"
+            exit 1
+          fi
           # The branch prefix is a contract: vendo-web's vendoai-bump-merge
           # workflow only ever merges `vendoai-bump/*`.
           branch="vendoai-bump/v$version"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,6 +129,11 @@ jobs:
     needs: publish
     if: github.event_name == 'push' || inputs.publish
     runs-on: ubuntu-latest
+    # Narrower than the workflow default: this job reads this repo and talks to
+    # vendo-web with VENDO_WEB_PAT. It publishes nothing, so it has no business
+    # holding the OIDC token that `publish` mints npm credentials with.
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
@@ -144,21 +149,37 @@ jobs:
             exit 0
           fi
           version=$(node -p "require('./packages/vendo/package.json').version")
+          # EVERY package the bump will pin, not just the umbrella. The lockstep
+          # group is exactly the public packages carrying this version, so
+          # matching on it is also what excludes @vendoai/telemetry, which
+          # versions on its own and never rides the bump.
+          group=$(node -e '
+            const fs = require("fs");
+            for (const dir of fs.readdirSync("packages")) {
+              const file = "packages/" + dir + "/package.json";
+              if (!fs.existsSync(file)) continue;
+              const pkg = JSON.parse(fs.readFileSync(file, "utf8"));
+              if (!pkg.private && pkg.version === process.argv[1]) console.log(pkg.name);
+            }' "$version")
           # `npm publish` returning is not the same as the version being
-          # installable: the registry's read path lags the write by seconds to
-          # minutes, and this job starts immediately after. v0.38.0's bump asked
-          # pnpm for a version npm had not surfaced yet and died with
-          # ERR_PNPM_NO_MATCHING_VERSION. Wait for the thing we just published to
-          # actually resolve before rewriting nine files against it.
-          published=false
-          for _ in $(seq 60); do
-            if npm view "@vendoai/vendo@$version" version >/dev/null 2>&1; then published=true; break; fi
-            sleep 5
+          # installable: the registry's read path lags the write, and this job
+          # starts immediately after. v0.38.0's bump asked pnpm for a version npm
+          # had not surfaced yet and died with ERR_PNPM_NO_MATCHING_VERSION.
+          #
+          # Every package is checked because propagation is per-package and
+          # unordered — the umbrella can be live while a sibling still 404s, and
+          # pnpm resolves all of them. One 5-minute budget covers the whole set.
+          deadline=$(( SECONDS + 300 ))
+          for name in $group; do
+            until npm view "$name@$version" version >/dev/null 2>&1; do
+              if [ "$SECONDS" -ge "$deadline" ]; then
+                echo "::error::$name@$version is still not resolvable 5 minutes after publish — refusing to open a bump PR pnpm cannot install"
+                exit 1
+              fi
+              sleep 5
+            done
           done
-          if [ "$published" != true ]; then
-            echo "::error::@vendoai/vendo@$version is still not resolvable 5 minutes after publish — refusing to open a bump PR pnpm cannot install"
-            exit 1
-          fi
+          echo "all of $(printf '%s' "$group" | wc -w) published packages resolve at $version"
           # The branch prefix is a contract: vendo-web's vendoai-bump-merge
           # workflow only ever merges `vendoai-bump/*`.
           branch="vendoai-bump/v$version"

--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -145,13 +145,12 @@ jobs:
       - name: Push the release tag
         id: tag
         env:
-          # The built-in token, spelled out, because the checkout above persists
-          # RELEASE_PAT and a plain `git push origin` would inherit it. A real
-          # credential's tag push DOES fire release.yml's `push: tags` trigger,
-          # so the tag and the dispatch below both started a publish and the two
-          # runs collided on npm (2026-08-21: dispatch 32437362971 lost to push
-          # 32437364008). GITHUB_TOKEN's silence is the interlock that makes the
-          # dispatch the single trigger — it is load-bearing, not incidental.
+          # The built-in token, spelled out, because a real credential's tag push
+          # DOES fire release.yml's `push: tags` trigger, and then the tag and the
+          # dispatch below each start a publish and the two collide on npm
+          # (2026-08-21 and again on v0.38.0: push run 32661101752 failed against
+          # dispatch 32661101524). GITHUB_TOKEN's silence is the interlock that
+          # makes the dispatch the single trigger — load-bearing, not incidental.
           TAG_PUSH_URL: https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
         run: |
           set -euo pipefail
@@ -167,7 +166,14 @@ jobs:
             exit 0
           fi
           git tag "$tag"
-          git push "$TAG_PUSH_URL" "refs/tags/$tag"
+          # The URL alone was NOT enough, and v0.38.0 proved it: actions/checkout
+          # persists its credential as `http.https://github.com/.extraheader:
+          # AUTHORIZATION: basic <RELEASE_PAT>`, and that header BEATS basic auth
+          # embedded in the URL — git sends both, GitHub honours the header. So
+          # the tag went up as yousefh409 and fired `push: tags` anyway. Emptying
+          # the header for this one command is what actually forces the URL's
+          # token; the config itself is left alone for every other git call.
+          git -c http.https://github.com/.extraheader= push "$TAG_PUSH_URL" "refs/tags/$tag"
           echo "pushed $tag -> $(git rev-parse HEAD)"
           echo "tag=$tag" >>"$GITHUB_OUTPUT"
 


### PR DESCRIPTION
Two defects from the v0.38.0 release. Both were mine.

## A — the #1585 interlock was defeated, and here is the mechanism

#1585 pushed the tag through a URL carrying `GITHUB_TOKEN`, on the theory that a silent credential keeps `release.yml`'s `push: tags` trigger from racing the explicit dispatch. It did not work: on v0.38.0 the push-triggered run [32661101752](https://github.com/runvendo/vendo/actions/runs/32661101752) came up **`actor: yousefh409`** and failed on npm against the dispatch run [32661101524](https://github.com/runvendo/vendo/actions/runs/32661101524), which succeeded.

`actions/checkout` is why. Its own log line, from the v0.38.0 version run:

```
[command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
```

That header applies to **every** request to `https://github.com/`, and it **beats** basic auth embedded in a URL — git sends both and GitHub honours the header. So the tag went up as RELEASE_PAT no matter what the URL said.

**Proven, not reasoned.** Local repo, bogus `extraheader` in config, good credentials in the URL — the production shape:

| | result |
| --- | --- |
| `git ls-remote <url-with-good-creds>` | **failed** — `Invalid username or token` → the extraheader won |
| `git -c http.https://github.com/.extraheader= ls-remote <same url>` | **succeeded** → the URL's token was used |

So the fix is to empty the header for that one command:

```bash
git -c http.https://github.com/.extraheader= push "$TAG_PUSH_URL" "refs/tags/$tag"
```

Scoped to the single push; the config is left intact for every other git call. **What is proven is the mechanism, not the outcome** — that only one `Release` run appears is observable on the next real release and nowhere else.

The `Commit the version to main` push is deliberately left alone. It *should* run under RELEASE_PAT: the comment above it explains that re-triggering this workflow is how a half-finished release retries itself.

## B — a bump that failed inside a green release

v0.38.0's bump step died on `ERR_PNPM_NO_MATCHING_VERSION`: `npm publish` had returned seconds earlier, but the registry read path lags the write, so pnpm asked for a version npm had not surfaced yet. Under `continue-on-error: true` that was a warning inside a green run — invisible. The console has been on `0.36.3` since 08-21.

Two changes:

**A bounded wait**, because the race is real and retrying is the correct response to it:
```bash
for _ in $(seq 60); do
  if npm view "@vendoai/vendo@$version" version >/dev/null 2>&1; then published=true; break; fi
  sleep 5
done
```
Five minutes, then `::error::` and exit.

**Its own job.** `continue-on-error` was hiding a real failure behind a green release, but deleting it alone would have made a bump failure look like a publish failure — and the publish genuinely succeeded, the packages genuinely are on npm. `bump-console` `needs: publish`, so the publish job stays green and the bump job goes red on its own. Verified the file parses into exactly two jobs: `publish` (9 steps), `bump-console` (3 steps, `needs: publish`).

## Also asked: where did 13 minutes go between hops 1 and 2

**Nothing is wrong, and there is nothing to fix.** The run timeline:

| time | event |
| --- | --- |
| 19:10:53Z | `merge_group` **CI** run 32660421665 starts |
| 19:22:24Z | it finishes — **11m31s** |
| 19:22:52Z | commit lands on main; **Version Packages fires 28s later** |
| 19:23:57Z | Version Packages done (65s total) |

The 13 minutes is the **merge queue** running the full required-check suite against the merge group before it merges — exactly what the `merge-queue-main` ruleset asks for (`grouping_strategy: ALLGREEN`). `19:10:35` is when the PR entered the queue, not when main got the commit. `version-packages.yml` reacted in 28 seconds. Cutting this would mean weakening the merge queue, which is not a trade worth making for a release path that already runs unattended.

## Gate

`actionlint` exit 0 on both workflows. `pnpm test:affected` — no tasks (workflow-only). `pnpm typecheck` — 44/44.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate publishes and makes console bump failures visible. Before: the tag push inherited `actions/checkout`’s credential and triggered `release.yml`’s push flow, racing the dispatch; after: we clear the extraheader and push with `GITHUB_TOKEN`, so only the dispatch publishes. The bump now runs as its own job, waits for the whole lockstep to propagate, and fails loudly when it can’t.

- Changes
  - `.github/workflows/version-packages.yml`: push tags with `git -c http.https://github.com/.extraheader= push "$TAG_PUSH_URL"` so the URL’s `GITHUB_TOKEN` wins and `push: tags` does not race the dispatch.
  - `.github/workflows/release.yml`: add `bump-console` with `needs: publish`; drop the OIDC token via narrower permissions; wait up to 5 minutes for all public packages in the lockstep (including `@vendoai/vendo`) to resolve on npm before opening the PR; on timeout, error and exit non-zero while `publish` stays green. If `VENDO_WEB_PAT` is missing, exit early without failing the release.

- Rollout/verification
  - On the next tagged release, expect one publish run (dispatch-triggered). `publish` should be green; `bump-console` is independently green or red based on registry availability for the whole lockstep.

<sup>Written for commit 7515a8995b6cb44923507fda36c44c7287d0da9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

