### PR TITLE
fix(vendo,apps): defects the live proof found on a real box (built apps)

### DIFF
--- a/.changeset/creations-lane-fixes.md
+++ b/.changeset/creations-lane-fixes.md
@@ -1,0 +1,7 @@
+---
+"@vendoai/vendo": minor
+"@vendoai/apps": minor
+"@vendoai/harnesses": minor
+---
+
+Built apps: five fixes found by a live proof against a real box. The build brief now sends the in-box agent to a real disk path, so the bundle it produces is where the host actually reads it — every build previously landed on "the build's own test did not pass" while a working bundle sat on the box. The build watchdog waits longer than the box's own message budget instead of killing real builds at four minutes. An app awaiting the person's yes now reads as pending rather than "This app can't be opened any more". A failed build keeps the app's name instead of renaming it to a cut of the prompt. And a propose that cannot finish takes its standing card back instead of leaving an ask with no build behind it. `@vendoai/harnesses` exports `BOX_WORKSPACE_ROOT` and `MESSAGE_BUDGET_MS`.

--- a/packages/apps/src/contract/build-deadlines.ts
+++ b/packages/apps/src/contract/build-deadlines.ts
@@ -8,7 +8,24 @@
  * affordance) lands before the client gives up with the generic deadline beat.
  */
 
-export const BUILD_WATCHDOG_MS = 4 * 60_000;
+/**
+ * A dead-man timer, so it has to outlast the work it guards.
+ *
+ * It was 4 minutes, which is shorter than a build: three real box builds took
+ * 229 s, 414 s and 450 s on 2026-08-24, and the first was killed at exactly 4:00
+ * while the box was still installing from npm. The bound that matters is the
+ * box's own — it gives ONE message 15 minutes (`MESSAGE_BUDGET_MS`,
+ * `@vendoai/harnesses`) before giving up and reporting a failure itself — so
+ * this sits above that plus boot, collect and seal. Anything shorter cannot
+ * distinguish a lane that died from one that is working, which is the only
+ * question it exists to answer. Pinned against the box's budget in
+ * `packages/vendo/tests/build-lane.test.ts`, the one package that sees both.
+ *
+ * The cost, stated: a screen create that dies SILENTLY (`startBuildWatchdog`,
+ * doors/build-surface.ts) now shows as building for this long instead of four
+ * minutes. `VENDO_APP_BUILD_WATCHDOG_MS` is the operator's escape hatch either way.
+ */
+export const BUILD_WATCHDOG_MS = 20 * 60_000;
 
 /** How long the UI keeps polling past the watchdog: covers the watchdog's
  *  persist + one poll cadence with generous slack. */

--- a/packages/apps/src/server/doors/build-door.ts
+++ b/packages/apps/src/server/doors/build-door.ts
@@ -215,22 +215,31 @@ export const createBuildDoor = (
         return { declined: decision.action === "block" ? decision.reason : BUILD_ALREADY_ASKED };
       }
       const approvalId = decision.approval.id;
-      // Parked BEFORE the row: the record is what the decision seam reads, and a
-      // yes that lands between these two writes must find the build to run.
-      await parkedBuilds.put({
-        approvalId,
-        appId: input.appId,
-        owner: ctx.principal.subject,
-        prompt: input.prompt,
-        why: input.why,
-        ctx: guardCtx,
-      });
-      await proposeRow(input.appId, input.name, {
-        approvalId,
-        prompt: input.prompt,
-        why: input.why,
-        at: new Date().toISOString(),
-      }, ctx);
+      try {
+        // Parked BEFORE the row: the record is what the decision seam reads, and
+        // a yes that lands between these two writes must find the build to run.
+        await parkedBuilds.put({
+          approvalId,
+          appId: input.appId,
+          owner: ctx.principal.subject,
+          prompt: input.prompt,
+          why: input.why,
+          ctx: guardCtx,
+        });
+        await proposeRow(input.appId, input.name, {
+          approvalId,
+          prompt: input.prompt,
+          why: input.why,
+          at: new Date().toISOString(),
+        }, ctx);
+      } catch (error) {
+        // The card was parked before either write, so a write that throws leaves
+        // an ask standing with no build behind it — a question the person can
+        // answer yes to and nothing happens. Taken back through the same verb the
+        // chat door uses for an ask nobody needs any more.
+        await config.guard.abandonApprovals?.([approvalId], guardCtx);
+        throw error;
+      }
       return { approvalId };
     },
 
