### PR TITLE
feat(apps): seal built-app bundles as content-addressed blobs (built apps S2/7)

### DIFF
--- a/.changeset/creations-seal-store.md
+++ b/.changeset/creations-seal-store.md
@@ -1,0 +1,5 @@
+---
+"@vendoai/apps": minor
+---
+
+seal a built app's bundle as content-addressed blobs: `sealBundleBlobs` freezes one build's files under `apps/<appId>/bundle/<sha256>` and describes them as an `AppBundle`, `readBundleBlob` reads one back by its hash. Keying by content rather than by path is what makes a seal immutable — a reseal mints fresh keys instead of overwriting the bytes an open tab is still rendering, and two concurrent seals cannot collide

--- a/packages/apps/src/server/index.ts
+++ b/packages/apps/src/server/index.ts
@@ -97,10 +97,18 @@ export { buildingAppsSkill } from "./skills/building-apps.js";
 // it lives outside this package: a sandboxed harness holds a `WorkspaceFs` and
 // never a store, so composition binds the store side once and hands these to
 // whoever is materializing an app.
+// The seal door beside it, plus the app row's compare-and-swap writer, exported
+// for the same reason `createAppHistory` is: `@vendoai/store` holds both the
+// bytes and the row revision a seal depends on, so it proves the whole seal —
+// content-addressed blobs, last-CAS-wins, loser kept as a version — against the
+// REAL writers rather than a hand-rolled copy of what they produce.
 export {
   commitApp,
+  readBundleBlob,
+  sealBundleBlobs,
   type AppSourceSeam,
 } from "./persistence/app-source.js";
+export { updateAppRow } from "./persistence/persistence.js";
 // The hot-path render seam (§1.6) — the commit-intercepting wrap that paints a
 // landing `app.tsx`. Public because the workspace it wraps lives
 // outside this package: composition fills the harness runtime's `wrapWorkspace`

--- a/packages/apps/src/server/persistence/app-source.ts
+++ b/packages/apps/src/server/persistence/app-source.ts
@@ -16,12 +16,14 @@
  *   untouched, along with storage, machine, pins, placements and grants — a
  *   commit is not a generation.
  */
