### PR TITLE
test(knowledge): unanswerable scorecard vs vendo_knowledge_search

### DIFF
--- a/packages/knowledge/tests/fixtures/unanswerable-scorecard.ts
+++ b/packages/knowledge/tests/fixtures/unanswerable-scorecard.ts
@@ -126,7 +126,7 @@ export const ITEMS: ScorecardItem[] = [
 
   { id: "M1", kind: "multi-source", query: "Compare Maple's wire cutoff time with international transfer duration." },
   { id: "M2", kind: "multi-source", query: "What is the savings APY and the monthly withdrawal limit?" },
-  { id: "M3", kind: "multi-source", query: "How do overdraft fees interact with refund timing?" },
+  { id: "M3", kind: "multi-source", query: "What is the daily wire limit and the 2FA threshold for a wire?" },
   { id: "M4", kind: "multi-source", query: "Which Settings screens cover debit card freeze and 2FA backup codes?" },
 
   { id: "E1", kind: "no-source-empty", query: "quantum blockchain espresso" },

--- a/packages/knowledge/tests/fixtures/unanswerable-scorecard.ts
+++ b/packages/knowledge/tests/fixtures/unanswerable-scorecard.ts
@@ -1,0 +1,141 @@
+import type { KnowledgeDoc } from "@vendoai/core";
+
+/** SVQ-shaped item kinds. `no-source-empty` has zero lexical overlap with the
+ *  corpus (the already-working refuse). `no-source-overlap` shares tokens with
+ *  the corpus but the answer is not in it — the 7–10/34 leak class at
+ *  default `weakScoreThreshold` 0. */
+export type ScorecardKind =
+  | "single-source"
+  | "multi-source"
+  | "no-source-empty"
+  | "no-source-overlap";
+
+export interface ScorecardItem {
+  id: string;
+  kind: ScorecardKind;
+  query: string;
+}
+
+const doc = (
+  id: string,
+  title: string,
+  text: string,
+  kind: KnowledgeDoc["kind"] = "docs",
+): KnowledgeDoc => ({
+  id,
+  kind,
+  visibility: "public",
+  title,
+  text,
+  source: `${id}.md`,
+});
+
+/** Small public host-docs corpus (payments product). Token inventory is
+ *  deliberate: overlap-unanswerable queries share content words with these
+ *  pages; empty-hit queries use tokens that never appear here. */
+export const CORPUS: KnowledgeDoc[] = [
+  doc(
+    "docs#wires",
+    "Wire transfers",
+    [
+      "# Wire transfers",
+      "Maple caps outbound wire transfers at $25,000 per business day.",
+      "Limits reset at midnight Eastern Time.",
+      "Wires submitted after 4pm ET process the next business day.",
+      "A wire cannot be cancelled once Maple has released it to the network.",
+    ].join("\n"),
+  ),
+  doc(
+    "docs#refunds",
+    "Refund policy",
+    [
+      "# Refund policy",
+      "Refunds are processed within five business days.",
+      "A refund lands on the original payment method.",
+      "Partial refunds are allowed when the original charge is still settling.",
+    ].join("\n"),
+  ),
+  doc(
+    "glossary#apy",
+    "APY",
+    "APY (annual percentage yield) is the effective annual rate of return accounting for compounding. Maple savings currently advertise 4.25% APY.",
+    "glossary",
+  ),
+  doc(
+    "docs#overdraft",
+    "Overdraft protection",
+    [
+      "# Overdraft protection",
+      "Maple covers overdrafts up to $200 for eligible checking accounts.",
+      "A $15 fee applies per overdraft event.",
+      "Overdraft protection is opt-in from Settings > Accounts.",
+    ].join("\n"),
+  ),
+  doc(
+    "docs#cards",
+    "Debit card freeze",
+    [
+      "# Debit card freeze",
+      "Freeze a lost debit card in Settings > Cards.",
+      "A frozen card declines all new charges.",
+      "Unfreeze instantly from the same screen.",
+    ].join("\n"),
+  ),
+  doc(
+    "docs#international",
+    "International transfers",
+    [
+      "# International transfers",
+      "Maple sends international transfers in 1-3 business days.",
+      "The FX markup is 1.5% over the mid-market rate.",
+      "SWIFT is used for USD, EUR, and GBP corridors.",
+    ].join("\n"),
+  ),
+  doc(
+    "docs#auth",
+    "Two-factor authentication",
+    [
+      "# Two-factor authentication",
+      "Maple requires 2FA for any wire over $5,000.",
+      "SMS and authenticator apps are supported.",
+      "Backup codes live under Settings > Security.",
+    ].join("\n"),
+  ),
+  doc(
+    "docs#accounts",
+    "Account types",
+    [
+      "# Account types",
+      "Maple offers checking (no interest, unlimited debit) and savings (4.25% APY, six withdrawals per month).",
+      "Joint accounts need both owners present to close.",
+    ].join("\n"),
+  ),
+];
+
+/** Twenty-item eval: 8 single-source, 4 multi-source, 3 empty-hit no-source,
+ *  5 overlap no-source. */
+export const ITEMS: ScorecardItem[] = [
+  { id: "S1", kind: "single-source", query: "What is Maple's daily outbound wire transfer limit?" },
+  { id: "S2", kind: "single-source", query: "How long do refunds take to process?" },
+  { id: "S3", kind: "single-source", query: "What does APY mean at Maple?" },
+  { id: "S4", kind: "single-source", query: "What overdraft amount does Maple cover?" },
+  { id: "S5", kind: "single-source", query: "How do I freeze a lost debit card?" },
+  { id: "S6", kind: "single-source", query: "How long do international transfers take?" },
+  { id: "S7", kind: "single-source", query: "When does Maple require 2FA for a wire?" },
+  { id: "S8", kind: "single-source", query: "How many savings withdrawals does Maple allow per month?" },
+
+  { id: "M1", kind: "multi-source", query: "Compare Maple's wire cutoff time with international transfer duration." },
+  { id: "M2", kind: "multi-source", query: "What is the savings APY and the monthly withdrawal limit?" },
+  { id: "M3", kind: "multi-source", query: "How do overdraft fees interact with refund timing?" },
+  { id: "M4", kind: "multi-source", query: "Which Settings screens cover debit card freeze and 2FA backup codes?" },
+
+  { id: "E1", kind: "no-source-empty", query: "quantum blockchain espresso" },
+  { id: "E2", kind: "no-source-empty", query: "neolithic kiln glaze" },
+  { id: "E3", kind: "no-source-empty", query: "zirconia ytterbium phosphor" },
+
+  { id: "O1", kind: "no-source-overlap", query: "Can I wire money to a dissolved company?" },
+  { id: "O2", kind: "no-source-overlap", query: "What is the cryptocurrency wire transfer limit?" },
+  { id: "O3", kind: "no-source-overlap", query: "Do Maple refunds cover NFT purchases?" },
+  { id: "O4", kind: "no-source-overlap", query: "What is the APY on Bitcoin savings?" },
+  { id: "O5", kind: "no-source-overlap", query: "Can I freeze someone else's debit card remotely?" },
+];

--- a/packages/knowledge/tests/unanswerable-scorecard.test.ts
+++ b/packages/knowledge/tests/unanswerable-scorecard.test.ts
@@ -201,15 +201,5 @@ describe("unanswerable scorecard vs vendo_knowledge_search (no verifier)", () =>
     // a production default change — overlap TF scores sit in the same band as
     // genuine answers, so the threshold cannot isolate the 7–10/34 class.
     expect(defaultLeak).toBe(overlapCount);
-    const { registry } = await seedTools();
-    const sample = ITEMS.find((item) => item.kind === "no-source-overlap")!;
-    const stillDefault = await registry.execute(
-      { id: "call_default_knob", tool: VENDO_KNOWLEDGE_SEARCH_TOOL, args: { query: sample.query } },
-      ctx,
-    );
-    expect(stillDefault.status).toBe("ok");
-    if (stillDefault.status === "ok") {
-      expect((stillDefault.output as unknown as KnowledgeResultEnvelope).outcome).toBe("answered");
-    }
   });
 });

