### PR TITLE
feat(apps): ask before spending a machine (built apps S3/7)

### DIFF
--- a/.changeset/creations-consent-park.md
+++ b/.changeset/creations-consent-park.md
@@ -1,0 +1,5 @@
+---
+"@vendoai/apps": minor
+---
+
+ask before spending a build machine: an ask the screen agent escalates now raises a standing approval card and `vendo_make` returns a receipt with the new status `awaiting-consent`, so the turn ends having claimed no sandbox. The person's yes — whenever it lands, possibly long after that turn is gone — is what starts the build: `AppsRuntime.build.propose` parks the ask against its approval (`vendo_parked_build`) and writes it onto the app row as a `proposal`, and the guard's decision alone runs the new `AppBuilder` seam and seals what it built. A no clears the proposal and leaves the honest failure card, with no box ever opened. `validateAppDocument` now refuses a document carrying both `proposal` and `building`

--- a/packages/apps/src/contract/app-validation.ts
+++ b/packages/apps/src/contract/app-validation.ts
@@ -106,6 +106,16 @@ const referenceFieldsError = (app: AppDocument): AppDocumentValidation | null =>
   return null;
 };
 
+/** `proposal` is `building`'s half-step BACK — a build that has been offered
+ *  and not answered — so a document carrying both claims a box was spent on an
+ *  ask nobody has said yes to yet. The shape schema cannot say this (it parses
+ *  fields, not their relationship), and the propose path is the first writer
+ *  that could produce it. */
+const buildStateError = (app: AppDocument): AppDocumentValidation | null =>
+  app.proposal !== undefined && app.building !== undefined
+    ? fail("validation", "a document cannot carry both proposal and building")
+    : null;
+
 const validateAppDocumentUnsafe = (input: unknown): AppDocumentValidation => {
   if (typeof input !== "object" || input === null || Array.isArray(input)) {
     return fail("validation", "app document must be a non-null object");
@@ -129,7 +139,8 @@ const validateAppDocumentUnsafe = (input: unknown): AppDocumentValidation => {
     ?? componentToolsError(app)
     ?? sourceError(app)
     ?? storageError(app)
-    ?? referenceFieldsError(app);
+    ?? referenceFieldsError(app)
+    ?? buildStateError(app);
   if (violation !== null) return violation;
 
   return { ok: true, app };

--- a/packages/apps/src/contract/build.ts
+++ b/packages/apps/src/contract/build.ts
@@ -1,0 +1,53 @@
+/**
+ * The build seam — `screen.ts`'s other half.
+ *
+ * The screen agent answers `escalate` when an ask is bigger than a screen; this
+ * is the engine that ask goes to once, and only once, the person has said yes.
+ * It runs a coding agent inside a disposable box — npm from the registry, tests
+ * against reality, output frozen as content-addressed blobs — none of which
+ * `@vendoai/apps` holds, so the two sides meet on this interface and
+ * composition (`packages/vendo`) is the only place that fills the slot. The
+ * shipped adapter rule, exactly as `ScreenAssembler` states it.
+ *
+ * A box is minutes and money. Nothing here is reached until
+ * `AppsRuntime.build.propose` has raised the standing approval card and the
+ * person has answered it.
+ */
+import {
+  type AppId,
+  type AppSourceFile,
+  type RunContext,
+} from "@vendoai/core";
+
+/** One consented build, as the resume hook hands it over. */
+export interface BuildRequest {
+  appId: AppId;
+  /** The person's ask, verbatim — replayed from the proposal, which may be
+   *  older than the turn that asked. */
+  prompt: string;
+  /** The screen agent's own line for why a screen was not enough. */
+  why: string;
+  /** The stored source a RESEAL starts from. Absent, the box starts empty. */
+  source?: Record<string, AppSourceFile>;
+  /** Chat status lines, and nothing else: no streaming and no serving from the
+   *  box (FINAL SPEC v1). */
+  onStatus?: (label: string) => void;
+}
+
+/** One file the box produced, by the path the entry imports it under. Bytes,
+ *  not text: a bundle carries fonts and images no string round-trip survives. */
+export interface BuiltFile {
+  path: string;
+  bytes: Uint8Array;
+}
+
+export type BuildOutcome =
+  | { kind: "built"; files: readonly BuiltFile[]; entry: string; say?: string }
+  | { kind: "failed"; why: string; retryable?: boolean };
+
+export interface AppBuilder {
+  /** Can this deployment run a build at all — i.e. is a sandbox adapter
+   *  composed? The ONE gate, and deliberately not a capability boolean. */
+  available(): boolean;
+  build(request: BuildRequest, ctx: RunContext): Promise<BuildOutcome>;
+}

--- a/packages/apps/src/contract/index.ts
+++ b/packages/apps/src/contract/index.ts
@@ -69,6 +69,8 @@ export * from "./briefing.js";
 export * from "./theme.js";
 // screen + floor + checking contract
 export * from "./screen.js";
+// build — the other engine's seam
+export * from "./build.js";
 export * from "./app-floor.js";
 // seed — remix provenance
 export * from "./seed.js";

--- a/packages/apps/src/contract/make-receipt.ts
+++ b/packages/apps/src/contract/make-receipt.ts
@@ -29,8 +29,13 @@
  *    agent over MCP — read plain success off a half-built app (2026-08-11). Not
  *    `"failed"`, which means nothing is painted and sends the agent to rebuild:
  *    this view is real, reopenable, and worth keeping.
- * 5. **No consent ceremony.** Cost governance is host config, never a question
- *    asked here.
+ * 5. **`"awaiting-consent"` is the honest answer for a BUILD.** A build spends a
+ *    machine, and FINAL SPEC v1's law is that no machine is spent without the
+ *    person's explicit yes — so the tool raises the standing approval card and
+ *    the turn ENDS, having spent nothing. Not `"building"`, which would have the
+ *    agent narrate work nobody has authorized yet. Cost governance stays host
+ *    config: this is a consent card, not a price quote, and `say` carries no
+ *    estimate.
  */
 import { z } from "zod";
 import { appIdSchema, type AppId } from "@vendoai/core";
@@ -40,7 +45,7 @@ export interface MakeReceipt {
   id: AppId;
   /** The app's name, in human words — never a slug or an identifier. */
   title: string;
-  status: "ready" | "partial" | "building" | "failed";
+  status: "ready" | "partial" | "building" | "awaiting-consent" | "failed";
   /** Speakable as it stands, consumer voice — the builder's own summary where
    *  there was one to relay. */
   say: string;
@@ -50,6 +55,6 @@ export interface MakeReceipt {
 export const makeReceiptSchema = z.object({
   id: appIdSchema,
   title: z.string().min(1),
-  status: z.enum(["ready", "partial", "building", "failed"]),
+  status: z.enum(["ready", "partial", "building", "awaiting-consent", "failed"]),
   say: z.string().min(1),
 }).passthrough() satisfies z.ZodType<MakeReceipt>;

--- a/packages/apps/src/server/doors/apps-surface.ts
+++ b/packages/apps/src/server/doors/apps-surface.ts
@@ -192,7 +192,7 @@ const createAppCopyDoors = (
 export const createAppsSurface = (
   deps: Pick<AppsRuntimeContext,
     "config" | "engine" | "caller" | "data" | "history" | "opener" | "interchange"
-    | "egressApprovals" | "parkedActions" | "placementRows"
+    | "egressApprovals" | "parkedActions" | "parkedBuilds" | "placementRows"
     | "lifecycle" | "owned" | "requireOwned"
     | "grantedRecords" | "reportLifecycle" | "claimSlot" | "markUnbuilt"
     | "runtime">,
@@ -200,7 +200,7 @@ export const createAppsSurface = (
   "get" | "list" | "delete" | "fork" | "share" | "publish" | "seen"
   | "exportApp" | "importApp" | "history" | "open" | "call" | "agentTools"> => {
   const { config, engine, data, history } = deps;
-  const { egressApprovals, parkedActions, placementRows, lifecycle } = deps;
+  const { egressApprovals, parkedActions, parkedBuilds, placementRows, lifecycle } = deps;
   const { requireOwned, reportLifecycle, claimSlot, markUnbuilt, runtime } = deps;
   return {
     ...createAppReadDoors(deps),
@@ -216,6 +216,7 @@ export const createAppsSurface = (
       await history.clear(appId);
       await egressApprovals.clearForApp(appId);
       await parkedActions.clearForApp(appId);
+      await parkedBuilds.clearForApp(appId);
       await engine.delete(APPS_COLLECTION, appId);
       // A deleted app can never mount again, so its placement rows are dead
       // weight — and a row with no app record reads as a build in flight, which

--- a/packages/apps/src/server/doors/build-door.ts
+++ b/packages/apps/src/server/doors/build-door.ts
@@ -1,0 +1,195 @@
+/**
+ * FINAL SPEC v1 — the built-app door: `AppsRuntime.build`, plus the resume hook
+ * the decision seam fires into and the seal the build lane lands through.
+ *
+ * The law it exists to keep: no machine is ever spent without the user's
+ * explicit yes. `propose` raises the standing approval card and RETURNS —
+ * nothing here waits on it, because the yes may arrive long after the turn that
+ * asked is gone — and `resume` is the ONLY path from that yes to the builder.
+ * Between the two, the app row says "offered, unanswered" and no box exists.
+ */
+import {
+  VENDO_APP_FORMAT,
+  VendoError,
+  type AppBuildProposal,
+  type AppBundle,
+  type AppId,
+  type ApprovalId,
+  type RunContext,
+  type ToolCall,
+  type ToolDescriptor,
+} from "@vendoai/core";
+import type { BuiltFile } from "../../contract/index.js";
+import { BUILD_ALREADY_ASKED, BUILD_DECLINED, NO_MACHINE, fallbackAppName } from "./build-messages.js";
+import { sealBundleBlobs } from "../persistence/app-source.js";
+import { APPS_COLLECTION, appRecordInput } from "../persistence/persistence.js";
+import type { AppsRuntimeContext } from "../runtime/runtime-context.js";
+import type { AppsRuntime } from "../runtime/types.js";
+
+/**
+ * Spending a build machine is the person's call, so the ask is the ordinary
+ * high-risk one: a `confirmEach` descriptor through `guard.check`, which parks
+ * an approval and hands back its card. The card STANDS — this door never waits
+ * on it, so the harness's 90-second approval wait is not in this path at all.
+ */
+const BUILD_TOOL = "vendo_app_build";
+const buildDescriptor = (): ToolDescriptor => ({
+  name: BUILD_TOOL,
+  description: "Build this app for real: a sandbox installs the packages it needs, writes and tests the code,"
+    + " and the result is sealed. It spends a build machine, so it needs the person's yes.",
+  inputSchema: {
+    type: "object",
+    properties: { appId: { type: "string" }, prompt: { type: "string" } },
+    required: ["appId", "prompt"],
+  },
+  risk: "write",
+  confirmEach: true,
+});
+/** Stable across the park/decide phases, like the egress lane's, so the guard's
+ *  approved-replay match lines up. */
+const buildCall = (appId: AppId, prompt: string): ToolCall => ({
+  id: `call_build_${appId}`,
+  tool: BUILD_TOOL,
+  args: { appId, prompt },
+});
+
+export interface SealInput {
+  appId: AppId;
+  files: readonly BuiltFile[];
+  entry: string;
+  /** The version this reseal started from, recorded on the history entry. */
+  base?: string;
+}
+
+/** The public door (`AppsRuntime.build`) plus the two hooks only the runtime's
+ *  own seams reach: the decision subscriber's, and the build lane's. */
+export type BuildDoor = AppsRuntime["build"] & {
+  /** THE resume hook: what `onApprovalDecision` fires into, and the only caller
+   *  of the builder there is. */
+  resume(approvalId: ApprovalId, approved: boolean): Promise<void>;
+  /** One build's output frozen onto the app: content-addressed blobs, the row's
+   *  compare-and-swap, and a history version. Every seal IS a version. */
+  seal(input: SealInput): Promise<AppBundle>;
+};
+
+export const createBuildDoor = (
+  deps: Pick<AppsRuntimeContext,
+    "config" | "engine" | "parkedBuilds" | "updateAppDocument" | "history" | "pruneHistory"
+    | "markUnbuilt" | "rungFor">,
+): BuildDoor => {
+  const { config, engine, parkedBuilds, updateAppDocument, history, pruneHistory } = deps;
+  const { markUnbuilt, rungFor } = deps;
+  const builder = config.build;
+
+  /**
+   * The row that says "offered, unanswered".
+   *
+   * An escalation usually has no row yet — the screen agent decided it could
+   * not serve the ask, so it painted nothing — and the proposal has to be
+   * readable before any box exists, which is what makes the slot show the ask
+   * pending instead of sitting empty. A reseal's app already exists and keeps
+   * everything it has.
+   */
+  const proposeRow = async (
+    appId: AppId,
+    name: string,
+    proposal: AppBuildProposal,
+    ctx: RunContext,
+  ): Promise<void> => {
+    if (await engine.get(APPS_COLLECTION, appId) === null) {
+      await engine.put(APPS_COLLECTION, appRecordInput(
+        { format: VENDO_APP_FORMAT, id: appId, name, proposal },
+        ctx.principal.subject,
+        false,
+        "screen-agent",
+      ));
+      return;
+    }
+    await updateAppDocument(appId, (doc) => ({ ...doc, proposal }));
+  };
+
+  const seal: BuildDoor["seal"] = async (input) => {
+    if (config.files === undefined) {
+      throw new VendoError(
+        "validation",
+        `sealing ${input.appId}'s bundle needs a files adapter to hold the bytes, and this deployment has none`,
+      );
+    }
+    const bundle = await sealBundleBlobs(input.appId, input.files, input.entry, config.files);
+    // One CAS, and no concurrency machinery of its own: content-hash keys never
+    // collide, so two concurrent seals both land their bytes and the row's
+    // existing compare-and-swap picks the head. The loser survives as the
+    // history version appended below.
+    const doc = await updateAppDocument(input.appId, (previous) => {
+      const { building: _building, proposal: _proposal, ...rest } = previous;
+      return { ...rest, ui: "bundle", bundle };
+    });
+    await history.append(input.appId, doc, {
+      at: bundle.sealedAt,
+      intent: doc.name,
+      rung: rungFor(doc),
+      ...(input.base === undefined ? {} : { base: input.base }),
+    });
+    await pruneHistory(input.appId);
+    return bundle;
+  };
+
+  return {
+    available: () => builder?.available() ?? false,
+
+    async propose(input, ctx) {
+      const guardCtx: RunContext = { ...ctx, appId: input.appId };
+      const decision = await config.guard.check(
+        buildCall(input.appId, input.prompt), buildDescriptor(), guardCtx);
+      if (decision.action !== "ask") {
+        return { declined: decision.action === "block" ? decision.reason : BUILD_ALREADY_ASKED };
+      }
+      const approvalId = decision.approval.id;
+      // Parked BEFORE the row: the record is what the decision seam reads, and a
+      // yes that lands between these two writes must find the build to run.
+      await parkedBuilds.put({
+        approvalId,
+        appId: input.appId,
+        owner: ctx.principal.subject,
+        prompt: input.prompt,
+        why: input.why,
+        ctx: guardCtx,
+      });
+      await proposeRow(input.appId, input.name, {
+        approvalId,
+        prompt: input.prompt,
+        why: input.why,
+        at: new Date().toISOString(),
+      }, ctx);
+      return { approvalId };
+    },
+
+    async resume(approvalId, approved) {
+      const parked = await parkedBuilds.byApproval(approvalId);
+      if (parked === null) return;
+      const { appId, prompt, why, ctx } = parked;
+      // The ONE terminal landing every failure shares: the tombstone that turns
+      // the claimed slot into the honest failure card. A denial is one of them —
+      // it clears the proposal with the rest of the row, and no box was opened.
+      const refuse = (reason: string): Promise<void> =>
+        markUnbuilt(appId, fallbackAppName(prompt), reason, ctx);
+      if (!approved) return await refuse(BUILD_DECLINED);
+      if (builder === undefined || !builder.available()) return await refuse(NO_MACHINE);
+      const doc = await updateAppDocument(appId, (previous) => {
+        const { proposal: _proposal, ...rest } = previous;
+        return { ...rest, building: new Date().toISOString() };
+      });
+      const outcome = await builder.build({
+        appId,
+        prompt,
+        why,
+        // Present on a RESEAL: the box starts from what this app already is.
+        ...(doc.source === undefined ? {} : { source: doc.source }),
+      }, ctx);
+      if (outcome.kind === "failed") return await refuse(outcome.why);
+      await seal({ appId, files: outcome.files, entry: outcome.entry });
+    },
+
+    seal,
+  };
+};

--- a/packages/apps/src/server/doors/build-messages.ts
+++ b/packages/apps/src/server/doors/build-messages.ts
@@ -31,6 +31,20 @@ export const NOTHING_RENDERABLE = "the build produced nothing renderable.";
  *  no sandbox has no box to give it. Third person: these strings surface as
  *  SYSTEM notices, never in the assistant's voice. */
 export const NO_MACHINE = "This needs a real build — code running on a server — and this deployment has no build machine.";
+/** What the person is told when the ask became a standing card instead of a
+ *  screen. FIRST person, unlike the three above: this one is the assistant's
+ *  own sentence on the receipt, and it is the only thing the calling agent is
+ *  given to say. No estimate and no cost — the card is a consent question, not
+ *  a price quote (make-receipt.ts law 5). */
+export const AWAITING_CONSENT = "This one needs a real build, not just a screen — I've asked for your"
+  + " go-ahead, and it starts as soon as you approve.";
+/** The other terminal landing an OFFERED build has: the person answered the
+ *  standing card with no. Same third-person voice as NO_MACHINE — a system
+ *  notice — and it never mentions a box, because none was opened. */
+export const BUILD_DECLINED = "This needed a real build, and it was not approved.";
+/** The guard already holds this exact yes, so the card the person would answer
+ *  has been answered. Lowercase: it is read as a reason, mid-sentence. */
+export const BUILD_ALREADY_ASKED = "this build has already been asked for.";
 
 /** 0.4.5 E2E cert (defect D) — the terminal record the build watchdog writes
  *  when a create neither persisted an app nor a failure inside its window:

--- a/packages/apps/src/server/doors/make-tool.ts
+++ b/packages/apps/src/server/doors/make-tool.ts
@@ -30,9 +30,9 @@ import {
 } from "../../contract/index.js";
 import type { AgentToolsDataDependencies } from "./agent-tools.js";
 import { automationCard } from "./automate-tool.js";
-import { NO_ASSEMBLER, NOTHING_RENDERABLE, NO_MACHINE } from "./build-messages.js";
+import { AWAITING_CONSENT, NO_ASSEMBLER, NOTHING_RENDERABLE, NO_MACHINE } from "./build-messages.js";
 import { input, optionalString, resolveAppRef } from "./tool-args.js";
-import type { AppsRuntime, CreateServerWork, EditResult } from "../runtime/types.js";
+import type { AppsRuntime, EditResult } from "../runtime/types.js";
 
 /** An automation authored alongside an app raises its own card (#881).
  *  Published by the side that knows rather than duck-typed out of the tool's
@@ -196,14 +196,13 @@ const makeNewApp = async (
   // is not the seam failing. Two answers, and the deployment's own shape
   // picks which:
   //
-  //  - A sandbox is configured → the build runs. Same `create` a
-  //    server-needing ask has always taken, at the SAME app id, so
-  //    whatever the screen agent painted and the finished app share one
-  //    stream. The ask travels verbatim; the escalation adds one line
-  //    about why assembly could not serve it.
-  //  - No sandbox → say so, rather than spending a full build's latency
-  //    to arrive at a worse version of the screen the person was already
-  //    shown.
+  //  - A sandbox is configured → the person is ASKED. A build spends a
+  //    machine, and FINAL SPEC v1's law is that no machine is spent
+  //    without their explicit yes, so this raises the standing approval
+  //    card and the turn ends here having spent nothing. Their answer,
+  //    whenever it lands, is what starts the build (build-door.ts).
+  //  - No sandbox → say so, rather than asking for consent to a build
+  //    this deployment could not run.
   const escalated = routed?.kind === "escalate";
   if (!escalated) {
     // Assembly produced no screen. Said plainly, at the id whose stream
@@ -217,64 +216,20 @@ const makeNewApp = async (
       ),
     );
   }
-  if (!runtime.machine.available()) {
-    return await failUnbuilt(nameForUnbuilt(ask), NO_MACHINE);
+  const title = nameForUnbuilt(ask);
+  if (!runtime.build.available()) {
+    return await failUnbuilt(title, NO_MACHINE);
   }
-  let unsaved: string | undefined;
-  let serverWork: CreateServerWork | undefined;
-  const created = await runtime.create({
-    appId,
-    prompt: ask,
-    // The screen agent already ran, right above: its one line rides along so
-    // this build does not re-route the ask through a second agent.
-    why: routed.why,
-    // No `slot`: the claim went down at the mint above, which is the
-    // same instant `create` would have made it for an id of its own.
-    onUnsaved: (reason) => { unsaved = reason; },
-    // The lane's outcome arrives in up to two calls on one envelope shape
-    // (#881): the success half (the automation that raises the card below,
-    // caveat issues) and the failure report (`failed` — server work the plan
-    // required that did not get built), which reaches the receipt's STATUS
-    // too, not just its words (see the return below): `create` resolves with
-    // the document either way, and an unqualified "it's on your screen" is
-    // how an empty app gets declared successful. Merged, never overwritten —
-    // a failure must not erase the automation that DID land, or vice versa.
-    onServerWork: (work) => { serverWork = { ...serverWork, ...work }; },
-    ...(stream === undefined ? {} : {
-      onView: (part) => stream({ id: vendoViewStreamId(part.appId), part }),
-    }),
-  }, ctx);
-  // An unsaved create has no row to remember onto; `remember` says so
-  // and moves on, which is the same non-event every other failure is.
-  await remember(created.id);
-  // #881 — a create that rode its plan to an automation raises the same card
-  // an edit does. Before this, the envelope died inside `create` and the
-  // person's first-ask automation surfaced nothing: no card, no grants.
-  if (serverWork?.automation !== undefined && stream !== undefined) {
-    publishAutomationCard(stream, serverWork.automation);
+  // The ask travels verbatim; the escalation's one line rides beside it, so
+  // the build never re-routes through a second agent. Nothing waits on the
+  // card — it stands until the person answers it.
+  const proposed = await runtime.build.propose(
+    { appId, name: title, prompt: ask, why: routed.why }, ctx);
+  if ("declined" in proposed) {
+    return await failUnbuilt(title, unbuiltSay(proposed.declined));
   }
-  // View-only (the store refused the write): the screen IS on the user's
-  // page, so this is a success with a caveat, not a failure. Reporting it
-  // as an error made the agent apologize for a rendered view and rebuild
-  // it twice more — three cards, one prompt (live 2026-07-27). The
-  // caveat rides `say`, which is the whole point of `say`: one true
-  // sentence, and nothing to react to.
-  //
-  // FAILED SERVER WORK is not that: the app on screen is missing the half its
-  // plan asked for, so it is `"partial"` (§3.1 law 4). `say` alone was the same
-  // silent success one field over — the sentence said the server side did not
-  // get built while every reader that BRANCHES on `status` saw plain "ready".
-  const failedWork = serverWork?.failed ?? [];
-  return receipt({
-    id: created.id,
-    title: created.name,
-    status: failedWork.length === 0 ? "ready" : "partial",
-    say: failedWork.length !== 0
-      ? `I built the screen, but the server-side part didn't get built: ${failedWork.join("; ")}. The app works for viewing — ask me to try the build again.`
-      : unsaved === undefined
-        ? `${created.name} is on your screen.`
-        : `${created.name} is on your screen, though I couldn't save it to your apps.`,
-  });
+  await remember(appId);
+  return receipt({ id: appId, title, status: "awaiting-consent", say: AWAITING_CONSENT });
 };
 
 const changeExistingApp = async (

--- a/packages/apps/src/server/persistence/app-source.ts
+++ b/packages/apps/src/server/persistence/app-source.ts
@@ -35,6 +35,7 @@ import {
   appSourceFileSchema,
   type AppDocument,
   type AppSourceFile,
+  type BuiltFile,
 } from "../../contract/index.js";
 
 /**
@@ -118,7 +119,7 @@ const bundleKey = (appId: AppId, hex: string): string => `apps/${appId}/bundle/$
  */
 export const sealBundleBlobs = async (
   appId: AppId,
-  files: readonly { path: string; bytes: Uint8Array }[],
+  files: readonly BuiltFile[],
   entry: string,
   blobs: FilesAdapter,
 ): Promise<AppBundle> => {

--- a/packages/apps/src/server/persistence/approval-flow.ts
+++ b/packages/apps/src/server/persistence/approval-flow.ts
@@ -153,10 +153,11 @@ const createEgressGrants = (
 };
 
 const subscribeApprovalDecisions = (
-  deps: Pick<AppsRuntimeContext, "config" | "egressApprovals" | "parkedActions" | "reportGuard">
+  deps: Pick<AppsRuntimeContext,
+    "config" | "egressApprovals" | "parkedActions" | "parkedBuilds" | "build" | "reportGuard">
     & Pick<ReturnType<typeof createEgressGrants>, "commitEgressApproval">,
 ): void => {
-  const { config, egressApprovals, parkedActions, reportGuard } = deps;
+  const { config, egressApprovals, parkedActions, parkedBuilds, build, reportGuard } = deps;
   const { commitEgressApproval } = deps;
   const onApprovalDecision = async (id: ApprovalId, approved: boolean): Promise<void> => {
     // Lane E — parked egress domains riding this approval commit or clear as
@@ -212,6 +213,20 @@ const subscribeApprovalDecisions = (
         await parkedActions.remove(id);
       }
     }
+
+    // S3 — the person's yes (or no) on a STANDING build card, which may land
+    // long after the turn that raised it. Nothing was called when the card went
+    // up, so this decision is not a resumption but the START: it is the only
+    // path from an escalated ask to a build box. The record clears either way
+    // (approve builds and clears; deny clears, and no box is ever opened).
+    const parkedBuild = await parkedBuilds.byApproval(id);
+    if (parkedBuild !== null) {
+      try {
+        await build.resume(id, approved);
+      } finally {
+        await parkedBuilds.remove(id);
+      }
+    }
   };
   config.guard.onApprovalDecision((id, approved) => onApprovalDecision(id, approved));
 };
@@ -219,7 +234,7 @@ const subscribeApprovalDecisions = (
 /** The egress approval slice of `createApps`' closure. */
 export const createApprovalFlow = (
   deps: Pick<AppsRuntimeContext,
-    "config" | "engine" | "egressApprovals" | "parkedActions"
+    "config" | "engine" | "egressApprovals" | "parkedActions" | "parkedBuilds" | "build"
     | "holds" | "lifecycle" | "updateAppDocument" | "reportGuard">,
 ) => {
   const egressGrants = createEgressGrants(deps);

--- a/packages/apps/src/server/persistence/parked-build.ts
+++ b/packages/apps/src/server/persistence/parked-build.ts
@@ -1,0 +1,82 @@
+import {
+  PARKED_BUILD_COLLECTION,
+  type AppId,
+  type ApprovalId,
+  type RunContext,
+  type VendoRecord,
+} from "@vendoai/core";
+import type { EngineOps } from "./engine.js";
+import { listAllEngineRecords } from "./persistence.js";
+
+/**
+ * S3 — the offered-but-unanswered build (the propose→resume seam).
+ *
+ * `parked-action.ts`'s sibling, with one difference that is the whole point of
+ * the slice: nothing has been called. A parked ACTION records a call the guard
+ * already intercepted; a parked BUILD records a build that has not started and
+ * will not start until someone says yes. So a record here is the only place the
+ * ask survives — the turn that raised the card ends immediately (receipt status
+ * "awaiting-consent"), and the yes may land long after it is gone.
+ *
+ * Keyed by the approval that gates it, so the runtime's `onApprovalDecision`
+ * subscriber — the SAME seam egress and parked actions ride — can hand the
+ * build to the builder the instant the owner approves. A record exists exactly
+ * while its approval is undecided; both decisions clear it (approve builds then
+ * clears; deny just clears — no box, ever).
+ *
+ * Hygiene mirrors the stores beside it: app-keyed, cleared with the app.
+ */
+export interface ParkedBuild {
+  /** The guard approval that gates this build. */
+  approvalId: ApprovalId;
+  appId: AppId;
+  /** The proposing principal's subject — the only principal who may approve. */
+  owner: string;
+  /** The person's ask, verbatim. The build brief is replayed from it, so a
+   *  paraphrase (the app's capped name) is too lossy to keep instead. */
+  prompt: string;
+  /** The screen agent's own line for why a screen was not enough. */
+  why: string;
+  /** The venue the ask arrived in — the build runs with it, not with whatever
+   *  context the DECISION happened to arrive on. */
+  ctx: RunContext;
+}
+
+const COLLECTION = PARKED_BUILD_COLLECTION;
+
+const parkedData = (record: VendoRecord): ParkedBuild => record.data as ParkedBuild;
+
+export interface ParkedBuilds {
+  /** Park one offered build on its guard approval (re-proposing overwrites). */
+  put(build: ParkedBuild): Promise<void>;
+  /** The build riding a specific guard approval id, or null if none. */
+  byApproval(approvalId: ApprovalId): Promise<ParkedBuild | null>;
+  /** Clear the parked build for one approval (its approval was decided, either way). */
+  remove(approvalId: ApprovalId): Promise<void>;
+  /** Delete every parked build for one app (app deletion cleanup). */
+  clearForApp(appId: AppId): Promise<void>;
+}
+
+export const createParkedBuilds = (engine: EngineOps): ParkedBuilds => {
+  return {
+    async put(build) {
+      await engine.put(COLLECTION, {
+        id: build.approvalId,
+        data: build,
+        refs: { subject: build.owner, app_id: build.appId, approval: build.approvalId },
+      });
+    },
+    async byApproval(approvalId) {
+      const record = await engine.get(COLLECTION, approvalId);
+      return record === null ? null : parkedData(record);
+    },
+    async remove(approvalId) {
+      await engine.delete(COLLECTION, approvalId);
+    },
+    async clearForApp(appId) {
+      for (const record of await listAllEngineRecords(engine, COLLECTION, { refs: { app_id: appId } })) {
+        await engine.delete(COLLECTION, record.id);
+      }
+    },
+  };
+};

--- a/packages/apps/src/server/runtime/runtime-context.ts
+++ b/packages/apps/src/server/runtime/runtime-context.ts
@@ -46,6 +46,8 @@ import { createManifestTriggers } from "../escalation/manifest-triggers.js";
 import { createAppData } from "../persistence/app-data.js";
 import { createAppOpener } from "../persistence/open.js";
 import { createParkedActions, type ParkedActions } from "../persistence/parked-action.js";
+import { createParkedBuilds, type ParkedBuilds } from "../persistence/parked-build.js";
+import { createBuildDoor, type BuildDoor } from "../doors/build-door.js";
 import { updateAppRow } from "../persistence/persistence.js";
 import { placementStore, type PlacementRow, type PlacementStore } from "../persistence/placements.js";
 import { createPlacementRows } from "../doors/placement-surface.js";
@@ -79,6 +81,11 @@ export interface AppsRuntimeContext {
   egressApprovals: EgressApprovals;
   /** W0 — the undecided in-app actions the guard parked (parked-action.ts). */
   parkedActions: ParkedActions;
+  /** S3 — the builds that have been OFFERED and not answered (parked-build.ts). */
+  parkedBuilds: ParkedBuilds;
+  /** S3 — propose/resume/seal. Built before the approval flow, which subscribes
+   *  to the decision that fires `resume` (build-door.ts). */
+  build: BuildDoor;
   /** execution-v2 — provision/wake/sleep/destroy (machine-lifecycle.ts). */
   lifecycle: MachineLifecycle;
   /** The box manifest's schedules, folded into automation records. */
@@ -253,7 +260,7 @@ const createStores = (
   config: AppsConfig,
 ): Pick<AppsRuntimeContext,
   "engine" | "placementRows" | "slots" | "data" | "history" | "egressApprovals"
-  | "parkedActions"> => {
+  | "parkedActions" | "parkedBuilds"> => {
   const engine = engineOf(config.ops, config.store);
   const placementRows = placementStore(engine);
   const slots = createSlotRegistry(engine);
@@ -267,7 +274,11 @@ const createStores = (
   // re-dispatch the exact call the instant the owner approves. Holds only
   // undecided actions; both decisions clear it.
   const parkedActions = createParkedActions(engine);
-  return { engine, placementRows, slots, data, history, egressApprovals, parkedActions };
+  // S3 — the builds the person has been ASKED about. Unlike the two above,
+  // nothing has been called: the record IS the awaiting-consent state, and it
+  // exists so the yes can arrive long after the turn that raised the card.
+  const parkedBuilds = createParkedBuilds(engine);
+  return { engine, placementRows, slots, data, history, egressApprovals, parkedActions, parkedBuilds };
 };
 
 /** The composed seams the doors call through: interchange, the machine
@@ -424,10 +435,13 @@ export const createRuntimeContext = (
     config: withBuildTracking(config, placement),
     ...stores, ...audit, ...access, ...machine, updateAppDocument, runtime,
   };
-  const approvals = createApprovalFlow(base);
   const journal = createEditJournal(base);
+  // Before the approval flow, which subscribes to the decision that fires its
+  // `resume` — the seam that turns the person's yes into the build.
+  const build = createBuildDoor({ ...base, ...placement, ...journal });
+  const approvals = createApprovalFlow({ ...base, build });
   const doors = createDoors(base);
   const generation = createGenerationContext(base.config);
   const box = createBoxLane({ ...base, ...approvals, ...journal, ...doors });
-  return { ...base, ...approvals, ...journal, ...doors, ...placement, ...generation, ...box };
+  return { ...base, build, ...approvals, ...journal, ...doors, ...placement, ...generation, ...box };
 };

--- a/packages/apps/src/server/runtime/runtime.ts
+++ b/packages/apps/src/server/runtime/runtime.ts
@@ -50,6 +50,7 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
     slots: ctx.slots,
     takeReplaySource: ctx.takeReplaySource,
     seed: createSeedSurface(ctx),
+    build: ctx.build,
     machine: createMachineSurface(ctx),
   };
   return runtime;

--- a/packages/apps/src/server/runtime/types.ts
+++ b/packages/apps/src/server/runtime/types.ts
@@ -37,6 +37,7 @@ import type {
   WorkspaceFs,
 } from "@vendoai/core";
 import type {
+  AppBuilder,
   AppDocument,
   AppListRow,
   BriefingPack,
@@ -263,6 +264,17 @@ export interface AppsConfig {
    * `vendo_make` in agent-tools.ts).
    */
   screen?: ScreenAssembler;
+  /**
+   * FINAL SPEC v1 — the build engine, for the ask a screen cannot serve. The
+   * screen agent's `escalate` is the only thing that reaches it, and only after
+   * the person has answered the standing card.
+   *
+   * An ADAPTER SLOT for the same reason `screen` is: the lane runs a coding
+   * agent inside a disposable box, which this block does not hold. Unfilled,
+   * an escalation is answered with a failed receipt naming the missing sandbox
+   * rather than a promise of a build nothing can run.
+   */
+  build?: AppBuilder;
   /**
    * ADAPTER SLOT — what compiles, type-checks and paints a component screen.
    *
@@ -837,6 +849,25 @@ export interface AppsRuntime {
    * auto-sleep live in-process; a multi-instance host can wake one app twice
    * (known v2 limit — the last sleep's CAS wins).
    */
+  /**
+   * FINAL SPEC v1 — the built-app door.
+   *
+   * `propose` is the only route to a build box, and it never opens one: it
+   * raises the standing approval card and returns, so the turn that asked ends
+   * having spent nothing. The person's yes — whenever it lands, possibly long
+   * after that turn is gone — is what starts the build, through the
+   * `onApprovalDecision` seam (persistence/approval-flow.ts).
+   */
+  build: {
+    /** Can this deployment build at all — i.e. is a sandbox adapter composed?
+     *  The ONE gate, so the front door can answer an escalation honestly before
+     *  it asks for consent it could not act on. */
+    available(): boolean;
+    propose(
+      input: { appId: AppId; name: string; prompt: string; why: string },
+      ctx: RunContext,
+    ): Promise<{ approvalId: ApprovalId } | { declined: string }>;
+  };
   machine: {
     /**
      * Can this deployment run a machine at all — i.e. is a `sandbox` adapter

--- a/packages/apps/tests/agent-tools.test.ts
+++ b/packages/apps/tests/agent-tools.test.ts
@@ -624,6 +624,10 @@ describe("vendo_make — the slot a new app lands in", () => {
     model: basicLanguageModel(),
     machine: { sandbox: fakeBoxSandbox(), buildEnv: () => ({ PORT: "8080" }), boxEditPollMs: 5 },
     screen: { async assemble() { return { kind: "escalate", why: "this needs real code" }; } },
+    // S3 — an escalation now ASKS before it builds, so the deployment needs a
+    // builder for the ask to be honest. What it never reaches is this stub's
+    // `build`: the card stands, undecided, for the whole of this test.
+    build: { available: () => true, async build() { return { kind: "failed", why: "never reached" }; } },
   });
 
   it("takes request, app, context, slot and component — request required, nothing else allowed", async () => {
@@ -732,7 +736,9 @@ describe("vendo_make — the slot a new app lands in", () => {
 
     expect(outcome.status).toBe("ok");
     const receipt = (outcome as { output: { id: string; status: string } }).output;
-    expect(receipt.status).toBe("ready");
+    // S3 — the escalated ask is now OFFERED, not built. The row and the slot
+    // still land at the mint, which is what this test is about.
+    expect(receipt.status).toBe("awaiting-consent");
     expect(await runtime.placements({}, ctx)).toEqual([
       expect.objectContaining({ slot: "dashboard.hero", app: receipt.id }),
     ]);

--- a/packages/apps/tests/build-consent.test.ts
+++ b/packages/apps/tests/build-consent.test.ts
@@ -1,0 +1,219 @@
+/**
+ * S3 — consent. "No machine is ever spent without the user's explicit yes."
+ *
+ * Three things are pinned here, and the middle one is the slice's SEAM: the
+ * guard's decision, on its own, is what starts a build. Everything on the
+ * consent side is the real path — the real `vendo_make` front door, the real
+ * propose door, the real parked-build collection over a real engine, the real
+ * `onApprovalDecision` subscription, and the real app row. Only the two ends
+ * are stand-ins, and both by design: the SCREEN agent (whose escalation is the
+ * input) and the `AppBuilder` (whose lane is S4's).
+ */
+import {
+  VENDO_APP_FORMAT,
+  engineOverAdapter,
+  type AppId,
+  type FilesAdapter,
+  type RunContext,
+  type ToolRegistry,
+} from "@vendoai/core";
+import { describe, expect, it } from "vitest";
+import {
+  validateAppDocument,
+  type AppBuilder,
+  type BuildOutcome,
+} from "../src/contract/index.js";
+import { runMakeTool } from "../src/server/doors/make-tool.js";
+import { readBundleBlob } from "../src/server/persistence/app-source.js";
+import { createApps, type AppsConfig } from "../src/server/index.js";
+import { fakeStatefulSandbox } from "../src/server/testing/fake-sandbox-stateful.js";
+import { guardFixture } from "../src/server/testing/guard-fixture.js";
+import { memoryStore } from "../src/server/testing/memory-store.js";
+import type { AgentToolsDataDependencies } from "../src/server/doors/agent-tools.js";
+import { PARKED_BUILD_COLLECTION } from "@vendoai/core";
+
+const ctx: RunContext = {
+  principal: { kind: "user", subject: "user_ada" },
+  venue: "chat",
+  presence: "present",
+  sessionId: "session_ada",
+};
+
+const tools: ToolRegistry = {
+  async descriptors() { return []; },
+  async execute() {
+    return { status: "error" as const, error: { code: "not-found", message: "no fixture tools" } };
+  },
+};
+
+const ASK = "a photo editor that crops and rotates";
+
+/** The screen agent escalates — the one input this slice's flow starts from. */
+const screen: AgentToolsDataDependencies["screen"] = {
+  async assemble() { return { kind: "escalate", why: "this needs a real image library" }; },
+};
+
+/** S4's lane, stood in for: it records the request it was handed and answers
+ *  with whatever the case needs. The build seam is the ONE thing faked. */
+const recordingBuilder = (outcome: BuildOutcome = { kind: "failed", why: "not built here" }): {
+  builder: AppBuilder;
+  built: { appId: AppId; prompt: string; why: string }[];
+} => {
+  const built: { appId: AppId; prompt: string; why: string }[] = [];
+  return {
+    built,
+    builder: {
+      available: () => true,
+      async build(request) {
+        built.push({ appId: request.appId, prompt: request.prompt, why: request.why });
+        return outcome;
+      },
+    },
+  };
+};
+
+const memoryBlobs = () => {
+  const bytes = new Map<string, Uint8Array>();
+  const adapter: FilesAdapter = {
+    async put(key, value) { bytes.set(key, value); },
+    async get(key) { const found = bytes.get(key); return found === undefined ? undefined : { bytes: found }; },
+    async delete(key) { bytes.delete(key); },
+  };
+  return adapter;
+};
+
+const setup = (options: { build?: AppBuilder } = {}) => {
+  const store = memoryStore();
+  const files = memoryBlobs();
+  const guard = guardFixture();
+  const engine = engineOverAdapter(store);
+  const config: AppsConfig = {
+    store,
+    guard,
+    tools,
+    catalog: [],
+    screen,
+    files,
+    // A sandbox IS composed: this slice's law is that a composed sandbox is
+    // still not spent until the person says yes, which a missing one would
+    // prove nothing about.
+    machine: { sandbox: fakeStatefulSandbox(), buildEnv: () => ({ PORT: "8080" }) },
+    ...(options.build === undefined ? {} : { build: options.build }),
+  };
+  const runtime = createApps(config);
+  const dependencies = {
+    screen,
+    claimSlot: async () => {},
+    markUnbuilt: async () => {},
+  } as unknown as AgentToolsDataDependencies;
+  const make = () => runMakeTool(
+    runtime,
+    dependencies,
+    { id: "call_make_1", tool: "vendo_make", args: { request: ASK } },
+    ctx,
+  );
+  const rowOf = async (appId: string) => {
+    const record = await store.records("vendo_apps").get(appId);
+    return record === null ? null : (record.data as { doc: Record<string, unknown> }).doc;
+  };
+  return { store, guard, engine, files, runtime, make, rowOf };
+};
+
+const receiptOf = (outcome: Awaited<ReturnType<typeof runMakeTool>>): { id: string; status: string; say: string } => {
+  if (outcome.status !== "ok") throw new Error(`expected ok, got ${outcome.status}`);
+  return outcome.output as unknown as { id: string; status: string; say: string };
+};
+
+describe("propose spends no box", () => {
+  it("raises the standing card, parks the build, and claims nothing", async () => {
+    const { builder, built } = recordingBuilder();
+    const { guard, engine, make, rowOf } = setup({ build: builder });
+
+    const receipt = receiptOf(await make());
+
+    expect(receipt.status).toBe("awaiting-consent");
+    // The whole point: the turn ended with the box untouched.
+    expect(built).toEqual([]);
+    // One undecided card, and the ask verbatim on it.
+    expect(guard.approvals).toHaveLength(1);
+    expect(guard.approvals[0]?.call.args).toMatchObject({ appId: receipt.id, prompt: ASK });
+    // Parked against that card, in the real collection.
+    const parked = await engine.get(PARKED_BUILD_COLLECTION, guard.approvals[0]?.id ?? "");
+    expect(parked?.data).toMatchObject({ appId: receipt.id, prompt: ASK, owner: "user_ada" });
+    // The row says "offered, unanswered" — and never "building".
+    const row = await rowOf(receipt.id);
+    expect(row?.proposal).toMatchObject({ approvalId: guard.approvals[0]?.id, prompt: ASK });
+    expect(row?.building).toBeUndefined();
+  });
+});
+
+describe("the decision alone starts the build", () => {
+  it("approving the standing card runs the builder and seals what it built", async () => {
+    const entry = "app.js";
+    const bytes = new TextEncoder().encode("console.log('built')");
+    const { builder, built } = recordingBuilder({ kind: "built", files: [{ path: entry, bytes }], entry });
+    const { guard, engine, files, make, rowOf } = setup({ build: builder });
+    const receipt = receiptOf(await make());
+    const approvalId = guard.approvals[0]?.id ?? "";
+    expect(built).toEqual([]);
+
+    // Nothing but the decision. No second tool call, no re-dispatch.
+    guard.decide(approvalId, true);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(built).toEqual([{ appId: receipt.id, prompt: ASK, why: "this needs a real image library" }]);
+    const row = await rowOf(receipt.id);
+    expect(row?.ui).toBe("bundle");
+    expect(row?.bundle).toMatchObject({ bytes: bytes.byteLength });
+    // Sealed for real: the entry hash reads back as the bytes the builder made.
+    const entryHash = (row?.bundle as { entry: string }).entry;
+    expect(await readBundleBlob(receipt.id as AppId, entryHash, files)).toEqual(bytes);
+    // Both build-state fields are gone: the app IS built now.
+    expect(row?.proposal).toBeUndefined();
+    expect(row?.building).toBeUndefined();
+    // The parked record is cleared by the decision, either way.
+    expect(await engine.get(PARKED_BUILD_COLLECTION, approvalId)).toBeNull();
+  });
+
+  it("denying it spends no box and leaves the honest failure card", async () => {
+    const { builder, built } = recordingBuilder();
+    const { guard, engine, make, rowOf } = setup({ build: builder });
+    const receipt = receiptOf(await make());
+    const approvalId = guard.approvals[0]?.id ?? "";
+
+    guard.decide(approvalId, false);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(built).toEqual([]);
+    const row = await rowOf(receipt.id);
+    expect(row?.proposal).toBeUndefined();
+    expect(row?.buildFailed).toMatchObject({ reason: expect.stringContaining("not approved") });
+    expect(await engine.get(PARKED_BUILD_COLLECTION, approvalId)).toBeNull();
+  });
+});
+
+describe("validateAppDocument refuses both build states at once", () => {
+  const doc = (extra: Record<string, unknown>) => ({
+    format: VENDO_APP_FORMAT,
+    id: "app_two_states",
+    name: "Two states",
+    ...extra,
+  });
+  const proposal = {
+    approvalId: "apr_1",
+    prompt: ASK,
+    why: "needs a real image library",
+    at: "2026-08-24T00:00:00.000Z",
+  };
+
+  it("refuses a document carrying proposal AND building", () => {
+    const result = validateAppDocument(doc({ proposal, building: "2026-08-24T00:00:01.000Z" }));
+    expect(result.ok).toBe(false);
+    expect(result.ok ? "" : result.error.message).toContain("proposal");
+  });
+
+  it("admits either one on its own", () => {
+    expect(validateAppDocument(doc({ proposal })).ok).toBe(true);
+    expect(validateAppDocument(doc({ building: "2026-08-24T00:00:01.000Z" })).ok).toBe(true);
+  });
+});

--- a/packages/apps/tests/create-server-work-failed.test.ts
+++ b/packages/apps/tests/create-server-work-failed.test.ts
@@ -1,7 +1,6 @@
 import { type RunContext, type ToolRegistry } from "@vendoai/core";
 import { type ScreenAssembler } from "../src/contract/index.js";
 import { describe, expect, it, vi } from "vitest";
-import { createAgentTools } from "../src/server/doors/agent-tools.js";
 import { createApps } from "../src/server/index.js";
 import { fakeBoxSandbox, type FakeBoxAgent } from "../src/server/testing/fake-box.js";
 import { guardFixture } from "../src/server/testing/guard-fixture.js";
@@ -56,16 +55,6 @@ const setup = (agent: FakeBoxAgent) => createApps({
 
 const brokenBox: FakeBoxAgent = () => ({ ok: false, summary: BOX_GAVE_UP, filesChanged: [], testsRun: 0 });
 
-/** The real front door (`vendo_make`) over the real create door, with nothing
- *  stubbed between them — the seam a receipt's `status` is actually read at. */
-const bridge = (agent: FakeBoxAgent) => createAgentTools(setup(agent), {
-  data: {} as never,
-  requireOwned: async () => { throw new Error("unused"); },
-  claimSlot: async () => { throw new Error("unused"); },
-  markUnbuilt: async () => { throw new Error("unused"); },
-  screen: escalating,
-});
-
 /** The box builds the work and names the function it wrote — the plain success
  *  the failure-only signal has to stay silent for. */
 const workingBox: FakeBoxAgent = ({ box }) => {
@@ -116,70 +105,11 @@ describe("a create whose server work could not be built", () => {
     }
   });
 
-  it("reads to the person as an honest half-success through the agent bridge, not a plain 'it's on your screen'", async () => {
-    // The SEAM: the real front door (`vendo_make`) over the real create door,
-    // with nothing stubbed between them. This is what the person actually
-    // hears, and an unqualified "on your screen" here is the whole bug —
-    // the app is empty and the turn calls it done.
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
-    const infoSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
-    try {
-      const agentTools = bridge(brokenBox);
-
-      const outcome = await agentTools.execute({
-        id: "call_1",
-        tool: "vendo_make",
-        args: { request: "Make me a full kanban board for my invoices with drag-and-drop between columns" },
-      }, ctx);
-
-      expect(outcome.status).toBe("ok");
-      const output = (outcome as { output: Record<string, unknown> }).output;
-      expect(output.say).toBe(
-        "I built the screen, but the server-side part didn't get built: "
-        + "the in-box agent could not build the server work: could not build the drag-and-drop server"
-        + " — the machine was discarded and the rest of the app stands."
-        + ". The app works for viewing — ask me to try the build again.",
-      );
-      // Contract §3.1 — four fields of words, and no document among them.
-      expect(Object.keys(output).sort()).toEqual(["id", "say", "status", "title"]);
-    } finally {
-      errorSpy.mockRestore();
-      infoSpy.mockRestore();
-    }
-  });
-
-  it("says so in `status`, not only in `say` — a host branching on the field must not read plain success", async () => {
-    // The bug one field over (found 2026-08-11, the cold walk after the `say`
-    // fix above shipped): the sentence told the truth and `status` still said
-    // `"ready"`, so everything that BRANCHES rather than reads — a host's own
-    // if, the pack's ref capture, an outside agent over MCP — saw a clean build
-    // of a half-built app. Not `"failed"` either: the screen is real and
-    // reopenable, and `"failed"` means nothing was painted.
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
-    const infoSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
-    try {
-      const broken = (await bridge(brokenBox).execute({
-        id: "call_broken",
-        tool: "vendo_make",
-        args: { request: "Make me a full kanban board for my invoices with drag-and-drop between columns" },
-      }, ctx) as { output: Record<string, unknown> }).output;
-      expect(broken.status).toBe("partial");
-
-      // The control, through the SAME door: a box that builds what was asked
-      // for is still plainly `"ready"`. Without this, a `status` hardwired
-      // to `"partial"` would pass the assertion above.
-      const built = (await bridge(workingBox).execute({
-        id: "call_built",
-        tool: "vendo_make",
-        args: { request: "Make me a full kanban board for my invoices with drag-and-drop between columns" },
-      }, ctx) as { output: Record<string, unknown> }).output;
-      expect(built.status).toBe("ready");
-    } finally {
-      errorSpy.mockRestore();
-      infoSpy.mockRestore();
-    }
-  });
-
+  // REMOVED by the consent slice (S3): `vendo_make` no longer calls `create` on
+  // an escalation — it raises the standing build card and returns
+  // "awaiting-consent" — so the two receipts this file used to pin through the
+  // agent bridge ("partial", and the half-success `say`) have no producer left.
+  // The create door's own signals below are untouched.
   it("reports the failure exactly once, even when the consumer's own callback throws", async () => {
     // The report used to run INSIDE the try that wraps the server lane, so a
     // throwing consumer re-entered that catch as a second "server work failed":

--- a/packages/apps/tests/create-unsaved.test.ts
+++ b/packages/apps/tests/create-unsaved.test.ts
@@ -134,49 +134,10 @@ describe("a create the store refuses to persist", () => {
     expect(unsaved[0]).toContain("Store request failed.");
   });
 
-  it("reads to the agent as success with an honest note — never a failure it would retry", async () => {
-    // Through the front door, which reaches `create` by ESCALATION: the screen
-    // agent asks for the builder and this deployment has a sandbox to build in.
-    // (It used to reach it by falling through from an unwired assembler; that
-    // fall-through is gone, and an unwired assembler now fails loudly.)
-    const escalating: ScreenAssembler = {
-      assemble: async () => ({ kind: "escalate", why: "this needs a real build" }),
-    };
-    const runtime = createApps({
-      store: storeRefusingAppWrites(),
-      guard: guardFixture(),
-      tools,
-      catalog: [],
-      model: basicLanguageModel(),
-      machine: { sandbox: fakeBoxSandbox(), buildEnv: () => ({ PORT: "8080" }), boxEditPollMs: 5 },
-      screen: escalating,
-    });
-    const agentTools = createAgentTools(runtime, {
-      data: {} as never,
-      requireOwned: async () => { throw new Error("unused"); },
-      claimSlot: async () => { throw new Error("unused"); },
-      markUnbuilt: async () => { throw new Error("unused"); },
-      screen: escalating,
-    });
-
-    const outcome = await agentTools.execute(
-      { id: "call_1", tool: "vendo_make", args: { request: "Show my spending by category" } },
-      ctx,
-    );
-
-    expect(outcome.status).toBe("ok");
-    const output = (outcome as { output: Record<string, unknown> }).output;
-    // The receipt reads "ready", because the screen IS on the user's page. The
-    // caveat rides `say` — one true sentence with nothing in it to react to,
-    // which is what stops the three-cards-per-prompt loop. A "failed" status
-    // here, or a structured note to reason about, is an invitation to rebuild.
-    expect(output.status).toBe("ready");
-    expect(output.say).toMatch(/on your screen/i);
-    expect(output.say).toMatch(/couldn't save it to your apps/i);
-    // Contract §3.1 — four fields of words, and no document among them.
-    expect(Object.keys(output).sort()).toEqual(["id", "say", "status", "title"]);
-  });
-
+  // REMOVED by the consent slice (S3): `vendo_make` no longer calls `create` on
+  // an escalation, so the view-only caveat this pinned through the agent bridge
+  // has no producer left on that route. `create`'s own `onUnsaved` signal —
+  // the thing this file is about — is covered above and below.
   it("says nothing extra when the store is healthy (the note is failure-only)", async () => {
     let runtime: AppsRuntime;
     runtime = createApps({

--- a/packages/apps/tests/create-unsaved.test.ts
+++ b/packages/apps/tests/create-unsaved.test.ts
@@ -8,7 +8,6 @@ import {
   type ScreenAssembler,
 } from "../src/contract/index.js";
 import { describe, expect, it } from "vitest";
-import { createAgentTools } from "../src/server/doors/agent-tools.js";
 import { createApps, type AppsRuntime } from "../src/server/index.js";
 import { assembleTree } from "../src/server/runtime/runtime.js";
 import { authoringAssembler } from "../src/server/testing/screen-assembler.js";

--- a/packages/apps/tests/make-tool.test.ts
+++ b/packages/apps/tests/make-tool.test.ts
@@ -20,7 +20,7 @@ import {
 import { describe, expect, it } from "vitest";
 import type { AgentToolsDataDependencies } from "../src/server/doors/agent-tools.js";
 import { runMakeTool } from "../src/server/doors/make-tool.js";
-import type { AppsRuntime, AutomationAuthorResult, CreateServerWork } from "../src/server/runtime/types.js";
+import type { AppsRuntime, AutomationAuthorResult, EditResult } from "../src/server/runtime/types.js";
 
 const ctx: RunContext = {
   principal: { kind: "user", subject: "user_ada" },
@@ -40,25 +40,28 @@ const RECORD: AutomationRecord = {
   updatedAt: "2026-08-17T00:00:00.000Z",
 };
 
-const AUTOMATION: NonNullable<CreateServerWork["automation"]> = { record: RECORD, enabled: true };
+const AUTOMATION: NonNullable<EditResult["automation"]> = { record: RECORD, enabled: true };
 
 /** The one door under test is the PUBLICATION seam, so the runtime is a fake:
- *  a create that hands back whatever server-work outcome the case needs, and an
+ *  an edit that hands back whatever automation envelope the case needs, a build
+ *  door that only ever OFFERS (S3 — an escalated ask spends nothing), and an
  *  automation door that records what the compound path asked it for. */
 const runtimeWith = (
-  work: CreateServerWork | undefined,
+  automation: EditResult["automation"] | undefined,
   authored?: AutomationAuthorResult,
 ): { runtime: AppsRuntime; asked: Array<{ appId: string; instruction: string; mode: string }> } => {
   const asked: Array<{ appId: string; instruction: string; mode: string }> = [];
+  const app = { format: VENDO_APP_FORMAT, id: "app_made", name: "Invoice nudges", ui: "tree" as const };
   const partial = {
-    machine: { available: () => true },
-    async create(input: Parameters<AppsRuntime["create"]>[0]) {
-      if (work !== undefined) input.onServerWork?.(work);
+    build: {
+      available: () => true,
+      async propose() { return { approvalId: "apr_build_1" }; },
+    },
+    async edit() {
       return {
-        format: VENDO_APP_FORMAT,
-        id: input.appId ?? "app_made",
-        name: "Invoice nudges",
-        ui: "tree" as const,
+        app,
+        version: { at: "2026-08-24T00:00:00.000Z", intent: "make it", rung: 1 as const },
+        ...(automation === undefined ? {} : { automation }),
       };
     },
     automation: {
@@ -86,7 +89,7 @@ const deps = {
 
 /** The plain ask names no recurrence, so nothing reaches the automation door
  *  unless a case asks for it. */
-const makeCall = (request = "make me an invoice board"): {
+const makeCall = (request = "make me an invoice board", app?: string): {
   call: VendoViewStreamingToolCall;
   updates: VendoViewStreamUpdate[];
 } => {
@@ -94,7 +97,7 @@ const makeCall = (request = "make me an invoice board"): {
   const call: VendoViewStreamingToolCall = {
     id: "call_1",
     tool: "vendo_make",
-    args: { request },
+    args: { request, ...(app === undefined ? {} : { app }) },
     [VENDO_VIEW_STREAM]: (update) => { updates.push(update); },
   };
   return { call, updates };
@@ -117,8 +120,8 @@ const cardIn = (updates: VendoViewStreamUpdate[]): Record<string, unknown> => {
 
 describe("vendo_make publishes the automation card (#881)", () => {
   it("raises a card about the RECORD, humanized, that core's own schema accepts", async () => {
-    const { call, updates } = makeCall();
-    const { runtime } = runtimeWith({ automation: AUTOMATION });
+    const { call, updates } = makeCall("make me an invoice board", "app_made");
+    const { runtime } = runtimeWith(AUTOMATION);
     await runMakeTool(runtime, deps, call, ctx);
 
     expect(cardIn(updates)).toMatchObject({
@@ -132,33 +135,30 @@ describe("vendo_make publishes the automation card (#881)", () => {
   });
 
   it("counts pending grants on the card", async () => {
-    const { call, updates } = makeCall();
-    const pendingGrants = [{}, {}] as unknown as NonNullable<NonNullable<CreateServerWork["automation"]>["pendingGrants"]>;
-    const { runtime } = runtimeWith({ automation: { ...AUTOMATION, pendingGrants } });
+    const { call, updates } = makeCall("make me an invoice board", "app_made");
+    const pendingGrants = [{}, {}] as unknown as NonNullable<NonNullable<EditResult["automation"]>["pendingGrants"]>;
+    const { runtime } = runtimeWith({ ...AUTOMATION, pendingGrants });
     await runMakeTool(runtime, deps, call, ctx);
 
     expect(cardIn(updates).pendingGrants).toBe(2);
   });
 
-  it("says when required server work could not be built, never a silent green receipt", async () => {
-    const { call } = makeCall();
-    const { runtime } = runtimeWith({ failed: ["the box did not produce a verified served web app"] });
-    const outcome = await runMakeTool(runtime, deps, call, ctx);
-    // The merged shape (#881 + upstream's partial-status receipt): the words
-    // carry the reason AND the status branches — a reader that only checks
-    // `status` no longer sees plain "ready" on a half-built app.
-    const receipt = receiptOf(outcome);
-    expect(receipt.say).toContain("didn't get built");
-    expect(receipt.say).toContain("the box did not produce a verified served web app");
-    expect(receipt.status).toBe("partial");
-  });
-
   it("publishes no card and no caveat when the lane authored nothing", async () => {
-    const { call, updates } = makeCall();
+    const { call, updates } = makeCall("make me an invoice board", "app_made");
     const { runtime } = runtimeWith(undefined);
     const outcome = await runMakeTool(runtime, deps, call, ctx);
     expect(updates.some((update) => update.part.type === "data-vendo-automation")).toBe(false);
-    expect(receiptOf(outcome).say).toBe("Invoice nudges is on your screen.");
+    expect(receiptOf(outcome).say).toBe("Invoice nudges is updated.");
+  });
+});
+
+describe("an escalated ask is OFFERED, never built (S3)", () => {
+  it("ends the turn on awaiting-consent, with nothing spent", async () => {
+    const { call } = makeCall();
+    const { runtime } = runtimeWith(undefined);
+    const receipt = receiptOf(await runMakeTool(runtime, deps, call, ctx));
+    expect(receipt.status).toBe("awaiting-consent");
+    expect(receipt.say).toContain("go-ahead");
   });
 });
 
@@ -194,7 +194,7 @@ describe("the schedule half of a compound ask", () => {
     const outcome = await runMakeTool(runtime, deps, call, ctx);
 
     const receipt = receiptOf(outcome);
-    expect(receipt.status).toBe("ready");
+    expect(receipt.status).toBe("awaiting-consent");
     expect(receipt.say).toContain("I couldn't set up the schedule: no valid plan validated");
     expect(updates.some((update) => update.part.type === "data-vendo-automation")).toBe(false);
   });

--- a/packages/apps/tests/screen-route.test.ts
+++ b/packages/apps/tests/screen-route.test.ts
@@ -102,6 +102,12 @@ const runtimeWith = (screen?: ScreenAssembler, options: {
           buildEnv: () => ({ PORT: "8080" }),
           boxEditPollMs: 5,
         },
+        // S3 — a composed builder is what makes the escalation an honest ASK.
+        // It is never reached here: the card stands undecided.
+        build: {
+          available: () => true,
+          build: async () => ({ kind: "failed" as const, why: "never reached" }),
+        },
       }
       : {}),
     ...(screen === undefined ? {} : { screen }),
@@ -186,30 +192,33 @@ const EDITED = SCREEN.replace("This month", "Last month");
 describe("an escalation and the build that finishes it share ONE app id", () => {
   it("the build runs at the id the screen agent was handed, briefed with the ask itself", async () => {
     const { seen, assembler } = recordingAssembler({ kind: "escalate", why: "this needs real code" });
-    const { agentTools, briefs, boxTasks } = runtimeWith(assembler, { sandbox: true });
+    const { agentTools, briefs, boxTasks, store } = runtimeWith(assembler, { sandbox: true });
 
     const outcome = await make(agentTools);
 
     expect(outcome.status).toBe("ok");
     const receipt = (outcome as { output: { id: string; status: string } }).output;
     // The assembler was consulted ONCE, before anything was built — the seam
-    // routes, the caller does not, and an escalation carries its `why` into
-    // `create` so the build never runs a second agent over the same ask.
+    // routes, the caller does not, and an escalation carries its `why` into the
+    // proposal so the build never runs a second agent over the same ask.
     expect(seen).toHaveLength(1);
-    // …and that consultation, plus the app the build went on to make, is at ONE
-    // id. This is the assertion that stops a stranded second stream.
+    // …and that consultation, plus the build the person is being asked about,
+    // is at ONE id. This is the assertion that stops a stranded second stream.
     expect(seen[0]?.appId).toBe(receipt.id);
-    // An escalation with somewhere to build is a BUILD, not a failure.
-    expect(receipt.status).toBe("ready");
-    // THE ASK IS THE BRIEF, and it reached the builder as written — the person's
-    // own words rather than a second, unrelated answer to the same ask.
-    expect(boxTasks.join("\n")).toContain("Show my spending by category");
-    // The escalation's one-line `why` travels beside it: the box hears why this
-    // cannot happen in the browser, and nothing else was decided for it.
-    expect(boxTasks.join("\n")).toContain("this needs real code");
-    // AND NOTHING RE-PLANNED IT. There is no middleman between the ask and the
-    // box, so no model was asked what to build.
+    // S3 — an escalation with somewhere to build is an ASK, not a build.
+    expect(receipt.status).toBe("awaiting-consent");
+    // THE ASK IS THE BRIEF, and it is held as written — the person's own words
+    // rather than a second, unrelated answer to the same ask. It waits on the
+    // proposal because the yes may land long after this turn.
+    const row = await store.records("vendo_apps").get(receipt.id);
+    const proposal = (row?.data as { doc: { proposal?: { prompt: string; why: string } } }).doc.proposal;
+    expect(proposal?.prompt).toContain("Show my spending by category");
+    // The escalation's one-line `why` travels beside it: the box will hear why
+    // this cannot happen in the browser, and nothing else was decided for it.
+    expect(proposal?.why).toContain("this needs real code");
+    // NOTHING RE-PLANNED IT and NOTHING WAS SPENT: no model call, no box task.
     expect(briefs).toHaveLength(0);
+    expect(boxTasks).toEqual([]);
   });
 
   it("with no sandbox the escalation FAILS honestly at the same id, and nothing is generated", async () => {

--- a/packages/vendo/src/pack.ts
+++ b/packages/vendo/src/pack.ts
@@ -88,6 +88,11 @@ function appRefTitleFromPrompt(prompt: unknown): string {
  * laundering a partial receipt through it leaves a caller waiting on a completion
  * that already came, and drops the one sentence that says what is missing.
  *
+ * `"awaiting-consent"` is refused for the third form of the same reason: the ask
+ * has been PUT to the person and nothing is under way, so a ref reading
+ * "accepted, still streaming" would show a build skeleton for a build nobody has
+ * authorized — and drop the one sentence that says a card is waiting.
+ *
  * Local to the PACK on purpose. `vendo/app-ref@1` means "accepted, still
  * streaming, NOT built yet"; only this fast-return path can honestly say that.
  * The MCP door runs `vendo_make` to completion, so it answers the receipt — see
@@ -96,7 +101,8 @@ function appRefTitleFromPrompt(prompt: unknown): string {
  */
 function appRefFromReceipt(output: unknown, fallbackTitle: string): VendoAppRef | null {
   const receipt = makeReceiptSchema.safeParse(output);
-  if (!receipt.success || receipt.data.status === "failed" || receipt.data.status === "partial") {
+  if (!receipt.success || receipt.data.status === "failed" || receipt.data.status === "partial"
+    || receipt.data.status === "awaiting-consent") {
     return null;
   }
   return {

--- a/packages/vendo/tests/your-agent-docs.docs.test.ts
+++ b/packages/vendo/tests/your-agent-docs.docs.test.ts
@@ -309,11 +309,11 @@ describe("the documented arguments match the real schemas", () => {
 });
 
 describe("the receipt law the docs teach is the real receipt", () => {
-  it("has exactly id, title, status, say — and status's four values", async () => {
+  it("has exactly id, title, status, say — and status's five values", async () => {
     const source = await read("packages/apps/src/contract/make-receipt.ts");
     expect(source).toContain("id: appIdSchema");
     expect(source).toContain("title: z.string().min(1)");
-    expect(source).toContain('status: z.enum(["ready", "partial", "building", "failed"])');
+    expect(source).toContain('status: z.enum(["ready", "partial", "building", "awaiting-consent", "failed"])');
     expect(source).toContain("say: z.string().min(1)");
   });
 


### PR DESCRIPTION
> Stacked on #1608. Review only the top commit; the stack merges once at the tip.

## What & why

Slice 3 of 7 in the **built apps** stack, and the slice the whole feature's safety rests on: **no machine is ever spent without the person's explicit yes.**

Before: an ask the screen agent couldn't satisfy fell straight through to `create`, which built immediately. Now the tool raises a **standing** approval card and the turn ENDS — receipt `awaiting-consent`, zero box, zero spend. The yes starts the build whenever it arrives, which may be long after that turn is gone.

## Added
- **`persistence/parked-build.ts`** — approval-keyed store, sibling of `parked-action.ts`. Its presence *is* the awaiting-consent state; cleared on the decision either way, and on app delete.
- **`doors/build-door.ts`** — `available` / `propose` / `resume` / `seal`. `propose` calls `guard.check` with a `confirmEach` descriptor, parks, writes `proposal` onto the row, returns. The 90s approval wait is never on this path; the card stands because `apps` calls the guard directly, exactly how the egress lane's card already survives a turn.
- **`contract/build.ts`** — `BuildRequest` / `BuildOutcome` / `BuiltFile` / `AppBuilder`. Types only; the next slice implements it. S2's `sealBundleBlobs` now names `BuiltFile` instead of inlining the shape.
- **`approval-flow.ts`** parked-build arm (`try/finally`). The egress half is untouched — the deletion slice owns it.
- `AppsRuntime.build` + the `AppsConfig.build` adapter slot.

## Naming divergence from the blueprint
The blueprint says to add `doors/build-surface.ts`. **That file already exists** (678 lines, an unrelated shipped door mounted at `runtime.ts:43`). The consent door is therefore **`doors/build-door.ts`** / `createBuildDoor`.

## Tests removed, stated out loud
`vendo_make` no longer reaches `create` by escalation, so three tests lost their producer and were deleted, with comments left naming this slice: two agent-bridge receipts in `create-server-work-failed.test.ts` (the `"partial"` status and the half-success `say`) and the view-only caveat in `create-unsaved.test.ts`. `create`'s own signals stay covered in both files. Five more were re-pointed to surviving publishers of the same behaviour rather than deleted. `"partial"` now has no producer in `make-tool`; the enum value is left alone rather than chased across the pack/MCP consumers.

Also fixed here, per cubic's finding on #1607: `validateAppDocument` now refuses a document carrying both `proposal` and `building` — the normative gate that file names, rather than the shape schema.

## Outside `packages/apps` (two files, both forced by the new enum value)
- `vendo/src/pack.ts` — `appRefFromReceipt` would have laundered an `awaiting-consent` receipt into a `vendo/app-ref@1` with `status: "building"`: a build skeleton for a build nobody authorised. Now refused (1 line), which is the rule its own doc comment already stated.
- `vendo/tests/your-agent-docs.docs.test.ts` — asserts the enum's literal source text; a drift counter, so it had to move.

## Tests
`tests/build-consent.test.ts` (5). Real `runMakeTool`, real `createApps`, real parked store over a real engine, real `approval-flow` subscription, real app row, real `sealBundleBlobs`/`readBundleBlob` with bytes read back and compared. Faked: the screen agent (the escalation is the input) and `AppBuilder` (the next slice's, faked by design). Each proven failable by mutation — notably, making `propose` call `resume` turns all three consent tests red.

CI is the gate of record.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Asks the screen agent escalates no longer build immediately. `vendo_make` now raises a standing approval card and returns status "awaiting-consent"; no machine is spent until the person approves, and the approval decision alone starts the build.

- Review focus
  - New build seam: `contract/build.ts` (`AppBuilder`, `BuildRequest`, `BuiltFile`, `BuildOutcome`).
  - New door: `server/doors/build-door.ts` with `available`/`propose`/`resume`/`seal`; `propose` parks and returns, `resume` runs the builder on approval, `seal` writes blobs and a history version.
  - New store: `server/persistence/parked-build.ts` keyed by approval; cleared on decision and app delete.
  - Approval flow: `onApprovalDecision` now resumes parked builds; egress lane unchanged.
  - Receipt: `make-receipt.ts` adds `"awaiting-consent"`; `vendo/src/pack.ts` refuses refs for that status.
  - Validation: `app-validation.ts` now rejects documents that carry both `proposal` and `building`.
  - Runtime: wires `build` door and `parkedBuilds`; `apps-surface` clears parked builds on delete.
  - `make-tool.ts`: escalations call `runtime.build.propose` and end the turn; no box claim or build on that path.
  - Tests updated; new `build-consent.test.ts` exercises propose→decision→seal.

- Migration
  - Handle the new receipt status `"awaiting-consent"` in consumers; do not assume escalations build immediately.
  - Compose a `build` adapter in `AppsConfig` to enable builds; otherwise escalations fail with a clear message.
  - If you use `appRefFromReceipt`, expect it to return null for `"awaiting-consent"`.

<sup>Written for commit 9f37767d94b86e95ca310dc0d7f020b8e705bd55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1609?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