@@ -241,7 +250,8 @@ export const createBuildDoor = (
       // Read raw and untyped, like the placement read: one unparseable row must
       // not decide how every other build fails.
       const record = await engine.get(APPS_COLLECTION, appId);
-      const alreadySealed = (record?.data as { doc?: { bundle?: unknown } } | null)?.doc?.bundle !== undefined;
+      const existing = (record?.data as { doc?: { bundle?: unknown; name?: string } } | null)?.doc;
+      const alreadySealed = existing?.bundle !== undefined;
       /**
        * The ONE terminal landing every failure shares: the tombstone that turns
        * the claimed slot into the honest failure card. A denial is one of them —
@@ -251,9 +261,16 @@ export const createBuildDoor = (
        * for a first build — there is nothing there to lose — and would destroy a
        * working app here. So a reseal that fails keeps everything it had and
        * loses only the build state; the person's app is still their app.
+       *
+       * The row's own NAME survives either way. `markUnbuilt` replaces the row,
+       * so naming it from the prompt renamed the person's app to a 60-character
+       * cut of what they typed — and that name then rode into the version
+       * history. `fallbackAppName` is left for the row that has no name to keep.
        */
       const refuse = async (reason: string): Promise<void> => {
-        if (!alreadySealed) return await markUnbuilt(appId, fallbackAppName(prompt), reason, ctx);
+        if (!alreadySealed) {
+          return await markUnbuilt(appId, existing?.name ?? fallbackAppName(prompt), reason, ctx);
+        }
         await updateAppDocument(appId, ({ building: _building, proposal: _proposal, ...rest }) => rest);
       };
       if (!approved) return await refuse(BUILD_DECLINED);

--- a/packages/apps/src/server/persistence/open.ts
+++ b/packages/apps/src/server/persistence/open.ts
@@ -235,6 +235,13 @@ const serveOpenApp = (
   if (app.seed !== undefined) {
     throw new VendoError("not-found", `app ${app.id} has no screen yet`);
   }
+  // Offered and unanswered. The row exists precisely so the slot can show the
+  // standing ask (`proposeRow`, doors/build-door.ts), and "can't be opened any
+  // more" is the one thing it must not say to someone who has just been asked
+  // whether to build it. Same not-found as the remix above, for the same reason.
+  if (app.proposal !== undefined) {
+    throw new VendoError("not-found", `app ${app.id} is waiting on its build to be approved`);
+  }
   // Nothing left to open. A document with no screen is one written back when a
   // stored tree was the artifact; that field is gone, so there is no layout to
   // serve and never will be. Terminal, and said as such, so the embed resolves

--- a/packages/apps/tests/contract/build-deadlines.test.ts
+++ b/packages/apps/tests/contract/build-deadlines.test.ts
@@ -17,7 +17,7 @@ describe("build deadlines", () => {
   });
 
   it("the UI cutoff strictly exceeds the watchdog and derives from it", () => {
-    expect(BUILD_WATCHDOG_MS).toBe(4 * 60_000);
+    expect(BUILD_WATCHDOG_MS).toBe(20 * 60_000);
     expect(APP_BUILD_UI_DEADLINE_MS).toBeGreaterThan(BUILD_WATCHDOG_MS);
     expect(APP_BUILD_UI_DEADLINE_MS).toBe(BUILD_WATCHDOG_MS + 60_000);
   });

--- a/packages/harnesses/src/claude-code/box.ts
+++ b/packages/harnesses/src/claude-code/box.ts
@@ -69,6 +69,16 @@ export interface SandboxMachineLike {
 
 /** The supervisor's control port, as `box-agent.ts` names it. */
 const CONTROL_PORT = 8811;
+/**
+ * Where the host's workspace is mounted ON THE BOX'S DISK. The session door
+ * maps every workspace path the host speaks onto this root (`toDisk`,
+ * `box/turn-routes.mjs`) and opens the in-box session with it as `cwd`.
+ *
+ * Exported because anything a PROMPT sends the in-box agent to has to be spelled
+ * from here: the agent has a shell, so it reads a bare `/user/apps/<id>` as the
+ * filesystem root and writes where `collect` never looks.
+ */
+export const BOX_WORKSPACE_ROOT = "/workspace";
 /** How long a box may sit between messages before it is destroyed. */
 export const BOX_IDLE_TTL_MS = 5 * 60_000;
 /** The box holds each poll open this long before answering empty. */
@@ -280,7 +290,7 @@ export async function boxMachine(options: BoxMachineOptions): Promise<SessionMac
       env: {
         ...options.env,
         VENDO_BOX_TOKEN: token,
-        VENDO_WORKSPACE_ROOT: "/workspace",
+        VENDO_WORKSPACE_ROOT: BOX_WORKSPACE_ROOT,
         // The dev port is DECLARED here, at create, from the same core constant
         // the template's vite config resolves. A preview URL is minted from it
         // before the dev server has necessarily booted, so it can never be
@@ -434,7 +444,7 @@ export async function boxMachine(options: BoxMachineOptions): Promise<SessionMac
     carriesSession: box.warm,
 
     // The frozen layout (§3.1) one level under the box's root.
-    pluginPath: "/workspace/host",
+    pluginPath: `${BOX_WORKSPACE_ROOT}/host`,
 
     tree: box.tree,
 

--- a/packages/harnesses/src/claude-code/index.ts
+++ b/packages/harnesses/src/claude-code/index.ts
@@ -38,6 +38,7 @@ import { boxEgress, boxMachine, inferenceEnv, type SandboxAdapterLike } from "./
 // and a host process that wants to reap idle conversation boxes on shutdown
 // (`disposeLocalSessions` in ./local.js is the `machine: "local"` counterpart).
 export {
+  BOX_WORKSPACE_ROOT,
   boxEgress,
   boxMachine,
   disposeSessionMachines,
@@ -45,6 +46,9 @@ export {
   type SandboxAdapterLike,
   type SandboxMachineLike,
 } from "./box.js";
+/** The bound a build's dead-man timer has to clear: what the box itself gives
+ *  ONE message before giving up on it. */
+export { MESSAGE_BUDGET_MS } from "./machine.js";
 
 /** The knobs a TURN may still carry (harness-declared; see optionsSchema). */
 export interface ClaudeCodeTurnOptions {

--- a/packages/ui/test/embeds.test.tsx
+++ b/packages/ui/test/embeds.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { effectiveAppBuildUiDeadlineMs } from "@vendoai/apps/contract";
 import type { VendoAppRef, VendoApprovalRef } from "@vendoai/core";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -428,7 +429,7 @@ describe("existing-agents embeds", () => {
           </VendoProvider>,
         );
         await act(async () => {
-          await vi.advanceTimersByTimeAsync(5 * 60_000 + 2_000);
+          await vi.advanceTimersByTimeAsync(effectiveAppBuildUiDeadlineMs() + 2_000);
         });
         expect(screen.getByText(/— couldn't finish/)).toBeDefined();
         // The deadline's own reason (embeds.tsx), since the wire gave none.
@@ -459,9 +460,9 @@ describe("existing-agents embeds", () => {
           </VendoProvider>,
         );
         expect(screen.getByText(/Building/)).toBeDefined();
-        // Well past APP_BUILD_DEADLINE_MS (5 min) — no poll ever settles.
+        // Well past APP_BUILD_DEADLINE_MS — no poll ever settles.
         await act(async () => {
-          await vi.advanceTimersByTimeAsync(5 * 60_000 + 2_000);
+          await vi.advanceTimersByTimeAsync(effectiveAppBuildUiDeadlineMs() + 2_000);
         });
         expect(screen.getByText(/— couldn't finish/)).toBeDefined();
         expect(screen.getByText("the build never finished")).toBeDefined();

--- a/packages/vendo/src/build-agent.ts
+++ b/packages/vendo/src/build-agent.ts
@@ -25,7 +25,12 @@ import {
 } from "@vendoai/core";
 import { buildFailureReason } from "@vendoai/apps";
 import type { AppBuilder, BuildOutcome, BuildRequest, BuiltFile } from "@vendoai/apps/contract";
-import { boxEgress, boxMachine, type SandboxAdapterLike } from "@vendoai/harnesses/claude-code/box";
+import {
+  BOX_WORKSPACE_ROOT,
+  boxEgress,
+  boxMachine,
+  type SandboxAdapterLike,
+} from "@vendoai/harnesses/claude-code/box";
 
 export interface AppBuilderDeps {
   sandbox: SandboxAdapterLike | undefined;
@@ -43,10 +48,24 @@ export interface AppBuilderDeps {
  */
 export const BUILD_ALLOWED_DOMAINS: readonly string[] = ["registry.npmjs.org"];
 
-/** Where a build works — the same `/user/apps/<id>` layout the screen agent
- *  writes under, which is also the only tree the box door carries back
- *  (`carriedBack`, `packages/harnesses/box/turn-routes.mjs`). */
+/**
+ * Where a build works, in the two spellings the box has.
+ *
+ * `materialize` and `collect` speak WORKSPACE paths, which the box door maps
+ * onto its disk under the mount root (`toDisk`,
+ * `packages/harnesses/box/turn-routes.mjs`) — and `/user/**` is the only tree
+ * that door carries back (`carriedBack`). The BRIEF cannot use that spelling:
+ * the in-box agent has a shell, so it reads a leading `/` as the filesystem
+ * root, sudo-creates `/user` there and bundles into a directory `collect` never
+ * looks at. Measured live 2026-08-24 — a real 28 KB bundle on the box, an empty
+ * collect, and "the build's own test did not pass" on every run.
+ *
+ * (The screen agent's identical-looking `/user/apps/<id>` is not a precedent:
+ * its model writes through the host's workspace FAÇADE, which speaks workspace
+ * paths, and never touches a disk.)
+ */
 const appDirectory = (appId: AppId): string => `/user/apps/${appId}`;
+const diskDirectory = (appId: AppId): string => `${BOX_WORKSPACE_ROOT}${appDirectory(appId)}`;
 
 /** What the frame boots, and the one file whose presence means the build worked:
  *  the brief tells the box to remove it if its own test does not pass. */
@@ -73,6 +92,7 @@ const checkoutOf = (source: Record<string, AppSourceFile> | undefined, directory
     ? []
     : [{ path: `${directory}/${path}`, bytes: encoder.encode(file.text), readOnly: false }]);
 
+/** `directory` is the DISK spelling — this text is read by a shell. */
 const briefFor = (request: BuildRequest, directory: string): string =>
   `Build this for real, in ${directory}.
 
@@ -137,7 +157,10 @@ export function appBuilder(deps: AppBuilderDeps): AppBuilder {
         request.onStatus?.("Writing the code, installing what it needs, and testing it…");
         // No `toolDoor`: this box reaches none of the host's tools, so there is
         // nothing for it to act with and no credential to act under.
-        await machine.send({ prompt: briefFor(request, directory), emit: () => undefined });
+        await machine.send({
+          prompt: briefFor(request, diskDirectory(request.appId)),
+          emit: () => undefined,
+        });
         const collected = await machine.collect([
           `${directory}/${ENTRY}`,
           `${directory}/src/*`,

--- a/packages/vendo/tests/build-lane.test.ts
+++ b/packages/vendo/tests/build-lane.test.ts
@@ -21,17 +21,25 @@ import { dirname, join } from "node:path";
 import type { LanguageModel } from "ai";
 import { memoryStoreAdapter } from "@vendoai/core/conformance";
 import {
+  PARKED_BUILD_COLLECTION,
   type AppId,
   type ApprovalId,
   type FilesAdapter,
   type Principal,
   type RunContext,
+  type StoreAdapter,
   type ToolRegistry,
 } from "@vendoai/core";
 import { createApps, readBundleBlob, type AppsConfig } from "@vendoai/apps";
+import { BUILD_WATCHDOG_MS } from "@vendoai/apps/contract";
 import { createGuard } from "@vendoai/guard";
+import { MESSAGE_BUDGET_MS } from "@vendoai/harnesses/claude-code";
 import { createSessionRoutes } from "@vendoai/harnesses/box-door";
-import { disposeSessionMachines, inferenceEnv } from "@vendoai/harnesses/claude-code/box";
+import {
+  BOX_WORKSPACE_ROOT,
+  disposeSessionMachines,
+  inferenceEnv,
+} from "@vendoai/harnesses/claude-code/box";
 import { createStore, type VendoStore } from "@vendoai/store";
 import * as kit from "@vendoai/ui/kit";
 import { afterEach, describe, expect, it } from "vitest";
@@ -75,9 +83,10 @@ interface Box {
   kill: () => void;
 }
 
-/** The in-box coding agent, scripted: handed the brief and the box's own disk
- *  root, it writes what a real one would write. */
-type InBoxAgent = (input: { prompt: string; root: string; box: Box }) => void | Promise<void>;
+/** The in-box coding agent, scripted: handed the brief and the box's WHOLE
+ *  disk, it writes what a real one would write. It has a shell, not the host's
+ *  workspace map, so it resolves the brief's paths against that disk. */
+type InBoxAgent = (input: { prompt: string; disk: string; box: Box }) => void | Promise<void>;
 
 interface ScriptedSandbox {
   boxes: Box[];
@@ -94,8 +103,14 @@ function scriptedSandbox(agent: InBoxAgent): ScriptedSandbox {
     boxes,
     async create(spec: unknown) {
       const { env, allowedDomains } = spec as { env: Record<string, string>; allowedDomains?: string[] };
-      const root = mkdtempSync(join(tmpdir(), "vendo-build-box-"));
-      boxRoots.push(root);
+      // The box's whole filesystem, with the host's workspace mounted where the
+      // host itself said to mount it. Two paths, because the box has two: the
+      // session door maps the host's workspace spellings onto `root`, while the
+      // agent inside writes absolute paths onto `disk`.
+      const disk = mkdtempSync(join(tmpdir(), "vendo-build-box-"));
+      const root = join(disk, env["VENDO_WORKSPACE_ROOT"] ?? "");
+      mkdirSync(root, { recursive: true });
+      boxRoots.push(disk);
       let dead = false;
       const box: Box = {
         env: { ...env },
@@ -113,7 +128,7 @@ function scriptedSandbox(agent: InBoxAgent): ScriptedSandbox {
         openSession: (input: { emit: (event: Record<string, unknown>) => void }) => ({
           async send(prompt: string) {
             box.prompts.push(prompt);
-            await agent({ prompt, root, box });
+            await agent({ prompt, disk, box });
             input.emit({ type: "text", delta: "done." });
           },
           async interrupt() { /* the turn stops; the session lives */ },
@@ -140,23 +155,30 @@ function scriptedSandbox(agent: InBoxAgent): ScriptedSandbox {
   };
 }
 
-/** What a working in-box agent leaves behind: a bundled entry, its source, and
- *  the lockfile of what it installed. */
-const wrote = (root: string, appId: string, files: Record<string, string>): void => {
+/**
+ * What a working in-box agent leaves behind: a bundled entry, its source, and
+ * the lockfile of what it installed — at the path the BRIEF named, resolved
+ * against the box's own disk the way its shell resolves it.
+ *
+ * Not against the host's workspace map, which is the whole point: a brief that
+ * spells a workspace path puts every write outside the mounted workspace, where
+ * `collect` never looks. Measured live 2026-08-24 — 28 KB really bundled from
+ * npm, `{"files":[]}` collected, every build reported as "its own test did not
+ * pass".
+ */
+const wrote = (disk: string, prompt: string, files: Record<string, string>): void => {
+  const directory = /^Build this for real, in (\S+)\.$/mu.exec(prompt)?.[1];
+  if (directory === undefined) throw new Error(`the brief names no build directory:\n${prompt}`);
   for (const [path, text] of Object.entries(files)) {
-    const disk = join(root, "user/apps", appId, path);
-    mkdirSync(dirname(disk), { recursive: true });
-    writeFileSync(disk, text);
+    const target = join(disk, directory, path);
+    mkdirSync(dirname(target), { recursive: true });
+    writeFileSync(target, text);
   }
 };
 
-/** The appId out of the brief the box was handed — the lane mints none, it is
- *  the one the proposal carried. */
-const appIdOf = (prompt: string): string => /\/user\/apps\/(app_[\w-]+)/u.exec(prompt)?.[1] ?? "";
-
 /** A build whose in-box agent does its job. */
-const buildsFine: InBoxAgent = ({ prompt, root }) => {
-  wrote(root, appIdOf(prompt), {
+const buildsFine: InBoxAgent = ({ prompt, disk }) => {
+  wrote(disk, prompt, {
     "dist/app.js": "console.log('cropped')",
     "src/index.ts": "export const crop = () => {};",
     "package-lock.json": "{}",
@@ -179,8 +201,7 @@ const memoryBlobs = (): FilesAdapter => {
   };
 };
 
-const setup = (sandbox: ScriptedSandbox | undefined) => {
-  const store = memoryStoreAdapter();
+const setup = (sandbox: ScriptedSandbox | undefined, store: StoreAdapter = memoryStoreAdapter()) => {
   const files = memoryBlobs();
   // The REAL guard: `decide` awaits its subscribers, which is the whole reason
   // the lane has to detach.
@@ -242,6 +263,9 @@ describe("a consented build runs the box and seals what it made", () => {
     expect(box.prompts).toHaveLength(1);
     expect(box.prompts[0]).toContain(ASK);
     expect(box.prompts[0]).toContain(WHY);
+    // A SHELL reads this brief, so it must name the box's own disk path. The
+    // host's workspace spelling puts every write outside the mounted workspace.
+    expect(box.prompts[0]).toContain(`${BOX_WORKSPACE_ROOT}/user/apps/${APP}`);
 
     // Sealed: the row is a bundle, and the entry hash reads back as the bytes
     // the box wrote — through the real seal and the real blob read.
@@ -351,6 +375,10 @@ describe("every failure lands on the ONE terminal record", () => {
     expect(row["building"]).toBeUndefined();
     expect(row["proposal"]).toBeUndefined();
     expect(row["ui"]).toBeUndefined();
+    // A failure loses the BUILD, never the app: the tombstone used to replace
+    // the row wholesale and rename the person's app to a cut of their prompt,
+    // which then rode into the version history.
+    expect(row["name"]).toBe("Photo editor");
   };
 
   it("no sandbox composed — the failure names the missing machine", async () => {
@@ -372,9 +400,9 @@ describe("every failure lands on the ONE terminal record", () => {
   });
 
   it("the agent's own test failed, so it left no entry behind", async () => {
-    const sandbox = scriptedSandbox(({ prompt, root }) => {
+    const sandbox = scriptedSandbox(({ prompt, disk }) => {
       // Source, but no `dist/app.js` — the brief's way of saying the test failed.
-      wrote(root, appIdOf(prompt), { "src/index.ts": "broken" });
+      wrote(disk, prompt, { "src/index.ts": "broken" });
     });
     const harness = setup(sandbox);
 
@@ -401,6 +429,42 @@ describe("every failure lands on the ONE terminal record", () => {
 
     failsWith(await settled(harness), /not approved/u);
     expect(sandbox.boxes).toHaveLength(0);
+  });
+});
+
+describe("the dead-man timer outlasts the work it guards", () => {
+  it("gives a build longer than the box's own message budget", () => {
+    // The two numbers only meet HERE — `@vendoai/apps` cannot see the box, and
+    // the box cannot see the watchdog. At 4 minutes the watchdog always won:
+    // three real builds (229 s, 414 s, 450 s) were killed mid-work on
+    // 2026-08-24, and the box will not even give up on one message for 15.
+    expect(BUILD_WATCHDOG_MS).toBeGreaterThan(MESSAGE_BUDGET_MS);
+  });
+});
+
+describe("a propose that cannot finish leaves no card standing", () => {
+  it("takes the ask back when the parked record cannot be written", async () => {
+    // What the real Cloud store did on 2026-08-24: its engine allowlist is a
+    // version behind, so `vendo_parked_build` was refused — AFTER the guard had
+    // already parked the card. Two orphan asks were left standing in a real
+    // person's feed with no build behind either of them.
+    const backing = memoryStoreAdapter();
+    const store: StoreAdapter = {
+      ...backing,
+      records: (collection) => collection !== PARKED_BUILD_COLLECTION
+        ? backing.records(collection)
+        : {
+          ...backing.records(collection),
+          put: () => Promise.reject(new Error(`collection "${collection}" is not an engine collection`)),
+        },
+    };
+    const harness = setup(scriptedSandbox(buildsFine), store);
+
+    await expect(harness.runtime.build.propose(
+      { appId: APP, name: "Photo editor", prompt: ASK, why: WHY }, ctx,
+    )).rejects.toThrow(/engine collection/u);
+
+    expect(await harness.guard.approvals.pending(principal)).toEqual([]);
   });
 });
 
@@ -444,6 +508,22 @@ describe("composition fills the slot", () => {
     await store.ensureSchema();
     return vendo;
   };
+
+  it("an app that is only OFFERED reads as pending on the wire, never as gone", async () => {
+    const vendo = await compose(scriptedSandbox(buildsFine));
+    const proposed = await vendo.apps.build.propose(
+      { appId: APP, name: "Photo editor", prompt: ASK, why: WHY }, ctx);
+    if (!("approvalId" in proposed)) throw new Error("expected a card");
+
+    // The exact request the embed makes while the card stands. It answered
+    // "This app can't be opened any more — create it again to replace it." to a
+    // person who had just been asked whether to build it (measured live
+    // 2026-08-24, on all three propose runs).
+    const answer = await vendo.handler(new Request(
+      `https://host.test/api/vendo/apps/${APP}/open?pending=1`));
+
+    expect(await answer.json()).toEqual({ kind: "pending" });
+  });
 
   it("a composed sandbox is the ONE gate, and the composed box holds no store credentials", async () => {
     expect((await compose(undefined)).apps.build.available()).toBe(false);


### PR DESCRIPTION
> Stacked on #1613. Review only the top commit; the stack merges once at the tip.

## What & why

An independent worker ran the build lane against a **real disposable box on a real Cloud account** and found the feature did not work. These are the fixes for what it observed live, with artifacts. Every one of these survived a green test suite — that is the point of each fix's test.

## Fixed

**1. Nothing a box built could ever be collected. [was a blocker]**
`build-agent.ts` told the in-box agent to work in `/user/apps/<id>` — an absolute path at the filesystem root — while `collect` reads the box workspace. Live: the model created `/user` at the root and wrote 28,832 bytes there; `/workspace` was empty; `collect` returned `{"files":[]}` on all three runs, reported to the person as "the build's own test did not pass".

Now two spellings: `appDirectory` (workspace-relative, for `materialize`/`collect`) and `diskDirectory` (`/workspace/user/apps/<id>`, for the brief). The `/workspace` literal is now `BOX_WORKSPACE_ROOT`, exported from `box.ts` and used at its own sites. The comment claiming the screen agent as precedent was **wrong** and is corrected — the screen agent's model writes through the host's workspace façade, never a disk.

*The test that would have caught it:* the scripted box now has a real filesystem with the workspace mounted where the host's own env says, and the in-box agent resolves the brief's path against that disk like a shell would. **The old fake wrote where `collect` looks regardless of what the brief said** — which is exactly why it stayed green through three dead live runs. Reverting the fix now reddens the happy path, the frame-protocol case and the reseal case.

**2. The watchdog killed real builds. [was a blocker]** Fired at 4 minutes; observed real builds took 229/414/450s, and the first proof run was killed mid-work at exactly 4:00. New default **20 minutes**: a dead-man timer must outlast the work it guards, and the real ceiling is the box's own 15-minute message budget, past which the box reports its own failure. 20 covers that plus boot, collect and seal; the UI cutoff follows at 21. Pinned by a test asserting `BUILD_WATCHDOG_MS > MESSAGE_BUDGET_MS` — `packages/vendo` is the only package that can see both. Accepted cost, stated in the code: the constant is shared with the screen-create watchdog, so a silently-dead screen create now shows "building" for 20 minutes rather than 4. Splitting them buys nothing, since the UI mount window must cover the longer of the two anyway.

**4. An app awaiting your consent said it was gone.** `open?pending=1` answered *"This app can't be opened any more"* for a row with a standing proposal. Now such a row reads as `{kind:"pending"}` on the wire. Placed at the fall-through, so a sealed or screen app awaiting a *reseal* yes still opens normally.

**5. A failed build renamed the app** to a truncated copy of the prompt, and that name rode into version history. `refuse` now keeps the row's own name; the fallback remains only for a row that never had one. All five failure paths pin it.

**6. A throwing propose left an orphan standing card** — two were left in the owner's real tenant feed. Both writes are now inside a `try`; a throw abandons the approval through `guard.abandonApprovals`, the existing feature-detected verb the chat and automations doors already use, then rethrows. Tested against the **real** guard with a store that refuses `vendo_parked_build` exactly as the live Cloud store does — the apps-package guard fixture has no `abandonApprovals`, so a test there would have proven nothing.

## Not fixed — parked with evidence

**3. Progress status lines remain unimplemented.** FINAL SPEC v1 says *"progress = chat status lines only"*, and `BuildRequest.onStatus` is emitted but supplied by nobody. There is **no shipped mechanism a detached job can use to write a chat status line**: every one needs a live turn's stream writer, the audit lifecycle is rendered by nobody, and `packages/apps` sees only `@vendoai/core` so it cannot reach the thread repository. Filling it means a row field + a `PendingSurface` text slot + UI to render it — i.e. building the progress channel, which is a scope decision for the owner, not something to invent inside a fix. Raised.

## Existing tests changed — stated out loud
- `contract/build-deadlines.test.ts` asserted the literal `4 * 60_000`. The constant **is** the assertion, so the number moved with it; the stronger replacement is the new box-budget seam test.
- `build-lane.test.ts`'s scripted in-box agent was rewritten to be honest about disk paths. That fake's assumptions are what kept defect 1 invisible, so making it faithful is the fix's own test, not a weakening.

Both were watched red before the code changed.

## Still broken end-to-end, outside this branch
`RunRecord.escalated` is never assigned, so no chat ask reaches this lane (a design decision with the owner), and the Cloud store's engine-allowlist mirror is at v7 while this stack is v8, so `build.propose` throws on any Cloud-store deployment — which is precisely the throw defect 6 now cleans up after.

CI is the gate of record.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes five live-box defects in the built-app lane so builds land where the host collects, long-running builds aren’t killed early, pending opens don’t 404, failed builds keep their names, and propose errors retract standing approvals.

- Pathing: introduce `appDirectory` (workspace) and `diskDirectory` (box disk). The brief now targets the box disk under `/workspace`; `@vendoai/harnesses` exports `BOX_WORKSPACE_ROOT`. The in-box test agent resolves paths against the box disk.
- Watchdog: default is 20 minutes (was 4). Assert it exceeds `MESSAGE_BUDGET_MS` (exported from `@vendoai/harnesses`); operators can override via `VENDO_APP_BUILD_WATCHDOG_MS`. Side effect: a dead screen create can appear “Building” up to 20 minutes.
- Open pending: `open?pending=1` for a proposed app returns `{kind:"pending"}` instead of not-found; sealed/reseal still open normally.
- Failure naming: failed builds keep the row’s existing `name`; fallback to a prompt-derived name only when the row had none.
- Propose cleanup: wrap parked-record and row writes in a try/catch; on error call `guard.abandonApprovals` to retract the card, then rethrow.
- UI tests: embeds derive the deadline from `effectiveAppBuildUiDeadlineMs()` instead of a hardcoded 5 minutes, so tests track the real cutoff.

<sup>Written for commit e7166582f796e9fd5c201b4c508141d2fe230f96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

