### PR TITLE
feat(vendo,apps): run a consented build in a disposable box (built apps S4/7)

### DIFF
--- a/.changeset/creations-build-lane.md
+++ b/.changeset/creations-build-lane.md
@@ -1,0 +1,7 @@
+---
+"@vendoai/vendo": minor
+"@vendoai/apps": minor
+"@vendoai/harnesses": minor
+---
+
+Built apps: the build lane. A consented build now runs the person's ask inside a disposable box — npm from the registry, the code written and tested in the box, the files sealed by the host — and the box is handed no store credentials at all. Approving a build card comes straight back instead of holding the request open for the whole build, and a reseal that fails keeps the app it was rebuilding. `@vendoai/harnesses` gains a `./claude-code/box` entry point carrying the box pool and the env/egress it boots with, so composition can reach them without the Agent SDK.

--- a/packages/apps/src/server/doors/build-door.ts
+++ b/packages/apps/src/server/doors/build-door.ts
@@ -20,7 +20,14 @@ import {
   type ToolDescriptor,
 } from "@vendoai/core";
 import type { BuiltFile } from "../../contract/index.js";
-import { BUILD_ALREADY_ASKED, BUILD_DECLINED, NO_MACHINE, fallbackAppName } from "./build-messages.js";
+import {
+  BUILD_ALREADY_ASKED,
+  BUILD_DECLINED,
+  BUILD_WATCHDOG_REASON,
+  NO_MACHINE,
+  buildWatchdogMs,
+  fallbackAppName,
+} from "./build-messages.js";
 import { sealBundleBlobs } from "../persistence/app-source.js";
 import { APPS_COLLECTION, appRecordInput } from "../persistence/persistence.js";
 import type { AppsRuntimeContext } from "../runtime/runtime-context.js";
@@ -168,26 +175,64 @@ export const createBuildDoor = (
       const parked = await parkedBuilds.byApproval(approvalId);
       if (parked === null) return;
       const { appId, prompt, why, ctx } = parked;
-      // The ONE terminal landing every failure shares: the tombstone that turns
-      // the claimed slot into the honest failure card. A denial is one of them —
-      // it clears the proposal with the rest of the row, and no box was opened.
-      const refuse = (reason: string): Promise<void> =>
-        markUnbuilt(appId, fallbackAppName(prompt), reason, ctx);
+      // Read raw and untyped, like the placement read: one unparseable row must
+      // not decide how every other build fails.
+      const record = await engine.get(APPS_COLLECTION, appId);
+      const alreadySealed = (record?.data as { doc?: { bundle?: unknown } } | null)?.doc?.bundle !== undefined;
+      /**
+       * The ONE terminal landing every failure shares: the tombstone that turns
+       * the claimed slot into the honest failure card. A denial is one of them —
+       * it clears the proposal with the rest of the row, and no box was opened.
+       *
+       * Except on a RESEAL. `markUnbuilt` REPLACES the whole row, which is right
+       * for a first build — there is nothing there to lose — and would destroy a
+       * working app here. So a reseal that fails keeps everything it had and
+       * loses only the build state; the person's app is still their app.
+       */
+      const refuse = async (reason: string): Promise<void> => {
+        if (!alreadySealed) return await markUnbuilt(appId, fallbackAppName(prompt), reason, ctx);
+        await updateAppDocument(appId, ({ building: _building, proposal: _proposal, ...rest }) => rest);
+      };
       if (!approved) return await refuse(BUILD_DECLINED);
       if (builder === undefined || !builder.available()) return await refuse(NO_MACHINE);
       const doc = await updateAppDocument(appId, (previous) => {
         const { proposal: _proposal, ...rest } = previous;
         return { ...rest, building: new Date().toISOString() };
       });
-      const outcome = await builder.build({
-        appId,
-        prompt,
-        why,
-        // Present on a RESEAL: the box starts from what this app already is.
-        ...(doc.source === undefined ? {} : { source: doc.source }),
-      }, ctx);
-      if (outcome.kind === "failed") return await refuse(outcome.why);
-      await seal({ appId, files: outcome.files, entry: outcome.entry });
+      /**
+       * FROM HERE THE BUILD IS ON ITS OWN, and it has to be.
+       *
+       * The guard AWAITS its decision subscribers (`#decideApprovals`), and this
+       * is one of them, so awaiting the box held `POST /approvals/decide` open
+       * for the whole build — minutes, while the person who just pressed Approve
+       * watched a request hang. Detached the way this codebase detaches every
+       * other long job (`runInboundDetached`, the umbrella's wire/channels.ts):
+       * the row's `building` is all a poll needs, and progress is chat status
+       * lines, never a held connection.
+       *
+       * A detached lane can also die saying nothing, so it is armed with the
+       * same dead-man timer `create` uses (`startBuildWatchdog`) and on the same
+       * window — cleared only once something terminal has landed, so a lane that
+       * threw leaves the switch to land it.
+       */
+      const watchdog = setTimeout(() => {
+        void refuse(BUILD_WATCHDOG_REASON).catch(() => undefined);
+      }, buildWatchdogMs());
+      (watchdog as { unref?: () => void }).unref?.();
+      void (async () => {
+        const outcome = await builder.build({
+          appId,
+          prompt,
+          why,
+          // Present on a RESEAL: the box starts from what this app already is.
+          ...(doc.source === undefined ? {} : { source: doc.source }),
+        }, ctx);
+        if (outcome.kind === "failed") await refuse(outcome.why);
+        else await seal({ appId, files: outcome.files, entry: outcome.entry });
+        clearTimeout(watchdog);
+        // Swallowed because the still-armed watchdog is what says so: a lane
+        // that threw never reached the clear above.
+      })().catch(() => undefined);
     },
 
     seal,

--- a/packages/apps/src/server/index.ts
+++ b/packages/apps/src/server/index.ts
@@ -109,6 +109,12 @@ export {
   type AppSourceSeam,
 } from "./persistence/app-source.js";
 export { updateAppRow } from "./persistence/persistence.js";
+// The one classifier for what goes on a failed build's record. Public because
+// the BUILD engine now lives outside this package too (`AppsConfig.build`), and
+// a lane that classified its own throws would grow a second vocabulary for the
+// same failures — and would surface the provider's raw words, which this one
+// deliberately never does.
+export { buildFailureReason } from "./doors/build-messages.js";
 // The hot-path render seam (§1.6) — the commit-intercepting wrap that paints a
 // landing `app.tsx`. Public because the workspace it wraps lives
 // outside this package: composition fills the harness runtime's `wrapWorkspace`

--- a/packages/harnesses/package.json
+++ b/packages/harnesses/package.json
@@ -39,6 +39,10 @@
       "types": "./dist/claude-code/index.d.ts",
       "default": "./dist/claude-code/index.js"
     },
+    "./claude-code/box": {
+      "types": "./dist/claude-code/box.d.ts",
+      "default": "./dist/claude-code/box.js"
+    },
     "./inference": {
       "types": "./dist/inference/model.d.ts",
       "default": "./dist/inference/model.js"

--- a/packages/harnesses/src/claude-code/box.ts
+++ b/packages/harnesses/src/claude-code/box.ts
@@ -603,6 +603,155 @@ export async function boxMachine(options: BoxMachineOptions): Promise<SessionMac
   };
 }
 