--- a/packages/knowledge/tests/unanswerable-scorecard.test.ts
+++ b/packages/knowledge/tests/unanswerable-scorecard.test.ts
@@ -1,0 +1,215 @@
+import type {
+  KnowledgeAdapter,
+  KnowledgeContext,
+  KnowledgeQuery,
+  RunContext,
+  ToolRegistry,
+} from "@vendoai/core";
+import { memoryStoreAdapter } from "@vendoai/core/conformance";
+import { describe, expect, it } from "vitest";
+import {
+  createKnowledgeTools,
+  VENDO_KNOWLEDGE_SEARCH_TOOL,
+  type KnowledgeResultEnvelope,
+  type KnowledgeResultOutcome,
+} from "../src/index.js";
+import * as knowledgeApi from "../src/index.js";
+import { vendoKnowledge } from "../src/local/lexical.js";
+import { CORPUS, ITEMS, type ScorecardItem } from "./fixtures/unanswerable-scorecard.js";
+
+const ctx: RunContext = {
+  principal: { kind: "user", subject: "scorecard" },
+  venue: "chat",
+  presence: "present",
+  sessionId: "scorecard-session",
+};
+
+interface SearchRecord {
+  intent: KnowledgeQuery["intent"];
+}
+
+interface ScorecardRow {
+  id: string;
+  kind: ScorecardItem["kind"];
+  query: string;
+  outcome: KnowledgeResultOutcome | "error";
+  hitCount: number;
+  topDocId: string | null;
+  intents: Array<KnowledgeQuery["intent"]>;
+}
+
+function spyAdapter(adapter: KnowledgeAdapter): KnowledgeAdapter & { searches: SearchRecord[] } {
+  const searches: SearchRecord[] = [];
+  return {
+    ...adapter,
+    searches,
+    async search(query: KnowledgeQuery, searchCtx: KnowledgeContext) {
+      searches.push({ intent: query.intent ?? "chat" });
+      return adapter.search(query, searchCtx);
+    },
+  };
+}
+
+async function seedTools(weakScoreThreshold?: number): Promise<{
+  registry: ToolRegistry;
+  adapter: KnowledgeAdapter & { searches: SearchRecord[] };
+}> {
+  const store = memoryStoreAdapter();
+  const base = vendoKnowledge({ store });
+  await base.upsert!(CORPUS);
+  const adapter = spyAdapter(base);
+  const registry = createKnowledgeTools(
+    adapter,
+    weakScoreThreshold === undefined ? {} : { weakScoreThreshold },
+  );
+  return { registry, adapter };
+}
+
+async function runItem(
+  registry: ToolRegistry,
+  adapter: { searches: SearchRecord[] },
+  item: ScorecardItem,
+): Promise<ScorecardRow> {
+  const before = adapter.searches.length;
+  const result = await registry.execute(
+    { id: `call_${item.id}`, tool: VENDO_KNOWLEDGE_SEARCH_TOOL, args: { query: item.query } },
+    ctx,
+  );
+  const intents = adapter.searches.slice(before).map((record) => record.intent);
+  if (result.status !== "ok") {
+    return {
+      id: item.id,
+      kind: item.kind,
+      query: item.query,
+      outcome: "error",
+      hitCount: 0,
+      topDocId: null,
+      intents,
+    };
+  }
+  const envelope = result.output as unknown as KnowledgeResultEnvelope;
+  const hits = envelope.hits ?? [];
+  return {
+    id: item.id,
+    kind: item.kind,
+    query: item.query,
+    outcome: envelope.outcome,
+    hitCount: hits.length,
+    topDocId: hits[0]?.docId ?? null,
+    intents,
+  };
+}
+
+function formatTable(rows: ScorecardRow[]): string {
+  const header = ["id", "kind", "outcome", "hits", "topDocId", "intents", "query"].join("\t");
+  const body = rows.map((row) =>
+    [
+      row.id,
+      row.kind,
+      row.outcome,
+      String(row.hitCount),
+      row.topDocId ?? "-",
+      row.intents.join("→") || "-",
+      row.query,
+    ].join("\t"),
+  );
+  return [header, ...body].join("\n");
+}
+
+describe("unanswerable scorecard vs vendo_knowledge_search (no verifier)", () => {
+  it("does not export or resurrect entailmentVerifier", () => {
+    expect(knowledgeApi).not.toHaveProperty("entailmentVerifier");
+    expect("entailmentVerifier" in knowledgeApi).toBe(false);
+  });
+
+  it("runs a 20-item single/multi/no-source eval through the shipped execute path", async () => {
+    expect(ITEMS).toHaveLength(20);
+    const { registry, adapter } = await seedTools();
+    const rows: ScorecardRow[] = [];
+    for (const item of ITEMS) {
+      rows.push(await runItem(registry, adapter, item));
+    }
+
+    const table = formatTable(rows);
+    // Printed so the captured vitest log is the raw outcomes table.
+    console.log("\n=== vendo_knowledge_search scorecard (weakScoreThreshold default 0) ===\n");
+    console.log(table);
+
+    const ofKind = (kind: ScorecardItem["kind"]) => rows.filter((row) => row.kind === kind);
+    const overlap = ofKind("no-source-overlap");
+    const empty = ofKind("no-source-empty");
+    const single = ofKind("single-source");
+    const multi = ofKind("multi-source");
+    const overlapAnswered = overlap.filter((row) => row.outcome === "answered");
+    const emptyRefused = empty.filter((row) => row.outcome === "insufficient-evidence");
+
+    console.log(
+      [
+        "",
+        `single-source answered: ${single.filter((row) => row.outcome === "answered").length}/${single.length}`,
+        `multi-source answered: ${multi.filter((row) => row.outcome === "answered").length}/${multi.length}`,
+        `no-source-empty insufficient-evidence: ${emptyRefused.length}/${empty.length}`,
+        `no-source-overlap answered (leak at threshold 0): ${overlapAnswered.length}/${overlap.length}`,
+        "",
+      ].join("\n"),
+    );
+
+    expect(rows.every((row) => row.outcome !== "error")).toBe(true);
+    expect(single.length).toBe(8);
+    expect(multi.length).toBe(4);
+    expect(empty.length).toBe(3);
+    expect(overlap.length).toBe(5);
+
+    // Answerable items retrieve. Empty-hit refuse is NOT the leak.
+    expect(single.every((row) => row.outcome === "answered" && row.hitCount > 0)).toBe(true);
+    expect(multi.every((row) => row.outcome === "answered" && row.hitCount > 0)).toBe(true);
+    expect(emptyRefused).toHaveLength(empty.length);
+    expect(empty.every((row) => row.hitCount === 0)).toBe(true);
+    expect(empty.every((row) => row.intents.join("→") === "chat→deep")).toBe(true);
+
+    // The leftover 7–10/34 class: token overlap still returns `answered` at
+    // default threshold 0, after chat search, with no deep retry and no verifier.
+    expect(overlapAnswered.length).toBe(overlap.length);
+    expect(overlap.every((row) => row.hitCount > 0)).toBe(true);
+    expect(overlap.every((row) => row.intents.join("→") === "chat")).toBe(true);
+  });
+
+  it("calibration: a positive weakScoreThreshold on the same fixture (default stays 0)", async () => {
+    const overlapCount = ITEMS.filter((item) => item.kind === "no-source-overlap").length;
+    const singleCount = ITEMS.filter((item) => item.kind === "single-source").length;
+    const leak = (rows: ScorecardRow[]) =>
+      rows.filter((row) => row.kind === "no-source-overlap" && row.outcome === "answered").length;
+    const singleAnswered = (rows: ScorecardRow[]) =>
+      rows.filter((row) => row.kind === "single-source" && row.outcome === "answered").length;
+
+    const lines = ["threshold\tleak_answered\tsingle_answered"];
+    let defaultLeak = -1;
+    for (const threshold of [0, 2, 8, 32]) {
+      const seeded = await seedTools(threshold === 0 ? undefined : threshold);
+      const rows: ScorecardRow[] = [];
+      for (const item of ITEMS) {
+        rows.push(await runItem(seeded.registry, seeded.adapter, item));
+      }
+      if (threshold === 0) defaultLeak = leak(rows);
+      lines.push(`${threshold}\t${leak(rows)}/${overlapCount}\t${singleAnswered(rows)}/${singleCount}`);
+    }
+
+    console.log("\n=== weakScoreThreshold calibration on this fixture (default stays 0) ===");
+    console.log(lines.join("\n"));
+
+    // Default path still leaks. Raising the knob is recorded here; it is not
+    // a production default change — overlap TF scores sit in the same band as
+    // genuine answers, so the threshold cannot isolate the 7–10/34 class.
+    expect(defaultLeak).toBe(overlapCount);
+    const { registry } = await seedTools();
+    const sample = ITEMS.find((item) => item.kind === "no-source-overlap")!;
+    const stillDefault = await registry.execute(
+      { id: "call_default_knob", tool: VENDO_KNOWLEDGE_SEARCH_TOOL, args: { query: sample.query } },
+      ctx,
+    );
+    expect(stillDefault.status).toBe("ok");
+    if (stillDefault.status === "ok") {
+      expect((stillDefault.output as unknown as KnowledgeResultEnvelope).outcome).toBe("answered");
+    }
+  });
+});


