### PR TITLE
feat(core): sealed-bundle document shape (built apps S1/7)

### DIFF
--- a/.changeset/creations-document-shape.md
+++ b/.changeset/creations-document-shape.md
@@ -1,0 +1,5 @@
+---
+"@vendoai/core": minor
+---
+
+add the sealed-bundle document shape: `AppBundle` and `AppBuildProposal` (with their schemas), the `bundle`/`proposal` fields and the `"bundle"` ui kind on `AppDocument`, and the `vendo_parked_build` engine collection

--- a/packages/apps/src/contract/index.ts
+++ b/packages/apps/src/contract/index.ts
@@ -16,6 +16,8 @@
 // (`core/src/conformance/memory-store.ts`), and core may not reach upward. The
 // door is what matters, so it is re-exported here and consumers read one place.
 export {
+  appBuildProposalSchema,
+  appBundleSchema,
   appDocumentSchema,
   appMemorySchema,
   appSourceFileSchema,
@@ -23,6 +25,8 @@ export {
   seedComponentName,
   storageDeclSchema,
   type AppBuildFailure,
+  type AppBuildProposal,
+  type AppBundle,
   type AppDocument,
   type AppMemory,
   type AppSeed,

--- a/packages/core/src/app-document.ts
+++ b/packages/core/src/app-document.ts
@@ -305,10 +305,12 @@ const appMachineSchema = z.object({
 
 /**
  * A SEALED bundle — the app's built client code, frozen as content-addressed
- * blobs. Every key here is a hash, never a path: the entry hash IS the version
- * and the blob key, so a reseal can never overwrite the bytes an open tab is
- * still rendering, and the loser of a concurrent seal stays readable as a
- * history version.
+ * blobs. Every hash BELOW is a blob key, and a blob is only ever stored under
+ * its own hash, never under a path (`assets` is keyed by path because that is
+ * how the entry names its imports — the path is a lookup, never a location):
+ * the entry hash IS the version and the blob key, so a reseal can never
+ * overwrite the bytes an open tab is still rendering, and the loser of a
+ * concurrent seal stays readable as a history version.
  *
  * Brand tokens and fonts are injected AT RENDER and are deliberately not baked
  * in, so one seal follows a host's palette instead of pinning the palette it

--- a/packages/core/src/app-document.ts
+++ b/packages/core/src/app-document.ts
@@ -1,7 +1,15 @@
 import { z } from "zod";
 import { VENDO_APP_FORMAT } from "./formats.js";
 import type { AutomationId } from "./automation.js";
-import { appIdSchema, isoDateTimeSchema, type AppId, type IsoDateTime, type Json } from "./ids.js";
+import {
+  appIdSchema,
+  approvalIdSchema,
+  isoDateTimeSchema,
+  type AppId,
+  type ApprovalId,
+  type IsoDateTime,
+  type Json,
+} from "./ids.js";
 import { sha256Hex } from "./sha256.js";
 
 /**
@@ -295,6 +303,62 @@ const appMachineSchema = z.object({
   provisionedAt: isoDateTimeSchema,
 }).passthrough() satisfies z.ZodType<AppMachine>;
 
+/**
+ * A SEALED bundle — the app's built client code, frozen as content-addressed
+ * blobs. Every key here is a hash, never a path: the entry hash IS the version
+ * and the blob key, so a reseal can never overwrite the bytes an open tab is
+ * still rendering, and the loser of a concurrent seal stays readable as a
+ * history version.
+ *
+ * Brand tokens and fonts are injected AT RENDER and are deliberately not baked
+ * in, so one seal follows a host's palette instead of pinning the palette it
+ * was built under.
+ */
+export interface AppBundle {
+  /** sha256 hex of the entry module's bytes. */
+  entry: string;
+  /** The modules the entry reaches: path it names them by -> sha256 hex. */
+  assets?: Record<string, string>;
+  bytes: number;
+  sealedAt: IsoDateTime;
+}
+
+const BUNDLE_HASH = /^[0-9a-f]{64}$/;
+
+/** 01-core §9 */
+export const appBundleSchema = z.object({
+  entry: z.string().regex(BUNDLE_HASH),
+  assets: z.record(z.string().regex(BUNDLE_HASH)).optional(),
+  bytes: z.number().int().nonnegative(),
+  sealedAt: isoDateTimeSchema,
+}).passthrough() satisfies z.ZodType<AppBundle>;
+
+/**
+ * A build the person has been ASKED about and has not answered yet. Written
+ * when the make tool raises the standing approval card, cleared the moment the
+ * decision lands either way — so its presence IS the awaiting-consent state,
+ * and while it is there no box has been claimed and nothing has been spent.
+ *
+ * `prompt` is verbatim because the build brief is replayed from it whenever the
+ * yes arrives, which may be long after the turn that asked is gone; the app's
+ * name is a capped collapse of it and too lossy to build from.
+ */
+export interface AppBuildProposal {
+  approvalId: ApprovalId;
+  prompt: string;
+  /** The screen agent's own line for why a screen was not enough. */
+  why: string;
+  at: IsoDateTime;
+}
+
+/** 01-core §9 */
+export const appBuildProposalSchema = z.object({
+  approvalId: approvalIdSchema,
+  prompt: z.string(),
+  why: z.string(),
+  at: isoDateTimeSchema,
+}).passthrough() satisfies z.ZodType<AppBuildProposal>;
+
 /** 01-core §9 */
 const appBuildFailureSchema = z.object({
   reason: z.string(),
@@ -309,7 +373,7 @@ export interface AppDocument {
   id: AppId;
   name: string;
   description?: string;
-  ui?: "tree" | "http";
+  ui?: "tree" | "http" | "bundle";
   components?: Record<string, ComponentEntry>;
   /**
    * W4b — the compiler-stamped per-island tool manifest: for each generated
@@ -331,6 +395,9 @@ export interface AppDocument {
    */
   source?: Record<string, AppSourceFile>;
   machine?: AppMachine;
+  /** The seal a `ui: "bundle"` app renders — the one field that says which
+   *  bytes this app IS right now. */
+  bundle?: AppBundle;
   /**
    * The app's automations, by id — maintained by the APPS layer ONLY
    * (`vendo_make`'s compound flow, the manifest fold-in), and resolved on read
@@ -376,6 +443,12 @@ export interface AppDocument {
    */
   building?: IsoDateTime;
   /**
+   * `building`'s half-step back: a build that has been OFFERED and not yet
+   * answered. Server-written by the propose path and cleared by the decision,
+   * so a document can never carry both this and `building`.
+   */
+  proposal?: AppBuildProposal;
+  /**
    * What this app remembers about itself. Server-written — stripped from a
    * generated document before persist and pinned from the stored row on every
    * edit, so only the memory door ever changes it.
@@ -396,12 +469,13 @@ export const appDocumentSchema = z.object({
   id: appIdSchema,
   name: z.string(),
   description: z.string().optional(),
-  ui: z.enum(["tree", "http"]).optional(),
+  ui: z.enum(["tree", "http", "bundle"]).optional(),
   components: z.record(componentEntrySchema).optional(),
   componentTools: z.record(z.array(z.string())).optional(),
   storage: z.record(storageDeclSchema).optional(),
   source: z.record(appSourceFileSchema).optional(),
   machine: appMachineSchema.optional(),
+  bundle: appBundleSchema.optional(),
   automations: z.array(z.string()).optional(),
   egress: z.array(z.string()).optional(),
   egressApproved: z.array(z.string()).optional(),
@@ -410,6 +484,7 @@ export const appDocumentSchema = z.object({
   forkedFrom: appIdSchema.optional(),
   buildFailed: appBuildFailureSchema.optional(),
   building: isoDateTimeSchema.optional(),
+  proposal: appBuildProposalSchema.optional(),
   memory: appMemorySchema.optional(),
   // Input widened for the same reason as {@link appSeedSchema}'s: a defaulted
   // field inside `seed` makes this schema's input looser than an AppDocument.

--- a/packages/core/src/engine-collections.ts
+++ b/packages/core/src/engine-collections.ts
@@ -7,7 +7,9 @@ import { VendoError } from "./errors.js";
 // refusal still quoting v5 would be describing a build without that entry.
 // 7: dropped `vendo_inclient_approvals` and `vendo_remix_rejections` with the
 // removal of in-client native execution and the remix review flow.
-export const ENGINE_ALLOWLIST_VERSION = 7;
+// 8: added `vendo_parked_build`, the approval-keyed record of a build nobody
+// has consented to yet.
+export const ENGINE_ALLOWLIST_VERSION = 8;
 
 /** What a collection HOLDS. `knowledge` is the retrieval corpus — documents and
     the chunks an engine mints from them; everything else is `storage`.
@@ -82,6 +84,7 @@ export const ENGINE_COLLECTION_REGISTRY = {
   vendo_placement_slots: { kind: "storage" }, // PLACEMENT_SLOTS_COLLECTION, packages/apps/src/server/persistence/placements.ts:54
   vendo_app_tokens: { kind: "storage" }, // APP_TOKEN_COLLECTION, packages/apps/src/server/persistence/app-token.ts:12
   vendo_parked_action: { kind: "storage" }, // COLLECTION, packages/apps/src/server/persistence/parked-action.ts:50
+  vendo_parked_build: { kind: "storage" }, // COLLECTION, packages/apps/src/server/persistence/parked-build.ts
   vendo_egress_approval: { kind: "storage" }, // COLLECTION, packages/apps/src/server/escalation/egress-approval.ts:96
   vendo_slots: { kind: "storage" }, // SLOTS_COLLECTION, packages/apps/src/server/persistence/slots.ts:24
   vendo_app_seen: { kind: "storage" }, // APP_SEEN_COLLECTION, packages/apps/src/server/persistence/app-seen.ts:26

--- a/packages/core/src/parked-outcome.ts
+++ b/packages/core/src/parked-outcome.ts
@@ -28,6 +28,19 @@ export const PARKED_CALL_OUTCOME_COLLECTION = "vendo_parked_call_outcome";
  */
 export const PARKED_ACTION_COLLECTION = "vendo_parked_action";
 
+/**
+ * The build lane's record, keyed by approval — the ask and the context a build
+ * the person has NOT consented to yet would run with, written when the make
+ * tool raises the standing build card and removed by the decision, either way.
+ *
+ * Unlike the two above, nothing was called: the record exists precisely so the
+ * yes can arrive long after the turn that asked is gone, and until it does no
+ * box has been claimed. Here for the same reason they are — the door that
+ * writes it (`packages/apps/src/server/persistence/parked-build.ts`) and the
+ * decision seam that reads it may not import each other.
+ */
+export const PARKED_BUILD_COLLECTION = "vendo_parked_build";
+
 export interface ParkedCallOutcome {
   approvalId: ApprovalId;
   /** The parking principal's subject — the only principal who may read it. */

--- a/packages/core/tests/app-document.test.ts
+++ b/packages/core/tests/app-document.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { appBundleSchema, appDocumentSchema } from "../src/app-document.js";
+import { VENDO_APP_FORMAT } from "../src/formats.js";
+
+const hex = "a".repeat(64);
+const bundle = {
+  entry: hex,
+  assets: { "chunk.js": "b".repeat(64) },
+  bytes: 4096,
+  sealedAt: "2026-08-24T16:00:00.000Z",
+};
+const app = { format: VENDO_APP_FORMAT, id: "app_a", name: "A" };
+
+describe("appBundleSchema", () => {
+  it("accepts a hash-keyed seal and passes unknown keys through", () => {
+    expect(appBundleSchema.parse({ ...bundle, future: true })).toMatchObject({ entry: hex, future: true });
+  });
+
+  // Every key of a seal is content-addressed. A path here would name a blob no
+  // seal ever wrote, and blobs are immutable, so the miss is unrecoverable.
+  it("refuses a path where a content hash belongs", () => {
+    expect(appBundleSchema.safeParse({ ...bundle, entry: "dist/app.js" }).success).toBe(false);
+    expect(appBundleSchema.safeParse({ ...bundle, assets: { "chunk.js": "dist/chunk.js" } }).success).toBe(false);
+  });
+});
+
+describe("appDocumentSchema", () => {
+  it("accepts a sealed bundle app and refuses a malformed seal", () => {
+    expect(appDocumentSchema.safeParse({ ...app, ui: "bundle", bundle }).success).toBe(true);
+    expect(appDocumentSchema.safeParse({ ...app, ui: "bundle", bundle: { ...bundle, entry: "dist/app.js" } }).success)
+      .toBe(false);
+  });
+
+  it("accepts a build awaiting consent and refuses one with no approval to answer", () => {
+    const proposal = { approvalId: "apr_1", prompt: "a budget tracker", why: "needs a chart library", at: bundle.sealedAt };
+    expect(appDocumentSchema.safeParse({ ...app, proposal }).success).toBe(true);
+    expect(appDocumentSchema.safeParse({ ...app, proposal: { ...proposal, approvalId: "" } }).success).toBe(false);
+  });
+});

--- a/packages/core/tests/engine-collections.test.ts
+++ b/packages/core/tests/engine-collections.test.ts
@@ -29,10 +29,10 @@ function messageOf(run: () => unknown): string {
 }
 
 describe("engine allowlist", () => {
-  it("holds 37 distinct static collections", () => {
-    expect(ENGINE_ALLOWLIST_VERSION).toBe(7);
-    expect(ENGINE_COLLECTIONS).toHaveLength(37);
-    expect(new Set(ENGINE_COLLECTIONS).size).toBe(37);
+  it("holds 38 distinct static collections", () => {
+    expect(ENGINE_ALLOWLIST_VERSION).toBe(8);
+    expect(ENGINE_COLLECTIONS).toHaveLength(38);
+    expect(new Set(ENGINE_COLLECTIONS).size).toBe(38);
   });
 
   it("admits one name from each group and refuses host/app data", () => {


### PR DESCRIPTION
## What & why

Slice 1 of 7 in the **built apps** stack: chat users create apps needing arbitrary npm packages, built on disposable boxes, sealed as immutable content-addressed bundles, rendered in a zero-network sandboxed iframe. This slice adds the document shape those later slices persist and read. **Types and schemas only — no behavior.**

## Added
- **`AppBundle` + `appBundleSchema`** (`core/src/app-document.ts`) — a seal: `entry` (sha256 hex of the entry module), `assets` (path → sha256 hex), `bytes`, `sealedAt`. Every key is a hash, never a path, so a reseal cannot overwrite bytes an open tab is still rendering and the loser of a concurrent seal stays readable as a history version. Hex-regex guarded, `.passthrough()` like its neighbours.
- **`AppBuildProposal` + `appBuildProposalSchema`** — a build the person has been asked about and has not answered. `prompt` is verbatim because the build brief is replayed from it whenever the yes arrives, possibly long after the asking turn is gone.
- **`AppDocument.bundle`** beside `machine`, **`AppDocument.proposal`** beside `building`, and `"bundle"` added to the `ui` enum (interface + schema).
- **`PARKED_BUILD_COLLECTION`** (`core/src/parked-outcome.ts`) and its `vendo_parked_build` registry row — the approval-keyed record whose presence *is* the awaiting-consent state, and while it exists no box has been claimed and nothing has been spent.

## Additive on purpose
The architecture's end state replaces `ui: "http"` with `"bundle"` and `machine` with `bundle`. Doing that here would be wrong: those two fields have ~12 live consumers, and the **last** slice in this stack (`delete-machines`) removes every one of them. So this slice only *widens* — `"http"`, `machine`, `AppMachine` and `vendo_egress_approval` are untouched — and the deletion slice narrows the enum and drops the dead fields as part of the removal it was already doing. Same end state, and the deletion slice stays droppable. No shims, no migration helpers.

## Tests
`core/tests/app-document.test.ts` (4). Two assert *refusals* through `appDocumentSchema` itself (malformed `bundle`, empty `approvalId`) — that schema is `.passthrough()`, so an accept-only test would pass without the fields being wired at all. Written first, watched fail 4/4 for the right reasons.

`core/tests/engine-collections.test.ts` is edited (+4/−4): it asserts the registry's exact size and allowlist version as a deliberate drift counter, so adding a collection makes those numbers wrong by construction. `ENGINE_ALLOWLIST_VERSION` 7 → 8 per that constant's own documented rule ("bump it whenever `ENGINE_COLLECTIONS` changes") — the version is quoted in refusal messages so a host can tell a stale list from a bad name.

CI is the gate of record.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce the sealed-bundle document shape to support immutable, content-addressed app bundles. This widens schemas only and adds the "bundle" UI kind without changing runtime behavior; the new types are exposed through the contract for a single import path.

- Add `AppBundle` and `appBundleSchema` (sha256-guarded entry; optional assets; bytes; sealedAt; schemas are passthrough).
- Add `AppBuildProposal` and `appBuildProposalSchema` for offered builds awaiting consent.
- Extend `AppDocument`: add `ui: "bundle"`, `bundle`, and `proposal` fields.
- Register `vendo_parked_build` and bump the engine allowlist to version 8; tests now expect 38 collections.
- Re-export `AppBundle`, `AppBuildProposal`, and their schemas from `@vendoai/apps/contract` so consumers import via the contract.

- Rollout:
  - No migrations. If you vendor the engine allowlist, update to version 8 to admit `vendo_parked_build`.
  - Import the new types and schemas from `@vendoai/apps/contract`.

<sup>Written for commit b8bcfd79560ab7db4c1f89af5f6f01446557d1c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1607?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