+import { createHash } from "node:crypto";
 import {
   VendoError,
   WORKSPACE_INLINE_MAX_BYTES,
   appRootPath,
   safeErrorMessage,
   sha256Hex,
+  type AppBundle,
   type AppId,
   type AppMount,
   type FilesAdapter,
@@ -95,6 +97,58 @@ export const appMountFor = (owner: string, ctx: RunContext): AppMount =>
  * the prerequisite for reaping them.
  */
 const blobKey = (appId: AppId, path: string): string => `apps/${appId}/${sha256Hex(path)}`;
+
+/**
+ * A SEALED bundle's namespace beside it — keyed by the CONTENT's hash, never by
+ * a path. That is what makes a seal immutable: a reseal mints fresh keys, so it
+ * cannot overwrite the bytes an open tab is still rendering, two concurrent
+ * seals cannot collide, and the loser of the row's compare-and-swap stays
+ * readable as a history version.
+ */
+const bundleKey = (appId: AppId, hex: string): string => `apps/${appId}/bundle/${hex}`;
+
+/**
+ * Freeze one build's output into that namespace and describe it.
+ *
+ * `entry` names which of `files` the frame boots; everything else lands in
+ * `assets` under the path the entry imports it by. Hashing goes over the BYTES
+ * (`node:crypto`, as `@vendoai/harnesses`' materialize seam does) rather than
+ * over text, because a bundle carries fonts and images that no string
+ * round-trip survives.
+ */
+export const sealBundleBlobs = async (
+  appId: AppId,
+  files: readonly { path: string; bytes: Uint8Array }[],
+  entry: string,
+  blobs: FilesAdapter,
+): Promise<AppBundle> => {
+  const assets: Record<string, string> = {};
+  let entryHash: string | undefined;
+  let bytes = 0;
+  for (const file of files) {
+    const hex = createHash("sha256").update(file.bytes).digest("hex");
+    await blobs.put(bundleKey(appId, hex), file.bytes);
+    bytes += file.bytes.byteLength;
+    if (file.path === entry) entryHash = hex;
+    else assets[file.path] = hex;
+  }
+  if (entryHash === undefined) {
+    throw new VendoError("validation", `the entry "${entry}" is not among ${appId}'s built files`);
+  }
+  return {
+    entry: entryHash,
+    ...(Object.keys(assets).length === 0 ? {} : { assets }),
+    bytes,
+    sealedAt: new Date().toISOString(),
+  };
+};
+
+/** One sealed file back, by the hash that IS its key. */
+export const readBundleBlob = async (
+  appId: AppId,
+  hex: string,
+  blobs: FilesAdapter,
+): Promise<Uint8Array | null> => (await blobs.get(bundleKey(appId, hex)))?.bytes ?? null;
 
 const encoder = new TextEncoder();
 const contentHash = (text: string): string => `sha256:${sha256Hex(text)}`;

--- a/packages/store/tests/bundle-seal.seam.test.ts
+++ b/packages/store/tests/bundle-seal.seam.test.ts
@@ -1,0 +1,118 @@
+/**
+ * The sealed bundle, end to end through REAL paths.
+ *
+ * A seal has two halves in two packages: `@vendoai/apps` decides the keys and
+ * the row, the store holds the bytes and arbitrates the row's revision. A suite
+ * that hand-rolled either half could only ever agree with itself, so everything
+ * below writes through the real writers (`sealBundleBlobs`, `updateAppRow`,
+ * `createAppHistory`) over a real store and reads back through the real reader
+ * (`readBundleBlob`) — no stand-in on either side.
+ *
+ * Two promises are on trial. That a blob key is the CONTENT's hash, so a reseal
+ * can never overwrite bytes an open tab is still rendering. And that versioning
+ * needs ZERO new code: the bounded CAS in `updateAppRow` plus the capped history
+ * already give last-CAS-wins with the loser kept as a readable version.
+ */
+import { createAppHistory, readBundleBlob, sealBundleBlobs, updateAppRow } from "@vendoai/apps";
+import { appBundleSchema, type AppDocument, type AppId } from "@vendoai/core";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { backends, type MadeBackend } from "../src/backends.test-util.js";
+import { storeFiles } from "../src/files-store.js";
+import { appFixture, persistentPrincipal } from "../src/fixtures.test-util.js";
+import { createStoreOps } from "../src/index.js";
+
+const text = (source: string): Uint8Array => new TextEncoder().encode(source);
+/** Bytes no string round-trip survives — the hash is over BYTES, not over text. */
+const PNG = Uint8Array.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0xff, 0xfe, 0x00]);
+
+for (const backend of backends()) {
+  describe(`${backend.name} sealed bundles`, () => {
+    let made: MadeBackend;
+    beforeAll(async () => {
+      made = await backend.make();
+      await made.store.ensureSchema();
+    });
+    afterAll(async () => { if (made) await made.cleanup(); });
+
+    const blobsOf = () => storeFiles(made.store);
+
+    const seedApp = async (appId: AppId): Promise<void> => {
+      await made.store.records("vendo_apps").put({
+        id: appId,
+        data: { subject: persistentPrincipal.subject, enabled: true, doc: appFixture(appId) },
+      });
+    };
+
+    const headOf = async (appId: AppId): Promise<AppDocument> =>
+      ((await made.store.records("vendo_apps").get(appId))?.data as { doc: AppDocument }).doc;
+
+    it("reads every sealed file back byte-identical, by its own hash", async () => {
+      const appId = "app_seal_read" as AppId;
+      const blobs = blobsOf();
+      const entry = text("export const app = () => 'hi';\n");
+
+      const bundle = await sealBundleBlobs(appId, [
+        { path: "index.js", bytes: entry },
+        { path: "logo.png", bytes: PNG },
+      ], "index.js", blobs);
+
+      expect(await readBundleBlob(appId, bundle.entry, blobs)).toEqual(entry);
+      expect(await readBundleBlob(appId, bundle.assets?.["logo.png"] ?? "", blobs)).toEqual(PNG);
+      expect(await readBundleBlob(appId, "0".repeat(64), blobs)).toBeNull();
+      expect(appBundleSchema.parse(bundle)).toEqual(bundle);
+      expect(bundle.bytes).toBe(entry.byteLength + PNG.byteLength);
+    });
+
+    it("refuses a seal whose entry is not one of the built files", async () => {
+      await expect(sealBundleBlobs(
+        "app_seal_no_entry" as AppId,
+        [{ path: "index.js", bytes: text("x\n") }],
+        "main.js",
+        blobsOf(),
+      )).rejects.toThrow(/not among/);
+    });
+
+    it("keys by content, so a reseal mints a new key and leaves the old bytes readable", async () => {
+      const appId = "app_seal_reseal" as AppId;
+      const blobs = blobsOf();
+      const first = text("v1\n");
+      const second = text("v2\n");
+
+      const before = await sealBundleBlobs(appId, [{ path: "index.js", bytes: first }], "index.js", blobs);
+      const after = await sealBundleBlobs(appId, [{ path: "index.js", bytes: second }], "index.js", blobs);
+
+      expect(after.entry).not.toBe(before.entry);
+      expect(await readBundleBlob(appId, before.entry, blobs)).toEqual(first);
+      expect(await readBundleBlob(appId, after.entry, blobs)).toEqual(second);
+    });
+
+    it("two concurrent seals: last CAS wins the head, the loser survives as a version", async () => {
+      const appId = "app_seal_race" as AppId;
+      await seedApp(appId);
+      const blobs = blobsOf();
+      const engine = createStoreOps(made.store).engine;
+      const history = createAppHistory(engine);
+
+      const seal = async (source: string) => {
+        const bundle = await sealBundleBlobs(
+          appId,
+          [{ path: "index.js", bytes: text(source) }],
+          "index.js",
+          blobs,
+        );
+        const sealed = await updateAppRow(engine, appId, (doc) => ({ ...doc, ui: "bundle", bundle }), "box");
+        await history.append(appId, sealed, { at: bundle.sealedAt, intent: source, rung: 3 });
+        return bundle;
+      };
+
+      const [a, b] = await Promise.all([seal("A\n"), seal("B\n")]);
+
+      const head = await headOf(appId);
+      expect([a.entry, b.entry]).toContain(head.bundle?.entry);
+      const loser = head.bundle?.entry === a.entry ? b : a;
+      expect((await history.documents(appId)).map((doc) => doc.bundle?.entry)).toContain(loser.entry);
+      expect(await readBundleBlob(appId, a.entry, blobs)).toEqual(text("A\n"));
+      expect(await readBundleBlob(appId, b.entry, blobs)).toEqual(text("B\n"));
+    });
+  });
+}


