### PR TITLE
feat(vendo,ui,apps): serve and render the sealed bundle (built apps S5/7)

### DIFF
--- a/.changeset/creations-bundle-route-and-frame.md
+++ b/.changeset/creations-bundle-route-and-frame.md
@@ -1,0 +1,7 @@
+---
+"@vendoai/vendo": minor
+"@vendoai/apps": minor
+"@vendoai/ui": minor
+---
+
+Built apps: rendering a sealed bundle. An app whose artifact is a seal opens as `{kind:"bundle", entry}` and is served by the new `GET /apps/:id/bundle/:hash` — the sealed bytes inline in their own document, behind `Content-Security-Policy: default-src 'none'` as a real header, so the frame makes no network request at all. `@vendoai/ui` renders it in an iframe sandboxed `allow-scripts` with no `allow-same-origin`, which makes the app's origin opaque: brand tokens are posted in at render rather than baked into the seal, and host data reaches the app through one door only — a postMessage call that lands on the same guarded tool path a screen's press does, with the viewer's own permissions.

--- a/examples/demo-bank/src/app/vendo/apps/page.tsx
+++ b/examples/demo-bank/src/app/vendo/apps/page.tsx
@@ -46,6 +46,7 @@ function OpenApp({ appId }: { appId: AppId }) {
           {surface ? (
             <AppFrame
               key={appId}
+              appId={appId}
               surface={surface}
               components={hostComponentMap(mapleRegistry)}
               onAction={({ action, payload }) => client.apps.call(appId, action, payload ?? {})}

--- a/packages/apps/src/contract/wire-types.ts
+++ b/packages/apps/src/contract/wire-types.ts
@@ -36,6 +36,10 @@ export interface AppListRow extends AppDocument {
 export type OpenSurface =
   | { kind: "tree"; payload: UIPayload; components?: Record<string, string> }
   | { kind: "http"; url: string }
+  /** A SEALED bundle. `entry` is the content hash of the file the frame boots,
+   *  so it is both the address to fetch (`GET /apps/:id/bundle/:hash`) and the
+   *  frame's remount key. */
+  | { kind: "bundle"; entry: string }
   | { kind: "resuming"; cover?: string }
   /**
    * The build turn terminally FAILED (model error, quota, timeout): the app

--- a/packages/apps/src/server/doors/build-door.ts
+++ b/packages/apps/src/server/doors/build-door.ts
@@ -28,7 +28,7 @@ import {
   buildWatchdogMs,
   fallbackAppName,
 } from "./build-messages.js";
-import { sealBundleBlobs } from "../persistence/app-source.js";
+import { readBundleBlob, sealBundleBlobs } from "../persistence/app-source.js";
 import { APPS_COLLECTION, appRecordInput } from "../persistence/persistence.js";
 import type { AppsRuntimeContext } from "../runtime/runtime-context.js";
 import type { AppsRuntime } from "../runtime/types.js";
@@ -68,9 +68,53 @@ export interface SealInput {
   base?: string;
 }
 
-/** The public door (`AppsRuntime.build`) plus the two hooks only the runtime's
- *  own seams reach: the decision subscriber's, and the build lane's. */
-export type BuildDoor = AppsRuntime["build"] & {
+/**
+ * THE ENFORCER a sealed bundle renders behind, and the reason the frame needs no
+ * trust: `default-src 'none'` is zero network — the bundle was sealed with
+ * everything it needs, so it has nothing to fetch and nowhere to phone home to.
+ * The two `'unsafe-inline'`s are what let the document carry its own script and
+ * styles at all, which is the point: nothing is loaded, so nothing can be
+ * injected from outside.
+ *
+ * It is a HEADER and never a `<meta>` tag, because `frame-ancestors` — the half
+ * that says only the host's own page may frame this — is ignored in meta.
+ */
+export const BUNDLE_CSP = "default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline';"
+  + " img-src data:; frame-ancestors 'self'";
+
+export const BUNDLE_HEADERS: Readonly<Record<string, string>> = {
+  "content-type": "text/html; charset=utf-8",
+  "content-security-policy": BUNDLE_CSP,
+  // The url IS the content's hash, so these bytes can never become stale.
+  // `private` because the answer is viewer-scoped: a shared cache must not hand
+  // one person's app to the next request for the same url.
+  "cache-control": "private, max-age=31536000, immutable",
+  "x-content-type-options": "nosniff",
+};
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+/**
+ * The frame's whole document: the sealed entry INLINE, and nothing else to
+ * fetch. Brand tokens and fonts are not in here — they arrive by postMessage at
+ * render (`sendFrameTheme`), so one seal follows the host's palette instead of
+ * pinning the palette it was built under.
+ */
+export function bundleDocument(entry: Uint8Array): Uint8Array {
+  // A bundle carries markup in its own strings, and a raw `</script` inside an
+  // inline script ends the script early — the app that renders HTML snippets
+  // would ship broken.
+  const script = decoder.decode(entry).split("</script").join("<\\/script");
+  return encoder.encode('<!doctype html><meta charset="utf-8">'
+    + "<style>html,body{margin:0;background:transparent}</style>"
+    + '<div id="root"></div>'
+    + `<script type="module">${script}</script>`);
+}
+
+/** The public door (`AppsRuntime.build`) plus the hooks only the runtime's
+ *  own seams reach: the decision subscriber's, the build lane's, and the wire's. */
+export type BuildDoor = AppsRuntime["build"] & Pick<AppsRuntime, "bundleDocument"> & {
   /** THE resume hook: what `onApprovalDecision` fires into, and the only caller
    *  of the builder there is. */
   resume(approvalId: ApprovalId, approved: boolean): Promise<void>;
@@ -82,10 +126,10 @@ export type BuildDoor = AppsRuntime["build"] & {
 export const createBuildDoor = (
   deps: Pick<AppsRuntimeContext,
     "config" | "engine" | "parkedBuilds" | "updateAppDocument" | "history" | "pruneHistory"
-    | "markUnbuilt" | "rungFor">,
+    | "markUnbuilt" | "rungFor" | "requireOwned">,
 ): BuildDoor => {
   const { config, engine, parkedBuilds, updateAppDocument, history, pruneHistory } = deps;
-  const { markUnbuilt, rungFor } = deps;
+  const { markUnbuilt, rungFor, requireOwned } = deps;
   const builder = config.build;
 
   /**
@@ -141,8 +185,27 @@ export const createBuildDoor = (
     return bundle;
   };
 
+  /**
+   * The render read. `viewer` is the level, exactly as the served door's was: a
+   * person who may SEE a shared app may render it, and one who may not is
+   * masked with the not-found every other app door gives them.
+   *
+   * The hash is checked against its own shape before it becomes a blob key —
+   * it arrives from a URL path segment, and a key is not a place to discover
+   * what "`..`" means.
+   */
+  const serveBundle: BuildDoor["bundleDocument"] = async (appId, hex, ctx) => {
+    await requireOwned(appId, ctx, "viewer");
+    const bytes = config.files === undefined || !/^[0-9a-f]{64}$/.test(hex)
+      ? null
+      : await readBundleBlob(appId, hex, config.files);
+    if (bytes === null) throw new VendoError("not-found", `app ${appId} has no sealed file ${hex}`);
+    return bundleDocument(bytes);
+  };
+
   return {
     available: () => builder?.available() ?? false,
+    bundleDocument: serveBundle,
 
     async propose(input, ctx) {
       const guardCtx: RunContext = { ...ctx, appId: input.appId };

--- a/packages/apps/src/server/index.ts
+++ b/packages/apps/src/server/index.ts
@@ -115,6 +115,10 @@ export { updateAppRow } from "./persistence/persistence.js";
 // same failures — and would surface the provider's raw words, which this one
 // deliberately never does.
 export { buildFailureReason } from "./doors/build-messages.js";
+// The sealed bundle's response headers. Public because the ROUTE that serves
+// them lives in the umbrella (`wire/apps.ts`), and a wire that restated the CSP
+// would be a second copy of the one enforcer a rendered bundle has.
+export { BUNDLE_CSP, BUNDLE_HEADERS } from "./doors/build-door.js";
 // The hot-path render seam (§1.6) — the commit-intercepting wrap that paints a
 // landing `app.tsx`. Public because the workspace it wraps lives
 // outside this package: composition fills the harness runtime's `wrapWorkspace`

--- a/packages/apps/src/server/persistence/open.ts
+++ b/packages/apps/src/server/persistence/open.ts
@@ -172,6 +172,12 @@ const serveOpenApp = (
       ...(app.buildFailed.prompt === undefined ? {} : { prompt: app.buildFailed.prompt }),
     };
   }
+  // FINAL SPEC v1 — a sealed bundle IS the app: the hash is all the surface
+  // needs, because the bytes are immutable and the frame fetches them itself
+  // (`GET /apps/:id/bundle/:hash`, behind BUNDLE_CSP).
+  if (app.ui === "bundle" && app.bundle !== undefined) {
+    return { kind: "bundle", entry: app.bundle.entry };
+  }
   if (app.ui === "http") {
     // A served document without a machine has NO surface anywhere (a v1-era
     // import or a de-graduated doc): say so instead of a confusing wake error.

--- a/packages/apps/src/server/runtime/runtime.ts
+++ b/packages/apps/src/server/runtime/runtime.ts
@@ -51,6 +51,7 @@ export const createApps = (config: AppsConfig): AppsRuntime => {
     takeReplaySource: ctx.takeReplaySource,
     seed: createSeedSurface(ctx),
     build: ctx.build,
+    bundleDocument: ctx.build.bundleDocument,
     machine: createMachineSurface(ctx),
   };
   return runtime;

--- a/packages/apps/src/server/runtime/types.ts
+++ b/packages/apps/src/server/runtime/types.ts
@@ -371,6 +371,9 @@ export interface VersionEntry {
 export type OpenSurface =
   | { kind: "tree"; payload: UIPayload; components?: Record<string, string> }
   | { kind: "http"; url: string }
+  /** A SEALED bundle. `entry` is the content hash of the file the frame boots,
+   *  so it is both the address to fetch and the frame's remount key. */
+  | { kind: "bundle"; entry: string }
   | { kind: "resuming"; cover?: string }
   /**
    * The build turn terminally FAILED (model error, quota, timeout): the app
@@ -719,6 +722,13 @@ export interface AppsRuntime {
    * every other caller gets. The pending kind is reachable only through it.
    */
   open(appId: AppId, ctx: RunContext, options?: { pending?: boolean }): Promise<OpenSurface | PendingSurface>;
+  /**
+   * FINAL SPEC v1 — the other half of a `{kind:"bundle"}` open: the sealed file
+   * named by `hash`, wrapped in the document the frame renders it as. Served
+   * behind {@link BUNDLE_CSP} (doors/build-door.ts), and viewer-scoped like
+   * every other read of an app.
+   */
+  bundleDocument(appId: AppId, hash: string, ctx: RunContext): Promise<Uint8Array>;
   call(appId: AppId, ref: string, args: Json, ctx: RunContext): Promise<ToolOutcome>;
   exportApp(appId: AppId, ctx: RunContext): Promise<Uint8Array>;
   importApp(source: Uint8Array | AppDocument, ctx: RunContext): Promise<AppDocument>;

--- a/packages/ui/src/chrome/embeds.tsx
+++ b/packages/ui/src/chrome/embeds.tsx
@@ -444,6 +444,9 @@ export function VendoAppEmbed({ refValue }: VendoAppEmbedProps) {
           ) : shown !== undefined ? (
             <AppFrame
               surface={shown}
+              // A sealed bundle is addressed by app — its frame's src is
+              // `/apps/<id>/bundle/<hash>`, so the id is not optional here.
+              appId={activeAppId}
               components={components}
               onParked={approval.onParked}
               // Actions bind to the app actually being SHOWN: after a retry

--- a/packages/ui/src/chrome/vendo-slot.tsx
+++ b/packages/ui/src/chrome/vendo-slot.tsx
@@ -219,7 +219,7 @@ function MountedApp({ appId, placement, onParked }: { appId: string; placement?:
     if (error && !isLoading) return <SlotLoadFailed reason={error} onRetry={() => void refresh()} />;
     return <SlotGhost label="Loading app…" loading appId={appId} />;
   }
-  return <AppFrame key={appId} surface={surface} components={components} keepalive={keepalive} onParked={onParked} onAction={({ action, payload }) => client.apps.call(appId, action, payload ?? {})} />;
+  return <AppFrame key={appId} appId={appId} surface={surface} components={components} keepalive={keepalive} onParked={onParked} onAction={({ action, payload }) => client.apps.call(appId, action, payload ?? {})} />;
 }
 
 /** A generated view pinned into a slot (08-ui §4 — "or a pinned component").

--- a/packages/ui/src/client-impl.ts
+++ b/packages/ui/src/client-impl.ts
@@ -256,6 +256,7 @@ export function createVendoClient(config: VendoClientConfig): VendoClient {
       seedFrom: body => json("/apps/seed", "POST", body),
       courierProps: (id, props) => json(`/apps/${idPath(id)}/props`, "POST", { props }),
       pingMachine: id => json(`/apps/${idPath(id)}/machine/ping`, "POST"),
+      bundleUrl: (id, entry) => joinPath(baseUrl, `/apps/${idPath(id)}/bundle/${idPath(entry)}`),
       place: (id, slot) => json(`/apps/${idPath(id)}/place`, "POST", { slot }),
       unplace: async (id, slot) => {
         await json(`/apps/${idPath(id)}/unplace`, "POST", { slot });

--- a/packages/ui/src/client.ts
+++ b/packages/ui/src/client.ts
@@ -171,6 +171,16 @@ export interface VendoClient {
      */
     pingMachine(id: AppId): Promise<{ state: "awake" | "woke" }>;
     /**
+     * `GET /apps/:id/bundle/:entry` — where a SEALED bundle's document lives.
+     *
+     * A url rather than a fetch, because the browser is what asks: it is an
+     * iframe's `src`, so the response's own CSP header (`default-src 'none'`,
+     * `frame-ancestors 'self'`) is what governs the document — which is exactly
+     * why the bundle is not inlined as `srcdoc`. `entry` is the content hash, so
+     * the url never goes stale.
+     */
+    bundleUrl(id: AppId, entry: string): string;
+    /**
      * Placement (2026-08-05) — "show this app in that slot". `POST
      * /apps/:id/place`; one app per slot, so the answer names whatever the
      * write displaced (`evicted`).

--- a/packages/ui/src/embedded-runtime.ts
+++ b/packages/ui/src/embedded-runtime.ts
@@ -19,6 +19,7 @@
  * pushes the host's layout. The clamp is the host's, and so is the min/max the
  * host configured.
  */
+import type { Json, ToolOutcome } from "@vendoai/core";
 import { normalizeViewportBlockCss } from "./tree/viewport-css.js";
 
 /** Post one message to the embedding host. Every message is stamped `vendo: true`
@@ -44,6 +45,41 @@ export function applyThemeVars(vars: unknown): void {
   document.body.style.fontSize = "var(--vendo-font-size, 15px)";
 }
 
+/** The calls this surface is waiting on an answer to, by their own id. */
+const awaiting = new Map<string, (outcome: ToolOutcome) => void>();
+let calls = 0;
+
+/**
+ * THE ONE DOOR to host data (FINAL SPEC v1). A sealed surface has an opaque
+ * origin and no network at all, so this is the only thing it can reach — and
+ * what it reaches is the host's guarded tool door, run with the VIEWER's own
+ * permissions. Nothing here decides what is allowed; the guard does, and a call
+ * the viewer may not make comes back as a refused outcome like any other.
+ */
+export function callHost(ref: string, args: Json = null): Promise<ToolOutcome> {
+  const id = `call_${(calls += 1)}`;
+  return new Promise((resolve) => {
+    awaiting.set(id, resolve);
+    postToHost({ kind: "call", id, ref, args });
+  });
+}
+
+/**
+ * The host's half of the protocol, received. `event.source` is the gate on this
+ * side too — only the window that embedded this surface may theme it or answer
+ * for it, and that is the one thing a sender cannot forge.
+ */
+function receiveFromHost(event: MessageEvent): void {
+  if (event.source !== parent) return;
+  const message = event.data as { vendo?: unknown; kind?: unknown; vars?: unknown; id?: unknown; outcome?: unknown } | null;
+  if (typeof message !== "object" || message === null || message.vendo !== true) return;
+  if (message.kind === "theme") applyThemeVars(message.vars);
+  if (message.kind === "result" && typeof message.id === "string") {
+    awaiting.get(message.id)?.(message.outcome as ToolOutcome);
+    awaiting.delete(message.id);
+  }
+}
+
 const VIEWPORT_BLOCK_UNIT = /(?:d|s|l)?v(?:h|b)(?![a-z])/iu;
 const VIEWPORT_BLOCK_PROPERTIES = ["height", "min-height", "block-size", "min-block-size"] as const;
 
@@ -52,10 +88,14 @@ const VIEWPORT_BLOCK_PROPERTIES = ["height", "min-height", "block-size", "min-bl
  * constraints, report the content height on every content change, and announce
  * `booted` once the observers are live.
  *
- * Messages out: `{ vendo: true, kind: "resize", height }` and
- * `{ vendo: true, kind: "booted" }`. Nothing else, ever.
+ * Messages out: `{ vendo: true, kind: "resize", height }`,
+ * `{ vendo: true, kind: "booted" }`, and one `{ kind: "call" }` per
+ * {@link callHost}. In: `theme` and `result`.
  */
 export function startFrameProtocol(mount: HTMLElement, post = postToHost): void {
+  // Before `booted`: the host answers that announcement with the brand tokens,
+  // so a listener installed after it would miss them.
+  addEventListener("message", receiveFromHost);
   let lastReportedHeight: number | undefined;
   let mutationObserver: MutationObserver | undefined;
 

--- a/packages/ui/src/kit/index.ts
+++ b/packages/ui/src/kit/index.ts
@@ -155,7 +155,7 @@ export { KIT_CSS, ensureKitStyles } from "./kit-css.js";
 // it — reachable from a generated app's box, where `@vendoai/ui`'s root barrel
 // (the client, the surfaces, the voice stage) is not what an app should import.
 export { defaultVendoTheme, resolveTheme, themeCssVariables } from "../theme.js";
-export { applyThemeVars, postToHost, startFrameProtocol } from "../embedded-runtime.js";
+export { applyThemeVars, callHost, postToHost, startFrameProtocol } from "../embedded-runtime.js";
 
 // ---------------------------------------------------------------------------
 // The code-land runtime (blueprint §5.4) — what a generated app imports inside

--- a/packages/ui/src/tree/frame-bridge.ts
+++ b/packages/ui/src/tree/frame-bridge.ts
@@ -1,0 +1,70 @@
+/**
+ * The postMessage bridge to a SEALED bundle — the one door between a built app
+ * and the host (FINAL SPEC v1).
+ *
+ * A bundle frame is sandboxed `allow-scripts` with no `allow-same-origin`, so
+ * its origin is OPAQUE: it can reach nothing of the host's, it can make no
+ * network request of its own (`default-src 'none'`), and postMessage is the
+ * only thing it can say. Which makes this module the whole attack surface, so
+ * it holds exactly three moves and no policy of its own:
+ *
+ *  - `readFrameCall` — what came in, and only if the frame we rendered sent it.
+ *    The identity gate is `isFromFrame`, shared with the resize protocol,
+ *    because a second copy of a security gate is a second gate to get wrong.
+ *  - `replyToFrame` — the outcome of that call, back.
+ *  - `sendFrameTheme` — the host's brand tokens, at render.
+ *
+ * What a call is ALLOWED to do is decided nowhere near here: the frame's call
+ * rides `AppFrameProps.onAction` → `client.apps.call` → the guard, with the
+ * viewer's own permissions, exactly as a tree surface's press does.
+ */
+import type { Json, ToolOutcome } from "@vendoai/core";
+import { isFromFrame } from "./frame-resize.js";
+
+/** One call a framed bundle is making of the host. `id` is the frame's own
+ *  correlation token, echoed back on the result and nothing more. */
+export interface FrameCall {
+  id: string;
+  ref: string;
+  args: Json;
+}
+
+/** Only `--vendo-*` custom properties may cross into an embedded surface (06 §5)
+ *  — filtered on the way OUT as well as on the way in, so a host token that is
+ *  not brand vocabulary never leaves the page. */
+const VENDO_VAR = /^--vendo-[a-z0-9-]+$/;
+
+/**
+ * Every message out goes to `"*"`. That is not laxity: an opaque origin
+ * serializes to "null" and matches no `targetOrigin` but the wildcard, so a
+ * stricter value here would silently deliver nothing. Nothing secret travels
+ * this way — a result the frame's own call earned, and the brand tokens.
+ */
+function postToFrame(frame: HTMLIFrameElement | null, message: Record<string, unknown>): void {
+  frame?.contentWindow?.postMessage({ vendo: true, ...message }, "*");
+}
+
+/** The inbound call, or `undefined` for anything that is not a well-formed,
+ *  Vendo-stamped call from THIS frame. */
+export function readFrameCall(frame: HTMLIFrameElement | null, event: MessageEvent): FrameCall | undefined {
+  if (!isFromFrame(frame, event)) return undefined;
+  const data = event.data as Record<string, unknown> | null;
+  if (typeof data !== "object" || data === null || data.vendo !== true || data.kind !== "call") return undefined;
+  const { id, ref, args } = data;
+  if (typeof id !== "string" || typeof ref !== "string") return undefined;
+  return { id, ref, args: (args ?? null) as Json };
+}
+
+/** The outcome of one call, back to the frame that made it. */
+export function replyToFrame(frame: HTMLIFrameElement | null, id: string, outcome: ToolOutcome): void {
+  postToFrame(frame, { kind: "result", id, outcome });
+}
+
+/** The host's brand tokens, injected AT RENDER — never baked into the seal, so
+ *  one sealed bundle follows whatever palette the host is wearing today. */
+export function sendFrameTheme(frame: HTMLIFrameElement | null, vars: Record<string, string>): void {
+  postToFrame(frame, {
+    kind: "theme",
+    vars: Object.fromEntries(Object.entries(vars).filter(([name]) => VENDO_VAR.test(name))),
+  });
+}

--- a/packages/ui/src/tree/frames.tsx
+++ b/packages/ui/src/tree/frames.tsx
@@ -1,7 +1,10 @@
-import { Component, useEffect, useRef, type ComponentType, type ErrorInfo, type ReactNode } from "react";
+import { Component, useEffect, useMemo, useRef, type ComponentType, type ErrorInfo, type ReactNode } from "react";
 import type { Json, ToolOutcome, UIPayload } from "@vendoai/core";
 import type { OpenSurface } from "../wire-types.js";
-import { applyFrameResize, FRAME_MAX_HEIGHT_CSS } from "./frame-resize.js";
+import { useVendoProvider } from "../context.js";
+import { themeCssVariables } from "../theme.js";
+import { applyFrameResize, isFromFrame, FRAME_MAX_HEIGHT_CSS } from "./frame-resize.js";
+import { readFrameCall, replyToFrame, sendFrameTheme } from "./frame-bridge.js";
 import { ContainedNotice } from "./notice.js";
 import { PayloadView, type ParkedPress } from "./renderer.js";
 import { Skeleton } from "./forming-skeleton.js";
@@ -165,10 +168,74 @@ function HttpFrame({ url, keepalive }: { url: string; keepalive?: AppFrameKeepal
   );
 }
 
+/**
+ * A SEALED bundle (FINAL SPEC v1) — the app's own document, served by
+ * `GET /apps/:id/bundle/:hash` behind `default-src 'none'`.
+ *
+ * `allow-scripts` WITHOUT `allow-same-origin` is the enforcer: it gives the
+ * frame an opaque origin, so the app runs in nobody's origin, reaches no host
+ * storage or cookie, and — with the route's CSP — makes no request at all. Host
+ * data reaches it through one door only, the postMessage bridge below, which
+ * lands on the same guarded `onAction` a tree surface's press does.
+ *
+ * The seal is content, never brand: the tokens are posted in at boot, so the
+ * same bytes follow whatever palette the host is wearing today.
+ */
+function BundleFrame({ appId, entry, onAction }: {
+  appId: string;
+  entry: string;
+  onAction: NonNullable<AppFrameProps["onAction"]>;
+}) {
+  const { client, theme } = useVendoProvider();
+  const frameRef = useRef<HTMLIFrameElement | null>(null);
+  const vars = useMemo(() => themeCssVariables(theme), [theme]);
+  useEffect(() => {
+    if (typeof window === "undefined") return undefined;
+    const onMessage = (event: MessageEvent) => {
+      const frame = frameRef.current;
+      if (applyFrameResize(frame, event)) return;
+      // The handshake: a frame that has not booted has no listener yet, so the
+      // tokens would land on nobody.
+      if ((event.data as { vendo?: unknown; kind?: unknown } | null)?.kind === "booted" && isFromFrame(frame, event)) {
+        sendFrameTheme(frame, vars);
+        return;
+      }
+      const call = readFrameCall(frame, event);
+      if (call === undefined) return;
+      void onAction({ nodeId: call.id, action: call.ref, payload: call.args })
+        .then((outcome) => replyToFrame(frame, call.id, outcome));
+    };
+    window.addEventListener("message", onMessage);
+    return () => window.removeEventListener("message", onMessage);
+  }, [onAction, vars]);
+  return (
+    <iframe
+      // The entry IS the content hash, so fresh bytes are a fresh frame.
+      key={entry}
+      ref={frameRef}
+      title="Vendo app"
+      src={client.apps.bundleUrl(appId, entry)}
+      sandbox="allow-scripts"
+      style={{
+        width: "100%",
+        minHeight: "var(--vendo-app-frame-height, 320px)",
+        maxHeight: FRAME_MAX_HEIGHT_CSS,
+        border: 0,
+      }}
+    />
+  );
+}
+
 /** 08-ui §5; 06-apps §1 — render every app execution plane fail-soft. */
 export function AppFrame({ surface, appId, components = {}, data, onAction = unavailableAction, onParked, onStateChange, keepalive }: AppFrameProps) {
   if (surface.kind === "http") {
     return <HttpFrame url={surface.url} keepalive={keepalive} />;
+  }
+
+  // A bundle is addressed by app: without one there is no url to open, and a
+  // frame pointed at a guess is worse than an honest "unsupported" below.
+  if (surface.kind === "bundle" && appId !== undefined) {
+    return <BundleFrame appId={appId} entry={surface.entry} onAction={onAction} />;
   }
 
   if (surface.kind === "resuming") {

--- a/packages/ui/test/tree/bundle-frame.test.tsx
+++ b/packages/ui/test/tree/bundle-frame.test.tsx
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+/**
+ * The sealed bundle's frame, and the ONE door through it.
+ *
+ * A bundle runs with an OPAQUE origin (`allow-scripts` with no
+ * `allow-same-origin`), so postMessage is the only thing it can say to the host
+ * and `event.source` is the only thing about it the host can trust. Both halves
+ * of that are asserted here: the identity gate on the way in, and the sandbox
+ * token list on the frame itself.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, render, screen } from "@testing-library/react";
+import type { ToolOutcome } from "@vendoai/core";
+import { AppFrame } from "../../src/tree/index.js";
+import { readFrameCall, replyToFrame, sendFrameTheme } from "../../src/tree/frame-bridge.js";
+
+afterEach(() => {
+  cleanup();
+  document.body.innerHTML = "";
+  vi.restoreAllMocks();
+});
+
+/** A real iframe in the document, so `contentWindow` is a real other window. */
+function mount(): HTMLIFrameElement {
+  const frame = document.createElement("iframe");
+  document.body.appendChild(frame);
+  return frame;
+}
+
+const posted = (source: Window | null, data: unknown) =>
+  new MessageEvent("message", { source: source as MessageEventSource | null, data });
+
+const CALL = { vendo: true, kind: "call", id: "c1", ref: "listAccounts", args: { limit: 2 } };
+const OK: ToolOutcome = { status: "ok", output: { rows: [] } };
+
+describe("the frame bridge", () => {
+  it("reads a well-formed call from the frame itself", () => {
+    const frame = mount();
+    expect(readFrameCall(frame, posted(frame.contentWindow, CALL)))
+      .toEqual({ id: "c1", ref: "listAccounts", args: { limit: 2 } });
+  });
+
+  it("ignores a call from a DIFFERENT window (the identity gate)", () => {
+    const frame = mount();
+    const other = mount();
+    // Well-formed in every respect except who sent it. A second embed, an ad
+    // frame, or the host page itself must not be able to speak for this app —
+    // the call it makes runs with the VIEWER's own permissions.
+    expect(readFrameCall(frame, posted(other.contentWindow, CALL))).toBeUndefined();
+    expect(readFrameCall(frame, posted(window, CALL))).toBeUndefined();
+    expect(readFrameCall(frame, posted(null, CALL))).toBeUndefined();
+    expect(readFrameCall(null, posted(null, CALL))).toBeUndefined();
+  });
+
+  it("ignores an unstamped message, a foreign kind, and a malformed envelope", () => {
+    const frame = mount();
+    const framed = frame.contentWindow;
+    for (const data of [
+      { ...CALL, vendo: false },
+      { kind: "call", id: "c1", ref: "x", args: {} },
+      { vendo: true, kind: "resize", height: 400 },
+      { vendo: true, kind: "call", ref: "x", args: {} },
+      { vendo: true, kind: "call", id: "c1", args: {} },
+      { vendo: true, kind: "call", id: 7, ref: "x", args: {} },
+      "call",
+      null,
+    ]) {
+      expect(readFrameCall(frame, posted(framed, data)), JSON.stringify(data)).toBeUndefined();
+    }
+  });
+
+  it("replies to the frame's OPAQUE origin, which only \"*\" matches", () => {
+    const frame = mount();
+    const post = vi.spyOn(frame.contentWindow!, "postMessage");
+    replyToFrame(frame, "c1", OK);
+    expect(post).toHaveBeenCalledWith({ vendo: true, kind: "result", id: "c1", outcome: OK }, "*");
+  });
+
+  it("sends brand tokens and nothing else — only --vendo-* may cross", () => {
+    const frame = mount();
+    const post = vi.spyOn(frame.contentWindow!, "postMessage");
+    sendFrameTheme(frame, { "--vendo-color-accent": "#0a7", "--host-secret": "leak", color: "red" });
+    expect(post).toHaveBeenCalledWith(
+      { vendo: true, kind: "theme", vars: { "--vendo-color-accent": "#0a7" } },
+      "*",
+    );
+  });
+});
+
+describe("BundleFrame", () => {
+  const surface = { kind: "bundle", entry: "a".repeat(64) } as const;
+
+  it("renders the sealed bundle with an OPAQUE origin: allow-scripts and nothing else", () => {
+    render(<AppFrame surface={surface} appId="app_built" />);
+    const frame = screen.getByTitle("Vendo app") as HTMLIFrameElement;
+    // `allow-same-origin` here would run the app in the HOST's origin, holding
+    // host storage, cookies and same-origin APIs — the one security rule.
+    expect(frame.getAttribute("sandbox")).toBe("allow-scripts");
+    expect(frame.getAttribute("src")).toBe(`/api/vendo/apps/app_built/bundle/${surface.entry}`);
+  });
+
+  it("sends the host's brand tokens once the frame reports booted", () => {
+    render(<AppFrame surface={surface} appId="app_built" />);
+    const frame = screen.getByTitle("Vendo app") as HTMLIFrameElement;
+    const post = vi.spyOn(frame.contentWindow!, "postMessage");
+
+    window.dispatchEvent(posted(frame.contentWindow, { vendo: true, kind: "booted" }));
+
+    const [theme] = post.mock.calls[0] as [{ kind: string; vars: Record<string, string> }];
+    expect(theme.kind).toBe("theme");
+    // Injected AT RENDER, never baked into the seal.
+    expect(theme.vars["--vendo-font-family"]).toBeTypeOf("string");
+    expect(Object.keys(theme.vars).every((name) => name.startsWith("--vendo-"))).toBe(true);
+  });
+
+  it("routes a frame call through onAction and posts the outcome back", async () => {
+    const onAction = vi.fn(async () => OK);
+    render(<AppFrame surface={surface} appId="app_built" onAction={onAction} />);
+    const frame = screen.getByTitle("Vendo app") as HTMLIFrameElement;
+    const post = vi.spyOn(frame.contentWindow!, "postMessage");
+
+    await act(async () => {
+      window.dispatchEvent(posted(frame.contentWindow, CALL));
+    });
+
+    // THE ONE DOOR: the same `onAction` the tree surface uses, which the slot
+    // binds to `client.apps.call` → the guard, with the viewer's permissions.
+    expect(onAction).toHaveBeenCalledWith({ nodeId: "c1", action: "listAccounts", payload: { limit: 2 } });
+    expect(post).toHaveBeenCalledWith({ vendo: true, kind: "result", id: "c1", outcome: OK }, "*");
+  });
+
+  it("fits the reported height through the shared resize gate", () => {
+    render(<AppFrame surface={surface} appId="app_built" />);
+    const frame = screen.getByTitle("Vendo app") as HTMLIFrameElement;
+    window.dispatchEvent(posted(frame.contentWindow, { vendo: true, kind: "resize", height: 512 }));
+    expect(frame.style.height).toBe("512px");
+  });
+});

--- a/packages/ui/test/tree/frame-protocol.seam.test.ts
+++ b/packages/ui/test/tree/frame-protocol.seam.test.ts
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+/**
+ * The frame protocol's SEAM: the inner half that a sealed bundle runs
+ * (`embedded-runtime.ts`) against the outer half the host runs
+ * (`tree/frame-bridge.ts`), with no restatement of the envelope on either side.
+ *
+ * The two halves live in one package and could each be "tested" against a
+ * hand-written copy of what the other sends — which is exactly how a protocol
+ * ships dead. So every envelope below is produced by one real half and consumed
+ * by the other.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ToolOutcome } from "@vendoai/core";
+import { callHost, startFrameProtocol } from "../../src/embedded-runtime.js";
+import { readFrameCall, replyToFrame, sendFrameTheme } from "../../src/tree/frame-bridge.js";
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  document.documentElement.removeAttribute("style");
+  vi.restoreAllMocks();
+});
+
+const OK: ToolOutcome = { status: "ok", output: { balance: 12 } };
+
+/** jsdom's top window IS its own `parent`, so the inner half's listener accepts
+ *  what this document dispatches — which is what a real host posts in. */
+const toFrame = (data: unknown) =>
+  window.dispatchEvent(new MessageEvent("message", { source: window, data }));
+
+describe("the frame protocol, both real halves", () => {
+  it("carries a call out and its outcome back", async () => {
+    startFrameProtocol(document.createElement("div"));
+    const out = vi.spyOn(parent, "postMessage");
+    const answer = callHost("listAccounts", { limit: 2 });
+
+    // What the INNER half actually posted, read by the OUTER half's gate.
+    const envelope = out.mock.calls.at(-1)?.[0];
+    const frame = document.createElement("iframe");
+    document.body.appendChild(frame);
+    const call = readFrameCall(frame, new MessageEvent("message", {
+      source: frame.contentWindow as MessageEventSource,
+      data: envelope,
+    }));
+    expect(call).toEqual({ id: expect.any(String), ref: "listAccounts", args: { limit: 2 } });
+
+    // …and the reply the OUTER half writes, delivered to the inner half.
+    const back = vi.spyOn(frame.contentWindow!, "postMessage");
+    replyToFrame(frame, call!.id, OK);
+    toFrame(back.mock.calls[0]![0]);
+    await expect(answer).resolves.toEqual(OK);
+  });
+
+  it("applies the brand tokens the host sends, and only those", () => {
+    startFrameProtocol(document.createElement("div"));
+    const frame = document.createElement("iframe");
+    document.body.appendChild(frame);
+    const out = vi.spyOn(frame.contentWindow!, "postMessage");
+
+    sendFrameTheme(frame, { "--vendo-color-accent": "#0a7", "--host-private": "leak" });
+    toFrame(out.mock.calls[0]![0]);
+
+    expect(document.documentElement.style.getPropertyValue("--vendo-color-accent")).toBe("#0a7");
+    expect(document.documentElement.style.getPropertyValue("--host-private")).toBe("");
+  });
+});

--- a/packages/vendo/src/build-agent.ts
+++ b/packages/vendo/src/build-agent.ts
@@ -84,6 +84,13 @@ ${request.why}
 
 HOW IT SHIPS
 - Write the source under ${directory}/src and install whatever npm packages it needs.
+- The document that serves your bundle is one <div id="root"></div>: mount into
+  that element, and once your first render is really in the DOM (an empty mount
+  measures as height 0, which the host renders as a collapsed frame) call
+  startFrameProtocol(mount) from @vendoai/ui/kit — install it like any other
+  package. That is what sizes the frame and applies the host's brand tokens, and
+  callHost(tool, args) from the same module is the only way to reach the host's
+  data.
 - Bundle it with esbuild to ${directory}/${ENTRY}: ONE self-contained file, no
   imports left at runtime and no network calls at all — the sealed bundle renders
   in an iframe where every request is blocked.

--- a/packages/vendo/src/wire/apps.ts
+++ b/packages/vendo/src/wire/apps.ts
@@ -1,3 +1,4 @@
+import { BUNDLE_HEADERS } from "@vendoai/apps";
 import { isVendoError, VendoError, type AccessLevel, type Json, type RunContext, type StoreOps } from "@vendoai/core";
 import { json, object, requestJson, route, string, type RouteEntry, type WireContext } from "./shared.js";
 
@@ -351,6 +352,13 @@ export const appRoutes: RouteEntry[] = [
     // the idle timer); "woke" tells the embed its URL is stale — re-open.
     if (op(wire, "POST", "machine", 4) && segments[3] === "ping") {
       return json(await deps.apps.machine.ping(appId, ctx));
+    }
+    // FINAL SPEC v1 — the sealed bundle's bytes, as the document the frame
+    // renders. `BUNDLE_HEADERS` carries the CSP that IS the frame's enforcer
+    // (zero network), so this route never assembles a header set of its own.
+    if (op(wire, "GET", "bundle", 4)) {
+      const bytes = await deps.apps.bundleDocument(appId, string(segments[3], "hash"), ctx);
+      return new Response(bytes as BodyInit, { headers: BUNDLE_HEADERS });
     }
     if (op(wire, "GET", "export")) {
       const bytes = await deps.apps.exportApp(appId, ctx);

--- a/packages/vendo/tests/build-lane.test.ts
+++ b/packages/vendo/tests/build-lane.test.ts
@@ -33,6 +33,7 @@ import { createGuard } from "@vendoai/guard";
 import { createSessionRoutes } from "@vendoai/harnesses/box-door";
 import { disposeSessionMachines, inferenceEnv } from "@vendoai/harnesses/claude-code/box";
 import { createStore, type VendoStore } from "@vendoai/store";
+import * as kit from "@vendoai/ui/kit";
 import { afterEach, describe, expect, it } from "vitest";
 import { appBuilder, BUILD_ALLOWED_DOMAINS } from "../src/build-agent.js";
 import { createVendo } from "../src/server.js";
@@ -44,6 +45,9 @@ const principal: Principal = { kind: "user", subject: "user_builder" };
 const ctx: RunContext = { principal, venue: "chat", presence: "present", sessionId: "session_builder" };
 
 const APP = "app_build_lane" as AppId;
+/** Where the brief sends the box for the frame protocol. This file imports it,
+ *  so a specifier that stopped resolving fails before any assertion runs. */
+const KIT_SPECIFIER = "@vendoai/ui/kit";
 const ASK = "a photo editor that crops and rotates";
 const WHY = "this needs a real image library";
 
@@ -247,6 +251,32 @@ describe("a consented build runs the box and seals what it made", () => {
     // The source and the lockfile came home beside it.
     expect(Object.keys(bundle.assets).sort()).toEqual(["package-lock.json", "src/index.ts"]);
     expect(row["buildFailed"]).toBeUndefined();
+  });
+
+  it("briefs the box to speak the frame protocol the served shell and the host half define", async () => {
+    // The seam this closes: the brief is the ONLY thing that tells the in-box
+    // agent to mount where the shell mounts and to start the protocol the host
+    // is already listening to. Both sides are read from the real thing — the
+    // mount point off the document the door really serves, the two entry points
+    // off the module the box really installs — so a rename on either side is a
+    // red test and not a bundle that renders and then sits there.
+    const sandbox = scriptedSandbox(buildsFine);
+    const harness = setup(sandbox);
+    await decide(harness, await propose(harness));
+    const row = await settled(harness);
+
+    const brief = sandbox.boxes[0]!.prompts[0] ?? "";
+    const shell = decoder.decode(await harness.runtime.bundleDocument(
+      APP, (row["bundle"] as { entry: string }).entry, ctx));
+    const mountId = /id="([^"]+)"/u.exec(shell)?.[1] ?? "";
+    expect(mountId).not.toBe("");
+    expect(brief).toContain(mountId);
+
+    for (const name of ["startFrameProtocol", "callHost"] as const) {
+      expect(kit[name]).toBeTypeOf("function");
+      expect(brief).toContain(name);
+    }
+    expect(brief).toContain(KIT_SPECIFIER);
   });
 
   it("hands the box ZERO store credentials and only the registry to reach", async () => {

--- a/packages/vendo/tests/bundle-route.seam.test.ts
+++ b/packages/vendo/tests/bundle-route.seam.test.ts
@@ -1,0 +1,114 @@
+/**
+ * The sealed bundle's RENDER seam, end to end through REAL paths.
+ *
+ * Three halves have to agree about one app: the seal writes content-addressed
+ * blobs (`sealBundleBlobs`), the open door names the entry hash the frame should
+ * boot (`{kind:"bundle", entry}`), and the wire route serves those bytes wrapped
+ * in the document that renders them. A suite that stubbed any of the three could
+ * only agree with itself, so everything below goes through the real writer, a
+ * real store, and the real `createVendo` handler — no stand-in anywhere.
+ *
+ * What is really on trial is the CSP, asserted byte for byte: it is the enforcer
+ * the whole "sealed bundles need no network" promise rests on, and it is a
+ * HEADER rather than a meta tag because `frame-ancestors` only exists there.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { sealBundleBlobs } from "@vendoai/apps";
+import { VENDO_APP_FORMAT, type AppBundle, type AppId, type Principal } from "@vendoai/core";
+import { createStore, storeFiles } from "@vendoai/store";
+import type { LanguageModel } from "ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { createVendo, type Vendo } from "../src/server.js";
+
+const CSP = "default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline';"
+  + " img-src data:; frame-ancestors 'self'";
+
+const ADA: Principal = { kind: "user", subject: "user_ada" };
+const APP = "app_built" as AppId;
+/** A built bundle carries markup in its own strings, and a raw `</script>` in an
+ *  inline script ends the script — so the shell has to escape it or the app that
+ *  renders a table of HTML snippets ships broken. */
+const ENTRY_BYTES = new TextEncoder().encode('const closer = "</script>";\ndocument.title = "built";\n');
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+async function setup(): Promise<{ vendo: Vendo; bundle: AppBundle }> {
+  const dataDir = await mkdtemp(join(tmpdir(), "vendo-bundle-route-"));
+  const store = createStore({ dataDir });
+  cleanups.push(async () => {
+    await store.close();
+    await rm(dataDir, { recursive: true, force: true });
+  });
+  await store.ensureSchema();
+  // THE REAL SEAL: the same writer the build door lands a box's output through.
+  const bundle = await sealBundleBlobs(
+    APP,
+    [{ path: "dist/app.js", bytes: ENTRY_BYTES }],
+    "dist/app.js",
+    storeFiles(store),
+  );
+  await store.records("vendo_apps").put({
+    id: APP,
+    data: {
+      subject: ADA.subject,
+      enabled: true,
+      doc: { format: VENDO_APP_FORMAT, id: APP, name: "Built app", ui: "bundle", bundle },
+    },
+    refs: { subject: ADA.subject },
+  });
+  const vendo = createVendo({
+    models: { default: {} as LanguageModel },
+    principal: async (request) => {
+      const subject = request.headers.get("x-test-user");
+      return subject === null ? null : { kind: "user", subject };
+    },
+    store,
+  });
+  return { vendo, bundle };
+}
+
+const get = (vendo: Vendo, path: string, subject?: string): Promise<Response> =>
+  vendo.handler(new Request(`http://wire.test/api/vendo${path}`, {
+    headers: subject === undefined ? {} : { "x-test-user": subject },
+  }));
+
+describe("the sealed bundle's render seam", () => {
+  it("opens as a bundle surface and serves those exact bytes inline, behind the CSP", async () => {
+    const { vendo, bundle } = await setup();
+
+    // The open door names the hash — which IS the frame's remount key.
+    const surface = await (await get(vendo, `/apps/${APP}/open`, ADA.subject)).json();
+    expect(surface).toEqual({ kind: "bundle", entry: bundle.entry });
+
+    const response = await get(vendo, `/apps/${APP}/bundle/${bundle.entry}`, ADA.subject);
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-security-policy")).toBe(CSP);
+    expect(response.headers.get("content-type")).toContain("text/html");
+
+    const document_ = await response.text();
+    // INLINE, so the frame fetches nothing — `default-src 'none'` blocks every
+    // request it could make, including one back for its own script.
+    expect(document_).toContain('document.title = "built";');
+    expect(document_).not.toContain("<script src");
+    // …and the bundle's own `</script>` did not end the script tag early.
+    expect(document_.split("</script>")).toHaveLength(2);
+  });
+
+  it("is viewer-scoped: a stranger gets not-found, never the bytes", async () => {
+    const { vendo, bundle } = await setup();
+    const response = await get(vendo, `/apps/${APP}/bundle/${bundle.entry}`, "user_bob");
+    expect(response.status).toBe(404);
+    expect(await response.text()).not.toContain("document.title");
+  });
+
+  it("answers not-found for a hash this app never sealed", async () => {
+    const { vendo } = await setup();
+    const response = await get(vendo, `/apps/${APP}/bundle/${"0".repeat(64)}`, ADA.subject);
+    expect(response.status).toBe(404);
+  });
+});


### PR DESCRIPTION
> Stacked on #1610. Review only the top commits; the stack merges once at the tip.

## What & why

Slice 5 of 7 in the **built apps** stack: serve a sealed bundle over the wire and render it in a frame that can do nothing except talk back through one door.

Every wall here has a named enforcer, per the spec:
- **Browser origin isolation** — `sandbox="allow-scripts"` with **no** `allow-same-origin`, so the frame gets an opaque origin and cannot touch the host page. Asserted as exact string equality, so adding a token fails the test.
- **CSP, as a real header** (not a meta tag): `default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data:; frame-ancestors 'self'`. Asserted byte-for-byte.
- **One door** — a frame call goes `postMessage` → `onAction` → `client.apps.call` → `POST /apps/:id/call` → the **guard**, with the viewer's own permissions. That whole chain is reused unchanged.

Brand tokens are injected **at render**, posted in on the frame's `booted` handshake from the live provider theme. Nothing brand-related is in the sealed bytes.

## Added
- `build-door.ts`: `BUNDLE_CSP`, `BUNDLE_HEADERS`, `bundleDocument(entry)` (HTML shell + inline bundle, no fetches), and viewer-scoped `AppsRuntime.bundleDocument`.
- `vendo/wire/apps.ts`: `GET /apps/:id/bundle/:hash`.
- `ui/tree/frame-bridge.ts`: `readFrameCall` (event.source gate), `replyToFrame` (opaque origin ⇒ `"*"`), `sendFrameTheme` (`--vendo-*` only).
- `ui/tree/frames.tsx`: `BundleFrame`. `embedded-runtime.ts`: `callHost` + theme/result kinds.
- `open.ts` / `wire-types.ts`: the `bundle` surface, added beside `http` (removal is S7's).

## The seam this nearly shipped broken
S5 built the host half of the frame protocol; S4's build brief never told the in-box agent to use it. Two halves written against each other, each assuming the other — the exact failure CLAUDE.md records. A bundle would have rendered and then sat there: no resize, no tokens, no host calls. Fixed in `1089d44` (+7 lines of brief), with a test that reads BOTH sides from the real thing — the mount id parsed out of the document the door actually serves, and `startFrameProtocol`/`callHost` looked up as live exports — so it cannot drift into agreeing with itself.

## Known limits — read before believing a built app is fully wired
1. **The frame protocol is unreleased.** The box installs `@vendoai/ui` from npm; the published `0.41.0` ships `startFrameProtocol` but **not** `callHost`, and handles only `resize`/`booted`. So until the next `@vendoai/ui` release, a real built app gets **auto-resize and nothing else** — no brand tokens, no host calls. The brief targets the exports the next release ships. Releasing is out of scope here.
2. **The brief names `callHost(tool, args)` but no tool catalog reaches the box.** `BuildRequest` carries none, so the in-box agent can only infer a tool name from the person's own words. Real gap, deliberately unfixed — plumbing the catalog into the build lane is a bigger change than this slice.
3. **Fonts cannot reach the frame** under the contracted CSP: there is no `font-src`, and `default-src 'none'` blocks even `data:` fonts. Tokens travel (including `--vendo-font-family`); font *files* cannot. The spec says "brand tokens + fonts injected AT RENDER", so this is a contradiction in the contract, raised with the owner rather than resolved unilaterally.
4. `frame-ancestors 'self'` assumes the wire is mounted on the host page's origin — true by default, but a host mounting it elsewhere would have its bundle refuse to frame.

## Tests
- `vendo/tests/bundle-route.seam.test.ts` (3) — the named seam: real `sealBundleBlobs` → real store → real `createVendo` handler → open answers `{kind:"bundle"}` → route serves those bytes. Exact CSP, inline-not-fetched, viewer scoping, unknown hash.
- `ui/test/tree/bundle-frame.test.tsx` (9) — event.source gate, opaque-origin reply, `--vendo-*`-only theme, sandbox token list, call round-trip.
- `ui/test/tree/frame-protocol.seam.test.ts` (2) — frame half against host half, no restated envelope.
- `vendo/tests/build-lane.test.ts` +1 — the brief seam above.

Each proven failable by mutation.

## Small hardening not in the contract (one line each, both tested)
The hash is shape-checked against `/^[0-9a-f]{64}$/` before becoming a blob key, and the bundle's own `</script>` is escaped so an app rendering HTML cannot break out of its own document.

CI is the gate of record. The live browser proof is run separately by an independent worker.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serves sealed app bundles and renders them in a locked-down iframe with a single postMessage door. Previously, built apps had no render path; now `open()` can return `{ kind: "bundle", entry }` and the UI loads `GET /apps/:id/bundle/:hash` under a strict CSP.

- Implements `GET /apps/:id/bundle/:hash` that inlines the sealed script in an HTML shell with headers `Content-Security-Policy: default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data:; frame-ancestors 'self'`, `cache-control: private, immutable`, and `x-content-type-options: nosniff`.
- Adds `bundleDocument(appId, hash, ctx)` to the apps runtime and exposes `BUNDLE_CSP`/`BUNDLE_HEADERS` from `@vendoai/apps`.
- UI: introduces `BundleFrame` in `frames.tsx` and a postMessage bridge (`frame-bridge.ts`) that:
  - Gates inbound messages by `event.source`, sends replies to `"*"` (opaque origin), and filters theme vars to `--vendo-*`.
  - Posts brand tokens on `booted` and routes calls via `onAction` → `client.apps.call` → guarded tools (viewer permissions).
  - Iframes use `sandbox="allow-scripts"` without `allow-same-origin` and never make network requests.
- Ships `callHost(ref, args)` and integrates it with `startFrameProtocol` in `@vendoai/ui/kit`; updates the build brief to require mounting into `#root` and starting the protocol.
- Hardens the route: validates `hash` as `/^[0-9a-f]{64}$/`; escapes `</script>` inlined content.
- Client adds `apps.bundleUrl(id, entry)`; server/UI wire up viewer-scoped access checks.

**Migration/rollout**
- Pass `appId` to `AppFrame` where a bundle surface can render (examples updated). Without `appId`, the bundle URL cannot be constructed.
- Ensure consumers upgrade to the next `@vendoai/ui` that includes `callHost`; current published versions auto-resize but cannot call host tools.
- Expect fonts to be blocked by the CSP (`default-src 'none'`); only brand tokens cross the boundary.

<sup>Written for commit 1089d44c721c1f4ef77643fcef547c2d51e399f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