### PR DESCRIPTION
## What

A 20-item no-source / weak-evidence scorecard against **current** `vendo_knowledge_search` (chat search → one deep retry on weak evidence → structured `insufficient-evidence`). No `entailmentVerifier` — that surface stays gone.

The fixture is SVQ-shaped: 8 single-source, 4 multi-source, 3 empty-hit no-source, 5 overlap no-source. Each item calls `createKnowledgeTools(vendoKnowledge(...)).execute` on the shipped tool, default `weakScoreThreshold` 0.

## Why

HEAD already deleted the verifier because a model-call check still answered 7–10 of 34 unanswerable questions on the 94-question corpus. The leftover hole is retrieval-side: token overlap plus a default threshold of 0 (any hit is `answered`; score-less engines never refuse). Empty-hit refuse is already tested and is not that class.

On this local lexical corpus, the leak still happens:

| kind | outcome at threshold 0 |
| --- | --- |
| single-source | 8/8 `answered` |
| multi-source | 4/4 `answered` |
| no-source-empty | 3/3 `insufficient-evidence` (chat→deep) |
| **no-source-overlap** | **5/5 `answered` (chat only — never treated as weak)** |

Overlap items ("Can I wire money to a dissolved company?", "APY on Bitcoin savings", …) share tokens with the host docs and come back `answered` with hits. That is the 7–10/34 class, not empty-hit refuse.