### PR DESCRIPTION
> Stacked on #1607. Review only the top commit; the base PR merges first. The whole stack merges once at the tip.

## What & why

Slice 2 of 7 in the **built apps** stack. Freezes a built app's bytes as **content-addressed** blobs, and shows that versioning them needs no new concurrency code.

The blob key is the sha256 of the bytes, never a path. That single choice is what makes the rest safe: a reseal mints new keys instead of overwriting, so it cannot pull the bytes out from under a tab that is still rendering the previous version, and two seals racing on the same app cannot collide.

## Added
- **`sealBundleBlobs`** (`apps/server/persistence/app-source.ts`, beside the existing `blobKey`) — writes every built file as a blob under its own hash and returns a formed `AppBundle` (entry hash, `assets` path → hash, total bytes, `sealedAt`).
- **`readBundleBlob`** — reads one back by hash; `null` when absent.
- **`bundleKey`** — `apps/<appId>/bundle/<sha256hex>`.

## Versioning is zero new code
`updateAppRow`'s existing 3-attempt CAS plus `history.append` (cap 50) already give last-CAS-wins with the loser surviving as a readable history version. No retry loop, no lock, no version counter, no conflict resolver was written.

## The seam test
`store/tests/bundle-seal.seam.test.ts` (4). Real PGlite backend, real `FilesAdapter` writing the `vendo_blobs` table, real `createStoreOps().engine`, real `updateAppRow` CAS, real `createAppHistory`. Producer is `sealBundleBlobs`, consumer is `readBundleBlob` — both the shipped functions, **nothing stubbed on either side**. It proves:
- byte-identical round-trip, including a non-UTF8 PNG payload, so the hash is demonstrably over bytes and not text;
- the returned bundle satisfies the real `appBundleSchema`;
- a reseal mints a new key and leaves the old bytes readable;
- two concurrent seals → last CAS wins the head, the loser survives in history, and **both** bundles stay readable by their own hashes.

Each was proven able to fail (blob keyed by path instead of hash → 3 red; entry guard dropped → refusal red; wrong byte total → round-trip red).

## Notes
- The test lives in `packages/store/tests` because layering allows only `apps → core` and the dependency guard scans test files, so a seam test over a real store cannot sit in `packages/apps`. `updateAppRow` is exported from the `@vendoai/apps` entry for that reason — the same reason, commented in the same voice, that `createAppHistory` is already exported one block above it.
- Hashing uses `node:crypto`'s `createHash("sha256")`, matching `harnesses/materialize.ts`, because core's `sha256Hex` takes a string and routing bundle bytes through a text decode would corrupt fonts and images.
- `BuiltFile` is inlined here rather than named; the next slice's `contract/build.ts` owns that name.

CI is the gate of record.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Seal built app bundles as content-addressed blobs to make seals immutable and race-safe. Previously files were implicitly keyed by path; now each file stores under `apps/<appId>/bundle/<sha256hex>`, so reseals mint new keys and keep old bytes readable.

- Add `sealBundleBlobs` and `readBundleBlob` in `apps/server/persistence/app-source.ts`. `sealBundleBlobs` hashes bytes (`node:crypto`), writes blobs under content hashes, and returns an `AppBundle` (entry hash, assets map, total bytes, `sealedAt`). `readBundleBlob` fetches by hash.
- Export `sealBundleBlobs`, `readBundleBlob`, and `updateAppRow` from `@vendoai/apps` to enable real-store seam tests and external composition.
- Versioning uses existing CAS and capped history: last CAS wins the head, the loser persists as a readable version. No new concurrency code.
- Add end-to-end seam test in `@vendoai/store` proving byte-identical round-trips (including binary), reseal behavior, and concurrent seals with both bundles readable.

<sup>Written for commit 6e85c09b3168470f976409a329810ae74bee4412. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

