### PR TITLE
docs(site): turn off PostHog session recording on the docs site

### DIFF
--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -28,7 +28,7 @@
   "integrations": {
     "posthog": {
       "apiKey": "phc_siVHW4wVh8yDeDzMgnjLGrYYqsHMceqfdqYF9fPEGXpS",
-      "sessionRecording": true
+      "sessionRecording": false
     }
   },
   "contextual": {


### PR DESCRIPTION
The public docs site was session-recording every visitor with no consent. Yousef decided we don't need docs recordings at all, so this turns them off (pageview analytics stay on). One line in `docs-site/docs.json`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disables session recording on the public docs site via the `posthog` integration to stop recording visitors without consent. Old: `sessionRecording` was true; new: false. Pageview analytics remain enabled.

- Review/rollout: Single config toggle in `docs-site/docs.json`. After deploy, verify no new session recordings appear in `posthog` for the docs site while pageview events continue.

<sup>Written for commit 61ac9c078d5911ff4dc5f5c59beff61481ed5e0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