+/* ─── what a box is BOOTED with ──────────────────────────────────────────────
+   Its model door and its network boundary, beside the pool that hands them to
+   the provider. They live here rather than in `claude-code/index.ts` because
+   composition needs them WITHOUT the driver: that module reaches the Agent SDK
+   (through `local.ts`'s dynamic import), which does not bundle for a Worker
+   target, and the umbrella's server entry has to. Re-exported from there, so
+   the names a host knows have not moved. */
+
+/**
+ * Every env var the Agent SDK reads a MODEL ID from — the default, the small/fast
+ * step, subagent spawns, and the four family aliases.
+ *
+ * Taken from the SDK's own model-env array (`_Ne` in `sdk.mjs`,
+ * `@anthropic-ai/claude-agent-sdk@0.3.214`) rather than guessed. The rest of that
+ * array is display metadata (`_NAME`, `_DESCRIPTION`,
+ * `_SUPPORTED_CAPABILITIES`) and `ANTHROPIC_SMALL_FAST_MODEL_AWS_REGION`, none of
+ * which name a model to ask for.
+ *
+ * Pinning the default alone is what shipped, and it was not enough: a step on any
+ * other slot asked the Cloud gateway for the SDK's built-in `claude-opus-4-8` and
+ * the `400 Unknown model id` reached an end user's chat verbatim.
+ */
+const SDK_MODEL_SLOT_ENV = [
+  "ANTHROPIC_MODEL",
+  "ANTHROPIC_SMALL_FAST_MODEL",
+  "CLAUDE_CODE_SUBAGENT_MODEL",
+  "ANTHROPIC_DEFAULT_OPUS_MODEL",
+  "ANTHROPIC_DEFAULT_SONNET_MODEL",
+  "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+  "ANTHROPIC_DEFAULT_FABLE_MODEL",
+] as const;
+
+/**
+ * The recorded v0 inference exception (design §9): a boxed harness must reach a
+ * model to think, and that is the ONLY credential in the machine.
+ *
+ * SELECTION LAW, the same one `boxInference()` in the umbrella obeys: the
+ * explicit VENDO_INFERENCE_URL+KEY pair — which is what the box env door sets —
+ * wins; otherwise VENDO_API_KEY funds the box's model through the console's
+ * Anthropic-compatible gateway at `<console>/api/v1`; otherwise the box gets no
+ * inference credential at all.
+ *
+ * A stray ANTHROPIC_API_KEY / ANTHROPIC_BASE_URL selects NOTHING. It used to
+ * outrank both rungs, so a provider key sitting in the deployment's environment
+ * silently decided which account every box billed. Naming an own endpoint is
+ * still fully supported — as the explicit pair, which is config.
+ */
+export function inferenceEnv(): Record<string, string> {
+  const source = globalThis.process?.env ?? {};
+  const set = (name: string): string | undefined => {
+    const value = source[name];
+    return value === undefined || value === "" ? undefined : value;
+  };
+  const env: Record<string, string> = {
+    // Nothing the CLI reaches for on the side: its telemetry and update hosts are
+    // not on the box's allowlist (`boxEgress` below), so those calls fail rather
+    // than answer — and a stalled one is a hung turn.
+    CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
+    DISABLE_AUTOUPDATER: "1",
+  };
+  // The PAIR, both halves or neither: half an endpoint is a misconfiguration, and
+  // quietly completing it from somewhere else is how a box ends up billing an
+  // account nobody chose.
+  const pairKey = set("VENDO_INFERENCE_KEY");
+  const pairUrl = set("VENDO_INFERENCE_URL");
+  const cloudKey = set("VENDO_API_KEY");
+  let key: string | undefined;
+  let url: string | undefined;
+  if (pairKey !== undefined && pairUrl !== undefined) {
+    key = pairKey;
+    url = pairUrl;
+  } else if (cloudKey !== undefined) {
+    const base = (set("VENDO_CLOUD_URL") ?? "https://console.vendo.run").replace(/\/+$/, "");
+    key = cloudKey;
+    url = base.endsWith("/api/v1") ? base : `${base}/api/v1`;
+    // The gateway serves the vendo model family as literal ids, so EVERY slot is
+    // pinned to the family name — each one the SDK leaves unset falls back to a
+    // raw claude-* id, which this gateway answers `400 Unknown model id`. Env
+    // only: an explicit `options.model` rides the session-open payload, which
+    // beats ANTHROPIC_MODEL.
+    for (const slot of SDK_MODEL_SLOT_ENV) env[slot] = "vendo";
+  }
+  if (key === undefined || url === undefined) return env;
+  env["ANTHROPIC_API_KEY"] = key;
+  // The bare origin: the SDK re-appends /v1 and wants no trailing slash.
+  env["ANTHROPIC_BASE_URL"] = url.replace(/\/+$/, "").replace(/\/v1$/, "");
+  return env;
+}
+
+/** The host the Agent SDK talks to when nothing overrides `ANTHROPIC_BASE_URL`. */
+const DEFAULT_INFERENCE_HOST = "api.anthropic.com";
+
+/** Domains compare case-insensitively and may carry stray spacing — the same
+ *  normalization `normalizeEgressDomain` applies to a declaration. */
+const normalizeDomain = (domain: string): string => domain.trim().toLowerCase();
+
+const hostOf = (url: string | undefined): string | undefined => {
+  if (url === undefined || url === "") return undefined;
+  try {
+    return new URL(url).hostname.toLowerCase();
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * The conversational box's outbound allowlist — the ONE place its network
+ * boundary is assembled.
+ *
+ * Same shape as the served-app machine's (`boxAllowlist` in `@vendoai/apps`
+ * `egress-approval.ts`): the box's OWN skin rides unconditionally, and
+ * everything else is filtered out at the provider's DOMAIN layer.
+ *
+ * Do not rely on that for anything: the filtering is real against ordinary
+ * clients and is BYPASSABLE by
+ * a client that omits SNI (`openssl s_client -noservername` reaches arbitrary
+ * IPs even under an empty list — measured). It is a provider-level gap this
+ * repo cannot close. So this list raises the cost of exfiltration and stops
+ * every ordinary client; it does not make the box unable to reach the network.
+ *
+ * Two skin entries, because a session box needs exactly two things to function:
+ *
+ *   1. the INFERENCE host — the SDK runs the model from inside the box, so a box
+ *      that cannot reach it cannot think. Read off the env the box is actually
+ *      handed, never guessed, so a managed-inference gateway
+ *      (`VENDO_INFERENCE_URL` → `ANTHROPIC_BASE_URL`) is allowed and
+ *      `api.anthropic.com` is not.
+ *   2. the DOOR origin — every host tool travels the host's MCP door now
+ *      (10-mcp §3b), so this is what replaced "the box holds nothing and reaches
+ *      nothing". Per DEPLOYMENT, so it arrives from composition's `toolDoor`
+ *      rather than being written down here.
+ *
+ * Nothing else: no npm registry, no telemetry, no update endpoint. The SDK is
+ * baked into the machine image, and the CLI's side traffic is switched off in
+ * `inferenceEnv()`.
+ */
+export function boxEgress(
+  inference: Record<string, string>,
+  doorUrl: string | undefined,
+  extra: readonly string[] = [],
+): string[] {
+  const domains = [
+    hostOf(inference["ANTHROPIC_BASE_URL"]) ?? DEFAULT_INFERENCE_HOST,
+    hostOf(doorUrl),
+    ...extra.map(normalizeDomain),
+  ].filter((domain): domain is string => domain !== undefined && domain !== "");
+  return [...new Set(domains)];
+}
+
 /** Test + shutdown seam: drop every live box. */
 export async function disposeSessionMachines(): Promise<void> {
   const entries = [...boxes.entries()];

--- a/packages/harnesses/src/claude-code/index.ts
+++ b/packages/harnesses/src/claude-code/index.ts
@@ -31,15 +31,17 @@ import { harnessAdapters, type HarnessAdapters } from "../harness-sandbox.js";
 import { checkoutWorkspace, type SyncFile } from "../materialize.js";
 import type { SessionMachine } from "./machine.js";
 import { localMachine } from "./local.js";
-import { boxMachine, type SandboxAdapterLike } from "./box.js";
+import { boxEgress, boxMachine, inferenceEnv, type SandboxAdapterLike } from "./box.js";
 
 // The session machine's own seams, re-exported for the callers that drive it
 // directly rather than through `claudeCode()`: the umbrella's live box proofs,
 // and a host process that wants to reap idle conversation boxes on shutdown
 // (`disposeLocalSessions` in ./local.js is the `machine: "local"` counterpart).
 export {
+  boxEgress,
   boxMachine,
   disposeSessionMachines,
+  inferenceEnv,
   type SandboxAdapterLike,
   type SandboxMachineLike,
 } from "./box.js";
@@ -142,147 +144,6 @@ const optionsSchema = z.object({
 export interface ClaudeCodeDeps
   extends Pick<HarnessAdapters, "hotPaths" | "validateApps" | "repairInstruction"> {
   sandbox?: SandboxAdapterLike;
-}
-
-/**
- * Every env var the Agent SDK reads a MODEL ID from — the default, the small/fast
- * step, subagent spawns, and the four family aliases.
- *
- * Taken from the SDK's own model-env array (`_Ne` in `sdk.mjs`,
- * `@anthropic-ai/claude-agent-sdk@0.3.214`) rather than guessed. The rest of that
- * array is display metadata (`_NAME`, `_DESCRIPTION`,
- * `_SUPPORTED_CAPABILITIES`) and `ANTHROPIC_SMALL_FAST_MODEL_AWS_REGION`, none of
- * which name a model to ask for.
- *
- * Pinning the default alone is what shipped, and it was not enough: a step on any
- * other slot asked the Cloud gateway for the SDK's built-in `claude-opus-4-8` and
- * the `400 Unknown model id` reached an end user's chat verbatim.
- */
-const SDK_MODEL_SLOT_ENV = [
-  "ANTHROPIC_MODEL",
-  "ANTHROPIC_SMALL_FAST_MODEL",
-  "CLAUDE_CODE_SUBAGENT_MODEL",
-  "ANTHROPIC_DEFAULT_OPUS_MODEL",
-  "ANTHROPIC_DEFAULT_SONNET_MODEL",
-  "ANTHROPIC_DEFAULT_HAIKU_MODEL",
-  "ANTHROPIC_DEFAULT_FABLE_MODEL",
-] as const;
-
-/**
- * The recorded v0 inference exception (design §9): a boxed harness must reach a
- * model to think, and that is the ONLY credential in the machine.
- *
- * SELECTION LAW, the same one `boxInference()` in the umbrella obeys: the
- * explicit VENDO_INFERENCE_URL+KEY pair — which is what the box env door sets —
- * wins; otherwise VENDO_API_KEY funds the box's model through the console's
- * Anthropic-compatible gateway at `<console>/api/v1`; otherwise the box gets no
- * inference credential at all.
- *
- * A stray ANTHROPIC_API_KEY / ANTHROPIC_BASE_URL selects NOTHING. It used to
- * outrank both rungs, so a provider key sitting in the deployment's environment
- * silently decided which account every box billed. Naming an own endpoint is
- * still fully supported — as the explicit pair, which is config.
- */
-export function inferenceEnv(): Record<string, string> {
-  const source = globalThis.process?.env ?? {};
-  const set = (name: string): string | undefined => {
-    const value = source[name];
-    return value === undefined || value === "" ? undefined : value;
-  };
-  const env: Record<string, string> = {
-    // Nothing the CLI reaches for on the side: its telemetry and update hosts are
-    // not on the box's allowlist (`boxEgress` below), so those calls fail rather
-    // than answer — and a stalled one is a hung turn.
-    CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
-    DISABLE_AUTOUPDATER: "1",
-  };
-  // The PAIR, both halves or neither: half an endpoint is a misconfiguration, and
-  // quietly completing it from somewhere else is how a box ends up billing an
-  // account nobody chose.
-  const pairKey = set("VENDO_INFERENCE_KEY");
-  const pairUrl = set("VENDO_INFERENCE_URL");
-  const cloudKey = set("VENDO_API_KEY");
-  let key: string | undefined;
-  let url: string | undefined;
-  if (pairKey !== undefined && pairUrl !== undefined) {
-    key = pairKey;
-    url = pairUrl;
-  } else if (cloudKey !== undefined) {
-    const base = (set("VENDO_CLOUD_URL") ?? "https://console.vendo.run").replace(/\/+$/, "");
-    key = cloudKey;
-    url = base.endsWith("/api/v1") ? base : `${base}/api/v1`;
-    // The gateway serves the vendo model family as literal ids, so EVERY slot is
-    // pinned to the family name — each one the SDK leaves unset falls back to a
-    // raw claude-* id, which this gateway answers `400 Unknown model id`. Env
-    // only: an explicit `options.model` rides the session-open payload, which
-    // beats ANTHROPIC_MODEL.
-    for (const slot of SDK_MODEL_SLOT_ENV) env[slot] = "vendo";
-  }
-  if (key === undefined || url === undefined) return env;
-  env["ANTHROPIC_API_KEY"] = key;
-  // The bare origin: the SDK re-appends /v1 and wants no trailing slash.
-  env["ANTHROPIC_BASE_URL"] = url.replace(/\/+$/, "").replace(/\/v1$/, "");
-  return env;
-}
-
-/** The host the Agent SDK talks to when nothing overrides `ANTHROPIC_BASE_URL`. */
-const DEFAULT_INFERENCE_HOST = "api.anthropic.com";
-
-/** Domains compare case-insensitively and may carry stray spacing — the same
- *  normalization `normalizeEgressDomain` applies to a declaration. */
-const normalizeDomain = (domain: string): string => domain.trim().toLowerCase();
-
-const hostOf = (url: string | undefined): string | undefined => {
-  if (url === undefined || url === "") return undefined;
-  try {
-    return new URL(url).hostname.toLowerCase();
-  } catch {
-    return undefined;
-  }
-};
-
-/**
- * The conversational box's outbound allowlist — the ONE place its network
- * boundary is assembled.
- *
- * Same shape as the served-app machine's (`boxAllowlist` in `@vendoai/apps`
- * `egress-approval.ts`): the box's OWN skin rides unconditionally, and
- * everything else is filtered out at the provider's DOMAIN layer.
- *
- * Do not rely on that for anything: the filtering is real against ordinary
- * clients and is BYPASSABLE by
- * a client that omits SNI (`openssl s_client -noservername` reaches arbitrary
- * IPs even under an empty list — measured). It is a provider-level gap this
- * repo cannot close. So this list raises the cost of exfiltration and stops
- * every ordinary client; it does not make the box unable to reach the network.
- *
- * Two skin entries, because a session box needs exactly two things to function:
- *
- *   1. the INFERENCE host — the SDK runs the model from inside the box, so a box
- *      that cannot reach it cannot think. Read off the env the box is actually
- *      handed, never guessed, so a managed-inference gateway
- *      (`VENDO_INFERENCE_URL` → `ANTHROPIC_BASE_URL`) is allowed and
- *      `api.anthropic.com` is not.
- *   2. the DOOR origin — every host tool travels the host's MCP door now
- *      (10-mcp §3b), so this is what replaced "the box holds nothing and reaches
- *      nothing". Per DEPLOYMENT, so it arrives from composition's `toolDoor`
- *      rather than being written down here.
- *
- * Nothing else: no npm registry, no telemetry, no update endpoint. The SDK is
- * baked into the machine image, and the CLI's side traffic is switched off in
- * `inferenceEnv()`.
- */
-export function boxEgress(
-  inference: Record<string, string>,
-  doorUrl: string | undefined,
-  extra: readonly string[] = [],
-): string[] {
-  const domains = [
-    hostOf(inference["ANTHROPIC_BASE_URL"]) ?? DEFAULT_INFERENCE_HOST,
-    hostOf(doorUrl),
-    ...extra.map(normalizeDomain),
-  ].filter((domain): domain is string => domain !== undefined && domain !== "");
-  return [...new Set(domains)];
 }
 
 /** The plain text of one message, for the re-seed. Parts we cannot render as

--- a/packages/vendo/src/build-agent.ts
+++ b/packages/vendo/src/build-agent.ts
@@ -1,0 +1,151 @@
+/**
+ * THE BUILD LANE — `screen-agent.ts`'s other half, and the only place the
+ * `AppBuilder` seam is filled.
+ *
+ * A screen agent answers `escalate` when an ask is bigger than a screen. Once —
+ * and only once — the person has said yes to the standing card, this runs their
+ * ask inside a disposable box: the in-box coding agent installs from npm, writes
+ * the code, bundles it and tests it against reality, and the files it leaves
+ * behind come home to be sealed. Single-phase, because the box's model key is
+ * temporary (FINAL SPEC v1).
+ *
+ * THE BOX HOLDS ZERO STORE CREDENTIALS. It is handed the inference env the
+ * session boxes get and nothing else — no store URL, no app token, no tool door
+ * — so the only thing that can come out of it is files, and the HOST is what
+ * writes them. That is a security invariant, not a preference: the box runs
+ * code a person's words asked for.
+ *
+ * It lives in the umbrella for `screenAssembler`'s reason: only composition
+ * holds both the box pool (`@vendoai/harnesses`) and the apps runtime.
+ */
+import {
+  isVendoError,
+  type AppId,
+  type AppSourceFile,
+} from "@vendoai/core";
+import { buildFailureReason } from "@vendoai/apps";
+import type { AppBuilder, BuildOutcome, BuildRequest, BuiltFile } from "@vendoai/apps/contract";
+import { boxEgress, boxMachine, type SandboxAdapterLike } from "@vendoai/harnesses/claude-code/box";
+
+export interface AppBuilderDeps {
+  sandbox: SandboxAdapterLike | undefined;
+  /** The same env the session boxes get (`inferenceEnv`) — the box's model door,
+   *  and deliberately nothing else. */
+  boxEnv: () => Record<string, string>;
+  template?: string;
+}
+
+/**
+ * What the build MINUTE may reach, on top of the inference host `boxEgress`
+ * always adds. The registry and nothing more: this box is driven by the
+ * person's own words, and the artifact it produces renders behind
+ * `default-src 'none'`, so nothing it installs is allowed to phone home either.
+ */
+export const BUILD_ALLOWED_DOMAINS: readonly string[] = ["registry.npmjs.org"];
+
+/** Where a build works — the same `/user/apps/<id>` layout the screen agent
+ *  writes under, which is also the only tree the box door carries back
+ *  (`carriedBack`, `packages/harnesses/box/turn-routes.mjs`). */
+const appDirectory = (appId: AppId): string => `/user/apps/${appId}`;
+
+/** What the frame boots, and the one file whose presence means the build worked:
+ *  the brief tells the box to remove it if its own test does not pass. */
+const ENTRY = "dist/app.js";
+
+/** The one capability gap that is this seam's own to report, in the person's
+ *  terms. Third person: it surfaces as a system notice. */
+const NO_SANDBOX = "This needs a real build machine, and this deployment has no sandbox adapter to boot one from.";
+/** A box that died, was reaped, or was refused by the provider — including a
+ *  meter's 402, which the box seam reports the same way. Never the ask's fault,
+ *  so it must not read like a verdict on the request. */
+const BOX_GONE = "the build machine went away before the build finished.";
+/** The box came back having produced no entry, which the brief defines as "my
+ *  own test did not pass". */
+const NO_ENTRY = "the build's own test did not pass, so it produced nothing to seal.";
+
+const encoder = new TextEncoder();
+
+/** The stored source a RESEAL starts from, on the box's disk. Spilled files are
+ *  left behind: the bytes live in a blob namespace this seam cannot reach, and
+ *  reaching it would put a store credential in this lane. */
+const checkoutOf = (source: Record<string, AppSourceFile> | undefined, directory: string) =>
+  Object.entries(source ?? {}).flatMap(([path, file]) => file.text === undefined
+    ? []
+    : [{ path: `${directory}/${path}`, bytes: encoder.encode(file.text), readOnly: false }]);
+
+const briefFor = (request: BuildRequest, directory: string): string =>
+  `Build this for real, in ${directory}.
+
+WHAT THE PERSON ASKED FOR, verbatim:
+${request.prompt}
+
+WHY A GENERATED SCREEN WAS NOT ENOUGH:
+${request.why}
+
+HOW IT SHIPS
+- Write the source under ${directory}/src and install whatever npm packages it needs.
+- Bundle it with esbuild to ${directory}/${ENTRY}: ONE self-contained file, no
+  imports left at runtime and no network calls at all — the sealed bundle renders
+  in an iframe where every request is blocked.
+- Test what you built against reality, and fix what fails.
+- If your own test does not pass, DELETE ${directory}/${ENTRY} and stop. Its
+  absence is how this host is told the build did not work; a broken one left
+  behind is shipped to the person as if it worked.`;
+
+/** How a throw out of the box becomes the sentence on the person's failure card.
+ *  `buildFailureReason` is the one classifier this record has (quota, timeout,
+ *  a busy service), and it never surfaces a provider's raw words — but it has no
+ *  sentence for a dead machine and would call that a generation failure, which
+ *  sends the person to rewrite an ask that was fine. */
+const failureOf = (error: unknown): BuildOutcome => {
+  if (isVendoError(error) && error.code === "sandbox-unavailable") {
+    return { kind: "failed", why: BOX_GONE, retryable: true };
+  }
+  const { reason, retryable } = buildFailureReason(error);
+  return { kind: "failed", why: reason, retryable };
+};
+
+export function appBuilder(deps: AppBuilderDeps): AppBuilder {
+  return {
+    // The ONE gate: a composed sandbox adapter, and nothing else.
+    available: () => deps.sandbox !== undefined,
+
+    async build(request) {
+      const { sandbox } = deps;
+      if (sandbox === undefined) return { kind: "failed", why: NO_SANDBOX };
+      const env = deps.boxEnv();
+      const directory = appDirectory(request.appId);
+      // Declared out here so the box is handed back even when the lane throws.
+      let machine: Awaited<ReturnType<typeof boxMachine>> | undefined;
+      try {
+        request.onStatus?.("Starting a build machine…");
+        machine = await boxMachine({
+          sandbox,
+          threadId: `build_${request.appId}`,
+          env,
+          allowedDomains: boxEgress(env, undefined, BUILD_ALLOWED_DOMAINS),
+          ...(deps.template === undefined ? {} : { template: deps.template }),
+        });
+        await machine.materialize(checkoutOf(request.source, directory));
+        request.onStatus?.("Writing the code, installing what it needs, and testing it…");
+        // No `toolDoor`: this box reaches none of the host's tools, so there is
+        // nothing for it to act with and no credential to act under.
+        await machine.send({ prompt: briefFor(request, directory), emit: () => undefined });
+        const collected = await machine.collect([
+          `${directory}/${ENTRY}`,
+          `${directory}/src/*`,
+          `${directory}/package-lock.json`,
+        ]);
+        const files: BuiltFile[] = collected.map(({ path, bytes }) => ({ path: path.slice(directory.length + 1), bytes }));
+        if (!files.some((file) => file.path === ENTRY)) return { kind: "failed", why: NO_ENTRY, retryable: true };
+        return { kind: "built", files, entry: ENTRY };
+      } catch (error) {
+        return failureOf(error);
+      } finally {
+        // Back to the pool on its idle timer, which destroys it. Nothing leaves
+        // the box but the files above.
+        await machine?.release();
+      }
+    },
+  };
+}

--- a/packages/vendo/src/compose-apps.ts
+++ b/packages/vendo/src/compose-apps.ts
@@ -12,6 +12,8 @@ import {
   type AppsConfig,
 } from "@vendoai/apps";
 import { unattendedIrreversibilityCheck } from "@vendoai/automations";
+import { inferenceEnv } from "@vendoai/harnesses/claude-code/box";
+import { appBuilder } from "./build-agent.js";
 import { screenAssembler } from "./screen-agent.js";
 import {
   engineOverAdapter,
@@ -276,6 +278,19 @@ const appsScreenSeam = (composition: VendoComposition, seams: AppsSeams): AppsCo
   });
 };
 
+/** THE OTHER SEAM — the build lane behind the escalations the screen agent
+ *  refuses, joined here for the same reason and on the same terms. */
+const appsBuildSeam = (composition: VendoComposition, seams: AppsSeams): AppsConfig["build"] =>
+  appBuilder({
+    sandbox: composition.sandbox.adapter,
+    // The SAME env a session box gets, and deliberately not `machineEnv`: that
+    // one carries the store URL and a minted app token, and a build box holds
+    // ZERO store credentials (FINAL SPEC v1). It returns files; the host seals
+    // them.
+    boxEnv: inferenceEnv,
+    ...(seams.boxTemplate === undefined ? {} : { template: seams.boxTemplate }),
+  });
+
 /** The host's own knobs, the config-surface providers, and the machine lane. */
 const appsTailSeams = (composition: VendoComposition, seams: AppsSeams): Partial<AppsConfig> => {
   const { config, automationsMounted, themeProvider, briefing, hostSemanticsProvider } = composition;
@@ -410,6 +425,7 @@ export const composeApps = (composition: VendoComposition): Pick<VendoCompositio
     ...appsStoreSeams(composition, seams),
     ...appsHostSeams(composition),
     screen: appsScreenSeam(composition, seams),
+    build: appsBuildSeam(composition, seams),
     ...appsTailSeams(composition, seams),
   } as AppsConfig);
   // Every contributed tool reaches the ONE registry here — the same `add` the

--- a/packages/vendo/tests/build-lane.test.ts
+++ b/packages/vendo/tests/build-lane.test.ts
@@ -1,0 +1,448 @@
+/**
+ * S4 — the build lane, from the person's yes to a sealed bundle.
+ *
+ * Real on every axis this slice owns: the real apps runtime and its real build
+ * door, the REAL guard (so the decision that starts a build is the one a person
+ * really makes, and `decide` really awaits its subscribers), the real box pool
+ * (`boxMachine`), the real box session door
+ * (`packages/harnesses/box/turn-routes.mjs`) over an in-process transport, and
+ * the real seal. Two things are stand-ins, both the legitimate BYO boundary: the
+ * SandboxAdapter, and the coding agent inside the box — a test cannot run a
+ * model, so the script writes the files a real in-box agent would write.
+ *
+ * The store is the in-memory adapter rather than PGlite, and the last case is
+ * the exception that says why: a composed deployment, for the two facts only
+ * composition can carry — that the slot is filled at all, and WITH WHAT env.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import type { LanguageModel } from "ai";
+import { memoryStoreAdapter } from "@vendoai/core/conformance";
+import {
+  type AppId,
+  type ApprovalId,
+  type FilesAdapter,
+  type Principal,
+  type RunContext,
+  type ToolRegistry,
+} from "@vendoai/core";
+import { createApps, readBundleBlob, type AppsConfig } from "@vendoai/apps";
+import { createGuard } from "@vendoai/guard";
+import { createSessionRoutes } from "@vendoai/harnesses/box-door";
+import { disposeSessionMachines, inferenceEnv } from "@vendoai/harnesses/claude-code/box";
+import { createStore, type VendoStore } from "@vendoai/store";
+import { afterEach, describe, expect, it } from "vitest";
+import { appBuilder, BUILD_ALLOWED_DOMAINS } from "../src/build-agent.js";
+import { createVendo } from "../src/server.js";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+const principal: Principal = { kind: "user", subject: "user_builder" };
+const ctx: RunContext = { principal, venue: "chat", presence: "present", sessionId: "session_builder" };
+
+const APP = "app_build_lane" as AppId;
+const ASK = "a photo editor that crops and rotates";
+const WHY = "this needs a real image library";
+
+const cleanups: Array<() => Promise<void>> = [];
+const boxRoots: string[] = [];
+afterEach(async () => {
+  // The box pool is module-scoped: without this, one case's box is the next
+  // case's thread-reuse.
+  await disposeSessionMachines();
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+  for (const root of boxRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+  delete process.env["VENDO_APP_BUILD_WATCHDOG_MS"];
+});
+
+/** One box, as a test can see it. */
+interface Box {
+  /** What the provider was asked to boot it with — the whole credential surface
+   *  the box ever sees. */
+  env: Record<string, string>;
+  allowedDomains: readonly string[];
+  /** Every brief the REAL session door opened a message with. */
+  prompts: string[];
+  destroyed: boolean;
+  /** The provider reaping the machine with no notice, mid-build. */
+  kill: () => void;
+}
+
+/** The in-box coding agent, scripted: handed the brief and the box's own disk
+ *  root, it writes what a real one would write. */
+type InBoxAgent = (input: { prompt: string; root: string; box: Box }) => void | Promise<void>;
+
+interface ScriptedSandbox {
+  boxes: Box[];
+  create: (spec: unknown) => Promise<unknown>;
+  destroy: () => Promise<void>;
+}
+
+/** A stand-in provider whose `request()` is a transport over the ACTUAL box
+ *  session door, so the protocol under test is the real one. The same shape
+ *  `tests/warm-spare.test.ts` proves the session path with. */
+function scriptedSandbox(agent: InBoxAgent): ScriptedSandbox {
+  const boxes: Box[] = [];
+  return {
+    boxes,
+    async create(spec: unknown) {
+      const { env, allowedDomains } = spec as { env: Record<string, string>; allowedDomains?: string[] };
+      const root = mkdtempSync(join(tmpdir(), "vendo-build-box-"));
+      boxRoots.push(root);
+      let dead = false;
+      const box: Box = {
+        env: { ...env },
+        allowedDomains: [...(allowedDomains ?? [])],
+        prompts: [],
+        destroyed: false,
+        kill: () => { dead = true; },
+      };
+      boxes.push(box);
+      const routes = createSessionRoutes({
+        root,
+        // Unclaimed, so the host's first `/session/hello` claims it.
+        token: "",
+        env: {},
+        openSession: (input: { emit: (event: Record<string, unknown>) => void }) => ({
+          async send(prompt: string) {
+            box.prompts.push(prompt);
+            await agent({ prompt, root, box });
+            input.emit({ type: "text", delta: "done." });
+          },
+          async interrupt() { /* the turn stops; the session lives */ },
+          async end() { /* the box is going away */ },
+        }),
+      }) as {
+        handle: (method: string, pathname: string, headers: Record<string, string>, payload: unknown)
+          => Promise<{ status: number; body: unknown }>;
+      };
+      return {
+        id: `box_${boxes.length}`,
+        async request(req: { method: string; path: string; headers?: Record<string, string>; body?: Uint8Array | string }) {
+          if (dead) throw new Error("machine is gone");
+          const payload = req.body === undefined
+            ? {}
+            : JSON.parse(typeof req.body === "string" ? req.body : decoder.decode(req.body)) as unknown;
+          const answer = await routes.handle(req.method, req.path, req.headers ?? {}, payload);
+          return { status: answer.status, headers: {}, body: encoder.encode(JSON.stringify(answer.body)) };
+        },
+        async destroy() { dead = true; box.destroyed = true; },
+      };
+    },
+    async destroy() { /* no machine to reap by ref */ },
+  };
+}
+
+/** What a working in-box agent leaves behind: a bundled entry, its source, and
+ *  the lockfile of what it installed. */
+const wrote = (root: string, appId: string, files: Record<string, string>): void => {
+  for (const [path, text] of Object.entries(files)) {
+    const disk = join(root, "user/apps", appId, path);
+    mkdirSync(dirname(disk), { recursive: true });
+    writeFileSync(disk, text);
+  }
+};
+
+/** The appId out of the brief the box was handed — the lane mints none, it is
+ *  the one the proposal carried. */
+const appIdOf = (prompt: string): string => /\/user\/apps\/(app_[\w-]+)/u.exec(prompt)?.[1] ?? "";
+
+/** A build whose in-box agent does its job. */
+const buildsFine: InBoxAgent = ({ prompt, root }) => {
+  wrote(root, appIdOf(prompt), {
+    "dist/app.js": "console.log('cropped')",
+    "src/index.ts": "export const crop = () => {};",
+    "package-lock.json": "{}",
+  });
+};
+
+const tools: ToolRegistry = {
+  async descriptors() { return []; },
+  async execute() {
+    return { status: "error" as const, error: { code: "not-found", message: "no fixture tools" } };
+  },
+};
+
+const memoryBlobs = (): FilesAdapter => {
+  const bytes = new Map<string, Uint8Array>();
+  return {
+    async put(key, value) { bytes.set(key, value); },
+    async get(key) { const found = bytes.get(key); return found === undefined ? undefined : { bytes: found }; },
+    async delete(key) { bytes.delete(key); },
+  };
+};
+
+const setup = (sandbox: ScriptedSandbox | undefined) => {
+  const store = memoryStoreAdapter();
+  const files = memoryBlobs();
+  // The REAL guard: `decide` awaits its subscribers, which is the whole reason
+  // the lane has to detach.
+  const guard = createGuard({ store: memoryStoreAdapter(), policy: { rules: [] } });
+  const runtime = createApps({
+    store,
+    guard,
+    tools,
+    catalog: [],
+    files,
+    // Composed exactly as `compose-apps.ts` composes it — the same `boxEnv`, so
+    // what the box is handed here is what a deployment hands it.
+    build: appBuilder({ sandbox: sandbox as never, boxEnv: inferenceEnv }),
+  } as AppsConfig);
+  const rowOf = async (appId: string): Promise<Record<string, unknown> | null> => {
+    const record = await store.records("vendo_apps").get(appId);
+    return record === null ? null : (record.data as { doc: Record<string, unknown> }).doc;
+  };
+  return { store, guard, files, runtime, rowOf };
+};
+
+type Harness = ReturnType<typeof setup>;
+
+const propose = async ({ runtime }: Harness, prompt = ASK): Promise<ApprovalId> => {
+  const outcome = await runtime.build.propose({ appId: APP, name: "Photo editor", prompt, why: WHY }, ctx);
+  if (!("approvalId" in outcome)) throw new Error(`expected a card, got ${JSON.stringify(outcome)}`);
+  return outcome.approvalId;
+};
+
+/** The person pressing Approve, through the guard the wire route drives. */
+const decide = ({ guard }: Harness, approvalId: ApprovalId, approve = true): Promise<void> =>
+  guard.approvals.decide(approvalId, { approve }, principal);
+
+/** Poll the row until the detached lane has landed something terminal. */
+const settled = async (harness: Harness): Promise<Record<string, unknown>> => {
+  for (let attempt = 0; attempt < 400; attempt += 1) {
+    const row = await harness.rowOf(APP);
+    if (row !== null && row["building"] === undefined && row["proposal"] === undefined) return row;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(`${APP} never settled`);
+};
+
+describe("a consented build runs the box and seals what it made", () => {
+  it("boots one box, briefs it with the person's ask, and seals the bundle it collected", async () => {
+    const sandbox = scriptedSandbox(buildsFine);
+    const harness = setup(sandbox);
+
+    const approvalId = await propose(harness);
+    // Nothing spent yet: the card stands and no machine exists.
+    expect(sandbox.boxes).toHaveLength(0);
+
+    await decide(harness, approvalId);
+    const row = await settled(harness);
+
+    // ONE box, briefed with the person's own words and the escalation's reason.
+    expect(sandbox.boxes).toHaveLength(1);
+    const [box] = sandbox.boxes as [Box];
+    expect(box.prompts).toHaveLength(1);
+    expect(box.prompts[0]).toContain(ASK);
+    expect(box.prompts[0]).toContain(WHY);
+
+    // Sealed: the row is a bundle, and the entry hash reads back as the bytes
+    // the box wrote — through the real seal and the real blob read.
+    expect(row["ui"]).toBe("bundle");
+    const bundle = row["bundle"] as { entry: string; assets: Record<string, string> };
+    expect(await readBundleBlob(APP, bundle.entry, harness.files)).toEqual(encoder.encode("console.log('cropped')"));
+    // The source and the lockfile came home beside it.
+    expect(Object.keys(bundle.assets).sort()).toEqual(["package-lock.json", "src/index.ts"]);
+    expect(row["buildFailed"]).toBeUndefined();
+  });
+
+  it("hands the box ZERO store credentials and only the registry to reach", async () => {
+    const sandbox = scriptedSandbox(buildsFine);
+    const harness = setup(sandbox);
+    await decide(harness, await propose(harness));
+    await settled(harness);
+
+    const [box] = sandbox.boxes as [Box];
+    // THE security invariant (FINAL SPEC v1): the box returns files, the host
+    // seals them. Nothing that could reach this deployment's store, its wire or
+    // its Cloud account is ever on that machine.
+    for (const name of Object.keys(box.env)) {
+      expect(name).not.toMatch(/VENDO_(STORE|HOST|APP_TOKEN|API_KEY|SECRET)/u);
+      expect(name).not.toMatch(/DATABASE_URL|POSTGRES/u);
+    }
+    // …and no host tool door either: nothing in that box can act as anyone.
+    expect(JSON.stringify(box.env)).not.toContain("/api/vendo");
+    // Registry egress, for the build minute only.
+    for (const domain of BUILD_ALLOWED_DOMAINS) expect(box.allowedDomains).toContain(domain);
+  });
+
+  it("leaves its box in the pool for the reaper rather than a second one", async () => {
+    const sandbox = scriptedSandbox(buildsFine);
+    const harness = setup(sandbox);
+    await decide(harness, await propose(harness));
+    await settled(harness);
+
+    expect(sandbox.boxes).toHaveLength(1);
+    // Not torn down inline and not leaked: the lane hands the box back to the
+    // pool, which is what its idle timer (and the shutdown reap below) act on.
+    // The wall-clock reap that `release()` arms is `boxMachine`'s own, proven
+    // against a shortened TTL in `packages/harnesses/tests/claude-code`.
+    expect(sandbox.boxes[0]!.destroyed).toBe(false);
+    await disposeSessionMachines();
+    expect(sandbox.boxes[0]!.destroyed).toBe(true);
+  });
+});
+
+describe("approving comes straight back", () => {
+  it("answers the decision while the build is still in the box", async () => {
+    let started: () => void = () => undefined;
+    const inTheBox = new Promise<void>((resolve) => { started = resolve; });
+    let release: () => void = () => undefined;
+    const held = new Promise<void>((resolve) => { release = resolve; });
+    const sandbox = scriptedSandbox(async (input) => {
+      started();
+      await held;
+      buildsFine(input);
+    });
+    const harness = setup(sandbox);
+    const approvalId = await propose(harness);
+
+    const decided = decide(harness, approvalId);
+    await inTheBox;
+    // THE assertion: the guard AWAITS its decision subscribers, so this promise
+    // settling while the box is still mid-build is the whole fix. Awaiting the
+    // box inside the subscriber held `POST /approvals/decide` open — the person
+    // pressed Approve and watched a request hang for the length of the build.
+    await decided;
+    expect(sandbox.boxes[0]!.prompts).toHaveLength(1);
+    expect((await harness.rowOf(APP))?.["building"]).toEqual(expect.any(String));
+
+    release();
+    expect((await settled(harness))["ui"]).toBe("bundle");
+  });
+});
+
+describe("every failure lands on the ONE terminal record", () => {
+  const failsWith = (row: Record<string, unknown>, reason: RegExp): void => {
+    expect(row["buildFailed"]).toMatchObject({ reason: expect.stringMatching(reason) });
+    expect(row["building"]).toBeUndefined();
+    expect(row["proposal"]).toBeUndefined();
+    expect(row["ui"]).toBeUndefined();
+  };
+
+  it("no sandbox composed — the failure names the missing machine", async () => {
+    const harness = setup(undefined);
+    expect(harness.runtime.build.available()).toBe(false);
+
+    await decide(harness, await propose(harness));
+
+    failsWith(await settled(harness), /build machine/u);
+  });
+
+  it("the box dies mid-build", async () => {
+    const sandbox = scriptedSandbox(({ box }) => { box.kill(); });
+    const harness = setup(sandbox);
+
+    await decide(harness, await propose(harness));
+
+    failsWith(await settled(harness), /machine went away/u);
+  });
+
+  it("the agent's own test failed, so it left no entry behind", async () => {
+    const sandbox = scriptedSandbox(({ prompt, root }) => {
+      // Source, but no `dist/app.js` — the brief's way of saying the test failed.
+      wrote(root, appIdOf(prompt), { "src/index.ts": "broken" });
+    });
+    const harness = setup(sandbox);
+
+    await decide(harness, await propose(harness));
+
+    failsWith(await settled(harness), /test did not pass/u);
+  });
+
+  it("the lane goes silent — the watchdog lands the record itself", async () => {
+    process.env["VENDO_APP_BUILD_WATCHDOG_MS"] = "60";
+    const sandbox = scriptedSandbox(async () => await new Promise(() => undefined));
+    const harness = setup(sandbox);
+
+    await decide(harness, await propose(harness));
+
+    failsWith(await settled(harness), /never finished/u);
+  });
+
+  it("denying it opens no box at all", async () => {
+    const sandbox = scriptedSandbox(buildsFine);
+    const harness = setup(sandbox);
+
+    await decide(harness, await propose(harness), false);
+
+    failsWith(await settled(harness), /not approved/u);
+    expect(sandbox.boxes).toHaveLength(0);
+  });
+});
+
+describe("a failed RESEAL keeps the app it was rebuilding", () => {
+  it("does not tombstone a row that already holds a sealed bundle", async () => {
+    let works = true;
+    const sandbox = scriptedSandbox((input) => { if (works) buildsFine(input); });
+    const harness = setup(sandbox);
+    await decide(harness, await propose(harness));
+    const sealed = (await settled(harness))["bundle"] as { entry: string };
+
+    // …and now the person asks for a change, and the rebuild fails.
+    works = false;
+    await decide(harness, await propose(harness, "make it dark"));
+    const row = await settled(harness);
+
+    // `markUnbuilt` would have REPLACED this row with a tombstone and taken a
+    // working app with it. A reseal that failed loses only the build state.
+    expect(row["ui"]).toBe("bundle");
+    expect(row["bundle"]).toMatchObject({ entry: sealed.entry });
+    expect(row["buildFailed"]).toBeUndefined();
+    expect(row["building"]).toBeUndefined();
+  });
+});
+
+describe("composition fills the slot", () => {
+  const compose = async (sandbox: ScriptedSandbox | undefined) => {
+    const dataDir = await mkdtemp(join(tmpdir(), "vendo-build-lane-"));
+    const store: VendoStore = createStore({ dataDir });
+    cleanups.push(async () => {
+      await store.close();
+      await rm(dataDir, { recursive: true, force: true });
+    });
+    const vendo = createVendo({
+      // Never reached: nothing in this lane thinks on the host.
+      models: { default: {} as LanguageModel },
+      principal: async () => principal,
+      store,
+      ...(sandbox === undefined ? {} : { sandbox }),
+    } as Parameters<typeof createVendo>[0]);
+    await store.ensureSchema();
+    return vendo;
+  };
+
+  it("a composed sandbox is the ONE gate, and the composed box holds no store credentials", async () => {
+    expect((await compose(undefined)).apps.build.available()).toBe(false);
+
+    let started: () => void = () => undefined;
+    const inTheBox = new Promise<void>((resolve) => { started = resolve; });
+    let release: () => void = () => undefined;
+    const held = new Promise<void>((resolve) => { release = resolve; });
+    const sandbox = scriptedSandbox(async (input) => {
+      started();
+      await held;
+      buildsFine(input);
+    });
+    const vendo = await compose(sandbox);
+    expect(vendo.apps.build.available()).toBe(true);
+
+    const proposed = await vendo.apps.build.propose(
+      { appId: APP, name: "Photo editor", prompt: ASK, why: WHY }, ctx);
+    if (!("approvalId" in proposed)) throw new Error("expected a card");
+    await vendo.guard.approvals.decide(proposed.approvalId, { approve: true }, principal);
+    await inTheBox;
+
+    // What a REAL deployment put on the machine: the inference door and the
+    // box's own handles, and not one thing that reaches this deployment's data.
+    const [box] = sandbox.boxes as [Box];
+    for (const name of Object.keys(box.env)) {
+      expect(name).not.toMatch(/VENDO_(STORE|HOST|APP_TOKEN|API_KEY|SECRET)/u);
+      expect(name).not.toMatch(/DATABASE_URL|POSTGRES/u);
+    }
+    release();
+  });
+});


### PR DESCRIPTION
> Stacked on #1609. Review only the top commit; the stack merges once at the tip.

## What & why

Slice 4 of 7 in the **built apps** stack. The previous slice made the yes possible; this one makes the yes *do* something. On approval a disposable box boots, in-box Claude installs from npm, builds and self-tests, the host seals the result, and the box dies.

**The box holds zero store credentials.** It returns files; the host writes them. That is a security invariant from the spec, not a preference, and it is asserted two ways below.

## Added
- **`vendo/src/build-agent.ts`** (151) — the lane, sibling of `screen-agent.ts`, over the existing `boxMachine`: spare-claim/cold-boot, `materialize`, `send`, `collect`, `release`. No new box plumbing. Single-phase, per spec. `BUILD_ALLOWED_DOMAINS` opens registry egress for the build minute only.
- **`compose-apps.ts`** — fills the `build:` slot exactly as `screen:` is filled; `available()` is true iff a sandbox adapter is composed, the one gate.
- **`build-door.ts`** — the failure arms, all landing on the single terminal landing from §4(c).

## The approve request no longer blocks
As handed over, `resume` awaited the whole build and the guard awaits its decision subscribers — so `POST /approvals/decide` would have hung for **minutes** while the box worked. The person clicks Approve and waits.

Fixed by detaching the lane with the **same idiom already shipped** for channel turns (`runInboundDetached`, `wire/channels.ts:74`) — no job queue, no new machinery. `resume` now awaits only the parked read, the refusal paths and the row flip to `building`, so the guard's subscriber returns in milliseconds. A dead-man `setTimeout` on the existing `buildWatchdogMs` is armed at detach and cleared only once something terminal lands, so a lane that throws still gets landed.

## The reseal landmine is defused
The failure landing called `markUnbuilt`, which replaces the whole row with a tombstone — correct for a first build, but it would have **destroyed a working app** on a failed re-edit. `resume` now reads the row once: if it already holds a `bundle`, failure clears `building`/`proposal` and keeps everything else. First builds are unchanged.

## Scope beyond `packages/vendo`, and why
Importing `@vendoai/harnesses/claude-code` from the umbrella pulled the Claude Agent SDK into the server entry and failed `portability-gate` ("server entry does not bundle for a Worker target"). `inferenceEnv`/`boxEgress` moved into `claude-code/box.ts` **verbatim, zero behaviour change**, with a `./claude-code/box` export; `claude-code/index.ts` re-exports both names, so no host-facing surface moved.

## Tests
`vendo/tests/build-lane.test.ts` (11), fake sandbox, green twice. Every one proven falsifiable: re-attaching the lane makes the promptness test time out at 30s; always-tombstone reddens the reseal test; a disarmed watchdog reddens "never settled"; adding a store credential to the composed `boxEnv` reddens the credential test.

Zero-credentials is proven twice: the composed case drives a real `createVendo` build to the point the box exists and asserts on the env the provider was actually handed — no store URL, app token, API key or `/api/vendo` anywhere; and structurally, composition passes `inferenceEnv` (never `machineEnv`, which carries the store URL and a minted app token) and the lane passes no `toolDoor` on `send`.

One test is honest about its limits: "leaves its box in the pool for the reaper" stays green with `release()` deleted, because the idle TTL is 5 minutes and the seam exposes nothing shorter. Reworded to claim only what it proves; `release()`'s reap is covered in `harnesses/tests/claude-code`.

## Found, not fixed — a pre-existing store bug
On the default embedded **PGlite** store, a request-path read interleaving with a detached job's writes makes an `INSERT INTO vendo_records` never return and blocks the Node event loop. Open transactions, read/write interleave in general, ordering, the data, the dir lock and a JS spin were all ruled out (`--cpu-prof` shows the isolate idle). It is `store/src/db.ts` + PGlite, **not this lane** — but the already-shipped `runInboundDetached` channel path can reach it too, so it is a live latent bug for zero-config deployments. Out of scope here; flagged for its own fix.

Also noticed, not fixed: `markUnbuilt` has no `retryable` field so `BuildOutcome.retryable` is dropped at the landing; nothing yet commits the build's source to `doc.source`, so reseal has nothing to materialise from (reseal isn't wired).

Live proof on a real box, run by an independent worker, is being recorded separately.

CI is the gate of record.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs consented app builds inside a disposable sandbox box and detaches them from the approval flow. Previously, Approve held the request open until the build finished; now the decision returns immediately, a watchdog lands silent failures, and a failed reseal no longer tombstones a working app.

- Builds run in a box with zero store credentials and minimal egress. The box gets only `inferenceEnv` (no store URL, app token, or `toolDoor`), egress is limited to the model host and `registry.npmjs.org` during the build minute, it returns files only, and the host seals them.

- Approval no longer blocks. The build lane detaches, marks `building`, and uses the existing watchdog window; outcomes land asynchronously.

- Reseal failures preserve the current bundle. On failure, we clear `building`/`proposal` and keep the prior bundle instead of replacing the row.

- New builder seam. `@vendoai/vendo` adds `build-agent.ts` and wires it in `compose-apps.ts` as `AppsConfig.build`; the lane is available only when a sandbox adapter is composed.

- Server adjustments. `@vendoai/apps` updates `build-door.ts` to detach and exports `buildFailureReason` for consistent failure wording.

- Harnesses export. `@vendoai/harnesses` adds `./claude-code/box` (exposes `boxMachine`, `inferenceEnv`, `boxEgress`) for Worker-safe composition; behavior unchanged.

- Tests. `vendo/tests/build-lane.test.ts` verifies detachment, zero-credential invariant, watchdog landing, and reseal behavior.

- Known caveat. The embedded PGlite store can hang under concurrent detached writes; pre-existing, tracked separately.

<sup>Written for commit 8e4ef21e1754b51f9d8eae7168ce8b886e9cca69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