## Calibration (default stays 0)

Same fixture, same execute path, `weakScoreThreshold` swept. Raising the knob does not isolate the leak: overlap TF scores sit in the same band as genuine answers.

```
threshold   leak_answered   single_answered
0           5/5             8/8
2           5/5             8/8
8           4/5             5/8
32          0/5             0/8
```

No production default change. No verifier resurrection.

## Verification

- `pnpm --filter @vendoai/knowledge test` — 107 passed, including the new scorecard (twice).
- `pnpm --filter @vendoai/knowledge typecheck` — clean.
- `packages/knowledge/src/index.ts` still does not export a verifier.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins a 20‑item scorecard test for `vendo_knowledge_search` to document current retrieval behavior without a verifier. Overlap‑unanswerable queries still return answered at default `weakScoreThreshold` 0; empty‑hit queries return `insufficient-evidence`.

- Runs 8 single‑source, 4 multi‑source, 3 no‑source‑empty, and 5 no‑source‑overlap items through `createKnowledgeTools(...).execute` (chat → one deep retry → structured outcome).
- Replaces M3 with a question both docs answer (daily wire limit + 2FA threshold). Removes a redundant default‑threshold execute in the calibration sweep (0/2/8/32 already covers 0).
- Confirms `entailmentVerifier` is not exported and remains removed; no production default change.
- Logs outcomes and sweeps `weakScoreThreshold` across 0/2/8/32 to show thresholding does not isolate the overlap leak.
- Tests only; no runtime or API changes. New files: `packages/knowledge/tests/fixtures/unanswerable-scorecard.ts`, `packages/knowledge/tests/unanswerable-scorecard.test.ts`.
- How to run: `pnpm --filter @vendoai/knowledge test` and `pnpm --filter @vendoai/knowledge typecheck`.

<sup>Written for commit f0d0def76abe2cdf2856f8f5121c6c95383ab660. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1604?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

