### PR TITLE
docs: replace inline SVG text diagrams Mintlify strips

### DIFF
--- a/docs-site/customize/instructions.mdx
+++ b/docs-site/customize/instructions.mdx
@@ -59,32 +59,24 @@ export const vendo = createVendo({
 
 The prompt is assembled fresh on every turn, in this order.
 
-<svg viewBox="0 0 560 236" role="img" aria-label="The assembled system prompt, top to bottom: Vendo's operating sections, Product from your brief, the User facts block, Directions from your guard, the theme line, and the knowledge index" style={{ width: "100%", height: "auto", margin: "1.5rem 0" }}>
-  <g fill="none" stroke="currentColor" strokeOpacity="0.2">
-    <rect x="1" y="1" width="558" height="34" rx="9" />
-    <rect x="1" y="79" width="558" height="34" rx="9" />
-    <rect x="1" y="118" width="558" height="34" rx="9" />
-    <rect x="1" y="157" width="558" height="34" rx="9" />
-    <rect x="1" y="196" width="558" height="34" rx="9" />
-  </g>
-  <rect x="1" y="40" width="558" height="34" rx="9" fill="#6c3bff" fillOpacity="0.06" stroke="#6c3bff" strokeOpacity="0.45" />
-  <g fill="currentColor" fontSize="13" fontWeight="600">
-    <text x="18" y="23">Vendo's operating sections</text>
-    <text x="18" y="101">[User]</text>
-    <text x="18" y="140">Directions</text>
-    <text x="18" y="179">Theme</text>
-    <text x="18" y="218">Knowledge</text>
-  </g>
-  <text x="18" y="62" fill="#6c3bff" fontSize="13" fontWeight="600">Product</text>
-  <g fill="currentColor" fillOpacity="0.55" fontSize="11.5" textAnchor="end">
-    <text x="542" y="23">how to work, how to speak</text>
-    <text x="542" y="101">facts you assert about the signed-in user</text>
-    <text x="542" y="140">policy steering from your guard</text>
-    <text x="542" y="179">one line about your brand</text>
-    <text x="542" y="218">an index of your docs</text>
-  </g>
-  <text x="542" y="62" fill="#6c3bff" fillOpacity="0.75" fontSize="11.5" textAnchor="end">your brief, verbatim</text>
-</svg>
+<Card title="Vendo's operating sections">
+  How to work, how to speak.
+</Card>
+<Card title="Product">
+  Your brief, verbatim.
+</Card>
+<Card title="[User]">
+  Facts you assert about the signed-in user.
+</Card>
+<Card title="Directions">
+  Policy steering from your guard.
+</Card>
+<Card title="Theme">
+  One line about your brand.
+</Card>
+<Card title="Knowledge">
+  An index of your docs.
+</Card>
 
 A section with nothing to say drops out entirely. The theme line and the
 knowledge index ride only the surfaces that can render a screen.

--- a/docs-site/customize/theming.mdx
+++ b/docs-site/customize/theming.mdx
@@ -77,29 +77,17 @@ your own styles and a custom panel tracks the same theme:
 
 You do not write it from scratch. You inherit it, then change what you want.
 
-<svg viewBox="0 0 760 118" role="img" aria-label="vendo init reads your live UI, writes .vendo/theme.json into your repo, and you edit it like any other file" style={{ width: "100%", height: "auto", margin: "1.5rem 0" }}>
-  <g fill="none" stroke="currentColor" strokeOpacity="0.2">
-    <rect x="1" y="1" width="226" height="52" rx="11" />
-    <rect x="533" y="1" width="226" height="52" rx="11" />
-  </g>
-  <rect x="267" y="1" width="226" height="52" rx="11" fill="#6c3bff" fillOpacity="0.06" stroke="#6c3bff" strokeOpacity="0.45" />
-  <g fill="none" stroke="#6c3bff" strokeWidth="1.5" strokeLinecap="round">
-    <path d="M235 27h20" /><path d="M501 27h20" />
-  </g>
-  <g fill="#6c3bff">
-    <path d="M255 23l7 4-7 4z" /><path d="M521 23l7 4-7 4z" />
-  </g>
-  <g fill="currentColor" fontSize="13.5" fontWeight="600" textAnchor="middle">
-    <text x="114" y="32">vendo init</text>
-    <text x="646" y="32">You</text>
-  </g>
-  <text x="380" y="32" fill="#6c3bff" fontSize="13.5" fontWeight="600" textAnchor="middle">.vendo/theme.json</text>
-  <g fill="currentColor" fillOpacity="0.55" fontSize="11.5" textAnchor="middle">
-    <text x="114" y="76">reads your live UI</text>
-    <text x="380" y="76">written into your repo</text>
-    <text x="646" y="76">edit it like any other file</text>
-  </g>
-</svg>
+<CardGroup cols={3}>
+  <Card title="vendo init">
+    Reads your live UI.
+  </Card>
+  <Card title=".vendo/theme.json">
+    Written into your repo.
+  </Card>
+  <Card title="You">
+    Edit it like any other file.
+  </Card>
+</CardGroup>
 
 `vendo init` reads your app's own CSS and writes the file. It then prints the
 paste that imports it into your provider:

--- a/docs-site/existing-agent/embeds.mdx
+++ b/docs-site/existing-agent/embeds.mdx
@@ -8,35 +8,19 @@ A `vendo_*` tool answers your loop with either plain data or a small versioned r
 
 ## The dispatch
 
-<svg viewBox="0 0 720 240" role="img" aria-label="A tool output enters VendoToolResult and leaves as nothing, an app embed, or an approval embed" style={{ width: "100%", height: "auto" }}>
-  <rect x="8" y="94" width="150" height="52" rx="10" fill="#faf9fc" stroke="#e9e6f1" />
-  <text x="83" y="117" textAnchor="middle" fontFamily="monospace" fontSize="13" fill="#4b4857">part.output</text>
-  <text x="83" y="134" textAnchor="middle" fontFamily="sans-serif" fontSize="11" fill="#7c7989">from a vendo_* tool</text>
+A tool output enters `VendoToolResult`, which reads `kind`.
 
-  <path d="M158 120h52" stroke="#a8a5b4" strokeWidth="1.5" fill="none" />
-  <path d="m204 115 8 5-8 5" stroke="#a8a5b4" strokeWidth="1.5" fill="none" />
-
-  <rect x="212" y="88" width="168" height="64" rx="12" fill="#f5f1ff" stroke="#ddd0ff" />
-  <text x="296" y="114" textAnchor="middle" fontFamily="monospace" fontSize="12.5" fill="#4a22bd">VendoToolResult</text>
-  <text x="296" y="132" textAnchor="middle" fontFamily="sans-serif" fontSize="11" fill="#6c3bff">reads kind</text>
-
-  <path d="M380 120h40v-72h48" stroke="#a8a5b4" strokeWidth="1.5" fill="none" />
-  <path d="M380 120h88" stroke="#a8a5b4" strokeWidth="1.5" fill="none" />
-  <path d="M380 120h40v72h48" stroke="#a8a5b4" strokeWidth="1.5" fill="none" />
-  <path d="m462 43 8 5-8 5M462 115l8 5-8 5M462 187l8 5-8 5" stroke="#a8a5b4" strokeWidth="1.5" fill="none" />
-
-  <rect x="478" y="26" width="234" height="44" rx="10" fill="#ffffff" stroke="#e9e6f1" />
-  <text x="494" y="45" fontFamily="sans-serif" fontSize="12.5" fill="#15141b">plain data</text>
-  <text x="494" y="61" fontFamily="sans-serif" fontSize="11" fill="#7c7989">renders nothing, your model already has it</text>
-
-  <rect x="478" y="98" width="234" height="44" rx="10" fill="#ffffff" stroke="#ddd0ff" />
-  <text x="494" y="117" fontFamily="monospace" fontSize="11.5" fill="#4a22bd">vendo/app-ref@1</text>
-  <text x="494" y="133" fontFamily="sans-serif" fontSize="11" fill="#7c7989">the app embed, building inline</text>
-
-  <rect x="478" y="170" width="234" height="44" rx="10" fill="#ffffff" stroke="#e2dfec" />
-  <text x="494" y="189" fontFamily="monospace" fontSize="11.5" fill="#4b4857">vendo/approval-ref@1</text>
-  <text x="494" y="205" fontFamily="sans-serif" fontSize="11" fill="#7c7989">the approve or deny card</text>
-</svg>
+<CardGroup cols={3}>
+  <Card title="plain data">
+    Renders nothing. Your model already has it.
+  </Card>
+  <Card title="vendo/app-ref@1">
+    The app embed, building inline.
+  </Card>
+  <Card title="vendo/approval-ref@1">
+    The approve or deny card.
+  </Card>
+</CardGroup>
 
 ## The envelope
 

--- a/docs-site/existing-agent/quickstart.mdx
+++ b/docs-site/existing-agent/quickstart.mdx
@@ -154,7 +154,6 @@ export default function Chat() {
   <rect x="6" y="6" width="208" height="108" rx="8" fill="#ffffff" stroke="#ddd9e8" />
   <rect x="110" y="16" width="96" height="12" rx="5" fill="#2c2a38" />
   <rect x="14" y="34" width="100" height="13" rx="4" fill="#e7f4f1" stroke="#cbe6e0" />
-  <text x="19" y="43.5" fontFamily="monospace" fontSize="7" fill="#1c6b5f">✓ vendo_listInvoices</text>
   <rect x="14" y="58" width="180" height="4" rx="2" fill="#e4e1ec" />
   <rect x="14" y="68" width="158" height="4" rx="2" fill="#e4e1ec" />
   <rect x="14" y="78" width="98" height="4" rx="2" fill="#e4e1ec" />
@@ -170,7 +169,6 @@ Your model reads the result and answers in words.
   <rect x="6" y="6" width="208" height="108" rx="8" fill="#ffffff" stroke="#ddd9e8" />
   <rect x="110" y="16" width="96" height="12" rx="5" fill="#2c2a38" />
   <rect x="14" y="34" width="100" height="13" rx="4" fill="#e7f4f1" stroke="#cbe6e0" />
-  <text x="19" y="43.5" fontFamily="monospace" fontSize="7" fill="#1c6b5f">✓ vendo_make</text>
   <rect x="14" y="54" width="182" height="52" rx="5" fill="#ffffff" stroke="#ddd0ff" />
   <path d="M19 54h172a5 5 0 0 1 5 5v6H14v-6a5 5 0 0 1 5-5Z" fill="#f5f1ff" />
   <rect x="20" y="58" width="44" height="3" rx="1.5" fill="#bda2f9" />
@@ -192,7 +190,6 @@ A live app builds inline, streamed over the wire.
   <rect x="6" y="6" width="208" height="108" rx="8" fill="#ffffff" stroke="#ddd9e8" />
   <rect x="110" y="16" width="96" height="12" rx="5" fill="#2c2a38" />
   <rect x="14" y="34" width="100" height="13" rx="4" fill="#e7f4f1" stroke="#cbe6e0" />
-  <text x="19" y="43.5" fontFamily="monospace" fontSize="7" fill="#1c6b5f">✓ vendo_refundOrder</text>
   <rect x="14" y="54" width="182" height="52" rx="5" fill="#ffffff" stroke="#e2dfec" />
   <rect x="22" y="62" width="90" height="4" rx="2" fill="#c9c5d6" />
   <rect x="22" y="73" width="34" height="4" rx="2" fill="#e4e1ec" />

--- a/docs-site/generated/apps.mdx
+++ b/docs-site/generated/apps.mdx
@@ -52,44 +52,19 @@ Most apps never leave layer 1. The agent climbs only when the instruction demand
   <Card title="1. Screen app">
     No server anywhere. The screen renders in the host surface and acts through guarded host tools.
 
-    <svg viewBox="0 0 220 104" width="100%" role="img" aria-label="Surface: app.tsx. Machine: none.">
-      <rect x="1" y="1" width="218" height="42" rx="8" fill="#6c3bff" fillOpacity="0.08" stroke="#6c3bff" strokeOpacity="0.35" />
-      <text x="12" y="17" fontSize="7" letterSpacing="1.2" fill="currentColor" fillOpacity="0.55">SURFACE</text>
-      <text x="12" y="33" fontSize="11" fontWeight="600" fill="#6c3bff">app.tsx</text>
-      <line x1="110" y1="45" x2="110" y2="59" stroke="currentColor" strokeOpacity="0.25" strokeDasharray="3 3" />
-      <rect x="1" y="61" width="218" height="42" rx="8" fill="none" stroke="currentColor" strokeOpacity="0.22" strokeDasharray="4 3" />
-      <text x="12" y="77" fontSize="7" letterSpacing="1.2" fill="currentColor" fillOpacity="0.45">MACHINE</text>
-      <text x="12" y="93" fontSize="11" fontWeight="500" fill="currentColor" fillOpacity="0.5">none</text>
-    </svg>
+    Surface: `app.tsx`. Machine: none.
   </Card>
 
   <Card title="2. Screen plus machine">
     The same screen, plus a persistent sandbox where execution lives. The machine never draws UI.
 
-    <svg viewBox="0 0 220 104" width="100%" role="img" aria-label="Surface: app.tsx. Machine: one sandbox.">
-      <rect x="1" y="1" width="218" height="42" rx="8" fill="#6c3bff" fillOpacity="0.08" stroke="#6c3bff" strokeOpacity="0.35" />
-      <text x="12" y="17" fontSize="7" letterSpacing="1.2" fill="currentColor" fillOpacity="0.55">SURFACE</text>
-      <text x="12" y="33" fontSize="11" fontWeight="600" fill="#6c3bff">app.tsx</text>
-      <line x1="110" y1="45" x2="110" y2="59" stroke="currentColor" strokeOpacity="0.25" strokeDasharray="3 3" />
-      <rect x="1" y="61" width="218" height="42" rx="8" fill="currentColor" fillOpacity="0.04" stroke="currentColor" strokeOpacity="0.22" />
-      <text x="12" y="77" fontSize="7" letterSpacing="1.2" fill="currentColor" fillOpacity="0.55">MACHINE</text>
-      <text x="12" y="93" fontSize="11" fontWeight="600" fill="currentColor">one sandbox</text>
-    </svg>
+    Surface: `app.tsx`. Machine: one sandbox.
   </Card>
 
   <Card title="3. Machine everything">
     The machine also serves a real web app, and the host embeds that URL as the surface.
 
-    <svg viewBox="0 0 220 104" width="100%" role="img" aria-label="Surface: the machine's web app, served up from the machine below it.">
-      <rect x="1" y="1" width="218" height="42" rx="8" fill="#6c3bff" fillOpacity="0.08" stroke="#6c3bff" strokeOpacity="0.35" />
-      <text x="12" y="17" fontSize="7" letterSpacing="1.2" fill="currentColor" fillOpacity="0.55">SURFACE</text>
-      <text x="12" y="33" fontSize="11" fontWeight="600" fill="#6c3bff">the machine's web app</text>
-      <line x1="110" y1="49" x2="110" y2="59" stroke="#6c3bff" strokeOpacity="0.45" strokeDasharray="3 3" />
-      <path d="M110 44 l5 6 h-10 z" fill="#6c3bff" fillOpacity="0.55" />
-      <rect x="1" y="61" width="218" height="42" rx="8" fill="currentColor" fillOpacity="0.04" stroke="currentColor" strokeOpacity="0.22" />
-      <text x="12" y="77" fontSize="7" letterSpacing="1.2" fill="currentColor" fillOpacity="0.55">MACHINE</text>
-      <text x="12" y="93" fontSize="11" fontWeight="600" fill="currentColor">one sandbox, serving the pages too</text>
-    </svg>
+    Surface: the machine's web app. Machine: one sandbox, serving the pages too.
   </Card>
 </Columns>
 
@@ -135,25 +110,19 @@ A refusal names the line and says what to write instead. Nothing paints, and no 
 
 Nobody uses someone else's app. They get their own copy of it.
 
-<Frame caption="Import and fork each mint a fresh app_ id.">
-  <svg viewBox="0 0 700 62" width="100%" role="img" aria-label="Ana's app_790892b0 imported into your app_c0d6b562, then forked into your app_3f11ad7c.">
-    <rect x="1" y="16" width="176" height="30" rx="8" fill="currentColor" fillOpacity="0.04" stroke="currentColor" strokeOpacity="0.22" />
-    <text x="89" y="30" fontSize="8" textAnchor="middle" fill="currentColor" fillOpacity="0.55">Ana's</text>
-    <text x="89" y="41" fontSize="11" fontWeight="600" textAnchor="middle" fill="currentColor">app_790892b0…</text>
-    <line x1="185" y1="31" x2="252" y2="31" stroke="#6c3bff" strokeOpacity="0.4" strokeWidth="1.5" />
-    <path d="M262 31 l-10 -5 v10 z" fill="#6c3bff" fillOpacity="0.6" />
-    <text x="218" y="17" fontSize="10" textAnchor="middle" fill="#6c3bff">import</text>
-    <rect x="262" y="16" width="176" height="30" rx="8" fill="#6c3bff" fillOpacity="0.08" stroke="#6c3bff" strokeOpacity="0.35" />
-    <text x="350" y="30" fontSize="8" textAnchor="middle" fill="#6c3bff" fillOpacity="0.75">yours</text>
-    <text x="350" y="41" fontSize="11" fontWeight="600" textAnchor="middle" fill="#6c3bff">app_c0d6b562…</text>
-    <line x1="446" y1="31" x2="513" y2="31" stroke="#6c3bff" strokeOpacity="0.4" strokeWidth="1.5" />
-    <path d="M523 31 l-10 -5 v10 z" fill="#6c3bff" fillOpacity="0.6" />
-    <text x="479" y="17" fontSize="10" textAnchor="middle" fill="#6c3bff">fork</text>
-    <rect x="523" y="16" width="176" height="30" rx="8" fill="#6c3bff" fillOpacity="0.08" stroke="#6c3bff" strokeOpacity="0.35" />
-    <text x="611" y="30" fontSize="8" textAnchor="middle" fill="#6c3bff" fillOpacity="0.75">yours</text>
-    <text x="611" y="41" fontSize="11" fontWeight="600" textAnchor="middle" fill="#6c3bff">app_3f11ad7c…</text>
-  </svg>
-</Frame>
+Import and fork each mint a fresh `app_` id.
+
+<CardGroup cols={3}>
+  <Card title="Ana's">
+    `app_790892b0…`
+  </Card>
+  <Card title="Yours, after import">
+    `app_c0d6b562…`
+  </Card>
+  <Card title="Yours, after fork">
+    `app_3f11ad7c…`
+  </Card>
+</CardGroup>
 
 Ana shares a link, and the link carries the app and nothing else. Importing it mints a fresh id in your account, reading your rows under your approvals.
 

--- a/docs-site/generated/host-components.mdx
+++ b/docs-site/generated/host-components.mdx
@@ -43,22 +43,18 @@ const vendo = createVendo({ catalog: registry });
 
 ## What a screen may name
 
-<Frame caption="A name outside these two sets fails the save. It never renders as an empty box.">
-  <svg viewBox="0 0 700 118" width="100%" role="img" aria-label="A generated screen may name the Kit's 51 components plus the components this host registered, and nothing else.">
-    <rect x="1" y="1" width="330" height="72" rx="10" fill="currentColor" fillOpacity="0.04" stroke="currentColor" strokeOpacity="0.22" />
-    <text x="166" y="27" fontSize="8" letterSpacing="1.2" textAnchor="middle" fill="currentColor" fillOpacity="0.55">SHIPPED WITH VENDO</text>
-    <text x="166" y="48" fontSize="14" fontWeight="600" textAnchor="middle" fill="currentColor">the Kit</text>
-    <text x="166" y="64" fontSize="11" textAnchor="middle" fill="currentColor" fillOpacity="0.55">51 components, themed by your tokens</text>
-    <text x="350" y="43" fontSize="18" fontWeight="500" textAnchor="middle" fill="currentColor" fillOpacity="0.35">+</text>
-    <rect x="369" y="1" width="330" height="72" rx="10" fill="#6c3bff" fillOpacity="0.08" stroke="#6c3bff" strokeOpacity="0.35" />
-    <text x="534" y="27" fontSize="8" letterSpacing="1.2" textAnchor="middle" fill="#6c3bff" fillOpacity="0.8">SHIPPED WITH YOUR PRODUCT</text>
-    <text x="534" y="48" fontSize="14" fontWeight="600" textAnchor="middle" fill="#6c3bff">your catalog</text>
-    <text x="534" y="64" fontSize="11" textAnchor="middle" fill="#6c3bff" fillOpacity="0.75">the ones you registered, with their schemas</text>
-    <line x1="350" y1="74" x2="350" y2="88" stroke="currentColor" strokeOpacity="0.25" strokeDasharray="3 3" />
-    <rect x="212" y="88" width="276" height="29" rx="8" fill="none" stroke="currentColor" strokeOpacity="0.22" />
-    <text x="350" y="107" fontSize="11" fontWeight="600" textAnchor="middle" fill="currentColor">everything a screen may render</text>
-  </svg>
-</Frame>
+A name outside these two sets fails the save. It never renders as an empty box.
+
+<Columns cols={2}>
+  <Card title="The Kit">
+    Shipped with Vendo. 51 components, themed by your tokens.
+  </Card>
+  <Card title="Your catalog">
+    Shipped with your product. The ones you registered, with their schemas.
+  </Card>
+</Columns>
+
+Together, everything a screen may render.
 
 The Kit is one family, and every component in it reads your [theme tokens](/customize/theming).
 
@@ -84,28 +80,19 @@ The Kit is one family, and every component in it reads your [theme tokens](/cust
 
 Two artifacts, both deterministic and byte-stable. Commit them.
 
-<Frame caption="catalog.json is what your components are called. .vendo/components/ is what they are.">
-  <svg viewBox="0 0 700 128" width="100%" role="img" aria-label="Your provider's components map feeds catalog.json for names and .vendo/components/ for source, split into per-component records and content-addressed modules.">
-    <rect x="1" y="34" width="182" height="60" rx="10" fill="currentColor" fillOpacity="0.04" stroke="currentColor" strokeOpacity="0.22" />
-    <text x="92" y="60" fontSize="8" letterSpacing="1.2" textAnchor="middle" fill="currentColor" fillOpacity="0.55">YOUR SOURCE</text>
-    <text x="92" y="78" fontSize="11" fontWeight="600" textAnchor="middle" fill="currentColor">&lt;VendoProvider components&gt;</text>
-    <line x1="183" y1="64" x2="222" y2="64" stroke="#6c3bff" strokeOpacity="0.4" strokeWidth="1.5" />
-    <path d="M232 64 l-10 -5 v10 z" fill="#6c3bff" fillOpacity="0.6" />
-    <text x="207" y="52" fontSize="9" textAnchor="middle" fill="#6c3bff">sync</text>
-    <rect x="232" y="1" width="200" height="54" rx="10" fill="#6c3bff" fillOpacity="0.08" stroke="#6c3bff" strokeOpacity="0.35" />
-    <text x="332" y="24" fontSize="11" fontWeight="600" textAnchor="middle" fill="#6c3bff">.vendo/catalog.json</text>
-    <text x="332" y="42" fontSize="10" textAnchor="middle" fill="#6c3bff" fillOpacity="0.75">names, prop schemas, examples</text>
-    <rect x="232" y="73" width="200" height="54" rx="10" fill="#6c3bff" fillOpacity="0.08" stroke="#6c3bff" strokeOpacity="0.35" />
-    <text x="332" y="96" fontSize="11" fontWeight="600" textAnchor="middle" fill="#6c3bff">.vendo/components/</text>
-    <text x="332" y="114" fontSize="10" textAnchor="middle" fill="#6c3bff" fillOpacity="0.75">the real source, content addressed</text>
-    <line x1="432" y1="100" x2="471" y2="100" stroke="currentColor" strokeOpacity="0.3" />
-    <path d="M481 100 l-10 -5 v10 z" fill="currentColor" fillOpacity="0.4" />
-    <rect x="481" y="66" width="218" height="26" rx="7" fill="none" stroke="currentColor" strokeOpacity="0.22" />
-    <text x="590" y="83" fontSize="10" textAnchor="middle" fill="currentColor" fillOpacity="0.8">&lt;Name&gt;.json, refs only</text>
-    <rect x="481" y="98" width="218" height="26" rx="7" fill="none" stroke="currentColor" strokeOpacity="0.22" />
-    <text x="590" y="115" fontSize="10" textAnchor="middle" fill="currentColor" fillOpacity="0.8">modules/&lt;hex&gt;.json, the bytes</text>
-  </svg>
-</Frame>
+`vendo sync` reads `<VendoProvider components>`. `catalog.json` is what your components are called. `.vendo/components/` is what they are.
+
+<Columns cols={2}>
+  <Card title=".vendo/catalog.json">
+    Names, prop schemas, examples.
+  </Card>
+  <Card title=".vendo/components/">
+    The real source, content addressed.
+
+    * `<Name>.json`, refs only
+    * `modules/<hex>.json`, the bytes
+  </Card>
+</Columns>
 
 `.vendo/catalog.json` records what your components are called: the module that exports each one, its JSON Schema props, its description, and its examples. Rescans preserve description and example copy you edited by hand.
 

--- a/docs-site/generated/import-and-fork.mdx
+++ b/docs-site/generated/import-and-fork.mdx
@@ -12,22 +12,22 @@ Export writes a `.vendoapp` archive. Import mints a fresh `app_` id before it ev
 
 `fork` does the same in one call and records `forkedFrom` so the lineage is readable. `share` and `publish` hand the copy to Vendo Cloud, and both need `VENDO_API_KEY`.
 
-<Frame caption="A copy re-approves its own egress before it can run anything.">
-  <svg viewBox="0 0 700 132" width="100%" role="img" aria-label="What travels with a copy: the document, the app.tsx screen, the declared secrets and egress domains. What stays behind: the machine, the owner's approved egress, and the conversation.">
-    <rect x="1" y="1" width="330" height="130" rx="10" fill="#6c3bff" fillOpacity="0.07" stroke="#6c3bff" strokeOpacity="0.35" />
-    <text x="20" y="26" fontSize="8" letterSpacing="1.2" fill="#6c3bff" fillOpacity="0.85">TRAVELS</text>
-    <text x="20" y="50" fontSize="12" fill="currentColor">the document and its app.tsx screen</text>
-    <text x="20" y="73" fontSize="12" fill="currentColor">the storage the app declares</text>
-    <text x="20" y="96" fontSize="12" fill="currentColor">the secret names it declares</text>
-    <text x="20" y="119" fontSize="12" fill="currentColor">the egress domains it declares</text>
-    <rect x="369" y="1" width="330" height="130" rx="10" fill="none" stroke="currentColor" strokeOpacity="0.22" strokeDasharray="4 3" />
-    <text x="388" y="26" fontSize="8" letterSpacing="1.2" fill="currentColor" fillOpacity="0.5">STAYS BEHIND</text>
-    <text x="388" y="50" fontSize="12" fill="currentColor" fillOpacity="0.65">the machine, so the copy re-graduates</text>
-    <text x="388" y="73" fontSize="12" fill="currentColor" fillOpacity="0.65">the owner's approved egress</text>
-    <text x="388" y="96" fontSize="12" fill="currentColor" fillOpacity="0.65">every grant, which is keyed to the old id</text>
-    <text x="388" y="119" fontSize="12" fill="currentColor" fillOpacity="0.65">the owner's conversation</text>
-  </svg>
-</Frame>
+A copy re-approves its own egress before it can run anything.
+
+<Columns cols={2}>
+  <Card title="Travels">
+    * the document and its app.tsx screen
+    * the storage the app declares
+    * the secret names it declares
+    * the egress domains it declares
+  </Card>
+  <Card title="Stays behind">
+    * the machine, so the copy re-graduates
+    * the owner's approved egress
+    * every grant, which is keyed to the old id
+    * the owner's conversation
+  </Card>
+</Columns>
 
 Two copies are refused outright, and both refusals are loud.
 
@@ -243,26 +243,16 @@ Acknowledged slots are skipped without error and their baselines are left alone.
 
 Update the component, run `vendo sync`, and the new baseline overwrites the old one. Existing forks are now drifted: the hash they recorded no longer matches the captured baseline.
 
-<Frame caption="Drift is a warning, never an action. A drifted fork keeps rendering its own content, untouched.">
-  <svg viewBox="0 0 700 112" width="100%" role="img" aria-label="A user's fork records the baseline hash it was created from. When sync captures a new baseline, the recorded hash no longer matches and the fork is reported as drifted.">
-    <rect x="1" y="16" width="200" height="52" rx="9" fill="currentColor" fillOpacity="0.04" stroke="currentColor" strokeOpacity="0.22" />
-    <text x="101" y="38" fontSize="11" fontWeight="600" textAnchor="middle" fill="currentColor">NetWorthCard</text>
-    <text x="101" y="55" fontSize="10" textAnchor="middle" fill="currentColor" fillOpacity="0.55">baseline sha256:a1c4…</text>
-    <line x1="209" y1="42" x2="248" y2="42" stroke="#6c3bff" strokeOpacity="0.4" strokeWidth="1.5" />
-    <path d="M258 42 l-10 -5 v10 z" fill="#6c3bff" fillOpacity="0.6" />
-    <text x="233" y="30" fontSize="9" textAnchor="middle" fill="#6c3bff">remix</text>
-    <rect x="258" y="16" width="200" height="52" rx="9" fill="#6c3bff" fillOpacity="0.08" stroke="#6c3bff" strokeOpacity="0.35" />
-    <text x="358" y="38" fontSize="11" fontWeight="600" textAnchor="middle" fill="#6c3bff">the user's fork</text>
-    <text x="358" y="55" fontSize="10" textAnchor="middle" fill="#6c3bff" fillOpacity="0.75">seed.baseline sha256:a1c4…</text>
-    <line x1="101" y1="68" x2="101" y2="84" stroke="currentColor" strokeOpacity="0.3" strokeDasharray="3 3" />
-    <rect x="1" y="84" width="200" height="27" rx="7" fill="none" stroke="currentColor" strokeOpacity="0.22" />
-    <text x="101" y="102" fontSize="10" textAnchor="middle" fill="currentColor" fillOpacity="0.75">you edit it, sync captures sha256:7f02…</text>
-    <line x1="209" y1="97" x2="248" y2="97" stroke="currentColor" strokeOpacity="0.3" />
-    <path d="M258 97 l-10 -5 v10 z" fill="currentColor" fillOpacity="0.4" />
-    <rect x="258" y="84" width="200" height="27" rx="7" fill="none" stroke="currentColor" strokeOpacity="0.3" strokeDasharray="4 3" />
-    <text x="358" y="102" fontSize="10" fontWeight="600" textAnchor="middle" fill="currentColor" fillOpacity="0.8">drifted: baseline-changed</text>
-  </svg>
-</Frame>
+Drift is a warning, never an action. A drifted fork keeps rendering its own content, untouched.
+
+<Columns cols={2}>
+  <Card title="NetWorthCard">
+    Remix starts from baseline `sha256:a1c4…`. You edit it, sync captures `sha256:7f02…`.
+  </Card>
+  <Card title="The user's fork">
+    Still records `seed.baseline sha256:a1c4…`. Reported as `drifted: baseline-changed`.
+  </Card>
+</Columns>
 
 Vendo says so everywhere the fork is opened or edited. `open()` attaches a server-authoritative `seedDrift` to the payload, edit results carry the same field, and the renderer shows an in-surface notice above the fork.
 

--- a/docs-site/generated/in-client-venue.mdx
+++ b/docs-site/generated/in-client-venue.mdx
@@ -10,28 +10,16 @@ A screen runs in a sealed VM with no DOM, no network, and no clock. An approved 
 
 `open()` computes the venue on every open. Nothing a stored, imported, or streamed document says about `inClient` survives to the client.
 
-<Frame caption="A stored approval pinning the current content hash is the only way into your page.">
-  <svg viewBox="0 0 700 196" width="100%" role="img" aria-label="open() checks for a stored approval pinning the current content hash. Granted, the code mounts in your page. Otherwise a contained notice takes its place.">
-    <rect x="252" y="1" width="196" height="30" rx="8" fill="currentColor" fillOpacity="0.04" stroke="currentColor" strokeOpacity="0.22" />
-    <text x="350" y="20" fontSize="12" fontWeight="600" textAnchor="middle" fill="currentColor">open()</text>
-    <line x1="350" y1="31" x2="350" y2="55" stroke="currentColor" strokeOpacity="0.3" />
-    <rect x="192" y="56" width="316" height="44" rx="8" fill="#6c3bff" fillOpacity="0.07" stroke="#6c3bff" strokeOpacity="0.35" />
-    <text x="350" y="74" fontSize="11" textAnchor="middle" fill="currentColor" fillOpacity="0.75">does a stored approval pin</text>
-    <text x="350" y="90" fontSize="11" fontWeight="600" textAnchor="middle" fill="#6c3bff">this version's content hash?</text>
-    <path d="M192 78 H120 V132" fill="none" stroke="currentColor" strokeOpacity="0.3" />
-    <path d="M120 142 l-5 -10 h10 z" fill="currentColor" fillOpacity="0.45" />
-    <text x="152" y="120" fontSize="10" fill="currentColor" fillOpacity="0.6">no</text>
-    <path d="M508 78 H580 V132" fill="none" stroke="#6c3bff" strokeOpacity="0.45" />
-    <path d="M580 142 l-5 -10 h10 z" fill="#6c3bff" fillOpacity="0.6" />
-    <text x="540" y="120" fontSize="10" fill="#6c3bff">yes</text>
-    <rect x="1" y="144" width="238" height="50" rx="8" fill="none" stroke="currentColor" strokeOpacity="0.22" strokeDasharray="4 3" />
-    <text x="120" y="164" fontSize="11" fontWeight="600" textAnchor="middle" fill="currentColor" fillOpacity="0.7">the code does not run</text>
-    <text x="120" y="181" fontSize="10" textAnchor="middle" fill="currentColor" fillOpacity="0.5">a contained notice takes its place</text>
-    <rect x="461" y="144" width="238" height="50" rx="8" fill="#6c3bff" fillOpacity="0.08" stroke="#6c3bff" strokeOpacity="0.35" />
-    <text x="580" y="164" fontSize="11" fontWeight="600" textAnchor="middle" fill="#6c3bff">it mounts in your page</text>
-    <text x="580" y="181" fontSize="10" textAnchor="middle" fill="#6c3bff" fillOpacity="0.75">your origin, your cookies, your CSP</text>
-  </svg>
-</Frame>
+A stored approval pinning the current content hash is the only way into your page.
+
+<Columns cols={2}>
+  <Card title="No">
+    The code does not run. A contained notice takes its place.
+  </Card>
+  <Card title="Yes">
+    It mounts in your page — your origin, your cookies, your CSP.
+  </Card>
+</Columns>
 
 <Columns cols={2}>
   <Frame>

--- a/docs-site/outside-agents/how-the-door-works.mdx
+++ b/docs-site/outside-agents/how-the-door-works.mdx
@@ -7,32 +7,20 @@ sidebarTitle: "How the door works"
 One bearer arrives, one user is named, and every call after that answers to the
 same guard your own UI answers to.
 
-<svg viewBox="0 0 760 118" role="img" aria-label="A request path: your agent, the door, your guard, your host API" style={{ width: "100%", height: "auto", margin: "1.5rem 0" }}>
-  <g fill="none" stroke="currentColor" strokeOpacity="0.2">
-    <rect x="1" y="1" width="164" height="52" rx="11" />
-    <rect x="199" y="1" width="164" height="52" rx="11" />
-    <rect x="397" y="1" width="164" height="52" rx="11" />
-    <rect x="595" y="1" width="164" height="52" rx="11" />
-  </g>
-  <g fill="none" stroke="#6c3bff" strokeWidth="1.5" strokeLinecap="round">
-    <path d="M169 27h20" /><path d="M367 27h20" /><path d="M565 27h20" />
-  </g>
-  <g fill="#6c3bff">
-    <path d="M189 23l7 4-7 4z" /><path d="M387 23l7 4-7 4z" /><path d="M585 23l7 4-7 4z" />
-  </g>
-  <g fill="currentColor" fontSize="13.5" fontWeight="600" textAnchor="middle">
-    <text x="83" y="32">Your agent</text>
-    <text x="281" y="32">The door</text>
-    <text x="479" y="32">Your guard</text>
-    <text x="677" y="32">Your host API</text>
-  </g>
-  <g fill="currentColor" fillOpacity="0.55" fontSize="11.5" textAnchor="middle">
-    <text x="83" y="76">bearer for user_1904</text>
-    <text x="281" y="76">principal + consent</text>
-    <text x="479" y="76">allow · ask · block</text>
-    <text x="677" y="76">called as that user</text>
-  </g>
-</svg>
+<CardGroup cols={4}>
+  <Card title="Your agent">
+    Bearer for `user_1904`.
+  </Card>
+  <Card title="The door">
+    Principal + consent.
+  </Card>
+  <Card title="Your guard">
+    Allow · ask · block.
+  </Card>
+  <Card title="Your host API">
+    Called as that user.
+  </Card>
+</CardGroup>
 
 ## Who is calling
 

--- a/docs-site/outside-agents/service-keys-and-broker.mdx
+++ b/docs-site/outside-agents/service-keys-and-broker.mdx
@@ -8,32 +8,20 @@ A service key is the one long-lived credential in this path. It never touches
 your agent, and it never leaves your backend. `vendo.tokenFor()` spends it for
 you — this page is what is behind that call.
 
-<svg viewBox="0 0 760 118" role="img" aria-label="A service key path: the key, the token exchange, a ten-minute bearer, your door" style={{ width: "100%", height: "auto", margin: "1.5rem 0" }}>
-  <g fill="none" stroke="currentColor" strokeOpacity="0.2">
-    <rect x="1" y="1" width="164" height="52" rx="11" />
-    <rect x="199" y="1" width="164" height="52" rx="11" />
-    <rect x="397" y="1" width="164" height="52" rx="11" />
-    <rect x="595" y="1" width="164" height="52" rx="11" />
-  </g>
-  <g fill="none" stroke="#6c3bff" strokeWidth="1.5" strokeLinecap="round">
-    <path d="M169 27h20" /><path d="M367 27h20" /><path d="M565 27h20" />
-  </g>
-  <g fill="#6c3bff">
-    <path d="M189 23l7 4-7 4z" /><path d="M387 23l7 4-7 4z" /><path d="M585 23l7 4-7 4z" />
-  </g>
-  <g fill="currentColor" fontSize="13.5" fontWeight="600" textAnchor="middle">
-    <text x="83" y="32">Service key</text>
-    <text x="281" y="32">tokenFor()</text>
-    <text x="479" y="32">10-minute bearer</text>
-    <text x="677" y="32">Your door</text>
-  </g>
-  <g fill="currentColor" fillOpacity="0.55" fontSize="11.5" textAnchor="middle">
-    <text x="83" y="76">lives in your backend</text>
-    <text x="281" y="76">RFC 8693 exchange</text>
-    <text x="479" y="76">bound to one user id</text>
-    <text x="677" y="76">verifies the signature</text>
-  </g>
-</svg>
+<CardGroup cols={4}>
+  <Card title="Service key">
+    Lives in your backend.
+  </Card>
+  <Card title="tokenFor()">
+    RFC 8693 exchange.
+  </Card>
+  <Card title="10-minute bearer">
+    Bound to one user id.
+  </Card>
+  <Card title="Your door">
+    Verifies the signature.
+  </Card>
+</CardGroup>
 
 ## Where the key lives
 

--- a/docs-site/product/how-it-works.mdx
+++ b/docs-site/product/how-it-works.mdx
@@ -7,48 +7,24 @@ sidebarTitle: "How it works"
 The panel is the only Vendo code in your browser. Every turn goes to a route
 inside your own app and streams back to that panel.
 
-<svg viewBox="0 0 704 208" width="100%" role="img" aria-labelledby="vendo-path-title">
-  <title id="vendo-path-title">A question travels from the panel to your route, through the turn and the guard, to your API, and streams back to the panel.</title>
-  <defs>
-    <marker id="vendo-flow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor" />
-    </marker>
-    <marker id="vendo-flow-brand" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="#6c3bff" />
-    </marker>
-  </defs>
+A question travels from the panel to your route, through the turn and the guard, to your API, and streams back to the panel. Vendo Cloud (model · sandbox · store) sits on the turn when you leave those slots unset.
 
-  <rect x="364" y="8" width="160" height="44" rx="10" fill="none" stroke="#6c3bff" strokeOpacity="0.55" strokeDasharray="4 4" />
-  <text x="444" y="27" textAnchor="middle" fontSize="12" fontWeight="600" fill="#6c3bff">Vendo Cloud</text>
-  <text x="444" y="42" textAnchor="middle" fontSize="10" fill="#6c3bff" fillOpacity="0.8">model · sandbox · store</text>
-  <path d="M 444 52 L 444 80" stroke="#6c3bff" strokeOpacity="0.55" strokeWidth="1.5" strokeDasharray="4 4" fill="none" markerEnd="url(#vendo-flow-brand)" />
+<CardGroup cols={4}>
+  <Card title="Panel">
+    Your page. Asks.
+  </Card>
+  <Card title="Your route">
+    `/api/vendo`. Runs.
+  </Card>
+  <Card title="The turn">
+    Harness, then guard.
+  </Card>
+  <Card title="Your API">
+    Called as this user.
+  </Card>
+</CardGroup>
 
-  <rect x="16" y="84" width="112" height="52" rx="10" fill="none" stroke="currentColor" strokeOpacity="0.25" />
-  <text x="72" y="106" textAnchor="middle" fontSize="12.5" fontWeight="600" fill="currentColor">Panel</text>
-  <text x="72" y="122" textAnchor="middle" fontSize="10" fill="currentColor" fillOpacity="0.6">your page</text>
-
-  <rect x="184" y="84" width="124" height="52" rx="10" fill="none" stroke="currentColor" strokeOpacity="0.25" />
-  <text x="246" y="106" textAnchor="middle" fontSize="12.5" fontWeight="600" fill="currentColor">Your route</text>
-  <text x="246" y="122" textAnchor="middle" fontSize="10" fill="currentColor" fillOpacity="0.6">/api/vendo</text>
-
-  <rect x="364" y="84" width="160" height="52" rx="10" fill="none" stroke="currentColor" strokeOpacity="0.25" />
-  <text x="444" y="106" textAnchor="middle" fontSize="12.5" fontWeight="600" fill="currentColor">The turn</text>
-  <text x="444" y="122" textAnchor="middle" fontSize="10" fill="currentColor" fillOpacity="0.6">harness, then guard</text>
-
-  <rect x="580" y="84" width="112" height="52" rx="10" fill="none" stroke="currentColor" strokeOpacity="0.25" />
-  <text x="636" y="106" textAnchor="middle" fontSize="12.5" fontWeight="600" fill="currentColor">Your API</text>
-  <text x="636" y="122" textAnchor="middle" fontSize="10" fill="currentColor" fillOpacity="0.6">as this user</text>
-
-  <path d="M 132 110 L 180 110" stroke="currentColor" strokeOpacity="0.45" strokeWidth="1.5" fill="none" markerEnd="url(#vendo-flow)" />
-  <path d="M 312 110 L 360 110" stroke="currentColor" strokeOpacity="0.45" strokeWidth="1.5" fill="none" markerEnd="url(#vendo-flow)" />
-  <path d="M 528 110 L 576 110" stroke="currentColor" strokeOpacity="0.45" strokeWidth="1.5" fill="none" markerEnd="url(#vendo-flow)" />
-  <text x="156" y="100" textAnchor="middle" fontSize="9.5" fill="currentColor" fillOpacity="0.55">asks</text>
-  <text x="336" y="100" textAnchor="middle" fontSize="9.5" fill="currentColor" fillOpacity="0.55">runs</text>
-  <text x="552" y="100" textAnchor="middle" fontSize="9.5" fill="currentColor" fillOpacity="0.55">calls</text>
-
-  <path d="M 444 136 L 444 172 L 72 172 L 72 140" stroke="#6c3bff" strokeOpacity="0.7" strokeWidth="1.5" fill="none" markerEnd="url(#vendo-flow-brand)" />
-  <text x="258" y="190" textAnchor="middle" fontSize="10.5" fill="#6c3bff">text, tool beats, and a live screen, streamed back through your route</text>
-</svg>
+Text, tool beats, and a live screen stream back through your route.
 
 ## The path of one question
 

--- a/docs-site/production/model-credentials.mdx
+++ b/docs-site/production/model-credentials.mdx
@@ -12,35 +12,19 @@ turn rides the console's gateway.
 Managed inference is not a bespoke client. It is the stock `@ai-sdk/anthropic`
 provider, pointed at the console instead of at Anthropic.
 
-<Frame caption="One provider, one base URL swap. VENDO_API_KEY is the bearer token.">
-  <svg viewBox="0 0 720 132" width="100%" role="img" aria-label="createVendo calls the stock Anthropic provider, which calls the console gateway at /api/v1">
-    <g fill="none" stroke="currentColor" strokeOpacity="0.28" strokeWidth="1.25">
-      <rect x="1" y="34" width="196" height="64" rx="12" />
-      <rect x="262" y="34" width="196" height="64" rx="12" />
-      <rect x="523" y="34" width="196" height="64" rx="12" />
-    </g>
-    <g fill="currentColor" fontFamily="ui-monospace, monospace" fontSize="12.5">
-      <text x="20" y="62">createVendo()</text>
-      <text x="281" y="62">@ai-sdk/anthropic</text>
-      <text x="542" y="62">console.vendo.run</text>
-    </g>
-    <g fill="currentColor" fillOpacity="0.6" fontSize="11.5">
-      <text x="20" y="82">your composition</text>
-      <text x="281" y="82">stock provider, no fork</text>
-      <text x="542" y="82">/api/v1 · Messages wire</text>
-    </g>
-    <g stroke="currentColor" strokeOpacity="0.45" strokeWidth="1.25" fill="none">
-      <path d="M205 66 h48" />
-      <path d="M243 61 l10 5 l-10 5" />
-      <path d="M466 66 h48" />
-      <path d="M504 61 l10 5 l-10 5" />
-    </g>
-    <g fill="currentColor" fillOpacity="0.6" fontSize="10.5" fontFamily="ui-monospace, monospace" textAnchor="middle">
-      <text x="229" y="28">baseURL</text>
-      <text x="490" y="28">VENDO_API_KEY</text>
-    </g>
-  </svg>
-</Frame>
+One provider, one base URL swap. `VENDO_API_KEY` is the bearer token.
+
+<CardGroup cols={3}>
+  <Card title="createVendo()">
+    Your composition. Hands `baseURL` to the provider.
+  </Card>
+  <Card title="@ai-sdk/anthropic">
+    Stock provider, no fork. Sends `VENDO_API_KEY`.
+  </Card>
+  <Card title="console.vendo.run">
+    `/api/v1` · Messages wire.
+  </Card>
+</CardGroup>
 
 The console speaks the Anthropic Messages wire, which is the whole reason the
 Anthropic provider serves it. Point the same provider at


### PR DESCRIPTION
## What

Replace every hand-authored inline-SVG diagram that used `<text>` with Mintlify `<Columns>`/`<Card>` or `<CardGroup>`. Mintlify strips those text nodes, so the diagrams already shipping on production docs render as empty boxes.

Fixes #1566.

## Why

PR #1561 left the two broken diagrams on `import-and-fork.mdx` alone as a separate change. Same sanitizer hits every labeled SVG on the docs site (19 diagrams across 12 files). The Columns/Card pattern from that PR already renders on desktop and mobile. Path-only logo SVGs are unchanged.

## Verification

- [x] `npx mintlify dev` from `docs-site/` — cards render with labels
- [x] Screenshots attached (if UI-affecting)

Before/after against live production vs local Mintlify:

- `import-and-fork` Travels / Stays behind (the reported empty boxes)
- `how-the-door-works` four-step flow
- `generated/apps` three layer cards
- mobile width (390px) on Travels / Stays behind, cards stack

No `@vendoai/*` code, no changeset.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces inline SVG diagrams that used text with Mintlify `Columns`/`Card`/`CardGroup` so labels render. Mintlify stripped `<text>` nodes before, so many diagrams showed as empty boxes in production; now they render consistently on desktop and mobile.

**Notes for review**
- Converts 19 labeled diagrams across 12 `.mdx` files from `<svg><text>` to Mintlify `Columns`/`Card`/`CardGroup`; path-only logo SVGs stay unchanged.
- Fixes the broken diagrams on `generated/import-and-fork.mdx`; similar patterns updated in `how-the-door-works`, `generated/apps`, and others.
- Verified locally via `npx mintlify dev`; cards render with labels and stack on mobile (~390px).
- Docs-only change: no `@vendoai/*` code, no changeset.
- Author guidance: for labeled diagrams, use `Card`, `Columns`, or `CardGroup`; avoid inline SVG text.

<sup>Written for commit e83a392ce9074d80802ea80da90e1506353c5610. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1611?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

