### PR TITLE
feat(shell): the agent gets hands — one guarded bash over the user's workspace

### DIFF
--- a/.changeset/shell-bash-hands.md
+++ b/.changeset/shell-bash-hands.md
@@ -1,0 +1,29 @@
+---
+"@vendoai/core": minor
+"@vendoai/harnesses": minor
+"@vendoai/vendo": minor
+---
+
+The agent has hands: one real `bash` over the user's own files.
+
+Every deployment running the default `vendo()` harness — no keys, no config —
+now projects one more tool: `bash`. It is a full shell (grep, sed, awk, jq, sort,
+cut, find, pipes, redirection) running IN THIS PROCESS over the same per-user
+workspace the file drawer already lives in, so a dropped CSV is something the
+agent can actually work on instead of something it can only page through 200
+lines at a time. There is no machine to provision, no sandbox key, and no network
+or package manager inside the shell — the interpreter is
+[just-bash](https://www.npmjs.com/package/just-bash) and the filesystem is the
+store, so the mounts the workspace already enforces (`/user` and
+`/orgs/<org>` writable, `/host` read-only, everything else `EACCES`) are the whole
+containment story. Each session also gets an in-memory `/tmp` that lasts the
+conversation and is never saved.
+
+It rides the ONE guarded registry like every other tool: graded `write`, so the
+guard's rules, grants and approvals apply to it unchanged, and every call lands
+an audit row.
+
+`createVendo({ shell: false })` withholds it; `createVendo({ shell: { limits } })`
+moves its per-call wall clock (30 s) and output ceiling (1 MB). It composes for
+the resident brain only — a harness that thinks on a machine already has a real
+disk and reaches it its own way.

--- a/docs-site/agents/index.mdx
+++ b/docs-site/agents/index.mdx
@@ -83,6 +83,20 @@ pointed at.
    Then run the version check — and every `npx vendo …` step below — from
    that same app directory.
 
+   On pnpm only: the install downloads everything and then exits 1 with
+   `Ignored build scripts: @mongodb-js/zstd, esbuild, node-liblzma`. None of
+   the three needs compiling. pnpm writes the names into `pnpm-workspace.yaml`
+   with a placeholder — set all three to `false` and install again. Do NOT run
+   `pnpm approve-builds` (it is interactive) or allow all builds.
+
+   ```yaml
+   # pnpm-workspace.yaml
+   allowBuilds:
+     '@mongodb-js/zstd': false
+     esbuild: false
+     node-liblzma: false
+   ```
+
    ONE package, and it is the umbrella. `@vendoai/vendo` carries every
    `@vendoai/vendo/*` subpath the files init writes import, and it carries the
    `vendo` binary into `node_modules/.bin` — which is what the version check

--- a/docs-site/index.mdx
+++ b/docs-site/index.mdx
@@ -51,7 +51,14 @@ No agent handy? Do it by hand. Three steps.
 
     </CodeGroup>
 
-    On pnpm the install ends with `Ignored build scripts: esbuild`. Nothing to approve — Vendo reaches esbuild through its Node API, which that script has nothing to do with.
+    On pnpm the install downloads everything and then exits 1 with `Ignored build scripts: @mongodb-js/zstd, esbuild, node-liblzma`. None of the three needs compiling — Vendo reaches esbuild through its Node API, which that script has nothing to do with, and the other two are the shell's optional native `tar` backends, behind guarded imports nothing calls. pnpm writes the three names into your `pnpm-workspace.yaml` with a placeholder; set all three to `false` and install again.
+
+    ```yaml pnpm-workspace.yaml
+    allowBuilds:
+      '@mongodb-js/zstd': false
+      esbuild: false
+      node-liblzma: false
+    ```
   </Step>
 
   <Step title="Run npx vendo init">

--- a/docs-site/reference/handler-options.mdx
+++ b/docs-site/reference/handler-options.mdx
@@ -41,6 +41,7 @@ One key is required, an identity, as either `principal` or an `auth` preset. `oa
 | `profileDir` | The project root `.vendo/` is read under. Unset keeps the process cwd |
 | `fetch` | The fetch host route and OpenAPI bindings execute through. An explicit function always wins |
 | `profile` | The `.vendo/` pieces as in-memory compose-time inputs. See [below](#profile) |
+| `shell` | The agent's `bash` over the user's own files. On by default when the resident brain is `vendo()`; `false` withholds it, `{ limits }` moves its per-call wall clock and output ceiling |
 | `mcp` | Opens the MCP door. Off by default. See [below](#mcp) |
 | `oauth` | `HostOAuthAdapter` used by the door for session lookup and principal resolution. Required when `mcp` is on and `auth` supplies no oauth half |
 | `agent` | A whole agent built by `agent()`. This deployment adopts its harness, store, files adapter, sandbox, and instructions |

--- a/fixtures/install-seam/src/pack.ts
+++ b/fixtures/install-seam/src/pack.ts
@@ -117,11 +117,20 @@ export async function vendorInto(targetDir: string, packed: Packed): Promise<voi
   const overrides = packed.tarballs
     .map((tarball) => `  "${tarball.name}": "file:vendor/${tarball.fileName}"`)
     .join("\n");
-  // pnpm 11 fails an install whose dependencies carry unapproved build scripts.
-  // These two are the ones the umbrella's tree brings and genuinely needs
-  // (esbuild and sharp both fetch a platform binary in theirs), so a real
-  // stranger has to approve them too — noted rather than hidden.
-  const allowBuilds = ["esbuild", "sharp"].map((name) => `  ${name}: true`).join("\n");
+  // pnpm 11 fails an install whose dependencies carry unapproved build scripts,
+  // so a real stranger writes these same four entries — noted rather than hidden.
+  // esbuild and sharp are approved: both fetch a platform binary in theirs.
+  // zstd and lzma are DENIED — they are just-bash's optional native tar
+  // backends, behind guarded imports nothing calls, so `false` compiles neither
+  // and still satisfies strictDepBuilds. Consumers meet the same two denials in
+  // docs-site/index.mdx; changing this line without changing that one would
+  // green the seam while every real install still exits 1.
+  const allowBuilds = [
+    "'@mongodb-js/zstd': false",
+    "esbuild: true",
+    "node-liblzma: false",
+    "sharp: true",
+  ].map((entry) => `  ${entry}`).join("\n");
   await fs.writeFile(
     path.join(targetDir, "pnpm-workspace.yaml"),
     `overrides:\n${overrides}\nallowBuilds:\n${allowBuilds}\n`,

--- a/packages/core/src/filesystem.ts
+++ b/packages/core/src/filesystem.ts
@@ -52,6 +52,10 @@ export interface FsStat {
   mode: number;
   size: number;
   mtime: Date;
+  /** Stable filesystem identity when the backend can expose it safely. */
+  dev?: number | bigint;
+  ino?: number | bigint;
+  identity?: string;
 }
 
 export interface MkdirOptions {

--- a/packages/core/src/tools.ts
+++ b/packages/core/src/tools.ts
@@ -214,6 +214,8 @@ export type GradedRiskLabel = "read" | "write" | "destructive";
  *  The name lives in core because two sides read it and a security-relevant
  *  name with two definitions drifts silently: the registry that implements it,
  *  and the loop that ends a turn on it. */
+export const ASK_USER_TOOL = "ask_user";
+
 /** The agent's hands over the user's own files: one shell, in this process,
  *  over the workspace (spec 2026-08-23 §1). Named here for `ASK_USER_TOOL`'s
  *  reason — the registry that implements it lives in `@vendoai/harnesses` and the
@@ -225,10 +227,9 @@ export type GradedRiskLabel = "read" | "write" | "destructive";
  *  knows from every other agent harness, and the name is what teaches it. The
  *  cost of leaving the `vendo_` prefix behind is that it is not covered by the
  *  loadout's always-active exemption for our own tools, so composition names it
- *  explicitly (`PROMPT_TAUGHT_TOOLS`). */
+ *  explicitly (`PROMPT_TAUGHT_TOOLS`) and the agent-menu projection exempts it
+ *  beside the connector four (`withAgentMenu`). */
 export const VENDO_BASH_TOOL = "bash";
-
-export const ASK_USER_TOOL = "ask_user";
 
 /** The connector dispatcher — the one tool whose real action is an ARGUMENT
  *  rather than its name, because a single

--- a/packages/core/src/tools.ts
+++ b/packages/core/src/tools.ts
@@ -127,6 +127,7 @@ export const VENDO_TOOL_TITLES: Readonly<Record<string, string>> = {
   vendo_user_files_list: "See the files you shared",
   vendo_user_files_read: "Read a file you shared",
   vendo_user_files_put: "Save a file to your files",
+  bash: "Work on your files",
   vendo_text_me: "Text me",
   // The verbs and `ask_user` authored these titles inline first; they moved here
   // verbatim so the CLIENT can say them too — a live browser proof caught a verb
@@ -213,6 +214,20 @@ export type GradedRiskLabel = "read" | "write" | "destructive";
  *  The name lives in core because two sides read it and a security-relevant
  *  name with two definitions drifts silently: the registry that implements it,
  *  and the loop that ends a turn on it. */
+/** The agent's hands over the user's own files: one shell, in this process,
+ *  over the workspace (spec 2026-08-23 §1). Named here for `ASK_USER_TOOL`'s
+ *  reason — the registry that implements it lives in `@vendoai/harnesses` and the
+ *  composition that mounts it lives in `@vendoai/vendo`, and a tool name with two
+ *  spellings is a tool the guard grades under one and the loadout exempts under
+ *  the other.
+ *
+ *  Deliberately NOT `vendo_bash`: this is the same `bash` every model already
+ *  knows from every other agent harness, and the name is what teaches it. The
+ *  cost of leaving the `vendo_` prefix behind is that it is not covered by the
+ *  loadout's always-active exemption for our own tools, so composition names it
+ *  explicitly (`PROMPT_TAUGHT_TOOLS`). */
+export const VENDO_BASH_TOOL = "bash";
+
 export const ASK_USER_TOOL = "ask_user";
 
 /** The connector dispatcher — the one tool whose real action is an ARGUMENT

--- a/packages/core/tests/bash-tool-name.test.ts
+++ b/packages/core/tests/bash-tool-name.test.ts
@@ -1,0 +1,14 @@
+/**
+ * The shell's name and its human title live in core for the reason every other
+ * `vendo_*` name does: two sides read them — the registry in `@vendoai/harnesses`
+ * that implements the tool, and the surfaces that show it to a person.
+ */
+import { describe, expect, it } from "vitest";
+import { VENDO_BASH_TOOL, VENDO_TOOL_TITLES } from "../src/tools.js";
+
+describe("the shell tool's name", () => {
+  it("is `bash`, and has a title a person can read", () => {
+    expect(VENDO_BASH_TOOL).toBe("bash");
+    expect(VENDO_TOOL_TITLES[VENDO_BASH_TOOL]).toBe("Work on your files");
+  });
+});

--- a/packages/core/tests/filesystem-parity.test.ts
+++ b/packages/core/tests/filesystem-parity.test.ts
@@ -1,27 +1,33 @@
 /**
  * `FsStat` is VENDORED from just-bash (`dist/fs/interface.d.ts`), and the
  * vendoring is only worth anything if it stays identical. A type has no runtime
- * to assert on, so the assertion is a structural one the compiler makes and this
- * test merely names: a stat carrying upstream's identity fields must satisfy
- * ours.
+ * to assert on, so the assertion is a structural one the compiler makes —
+ * against UPSTREAM's own declaration, not a literal maintained by hand here,
+ * which would keep passing through any drift on their side.
  */
+import { InMemoryFs, type FsStat as UpstreamFsStat } from "just-bash";
 import { describe, expect, it } from "vitest";
 import type { FsStat } from "../src/filesystem.js";
 
-describe("the vendored FsStat", () => {
-  it("accepts upstream's optional identity fields", () => {
-    const stat: FsStat = {
-      isFile: true,
-      isDirectory: false,
-      isSymbolicLink: false,
-      mode: 0o644,
-      size: 3,
-      mtime: new Date(0),
-      dev: 1,
-      ino: 2n,
-      identity: "inode:2",
-    };
+/** Identical, for a structural type, is assignable BOTH ways: a renamed field, a
+ *  widened member, or a key that became required breaks one direction or the
+ *  other, and `pnpm typecheck` is where it says so. */
+type Assignable<A, B> = A extends B ? true : never;
+export const upstreamSatisfiesOurs: Assignable<UpstreamFsStat, FsStat> = true;
+export const oursSatisfiesUpstream: Assignable<FsStat, UpstreamFsStat> = true;
 
-    expect(stat.identity).toBe("inode:2");
+describe("the vendored FsStat", () => {
+  it("accepts what upstream's own filesystem hands back", async () => {
+    const fs = new InMemoryFs();
+    await fs.writeFile("/ledger.csv", "jan\n");
+
+    // The annotation IS the seam: upstream's real `stat()` return type has to
+    // flow into our vendored one, and the values below are upstream's real ones.
+    const stat: FsStat = await fs.stat("/ledger.csv");
+
+    expect(stat.isFile).toBe(true);
+    expect(stat.isDirectory).toBe(false);
+    expect(stat.size).toBe(4);
+    expect(stat.mtime).toBeInstanceOf(Date);
   });
 });

--- a/packages/core/tests/filesystem-parity.test.ts
+++ b/packages/core/tests/filesystem-parity.test.ts
@@ -1,0 +1,27 @@
+/**
+ * `FsStat` is VENDORED from just-bash (`dist/fs/interface.d.ts`), and the
+ * vendoring is only worth anything if it stays identical. A type has no runtime
+ * to assert on, so the assertion is a structural one the compiler makes and this
+ * test merely names: a stat carrying upstream's identity fields must satisfy
+ * ours.
+ */
+import { describe, expect, it } from "vitest";
+import type { FsStat } from "../src/filesystem.js";
+
+describe("the vendored FsStat", () => {
+  it("accepts upstream's optional identity fields", () => {
+    const stat: FsStat = {
+      isFile: true,
+      isDirectory: false,
+      isSymbolicLink: false,
+      mode: 0o644,
+      size: 3,
+      mtime: new Date(0),
+      dev: 1,
+      ino: 2n,
+      identity: "inode:2",
+    };
+
+    expect(stat.identity).toBe("inode:2");
+  });
+});

--- a/packages/harnesses/package.json
+++ b/packages/harnesses/package.json
@@ -71,6 +71,7 @@
     "@vendoai/apps": "workspace:*",
     "@vendoai/core": "workspace:*",
     "@vendoai/guard": "workspace:*",
+    "just-bash": "^3.4.2",
     "zod": "^3.25.0"
   },
   "peerDependencies": {
@@ -83,7 +84,6 @@
     "@ai-sdk/openai-compatible": "2.0.9",
     "@types/node": "^22.0.0",
     "ai": "6.0.28",
-    "just-bash": "^3.1.0",
     "typescript": "^5.6.0",
     "vitest": "^3.2.6"
   },

--- a/packages/harnesses/src/vendo/index.ts
+++ b/packages/harnesses/src/vendo/index.ts
@@ -43,3 +43,16 @@ export {
 // surface the failure.
 export { isContextOverflow } from "./overflow.js";
 export { failoverModel, type ResolvedModel } from "./failover.js";
+// The shell — `vendo()`'s hands over the user's own files. It lives inside this
+// harness's directory and leaves through this subpath because it IS this
+// harness's hand: a sandbox harness has a machine and reaches a disk its own
+// way, and the umbrella mounts these tools only when the resident brain is
+// `vendo()` (compose-tools.ts).
+export {
+  createShellSession,
+  DEFAULT_MAX_EXECUTION_TIME_MS,
+  DEFAULT_MAX_OUTPUT_BYTES,
+  type ShellLimits,
+  type ShellSession,
+} from "./shell/engine.js";
+export { createShellTools } from "./shell/tool.js";

--- a/packages/harnesses/src/vendo/shell/engine.ts
+++ b/packages/harnesses/src/vendo/shell/engine.ts
@@ -43,8 +43,10 @@ const TMP_MAX_BYTES = 32 * 1024 * 1024;
 
 /** Routed through a mutable binding so NO bundler ever statically resolves the
  *  interpreter. just-bash's graph reaches `node:worker_threads`, `undici` and
- *  `sql.js`, and it `import()`s two packages that are not its dependencies at
- *  all (`@mongodb-js/zstd`, `node-liblzma`) — esbuild hard-fails a Worker build
+ *  `sql.js`, and it `import()`s the two native packages it declares as
+ *  `optionalDependencies` (`@mongodb-js/zstd`, `node-liblzma`) — installed on a
+ *  consumer's disk, which is why their build scripts have to be denied
+ *  (pnpm-workspace.yaml), and unbundleable, so esbuild hard-fails a Worker build
  *  on those two, which is `scripts/portability-gate.mjs` Leg A. Same containment,
  *  and the same reasoning, as the optional e2b SDK
  *  (`packages/apps/src/server/escalation/e2b/index.ts`); a `let` is what defeats

--- a/packages/harnesses/src/vendo/shell/engine.ts
+++ b/packages/harnesses/src/vendo/shell/engine.ts
@@ -33,6 +33,13 @@ export const DEFAULT_MAX_EXECUTION_TIME_MS = 30_000;
  *  a script may legitimately produce a lot and pipe it into `tail`; the cap is
  *  what the MODEL sees, this is what the SHELL may make. */
 export const DEFAULT_MAX_OUTPUT_BYTES = 1_000_000;
+/** What the whole session's `/tmp` may hold. `maxOutputBytes` bounds ONE
+ *  redirect and nothing bounded the session, so a turn that kept appending grew
+ *  this in-process filesystem without limit. Not a `ShellLimits` knob: it is
+ *  memory this process has to survive, not a ceiling a deployment tunes — 32× the
+ *  default per-call output, and 6× the 5 MB an upload may be, so a script can
+ *  still hold several copies of the largest file a person can drop. */
+const TMP_MAX_BYTES = 32 * 1024 * 1024;
 
 /** Routed through a mutable binding so NO bundler ever statically resolves the
  *  interpreter. just-bash's graph reaches `node:worker_threads`, `undici` and
@@ -69,7 +76,7 @@ export function createShellSession(opts: {
     // an intermediate is a shell that can only run one-liners. In memory, and
     // owned by the session, so it lasts exactly as long as the turn does.
     const fs = new MountableFs({ base: opts.workspace });
-    fs.mount("/tmp", new InMemoryFs());
+    fs.mount("/tmp", new InMemoryFs(undefined, { maxTotalBytes: TMP_MAX_BYTES }));
     return new Bash({
       fs,
       // The person's own mount, so the paths the agent types are the paths the

--- a/packages/harnesses/src/vendo/shell/engine.ts
+++ b/packages/harnesses/src/vendo/shell/engine.ts
@@ -1,0 +1,95 @@
+/**
+ * The agent's hands: ONE bash session over one caller's workspace, in this
+ * process, with no machine anywhere.
+ *
+ * The disk is the caller's own `WorkspaceFs` — the store, wearing just-bash's
+ * `IFileSystem` (build contract §3.2) — so a script reads and writes exactly the
+ * files that person already has, under exactly the mounts §3.1 froze
+ * (`/user`, `/orgs/<org>` rw, `/host` ro). There is no path argument to escape
+ * with and no host disk to reach: a write outside the mounts is `EACCES` from
+ * the filesystem itself, not from a check bolted on here.
+ */
+import type { IFileSystem } from "@vendoai/core";
+import type { Bash as BashInstance } from "just-bash";
+
+/** One `bash` call's ceilings. Both map onto just-bash's own execution limits;
+ *  everything else keeps just-bash's `normal` profile. */
+export interface ShellLimits {
+  /** Wall clock for ONE call, in milliseconds. */
+  maxExecutionTimeMs?: number;
+  /** Total stdout + stderr bytes one call may produce. */
+  maxOutputBytes?: number;
+}
+
+/** What a turn holds: a shell that keeps its filesystem between calls. */
+export interface ShellSession {
+  exec(command: string): Promise<{ stdout: string; stderr: string; exitCode: number }>;
+}
+
+/** A turn is a person waiting, so the default is the length of a person's
+ *  patience rather than just-bash's compatibility-oriented hour. */
+export const DEFAULT_MAX_EXECUTION_TIME_MS = 30_000;
+/** Generous next to the 32 000-char tool-output cap the bridge applies, because
+ *  a script may legitimately produce a lot and pipe it into `tail`; the cap is
+ *  what the MODEL sees, this is what the SHELL may make. */
+export const DEFAULT_MAX_OUTPUT_BYTES = 1_000_000;
+
+/** Routed through a mutable binding so NO bundler ever statically resolves the
+ *  interpreter. just-bash's graph reaches `node:worker_threads`, `undici` and
+ *  `sql.js`, and it `import()`s two packages that are not its dependencies at
+ *  all (`@mongodb-js/zstd`, `node-liblzma`) — esbuild hard-fails a Worker build
+ *  on those two, which is `scripts/portability-gate.mjs` Leg A. Same containment,
+ *  and the same reasoning, as the optional e2b SDK
+ *  (`packages/apps/src/server/escalation/e2b/index.ts`); a `let` is what defeats
+ *  esbuild's constant folding. */
+let JUST_BASH_SPECIFIER = "just-bash";
+
+type JustBash = typeof import("just-bash");
+
+const loadJustBash = async (): Promise<JustBash> =>
+  await import(/* webpackIgnore: true */ /* turbopackIgnore: true */ /* @vite-ignore */ JUST_BASH_SPECIFIER) as JustBash;
+
+/**
+ * One session, one workspace. The interpreter boots on the FIRST call and is
+ * kept: booting it costs a module load, and a turn that runs three commands
+ * should pay that once.
+ */
+export function createShellSession(opts: {
+  workspace: IFileSystem;
+  limits?: ShellLimits;
+  javascript?: boolean;
+}): ShellSession {
+  let booting: Promise<BashInstance> | undefined;
+
+  const boot = async (): Promise<BashInstance> => {
+    const { Bash, InMemoryFs, MountableFs } = await loadJustBash();
+    // `/tmp` is the one place a script may scribble that is NOT the person's
+    // workspace. It has to exist: the workspace holds `/user`, `/orgs/<org>` and
+    // `/host` and answers EACCES everywhere else, and a shell with nowhere to put
+    // an intermediate is a shell that can only run one-liners. In memory, and
+    // owned by the session, so it lasts exactly as long as the turn does.
+    const fs = new MountableFs({ base: opts.workspace });
+    fs.mount("/tmp", new InMemoryFs());
+    return new Bash({
+      fs,
+      // The person's own mount, so the paths the agent types are the paths the
+      // user's files actually have.
+      cwd: "/user",
+      javascript: opts.javascript === true,
+      executionLimits: {
+        maxExecutionTimeMs: opts.limits?.maxExecutionTimeMs ?? DEFAULT_MAX_EXECUTION_TIME_MS,
+        maxOutputSize: opts.limits?.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES,
+      },
+      // Network is off by definition: just-bash registers curl/wget only when a
+      // `network` or `fetch` option is passed, and neither is.
+    });
+  };
+
+  return {
+    async exec(command) {
+      const bash = await (booting ??= boot());
+      const { stdout, stderr, exitCode } = await bash.exec(command);
+      return { stdout, stderr, exitCode };
+    },
+  };
+}

--- a/packages/harnesses/src/vendo/shell/engine.ts
+++ b/packages/harnesses/src/vendo/shell/engine.ts
@@ -88,8 +88,18 @@ export function createShellSession(opts: {
   return {
     async exec(command) {
       const bash = await (booting ??= boot());
-      const { stdout, stderr, exitCode } = await bash.exec(command);
-      return { stdout, stderr, exitCode };
+      try {
+        const { stdout, stderr, exitCode } = await bash.exec(command);
+        return { stdout, stderr, exitCode };
+      } catch (error) {
+        // The workspace refuses a write outside the caller's mounts by THROWING
+        // (`EACCES`, store/src/workspace-fs.ts:65), and just-bash lets that out of
+        // `exec` instead of turning it into an exit code. A path the person's own
+        // filesystem refused is an ordinary shell failure, not a broken tool call:
+        // the model has to READ it and pick another path, which it cannot do if
+        // the turn dies instead.
+        return { stdout: "", stderr: `${(error as Error).message}\n`, exitCode: 1 };
+      }
     },
   };
 }

--- a/packages/harnesses/src/vendo/shell/tool.ts
+++ b/packages/harnesses/src/vendo/shell/tool.ts
@@ -45,6 +45,28 @@ const descriptors: ToolDescriptor[] = [
 const ok = (output: Record<string, unknown>): ToolOutcome => ({ status: "ok", output: output as never });
 const fail = (code: string, message: string): ToolOutcome => ({ status: "error", error: { code, message } });
 
+/** What ONE stream may hand back. Half the bridge's 32 000-char cap, so stdout
+ *  and stderr together can never reach it: `capOutcome` does not clip, it
+ *  REPLACES the whole result with a preview string, which would throw away the
+ *  exit code and the stderr a failing command is diagnosed from. Clipping is the
+ *  shell's own job, and it keeps the TAIL — the end of a long output is where a
+ *  script's answer and its error both live. */
+const MAX_STREAM_CHARS = 16_000;
+
+const note = (dropped: number): string =>
+  `[clipped] ${dropped} earlier characters dropped; `
+  + `re-run with head/tail/grep to see them.\n`;
+
+const clip = (text: string): string => {
+  if (text.length <= MAX_STREAM_CHARS) return text;
+  // The note is INSIDE the budget, not on top of it — the cap is what one stream
+  // may hand back in TOTAL, and half the bridge's is only headroom if the note
+  // counts. Reserved against `text.length`, the largest the drop can ever be, so
+  // the digits are never underestimated and the result never exceeds the cap.
+  const kept = MAX_STREAM_CHARS - note(text.length).length;
+  return note(text.length - kept) + text.slice(text.length - kept);
+};
+
 export function createShellTools(
   open: (principal: Principal) => Promise<WorkspaceFs>,
   config: { limits?: ShellLimits } = {},
@@ -66,7 +88,7 @@ export function createShellTools(
       });
       const result = await session.exec(args.command);
       await workspace.commit();
-      return ok({ stdout: result.stdout, stderr: result.stderr, exitCode: result.exitCode });
+      return ok({ stdout: clip(result.stdout), stderr: clip(result.stderr), exitCode: result.exitCode });
     },
   };
 }

--- a/packages/harnesses/src/vendo/shell/tool.ts
+++ b/packages/harnesses/src/vendo/shell/tool.ts
@@ -159,6 +159,13 @@ export function createShellTools(
         // `/tmp` and staged writes are then unreachable.
         opening = openTurn(ctx.principal);
         live.set(key, opening);
+        // A REJECTED open is not cached, though: the store blinking once must
+        // not wedge the rest of the turn. Guarded on identity so a turn that was
+        // evicted and re-opened keeps its newer entry.
+        const failed = opening;
+        void failed.catch(() => {
+          if (live.get(key) === failed) live.delete(key);
+        });
       }
       const turn = await opening;
       const run = turn.queue.then(async () => ({
@@ -168,12 +175,16 @@ export function createShellTools(
       turn.queue = run.catch(() => undefined);
       const { result, committed } = await run;
       if (committed.status === "conflict") {
-        // `/orgs` is compare-and-swap: the command ran, and nothing it wrote was
-        // kept. Saying `ok` here would tell the model a durable write happened.
+        // `/orgs` is compare-and-swap and a commit batches PER OWNER
+        // (store/src/workspace-fs.ts:592-595), so the losing swap is the only
+        // thing rolled back — the same command's `/user` writes DID land. Saying
+        // `ok` would hide the lost write; saying nothing was saved would send the
+        // model to re-run a command that already half-applied.
         return fail(
           "conflict",
-          `Someone else changed ${committed.paths.join(", ")} while this ran, so none of this command's `
-          + `writes were saved. Re-read those paths and run it again.`,
+          `Someone else changed ${committed.paths.join(", ")} while this ran, so the writes to those `
+          + `paths were rejected. Anything this command wrote elsewhere DID land. Re-read those paths `
+          + `and redo only that part.`,
         );
       }
       return ok({ stdout: clip(result.stdout), stderr: clip(result.stderr), exitCode: result.exitCode });

--- a/packages/harnesses/src/vendo/shell/tool.ts
+++ b/packages/harnesses/src/vendo/shell/tool.ts
@@ -1,0 +1,72 @@
+/**
+ * The shell's hand on the ONE registry.
+ *
+ * Modelled on the drawer's tools (`@vendoai/vendo` user-files.ts): a
+ * `ToolRegistry` whose descriptor carries its own `risk`, whose every call opens
+ * the workspace for `ctx.principal` and NOBODY else, and which commits what the
+ * call wrote before answering. There is no subject argument to get wrong.
+ */
+import {
+  VENDO_BASH_TOOL,
+  VENDO_TOOL_TITLES,
+  type Principal,
+  type ToolDescriptor,
+  type ToolOutcome,
+  type ToolRegistry,
+  type WorkspaceFs,
+} from "@vendoai/core";
+import { createShellSession, type ShellLimits, type ShellSession } from "./engine.js";
+
+const DRAFT_2020_12 = "https://json-schema.org/draft/2020-12/schema";
+
+const descriptors: ToolDescriptor[] = [
+  {
+    name: VENDO_BASH_TOOL,
+    title: VENDO_TOOL_TITLES[VENDO_BASH_TOOL]!,
+    description:
+      "Run a bash command over this user's own files. You have a real shell — grep, sed, awk, jq, sort, "
+      + "cut, head, tail, wc, find, pipes and redirection all work — and the filesystem IS the user's "
+      + "workspace: /user/threads/<thread>/files holds what they dropped in THIS conversation, "
+      + "/user/apps/<app> holds an app's files, and /user/files is the shelf of things they asked you to "
+      + "keep. /tmp is scratch that lasts this conversation and is never saved. "
+      + "There is no network and no package manager: everything you need is already here. "
+      + "Prefer this over reading a file line by line — one command answers what twenty reads would.",
+    inputSchema: {
+      $schema: DRAFT_2020_12,
+      type: "object",
+      properties: { command: { type: "string", minLength: 1 } },
+      required: ["command"],
+      additionalProperties: false,
+    },
+    risk: "write",
+  },
+];
+
+const ok = (output: Record<string, unknown>): ToolOutcome => ({ status: "ok", output: output as never });
+const fail = (code: string, message: string): ToolOutcome => ({ status: "error", error: { code, message } });
+
+export function createShellTools(
+  open: (principal: Principal) => Promise<WorkspaceFs>,
+  config: { limits?: ShellLimits } = {},
+): ToolRegistry {
+  return {
+    async descriptors() {
+      return structuredClone(descriptors);
+    },
+    async execute(call, ctx): Promise<ToolOutcome> {
+      if (call.tool !== VENDO_BASH_TOOL) return fail("not-found", `Unknown tool: ${call.tool}`);
+      const args = (call.args ?? {}) as { command?: unknown };
+      if (typeof args.command !== "string" || args.command.trim() === "") {
+        return fail("validation", "command must be the shell command to run, as a single string");
+      }
+      const workspace = await open(ctx.principal);
+      const session: ShellSession = createShellSession({
+        workspace,
+        ...(config.limits === undefined ? {} : { limits: config.limits }),
+      });
+      const result = await session.exec(args.command);
+      await workspace.commit();
+      return ok({ stdout: result.stdout, stderr: result.stderr, exitCode: result.exitCode });
+    },
+  };
+}

--- a/packages/harnesses/src/vendo/shell/tool.ts
+++ b/packages/harnesses/src/vendo/shell/tool.ts
@@ -45,26 +45,57 @@ const descriptors: ToolDescriptor[] = [
 const ok = (output: Record<string, unknown>): ToolOutcome => ({ status: "ok", output: output as never });
 const fail = (code: string, message: string): ToolOutcome => ({ status: "error", error: { code, message } });
 
-/** What ONE stream may hand back. Half the bridge's 32 000-char cap, so stdout
- *  and stderr together can never reach it: `capOutcome` does not clip, it
- *  REPLACES the whole result with a preview string, which would throw away the
- *  exit code and the stderr a failing command is diagnosed from. Clipping is the
- *  shell's own job, and it keeps the TAIL — the end of a long output is where a
- *  script's answer and its error both live. */
-const MAX_STREAM_CHARS = 16_000;
+/** The bridge's default `toolOutputCap`, mirrored because the layering forbids
+ *  importing `@vendoai/vendo`'s `DEFAULT_TOOL_OUTPUT_CAP` from here. `capOutcome`
+ *  does not clip at it, it REPLACES the whole result with a preview string,
+ *  throwing away the exit code and the stderr a failing command is diagnosed
+ *  from — so the shell stays under it itself. */
+const BRIDGE_CAP_CHARS = 32_000;
+
+/** `{"stdout":"…","stderr":"…","exitCode":0}` — the keys and punctuation the two
+ *  streams sit inside, which `JSON.stringify` weighs too. */
+const ENVELOPE_CHARS = 64;
+
+/** What ONE stream may hand back, so BOTH plus the envelope stay under the cap.
+ *  Clipping keeps the TAIL — the end of a long output is where a script's answer
+ *  and its error both live.
+ *
+ *  Counted in JSON characters, not raw ones: `capOutcome` weighs
+ *  `JSON.stringify(output)`, where a newline costs two characters and a control
+ *  byte six, so a raw budget let an all-newline stream (`cut` over empty fields,
+ *  a bare `find`) reach the very cap this exists to stay under. */
+const MAX_STREAM_JSON_CHARS = (BRIDGE_CAP_CHARS - ENVELOPE_CHARS) / 2;
+
+/** What `text` costs inside a JSON string, quotes excluded. */
+const jsonLength = (text: string): number => JSON.stringify(text).length - 2;
 
 const note = (dropped: number): string =>
   `[clipped] ${dropped} earlier characters dropped; `
   + `re-run with head/tail/grep to see them.\n`;
 
+/** The longest TAIL of `text` that fits `budget` JSON characters. Spent
+ *  character by character from the end, because escaping is per character and
+ *  the end is the half worth keeping. */
+const tail = (text: string, budget: number): string => {
+  let spent = 0;
+  let start = text.length;
+  while (start > 0) {
+    const cost = jsonLength(text[start - 1]!);
+    if (spent + cost > budget) break;
+    spent += cost;
+    start -= 1;
+  }
+  return text.slice(start);
+};
+
 const clip = (text: string): string => {
-  if (text.length <= MAX_STREAM_CHARS) return text;
+  if (jsonLength(text) <= MAX_STREAM_JSON_CHARS) return text;
   // The note is INSIDE the budget, not on top of it — the cap is what one stream
   // may hand back in TOTAL, and half the bridge's is only headroom if the note
   // counts. Reserved against `text.length`, the largest the drop can ever be, so
   // the digits are never underestimated and the result never exceeds the cap.
-  const kept = MAX_STREAM_CHARS - note(text.length).length;
-  return note(text.length - kept) + text.slice(text.length - kept);
+  const kept = tail(text, MAX_STREAM_JSON_CHARS - jsonLength(note(text.length)));
+  return note(text.length - kept.length) + kept;
 };
 
 /** Sessions outlive a call and nothing here is told a turn ended, so the cache is
@@ -73,11 +104,34 @@ const clip = (text: string): string => {
  *  which is the one thing in the session that was never durable anyway. */
 const MAX_LIVE_SESSIONS = 32;
 
+interface Turn {
+  session: ShellSession;
+  workspace: WorkspaceFs;
+  /** This turn's calls run ONE at a time. A model may emit two `bash` calls in a
+   *  single step and the AI SDK runs those together, and they share a workspace
+   *  whose writes STAGE until `commit()` — two in flight over one staging area is
+   *  one call committing the other's half-written files. */
+  queue: Promise<unknown>;
+}
+
 export function createShellTools(
   open: (principal: Principal) => Promise<WorkspaceFs>,
   config: { limits?: ShellLimits } = {},
 ): ToolRegistry {
-  const live = new Map<string, { session: ShellSession; workspace: WorkspaceFs }>();
+  const live = new Map<string, Promise<Turn>>();
+
+  const openTurn = async (principal: Principal): Promise<Turn> => {
+    const workspace = await open(principal);
+    return {
+      workspace,
+      session: createShellSession({
+        workspace,
+        ...(config.limits === undefined ? {} : { limits: config.limits }),
+      }),
+      queue: Promise.resolve(),
+    };
+  };
+
   return {
     async descriptors() {
       return structuredClone(descriptors);
@@ -88,6 +142,7 @@ export function createShellTools(
       if (typeof args.command !== "string" || args.command.trim() === "") {
         return fail("validation", "command must be the shell command to run, as a single string");
       }
+      const command = args.command;
       // ONE session per TURN: `/tmp` is where a multi-step script keeps its
       // intermediates, and a fresh interpreter per call would throw them away
       // between `sort > /tmp/x` and `cat /tmp/x`. Keyed on `turnId` because that
@@ -95,21 +150,32 @@ export function createShellTools(
       // going"; a run with no turn (a webhook, a schedule fire) falls back to its
       // session so it is at least not sharing with anyone else.
       const key = ctx.turnId ?? `session:${ctx.principal.subject}:${ctx.sessionId}`;
-      let held = live.get(key);
-      if (held === undefined) {
+      let opening = live.get(key);
+      if (opening === undefined) {
         if (live.size >= MAX_LIVE_SESSIONS) live.delete(live.keys().next().value!);
-        const workspace = await open(ctx.principal);
-        held = {
-          workspace,
-          session: createShellSession({
-            workspace,
-            ...(config.limits === undefined ? {} : { limits: config.limits }),
-          }),
-        };
-        live.set(key, held);
+        // The PROMISE is cached, before anything is awaited. A check-then-set
+        // around `open` lets a second concurrent call for the same turn find
+        // nothing, build a second workspace, and overwrite the first — whose
+        // `/tmp` and staged writes are then unreachable.
+        opening = openTurn(ctx.principal);
+        live.set(key, opening);
       }
-      const result = await held.session.exec(args.command);
-      await held.workspace.commit();
+      const turn = await opening;
+      const run = turn.queue.then(async () => ({
+        result: await turn.session.exec(command),
+        committed: await turn.workspace.commit(),
+      }));
+      turn.queue = run.catch(() => undefined);
+      const { result, committed } = await run;
+      if (committed.status === "conflict") {
+        // `/orgs` is compare-and-swap: the command ran, and nothing it wrote was
+        // kept. Saying `ok` here would tell the model a durable write happened.
+        return fail(
+          "conflict",
+          `Someone else changed ${committed.paths.join(", ")} while this ran, so none of this command's `
+          + `writes were saved. Re-read those paths and run it again.`,
+        );
+      }
       return ok({ stdout: clip(result.stdout), stderr: clip(result.stderr), exitCode: result.exitCode });
     },
   };

--- a/packages/harnesses/src/vendo/shell/tool.ts
+++ b/packages/harnesses/src/vendo/shell/tool.ts
@@ -67,10 +67,17 @@ const clip = (text: string): string => {
   return note(text.length - kept) + text.slice(text.length - kept);
 };
 
+/** Sessions outlive a call and nothing here is told a turn ended, so the cache is
+ *  BOUNDED rather than swept: the oldest entry leaves when a new one would be the
+ *  33rd. A turn evicted early re-opens on its next call and loses only `/tmp`,
+ *  which is the one thing in the session that was never durable anyway. */
+const MAX_LIVE_SESSIONS = 32;
+
 export function createShellTools(
   open: (principal: Principal) => Promise<WorkspaceFs>,
   config: { limits?: ShellLimits } = {},
 ): ToolRegistry {
+  const live = new Map<string, { session: ShellSession; workspace: WorkspaceFs }>();
   return {
     async descriptors() {
       return structuredClone(descriptors);
@@ -81,13 +88,28 @@ export function createShellTools(
       if (typeof args.command !== "string" || args.command.trim() === "") {
         return fail("validation", "command must be the shell command to run, as a single string");
       }
-      const workspace = await open(ctx.principal);
-      const session: ShellSession = createShellSession({
-        workspace,
-        ...(config.limits === undefined ? {} : { limits: config.limits }),
-      });
-      const result = await session.exec(args.command);
-      await workspace.commit();
+      // ONE session per TURN: `/tmp` is where a multi-step script keeps its
+      // intermediates, and a fresh interpreter per call would throw them away
+      // between `sort > /tmp/x` and `cat /tmp/x`. Keyed on `turnId` because that
+      // is the only thing a tool call carries meaning "same conversation, still
+      // going"; a run with no turn (a webhook, a schedule fire) falls back to its
+      // session so it is at least not sharing with anyone else.
+      const key = ctx.turnId ?? `session:${ctx.principal.subject}:${ctx.sessionId}`;
+      let held = live.get(key);
+      if (held === undefined) {
+        if (live.size >= MAX_LIVE_SESSIONS) live.delete(live.keys().next().value!);
+        const workspace = await open(ctx.principal);
+        held = {
+          workspace,
+          session: createShellSession({
+            workspace,
+            ...(config.limits === undefined ? {} : { limits: config.limits }),
+          }),
+        };
+        live.set(key, held);
+      }
+      const result = await held.session.exec(args.command);
+      await held.workspace.commit();
       return ok({ stdout: clip(result.stdout), stderr: clip(result.stderr), exitCode: result.exitCode });
     },
   };

--- a/packages/harnesses/tests/shell/barrel.test.ts
+++ b/packages/harnesses/tests/shell/barrel.test.ts
@@ -1,0 +1,14 @@
+/**
+ * The shell is `vendo()`'s hand, so it leaves this package where the rest of
+ * that harness's knobs do — `@vendoai/harnesses/vendo`. A sandbox harness
+ * (`claudeCode()`) never imports it and must never see it.
+ */
+import { describe, expect, it } from "vitest";
+import * as vendoSubpath from "../../src/vendo/index.js";
+
+describe("the vendo subpath", () => {
+  it("exports the shell's tool factory and its limits type", () => {
+    expect(typeof vendoSubpath.createShellTools).toBe("function");
+    expect(typeof vendoSubpath.createShellSession).toBe("function");
+  });
+});

--- a/packages/harnesses/tests/shell/engine.test.ts
+++ b/packages/harnesses/tests/shell/engine.test.ts
@@ -75,6 +75,32 @@ describe("one shell session over the workspace", () => {
     const result = await createShellSession({ workspace }).exec("echo pwned > /etc/passwd");
 
     expect(result.exitCode).not.toBe(0);
+    // The workspace's OWN sentence, verbatim — a non-zero exit alone would also
+    // be satisfied by an engine that swallowed the EACCES and failed some other
+    // way, which is the opposite of the non-interference this proves.
+    expect(result.stderr).toContain("EACCES: permission denied, open '/etc/passwd'");
+  });
+
+  it("bounds that /tmp across the whole session, not just one call", async () => {
+    // `maxOutputBytes` bounds ONE redirect (`redirection: total output size
+    // exceeded`); nothing bounded the SESSION, so a turn that kept appending grew
+    // `/tmp` without limit — 200 MB over 400 calls, measured. Raised here so the
+    // ceiling is reached in a handful of copies rather than sixty appends.
+    const session = createShellSession({ workspace: await disk({}), limits: { maxOutputBytes: 8_000_000 } });
+    const repeat = (path: string, times: number): string => Array.from({ length: times }, () => path).join(" ");
+    expect((await session.exec(`printf 'x%.0s' $(seq 1 100000) > /tmp/kb100`)).exitCode).toBe(0);
+    expect((await session.exec(`cat ${repeat("/tmp/kb100", 10)} > /tmp/mb1`)).exitCode).toBe(0);
+    expect((await session.exec(`cat ${repeat("/tmp/mb1", 5)} > /tmp/mb5`)).exitCode).toBe(0);
+
+    let last = { exitCode: 0, stderr: "" };
+    for (let copy = 0; copy < 8 && last.exitCode === 0; copy += 1) {
+      // Each copy has to be its OWN bytes: `cp` alone shares one hard-link
+      // buffer, so eight identical copies retain what one does.
+      last = await session.exec(`cp /tmp/mb5 /tmp/copy${copy} && echo ${copy} >> /tmp/copy${copy}`);
+    }
+
+    expect(last.exitCode).not.toBe(0);
+    expect(last.stderr).toContain("ENOSPC");
   });
 
   it("stops a command that will not stop", async () => {

--- a/packages/harnesses/tests/shell/engine.test.ts
+++ b/packages/harnesses/tests/shell/engine.test.ts
@@ -76,4 +76,29 @@ describe("one shell session over the workspace", () => {
 
     expect(result.exitCode).not.toBe(0);
   });
+
+  it("stops a command that will not stop", async () => {
+    const session = createShellSession({
+      workspace: await disk({}),
+      limits: { maxExecutionTimeMs: 250 },
+    });
+
+    const result = await session.exec("while true; do echo spin > /dev/null; done");
+
+    expect(result.exitCode).not.toBe(0);
+  });
+
+  it("stops a command that will not stop TALKING", async () => {
+    const session = createShellSession({
+      workspace: await disk({}),
+      limits: { maxOutputBytes: 512 },
+    });
+
+    // `seq`, not `yes`: just-bash 3.4.2 ships no `yes`, and in a pipeline the
+    // `command not found` is invisible — the exit code is `head`'s 0.
+    const result = await session.exec("seq 1 100000");
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout.length).toBeLessThan(4096);
+  });
 });

--- a/packages/harnesses/tests/shell/engine.test.ts
+++ b/packages/harnesses/tests/shell/engine.test.ts
@@ -45,4 +45,35 @@ describe("one shell session over the workspace", () => {
     expect(result.exitCode).not.toBe(0);
     expect(result.stderr).toContain("No such file or directory");
   });
+
+  it("gives the session a writable /tmp the workspace never sees", async () => {
+    const workspace = await disk({ "/user/files/a.txt": "one\ntwo\n" });
+    const session = createShellSession({ workspace });
+
+    const wrote = await session.exec("sort files/a.txt > /tmp/sorted.txt");
+    expect(wrote.exitCode).toBe(0);
+    // Same session, second call: the scratch is still there.
+    expect((await session.exec("cat /tmp/sorted.txt")).stdout).toBe("one\ntwo\n");
+    // And it is NOT in the workspace — nothing to commit, nothing to leak.
+    expect(await workspace.exists("/tmp/sorted.txt")).toBe(false);
+  });
+
+  it("refuses a write outside the mounts, because the filesystem does", async () => {
+    // The refusal is the WORKSPACE's, never the engine's — `WorkspaceStoreFs`
+    // raises EACCES outside the caller's mounts (store/src/workspace-fs.ts:229),
+    // and this module deliberately bolts no check of its own on top. So the base
+    // here is one that refuses, and what this proves is the engine's
+    // non-interference: it surfaces the filesystem's EACCES rather than routing
+    // around it. A bare `InMemoryFs` has no mounts and would assert nothing.
+    const workspace = await disk({});
+    const mounted = workspace.writeFile.bind(workspace);
+    workspace.writeFile = async (path, data) => {
+      if (!path.startsWith("/user/")) throw new Error(`EACCES: permission denied, open '${path}'`);
+      return await mounted(path, data);
+    };
+
+    const result = await createShellSession({ workspace }).exec("echo pwned > /etc/passwd");
+
+    expect(result.exitCode).not.toBe(0);
+  });
 });

--- a/packages/harnesses/tests/shell/engine.test.ts
+++ b/packages/harnesses/tests/shell/engine.test.ts
@@ -1,0 +1,48 @@
+/**
+ * The engine, over a REAL just-bash filesystem — the same interface a
+ * `WorkspaceFs` satisfies, so what passes here is what a turn gets.
+ */
+import { InMemoryFs } from "just-bash";
+import type { IFileSystem } from "@vendoai/core";
+import { describe, expect, it } from "vitest";
+import { createShellSession } from "../../src/vendo/shell/engine.js";
+
+const disk = async (files: Record<string, string>): Promise<IFileSystem> => {
+  const fs = new InMemoryFs();
+  for (const [path, content] of Object.entries(files)) {
+    await fs.mkdir(path.slice(0, path.lastIndexOf("/")), { recursive: true });
+    await fs.writeFile(path, content);
+  }
+  return fs as unknown as IFileSystem;
+};
+
+describe("one shell session over the workspace", () => {
+  it("greps a file the workspace holds", async () => {
+    const workspace = await disk({
+      "/user/threads/thr_1/files/ledger.csv": "month,revenue\njan,31000\nfeb,39000\n",
+    });
+    const session = createShellSession({ workspace });
+
+    const result = await session.exec("grep -c , threads/thr_1/files/ledger.csv");
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe("3");
+    expect(result.stderr).toBe("");
+  });
+
+  it("starts in /user, so the agent's paths are the user's paths", async () => {
+    const session = createShellSession({ workspace: await disk({ "/user/files/a.txt": "hi\n" }) });
+
+    expect((await session.exec("pwd")).stdout.trim()).toBe("/user");
+    expect((await session.exec("cat files/a.txt")).stdout).toBe("hi\n");
+  });
+
+  it("reports a failing command instead of throwing", async () => {
+    const session = createShellSession({ workspace: await disk({}) });
+
+    const result = await session.exec("cat /user/nope.txt");
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain("No such file or directory");
+  });
+});

--- a/packages/harnesses/tests/shell/tool.test.ts
+++ b/packages/harnesses/tests/shell/tool.test.ts
@@ -107,3 +107,35 @@ describe("a very talkative command", () => {
     expect(JSON.stringify((outcome as { output: unknown }).output).length).toBeLessThan(32_000);
   });
 });
+
+describe("the session's lifetime", () => {
+  it("keeps /tmp across calls in ONE turn", async () => {
+    const workspace = workspaceDouble();
+    const registry = createShellTools(async () => workspace);
+    const turn = ctx({ turnId: "trn_same" });
+
+    await registry.execute({ id: "c5", tool: VENDO_BASH_TOOL, args: { command: "echo kept > /tmp/note" } }, turn);
+    const second = await registry.execute(
+      { id: "c6", tool: VENDO_BASH_TOOL, args: { command: "cat /tmp/note" } },
+      turn,
+    );
+
+    expect((second as { output: { stdout: string } }).output.stdout).toBe("kept\n");
+  });
+
+  it("does NOT carry /tmp into another turn", async () => {
+    const workspace = workspaceDouble();
+    const registry = createShellTools(async () => workspace);
+
+    await registry.execute(
+      { id: "c7", tool: VENDO_BASH_TOOL, args: { command: "echo leaked > /tmp/note" } },
+      ctx({ turnId: "trn_one" }),
+    );
+    const other = await registry.execute(
+      { id: "c8", tool: VENDO_BASH_TOOL, args: { command: "cat /tmp/note" } },
+      ctx({ turnId: "trn_two" }),
+    );
+
+    expect((other as { output: { exitCode: number } }).output.exitCode).not.toBe(0);
+  });
+});

--- a/packages/harnesses/tests/shell/tool.test.ts
+++ b/packages/harnesses/tests/shell/tool.test.ts
@@ -57,3 +57,34 @@ describe("the shell tool's descriptor", () => {
       .toMatchObject({ status: "error", error: { code: "validation" } });
   });
 });
+
+describe("the shell tool's hands", () => {
+  it("reads a file the workspace holds and answers with the shell's three outputs", async () => {
+    const workspace = workspaceDouble();
+    await workspace.mkdir("/user/files", { recursive: true });
+    await workspace.writeFile("/user/files/ledger.csv", "month,revenue\njan,31000\n");
+    const registry = createShellTools(async () => workspace);
+
+    const outcome = await registry.execute(
+      { id: "c2", tool: VENDO_BASH_TOOL, args: { command: "cut -d, -f2 files/ledger.csv | tail -1" } },
+      ctx(),
+    );
+
+    expect(outcome).toMatchObject({ status: "ok", output: { exitCode: 0, stderr: "" } });
+    expect((outcome as { output: { stdout: string } }).output.stdout.trim()).toBe("31000");
+  });
+
+  it("commits what the call wrote, so the next turn sees it", async () => {
+    const workspace = workspaceDouble();
+    await workspace.mkdir("/user/files", { recursive: true });
+    const registry = createShellTools(async () => workspace);
+
+    await registry.execute(
+      { id: "c3", tool: VENDO_BASH_TOOL, args: { command: "echo 'jan,31000' > files/out.csv" } },
+      ctx(),
+    );
+
+    expect(await workspace.readFile("/user/files/out.csv")).toBe("jan,31000\n");
+    expect(workspace.commits).toBe(1);
+  });
+});

--- a/packages/harnesses/tests/shell/tool.test.ts
+++ b/packages/harnesses/tests/shell/tool.test.ts
@@ -88,3 +88,22 @@ describe("the shell tool's hands", () => {
     expect(workspace.commits).toBe(1);
   });
 });
+
+describe("a very talkative command", () => {
+  it("comes back clipped, and says so, instead of tripping the bridge's cap", async () => {
+    const workspace = workspaceDouble();
+    const registry = createShellTools(async () => workspace);
+
+    // `seq`, not `yes`: just-bash 3.4.2 ships no `yes`. ~48 900 chars — well over
+    // the 16 000-char clip, well under the 1 MB default output ceiling.
+    const outcome = await registry.execute(
+      { id: "c4", tool: VENDO_BASH_TOOL, args: { command: "seq 1 10000" } },
+      ctx(),
+    );
+
+    const { stdout } = (outcome as { output: { stdout: string } }).output;
+    expect(stdout.length).toBeLessThanOrEqual(16_000);
+    expect(stdout).toContain("[clipped]");
+    expect(JSON.stringify((outcome as { output: unknown }).output).length).toBeLessThan(32_000);
+  });
+});

--- a/packages/harnesses/tests/shell/tool.test.ts
+++ b/packages/harnesses/tests/shell/tool.test.ts
@@ -99,7 +99,14 @@ describe("the shell tool's hands", () => {
     );
 
     expect(outcome).toMatchObject({ status: "error", error: { code: "conflict" } });
-    expect((outcome as { error: { message: string } }).error.message).toContain("/orgs/acme/files/ledger.csv");
+    const { message } = (outcome as { error: { message: string } }).error;
+    expect(message).toContain("/orgs/acme/files/ledger.csv");
+    // A commit batches PER OWNER (store/src/workspace-fs.ts:592-595), so a lost
+    // `/orgs` swap does NOT take the same command's `/user` writes down with it.
+    // Saying nothing was saved would send the model to re-run a command that
+    // already half-landed.
+    expect(message).not.toContain("none of this command");
+    expect(message).toContain("elsewhere");
   });
 });
 
@@ -192,5 +199,29 @@ describe("the session's lifetime", () => {
 
     expect(opened).toBe(1);
     expect((second as { output: { stdout: string } }).output.stdout).toBe("one\n");
+  });
+
+  it("does not poison the turn when opening the workspace fails once", async () => {
+    const workspace = workspaceDouble();
+    let attempt = 0;
+    const registry = createShellTools(async () => {
+      attempt += 1;
+      if (attempt === 1) throw new Error("store unreachable");
+      return workspace;
+    });
+    const turn = ctx({ turnId: "trn_flaky" });
+
+    await expect(registry.execute(
+      { id: "c13", tool: VENDO_BASH_TOOL, args: { command: "echo hi" } },
+      turn,
+    )).rejects.toThrow("store unreachable");
+    // Caching the PROMISE is what fixes the open race; caching a REJECTED one
+    // would wedge the rest of the turn on a blip the store already recovered from.
+    const second = await registry.execute(
+      { id: "c14", tool: VENDO_BASH_TOOL, args: { command: "echo recovered" } },
+      turn,
+    );
+
+    expect((second as { output: { stdout: string } }).output.stdout).toBe("recovered\n");
   });
 });

--- a/packages/harnesses/tests/shell/tool.test.ts
+++ b/packages/harnesses/tests/shell/tool.test.ts
@@ -1,0 +1,59 @@
+/**
+ * The shell on the ONE registry — guarded, audited and projected exactly like a
+ * host tool, with no privileged side door. The descriptor IS the guard story:
+ * `guard.bind` keys off `risk`.
+ */
+import { InMemoryFs } from "just-bash";
+import { VENDO_BASH_TOOL, type Principal, type RunContext, type WorkspaceFs } from "@vendoai/core";
+import { describe, expect, it } from "vitest";
+import { createShellTools } from "../../src/vendo/shell/tool.js";
+
+const principal: Principal = { kind: "user", subject: "user_shell" };
+
+const ctx = (overrides: Partial<RunContext> = {}): RunContext => ({
+  principal,
+  venue: "chat",
+  presence: "present",
+  sessionId: "s_shell",
+  ...overrides,
+});
+
+/** A workspace double that is a REAL just-bash filesystem plus the one method
+    the façade adds — so nothing about the bash half is faked. */
+const workspaceDouble = (): WorkspaceFs & { commits: number } => {
+  const fs = new InMemoryFs() as unknown as WorkspaceFs & { commits: number };
+  fs.commits = 0;
+  fs.commit = async () => {
+    fs.commits += 1;
+    return { status: "ok", changed: [] };
+  };
+  return fs;
+};
+
+describe("the shell tool's descriptor", () => {
+  it("is one tool called bash, graded write", async () => {
+    const registry = createShellTools(async () => workspaceDouble());
+
+    const [descriptor, ...rest] = await registry.descriptors();
+
+    expect(rest).toEqual([]);
+    expect(descriptor?.name).toBe(VENDO_BASH_TOOL);
+    expect(descriptor?.title).toBe("Work on your files");
+    expect(descriptor?.risk).toBe("write");
+    expect(descriptor?.inputSchema).toMatchObject({
+      type: "object",
+      properties: { command: { type: "string" } },
+      required: ["command"],
+      additionalProperties: false,
+    });
+  });
+
+  it("refuses a call that is not this tool, and a call with no command", async () => {
+    const registry = createShellTools(async () => workspaceDouble());
+
+    expect(await registry.execute({ id: "c0", tool: "nope", args: {} }, ctx()))
+      .toMatchObject({ status: "error", error: { code: "not-found" } });
+    expect(await registry.execute({ id: "c1", tool: VENDO_BASH_TOOL, args: {} }, ctx()))
+      .toMatchObject({ status: "error", error: { code: "validation" } });
+  });
+});

--- a/packages/harnesses/tests/shell/tool.test.ts
+++ b/packages/harnesses/tests/shell/tool.test.ts
@@ -87,6 +87,20 @@ describe("the shell tool's hands", () => {
     expect(await workspace.readFile("/user/files/out.csv")).toBe("jan,31000\n");
     expect(workspace.commits).toBe(1);
   });
+
+  it("says the write did NOT land when the workspace answers conflict", async () => {
+    const workspace = workspaceDouble();
+    workspace.commit = async () => ({ status: "conflict", paths: ["/orgs/acme/files/ledger.csv"] });
+    const registry = createShellTools(async () => workspace);
+
+    const outcome = await registry.execute(
+      { id: "c9", tool: VENDO_BASH_TOOL, args: { command: "echo 'jan,31000' > /tmp/out.csv" } },
+      ctx(),
+    );
+
+    expect(outcome).toMatchObject({ status: "error", error: { code: "conflict" } });
+    expect((outcome as { error: { message: string } }).error.message).toContain("/orgs/acme/files/ledger.csv");
+  });
 });
 
 describe("a very talkative command", () => {
@@ -95,7 +109,7 @@ describe("a very talkative command", () => {
     const registry = createShellTools(async () => workspace);
 
     // `seq`, not `yes`: just-bash 3.4.2 ships no `yes`. ~48 900 chars — well over
-    // the 16 000-char clip, well under the 1 MB default output ceiling.
+    // the clip, well under the 1 MB default output ceiling.
     const outcome = await registry.execute(
       { id: "c4", tool: VENDO_BASH_TOOL, args: { command: "seq 1 10000" } },
       ctx(),
@@ -105,6 +119,25 @@ describe("a very talkative command", () => {
     expect(stdout.length).toBeLessThanOrEqual(16_000);
     expect(stdout).toContain("[clipped]");
     expect(JSON.stringify((outcome as { output: unknown }).output).length).toBeLessThan(32_000);
+  });
+
+  it("keeps stdout AND stderr together under the bridge's cap, escaping and all", async () => {
+    const workspace = workspaceDouble();
+    const registry = createShellTools(async () => workspace);
+
+    // Both streams full of the one character JSON doubles. Raw, each is 30 000
+    // characters; in the JSON `capOutcome` weighs, each is 60 000, so a
+    // raw-character budget hands the bridge far more than it caps at.
+    const blanks = `awk 'BEGIN{for(i=0;i<30000;i++)print ""}'`;
+    const outcome = await registry.execute(
+      { id: "c10", tool: VENDO_BASH_TOOL, args: { command: `${blanks}; ${blanks} >&2` } },
+      ctx(),
+    );
+
+    const { stdout, stderr } = (outcome as { output: { stdout: string; stderr: string } }).output;
+    expect(stdout).toContain("[clipped]");
+    expect(stderr).toContain("[clipped]");
+    expect(JSON.stringify((outcome as { output: unknown }).output).length).toBeLessThanOrEqual(32_000);
   });
 });
 
@@ -127,7 +160,7 @@ describe("the session's lifetime", () => {
     const workspace = workspaceDouble();
     const registry = createShellTools(async () => workspace);
 
-    await registry.execute(
+    const wrote = await registry.execute(
       { id: "c7", tool: VENDO_BASH_TOOL, args: { command: "echo leaked > /tmp/note" } },
       ctx({ turnId: "trn_one" }),
     );
@@ -136,6 +169,28 @@ describe("the session's lifetime", () => {
       ctx({ turnId: "trn_two" }),
     );
 
+    // The write has to have LANDED, or the second turn's failure proves nothing
+    // but that nobody ever wrote the file.
+    expect((wrote as { output: { exitCode: number } }).output.exitCode).toBe(0);
     expect((other as { output: { exitCode: number } }).output.exitCode).not.toBe(0);
+  });
+
+  it("opens ONE workspace for a turn whose two calls arrive together", async () => {
+    const workspace = workspaceDouble();
+    let opened = 0;
+    const registry = createShellTools(async () => {
+      opened += 1;
+      return workspace;
+    });
+    const turn = ctx({ turnId: "trn_parallel" });
+
+    // What the AI SDK does with two tool calls in one step: both at once.
+    const [, second] = await Promise.all([
+      registry.execute({ id: "c11", tool: VENDO_BASH_TOOL, args: { command: "echo one > /tmp/shared" } }, turn),
+      registry.execute({ id: "c12", tool: VENDO_BASH_TOOL, args: { command: "cat /tmp/shared" } }, turn),
+    ]);
+
+    expect(opened).toBe(1);
+    expect((second as { output: { stdout: string } }).output.stdout).toBe("one\n");
   });
 });

--- a/packages/vendo/src/compose-harness.ts
+++ b/packages/vendo/src/compose-harness.ts
@@ -8,6 +8,7 @@ import { awayRunner } from "@vendoai/agents";
 import {
   CONNECTOR_DISCOVERY_TOOLS,
   VENDO_AUTOMATE_TOOL,
+  VENDO_BASH_TOOL,
   VENDO_MAKE_TOOL,
   type AgentRunner,
   type Harness,
@@ -48,10 +49,17 @@ import { registerTurnSteer } from "./turn-liveness.js";
  *  A name with nothing behind it costs nothing: `computeInitialLoadout` filters
  *  the turn's OWN listings through this set (tool-search.ts), so on a deployment
  *  that never opted into texts it simply never matches — no `channels` gate. */
-const PROMPT_TAUGHT_TOOLS: readonly string[] = [
+export const PROMPT_TAUGHT_TOOLS: readonly string[] = [
   VENDO_MAKE_TOOL,
   VENDO_AUTOMATE_TOOL,
   VENDO_TEXT_ME_TOOL,
+  // The shell has no `vendo_` prefix on purpose (it is the `bash` every model
+  // already knows), so it is not covered by the always-active exemption that
+  // prefix buys. Named here instead: a deployment past the loadout cap must not
+  // lose the one tool that opens the user's files. An entry with no matching
+  // listing costs nothing — a deployment with the shell withheld simply has
+  // nothing for this name to exempt.
+  VENDO_BASH_TOOL,
   ...CONNECTOR_DISCOVERY_TOOLS,
 ];
 

--- a/packages/vendo/src/compose-tools.ts
+++ b/packages/vendo/src/compose-tools.ts
@@ -5,6 +5,7 @@
  */
 import type { Connector } from "@vendoai/actions";
 import { consoleLogger, emitUsage, setLogger, setUsageSink, type Json } from "@vendoai/core";
+import { createShellTools } from "@vendoai/harnesses/vendo";
 import { createKnowledgeTools, knowledgeIndexResolver } from "@vendoai/knowledge";
 import { workspaceStore } from "@vendoai/store";
 import {
@@ -133,7 +134,7 @@ export const emitDeploymentBoot = (composition: VendoComposition): void => {
 export const composeTools = (composition: VendoComposition): Pick<VendoComposition,
   "toolOutputCap" | "catalogConnectors" | "serviceCatalog" | "knowledgeIndex"
   | "missSurface" | "missCapture"> => {
-  const { config, actions, store, resolvedConnectors, surfaceRoot } = composition;
+  const { config, actions, store, resolvedConnectors, surfaceRoot, composed } = composition;
   // One value, three readers: the agent's context, the harness bridge, and the
   // discovery registry — which bounds its own search under it rather than being
   // cut by it (the cap slices serialized JSON, so a search that reaches it loses
@@ -183,6 +184,26 @@ export const composeTools = (composition: VendoComposition): Pick<VendoCompositi
     async (principal) => await (drawer ??= workspaceStore(store, { files: composition.files })).open(principal),
     uploadCapOf(config),
   ));
+
+  // The shell (spec 2026-08-23 §1) — the RESIDENT brain's hands, on the same
+  // registry, guarded and audited like everything else.
+  //
+  // The condition is WHO THINKS, resolved from the same two slots
+  // compose-harness.ts resolves it from (`composed?.harness ?? config.harness`,
+  // then the `vendo()` default). It is re-derived here rather than read off
+  // `composition.harness` because this phase runs BEFORE composeHarness
+  // (compose-context.ts:323 vs :325) — and a brain that thinks on a MACHINE
+  // already has a real disk, so handing it a second, virtual one would be two
+  // filesystems disagreeing about the same files.
+  const brain = composed?.harness ?? config.harness;
+  const residentBrain = brain === undefined || brain.name === "vendo";
+  const shellLimits = typeof config.shell === "object" ? config.shell.limits : undefined;
+  if (config.shell !== false && residentBrain) {
+    actions.add(createShellTools(
+      async (principal) => await (drawer ??= workspaceStore(store, { files: composition.files })).open(principal),
+      shellLimits === undefined ? {} : { limits: shellLimits },
+    ));
+  }
 
   // Knowledge K1 — the tool exists exactly when an adapter is configured;
   // no adapter, no `vendo_knowledge_search` in any descriptor surface.

--- a/packages/vendo/src/config-keys.ts
+++ b/packages/vendo/src/config-keys.ts
@@ -59,6 +59,7 @@ export const CREATE_VENDO_CONFIG_KEYS = [
   "profileDir",
   "fetch",
   "profile",
+  "shell",
   "mcp",
   "oauth",
   "agent",

--- a/packages/vendo/src/surface-menu.ts
+++ b/packages/vendo/src/surface-menu.ts
@@ -1,4 +1,4 @@
-import { CONNECTOR_DISCOVERY_TOOLS, type ToolRegistry } from "@vendoai/core";
+import { CONNECTOR_DISCOVERY_TOOLS, VENDO_BASH_TOOL, type ToolRegistry } from "@vendoai/core";
 import { VENDO_TOOL_PACK_PREFIX } from "./tool-pack.js";
 
 /**
@@ -56,12 +56,18 @@ export function memoizedSurfaceMenu(
  * four carry no prefix while the system prompt teaches them by name — filtering
  * them out is the uiaudit-2026-08-06 regression (a curated host lost
  * `request_connection` while the prompt kept teaching it).
+ *
+ * `bash` is exempt for exactly that second reason, and named for exactly that
+ * reason too: it is Vendo's own, the prompt teaches it, and it deliberately
+ * carries no `vendo_` prefix, so the prefix cannot cover it (the same gap
+ * `PROMPT_TAUGHT_TOOLS` closes on the loadout side). A deployment that does not
+ * want the shell says `shell: false`; a curated menu is not where it goes.
  */
 export function withAgentMenu(
   tools: ToolRegistry,
   menu: () => Promise<ReadonlySet<string> | undefined>,
 ): ToolRegistry {
-  const exempt: ReadonlySet<string> = new Set(CONNECTOR_DISCOVERY_TOOLS);
+  const exempt: ReadonlySet<string> = new Set([...CONNECTOR_DISCOVERY_TOOLS, VENDO_BASH_TOOL]);
   return {
     ...tools,
     async descriptors(ctx) {

--- a/packages/vendo/src/types.ts
+++ b/packages/vendo/src/types.ts
@@ -42,6 +42,7 @@ import type {
   VendoTheme,
 } from "@vendoai/apps/contract";
 import type { GuardRules, PolicyFile, VendoGuard } from "@vendoai/guard";
+import type { ShellLimits } from "@vendoai/harnesses/vendo";
 import type { HostOAuthAdapter } from "@vendoai/mcp";
 import type { VendoStore } from "@vendoai/store";
 import type { VendoAgentTools } from "./agent-tools.js";
@@ -423,6 +424,23 @@ export interface CreateVendoConfig {
       exchanges one of these keys plus a user id for a short-lived user-bound
       token at the door's token endpoint (rotation is listing both keys until
       the old one is out of use). */
+  /** The agent's hands over the user's own files (spec 2026-08-23 §1): one
+      in-process `bash` over the workspace, on the same guarded registry as
+      everything else. ON by default — a deployment's users drop files into chat
+      whether or not anyone configured anything, and an agent that cannot open
+      them is the whole problem this exists to fix.
+
+      `false` withholds the tool entirely. The object form keeps it and moves its
+      ceilings: `limits.maxExecutionTimeMs` (default 30 000) is one call's wall
+      clock, `limits.maxOutputBytes` (default 1 000 000) is how much one call may
+      produce before the shell stops it.
+
+      It rides the RESIDENT BRAIN, not the deployment: `vendo()` runs in this
+      process and has the workspace in hand, so the tool composes for it and for
+      an `agent()` that adopted it. A harness that thinks on a MACHINE
+      (`claudeCode()`) already has a real disk and reaches it its own way, so this
+      flag is silently irrelevant there rather than half-wired. */
+  shell?: boolean | { limits?: ShellLimits };
   mcp?: boolean | {
     baseUrl?: string;
     remoteAs?: { issuer: string; jwksUri?: string; audience: string };

--- a/packages/vendo/src/types.ts
+++ b/packages/vendo/src/types.ts
@@ -424,6 +424,12 @@ export interface CreateVendoConfig {
       exchanges one of these keys plus a user id for a short-lived user-bound
       token at the door's token endpoint (rotation is listing both keys until
       the old one is out of use). */
+  mcp?: boolean | {
+    baseUrl?: string;
+    remoteAs?: { issuer: string; jwksUri?: string; audience: string };
+    federation?: { secret: string };
+    serviceAuth?: { keys: readonly string[] };
+  };
   /** The agent's hands over the user's own files (spec 2026-08-23 §1): one
       in-process `bash` over the workspace, on the same guarded registry as
       everything else. ON by default — a deployment's users drop files into chat
@@ -441,12 +447,6 @@ export interface CreateVendoConfig {
       (`claudeCode()`) already has a real disk and reaches it its own way, so this
       flag is silently irrelevant there rather than half-wired. */
   shell?: boolean | { limits?: ShellLimits };
-  mcp?: boolean | {
-    baseUrl?: string;
-    remoteAs?: { issuer: string; jwksUri?: string; audience: string };
-    federation?: { secret: string };
-    serviceAuth?: { keys: readonly string[] };
-  };
   /** 10-mcp §3 plus its additive prebuilt flow — the host's session + identity seam. Threaded top-level like
       `actAs`/`principal` (the door is agnostic; the umbrella owns the shape).
       REQUIRED when `mcp` is true: the door cannot mint principals without it. */

--- a/packages/vendo/tests/shell-config.test.ts
+++ b/packages/vendo/tests/shell-config.test.ts
@@ -1,0 +1,16 @@
+/**
+ * The shell's config surface: the SAME shape `mcp` has — a boolean for the
+ * decision, an object for the decision plus its knobs. Default ON.
+ */
+import { describe, expect, it } from "vitest";
+import type { CreateVendoConfig } from "../src/types.js";
+
+describe("createVendo({ shell })", () => {
+  it("takes a boolean or an object carrying limits", () => {
+    const off: CreateVendoConfig["shell"] = false;
+    const on: CreateVendoConfig["shell"] = true;
+    const tuned: CreateVendoConfig["shell"] = { limits: { maxExecutionTimeMs: 5_000, maxOutputBytes: 4_096 } };
+
+    expect([off, on, tuned]).toHaveLength(3);
+  });
+});

--- a/packages/vendo/tests/shell-config.test.ts
+++ b/packages/vendo/tests/shell-config.test.ts
@@ -1,16 +1,33 @@
 /**
  * The shell's config surface: the SAME shape `mcp` has — a boolean for the
  * decision, an object for the decision plus its knobs. Default ON.
+ *
+ * A type has no runtime, so the shape's assertions are the compiler's and
+ * `tsc -p tsconfig.test.json` is where they bite. Each `@ts-expect-error` is
+ * itself an assertion: it fails the build the day the surface widens enough to
+ * accept what it refuses today.
  */
 import { describe, expect, it } from "vitest";
+import { CREATE_VENDO_CONFIG_KEYS } from "../src/config-keys.js";
 import type { CreateVendoConfig } from "../src/types.js";
 
-describe("createVendo({ shell })", () => {
-  it("takes a boolean or an object carrying limits", () => {
-    const off: CreateVendoConfig["shell"] = false;
-    const on: CreateVendoConfig["shell"] = true;
-    const tuned: CreateVendoConfig["shell"] = { limits: { maxExecutionTimeMs: 5_000, maxOutputBytes: 4_096 } };
+type Shell = CreateVendoConfig["shell"];
 
-    expect([off, on, tuned]).toHaveLength(3);
+export const off: Shell = false;
+export const on: Shell = true;
+export const tuned: Shell = { limits: { maxExecutionTimeMs: 5_000, maxOutputBytes: 4_096 } };
+
+// @ts-expect-error — `limits` is the only member; a near-miss must not pass silently.
+export const typo: Shell = { limit: { maxExecutionTimeMs: 5_000 } };
+// @ts-expect-error — the ceilings are a number of milliseconds and a number of bytes.
+export const wrongUnit: Shell = { limits: { maxExecutionTimeMs: "5s" } };
+// @ts-expect-error — two knobs, and only two: just-bash 3.4.2's QuickJS memory
+// ceiling is a compiled-in constant, so a `jsMemoryBytes` nothing could read
+// would be a lie in a public type.
+export const unimplementable: Shell = { limits: { jsMemoryBytes: 1_000_000 } };
+
+describe("createVendo({ shell })", () => {
+  it("is a key the closed config list accepts", () => {
+    expect(CREATE_VENDO_CONFIG_KEYS).toContain("shell");
   });
 });

--- a/packages/vendo/tests/shell-loadout.test.ts
+++ b/packages/vendo/tests/shell-loadout.test.ts
@@ -1,0 +1,9 @@
+import { VENDO_BASH_TOOL } from "@vendoai/core";
+import { describe, expect, it } from "vitest";
+import { PROMPT_TAUGHT_TOOLS } from "../src/compose-harness.js";
+
+describe("the shell and the loadout cap", () => {
+  it("is named as prompt-taught, so the cap never hides it", () => {
+    expect(PROMPT_TAUGHT_TOOLS).toContain(VENDO_BASH_TOOL);
+  });
+});

--- a/packages/vendo/tests/shell-mount.test.ts
+++ b/packages/vendo/tests/shell-mount.test.ts
@@ -1,0 +1,60 @@
+/**
+ * WHO gets hands. The shell is the resident brain's, so it composes for the
+ * default `vendo()` and for a host-constructed one, and NOT for a harness whose
+ * thinker lives on a machine.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { defineHarness } from "@vendoai/harnesses";
+import { VENDO_BASH_TOOL } from "@vendoai/core";
+import { createStore, type VendoStore } from "@vendoai/store";
+import { afterEach, describe, expect, it } from "vitest";
+import { createVendo, type Vendo } from "../src/server.js";
+import { vendo as vendoHarness } from "@vendoai/harnesses";
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+async function compose(extra: Record<string, unknown> = {}): Promise<Vendo> {
+  const dataDir = await mkdtemp(join(tmpdir(), "vendo-shell-mount-"));
+  const store: VendoStore = createStore({ dataDir });
+  cleanups.push(async () => {
+    await store.close();
+    await rm(dataDir, { recursive: true, force: true });
+  });
+  return createVendo({
+    store,
+    principal: async () => ({ kind: "user", subject: "dev" }),
+    ...extra,
+  } as never);
+}
+
+const names = async (deployment: Vendo): Promise<string[]> =>
+  (await deployment.guardedTools.descriptors()).map((descriptor) => descriptor.name);
+
+describe("who gets hands", () => {
+  it("mounts bash on a default deployment, with no keys and no config", async () => {
+    expect(await names(await compose())).toContain(VENDO_BASH_TOOL);
+  });
+
+  it("mounts bash for a HOST-constructed vendo() too", async () => {
+    expect(await names(await compose({ harness: vendoHarness() }))).toContain(VENDO_BASH_TOOL);
+  });
+
+  it("withholds bash from a harness that thinks somewhere else", async () => {
+    const elsewhere = defineHarness({
+      name: "elsewhere",
+      // eslint-disable-next-line require-yield
+      async *run() {},
+    });
+
+    expect(await names(await compose({ harness: elsewhere }))).not.toContain(VENDO_BASH_TOOL);
+  });
+
+  it("withholds bash when the host says shell: false", async () => {
+    expect(await names(await compose({ shell: false }))).not.toContain(VENDO_BASH_TOOL);
+  });
+});

--- a/packages/vendo/tests/shell-upload.seam.test.ts
+++ b/packages/vendo/tests/shell-upload.seam.test.ts
@@ -1,0 +1,121 @@
+/**
+ * SEAM: the upload door WRITES and the shell READS, with no stub between them.
+ *
+ * Both halves are the shipped ones — a real `POST /files` request through
+ * `vendo.handler`, and a real `bash` call through `vendo.guardedTools`, which is
+ * the same guard-bound registry a turn executes on. A harness that mocked either
+ * side could never catch the two disagreeing about where the bytes are.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { genericJwtPreset } from "@vendoai/actions/presets";
+import {
+  UPLOAD_HEADER,
+  VENDO_BASH_TOOL,
+  type PermissionGrant,
+  type Principal,
+  type RunContext,
+} from "@vendoai/core";
+import { createStore, type VendoStore } from "@vendoai/store";
+import { afterEach, describe, expect, it } from "vitest";
+import { jwt } from "../src/auth-presets/jwt.js";
+import { createVendo, type Vendo } from "../src/server.js";
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+const SECRET = "vendo-shell-seam-secret-with-entropy";
+const SUBJECT = "host_sam";
+const principal: Principal = { kind: "user", subject: SUBJECT };
+
+const grant: PermissionGrant = {
+  id: "grt_shell_seam",
+  subject: SUBJECT,
+  tool: "host_profile",
+  descriptorHash: "sha256:shell-seam",
+  scope: { kind: "tool" },
+  duration: "standing",
+  source: "automation",
+  grantedAt: "2026-08-23T00:00:00.000Z",
+};
+
+async function bearer(): Promise<Record<string, string>> {
+  const mint = genericJwtPreset({ secret: SECRET });
+  return (await mint(principal, grant))!.headers;
+}
+
+async function compose(): Promise<Vendo> {
+  const dataDir = await mkdtemp(join(tmpdir(), "vendo-shell-seam-"));
+  const store: VendoStore = createStore({ dataDir });
+  cleanups.push(async () => {
+    await store.close();
+    await rm(dataDir, { recursive: true, force: true });
+  });
+  return createVendo({ store, auth: jwt({ secret: SECRET }) });
+}
+
+const upload = (deployment: Vendo, name: string, body: string, headers: Record<string, string>) =>
+  deployment.handler(new Request(`https://host.test/api/vendo/files?name=${encodeURIComponent(name)}`, {
+    method: "POST",
+    headers: { "content-type": "text/csv", [UPLOAD_HEADER]: "1", ...headers },
+    body: new TextEncoder().encode(body) as BodyInit,
+  }));
+
+const ctx: RunContext = {
+  principal,
+  venue: "chat",
+  presence: "present",
+  sessionId: "s_shell_seam",
+  // `trn_` + exactly 32 hex (ids.ts:69) — the guard writes a real audit row for
+  // this call and `auditEventSchema` rejects anything else.
+  turnId: `trn_${"0".repeat(28)}5ea1`,
+};
+
+const run = async (deployment: Vendo, command: string): Promise<{ stdout: string; exitCode: number }> => {
+  const outcome = await deployment.guardedTools.execute(
+    { id: `call_${Math.random().toString(36).slice(2)}`, tool: VENDO_BASH_TOOL, args: { command } },
+    ctx,
+  );
+  expect(outcome.status).toBe("ok");
+  return (outcome as { output: { stdout: string; exitCode: number } }).output;
+};
+
+describe("SEAM — what the upload door writes, the shell reads", () => {
+  it("greps a file that arrived over the wire seconds earlier", async () => {
+    const deployment = await compose();
+    const headers = await bearer();
+    const response = await upload(
+      deployment,
+      "ledger.csv",
+      "month,revenue\njan,31000\nfeb,39000\nmar,28000\n",
+      headers,
+    );
+    const { path } = await response.json() as { path: string };
+
+    const counted = await run(deployment, `wc -l < ${path}`);
+    expect(counted.exitCode).toBe(0);
+    expect(counted.stdout.trim()).toBe("4");
+
+    // `awk`, not `bc`: just-bash 3.4.2 ships no `bc`.
+    const summed = await run(deployment, `tail -n +2 ${path} | cut -d, -f2 | awk '{t+=$1} END {print t}'`);
+    expect(summed.stdout.trim()).toBe("98000");
+  });
+
+  it("writes a file the workspace keeps, readable through the workspace door", async () => {
+    const deployment = await compose();
+    await upload(deployment, "ledger.csv", "month,revenue\njan,31000\nfeb,39000\n", await bearer());
+
+    const written = await run(
+      deployment,
+      "mkdir -p /user/files && tail -n +2 /user/files/ledger.csv | sort -t, -k2 -nr > /user/files/ranked.csv",
+    );
+    expect(written.exitCode).toBe(0);
+
+    // The REAL read path, through a workspace opened AFTER the tool call.
+    const workspace = await deployment.harness.workspace(principal);
+    expect(await workspace.readFile("/user/files/ranked.csv")).toBe("feb,39000\njan,31000\n");
+  });
+});

--- a/packages/vendo/tests/surface-menu.test.ts
+++ b/packages/vendo/tests/surface-menu.test.ts
@@ -1,5 +1,31 @@
+import { CONNECTOR_DISCOVERY_TOOLS, VENDO_BASH_TOOL, type ToolDescriptor, type ToolRegistry } from "@vendoai/core";
 import { describe, expect, it, vi } from "vitest";
-import { memoizedSurfaceMenu } from "../src/surface-menu.js";
+import { memoizedSurfaceMenu, withAgentMenu } from "../src/surface-menu.js";
+
+const listing = (...names: string[]): ToolRegistry => ({
+  async descriptors(): Promise<ToolDescriptor[]> {
+    return names.map((name) => ({ name, description: name, inputSchema: { type: "object" }, risk: "read" }));
+  },
+  async execute() {
+    return { status: "ok", output: {} as never };
+  },
+});
+
+describe("withAgentMenu", () => {
+  it("curates the host's surface and leaves Vendo's own plumbing alone", async () => {
+    const [discovery] = CONNECTOR_DISCOVERY_TOOLS;
+    const tools = listing("host_invoices", "host_payroll", "vendo_make", VENDO_BASH_TOOL, discovery!);
+
+    const curated = withAgentMenu(tools, async () => new Set(["host_invoices"]));
+
+    // `bash` carries no `vendo_` prefix — that is the whole point of its name —
+    // so the prefix exemption cannot cover it and it has to be named. Without
+    // that, a curated deployment loses the one tool that opens the user's files
+    // while the system prompt keeps teaching it.
+    expect((await curated.descriptors()).map(({ name }) => name))
+      .toEqual(["host_invoices", "vendo_make", VENDO_BASH_TOOL, discovery]);
+  });
+});
 
 describe("memoizedSurfaceMenu", () => {
   it("resolves once and reuses the answer", async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1189,6 +1189,9 @@ importers:
       '@vendoai/guard':
         specifier: workspace:*
         version: link:../guard
+      just-bash:
+        specifier: ^3.4.2
+        version: 3.4.2
       zod:
         specifier: ^3.25.0
         version: 3.25.76
@@ -1205,9 +1208,6 @@ importers:
       ai:
         specifier: 6.0.28
         version: 6.0.28(zod@3.25.76)
-      just-bash:
-        specifier: ^3.1.0
-        version: 3.2.0
       typescript:
         specifier: ^5.6.0
         version: 5.9.3
@@ -7314,6 +7314,11 @@ packages:
     engines: {node: '>=20.18.1'}
     hasBin: true
 
+  just-bash@3.4.2:
+    resolution: {integrity: sha512-T0Vpy7YRgCjxJdqG3tkxn0ZnIDLJvVwb8hH4L+6NVdp+Te27jQxjxnszW9ODjEKbWxWujj83rP5S0GQxCSufgg==}
+    engines: {node: '>=20.18.1'}
+    hasBin: true
+
   katex@0.16.47:
     resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
     hasBin: true
@@ -7748,6 +7753,10 @@ packages:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
 
+  minimatch@10.2.6:
+    resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
+    engines: {node: 18 || 20 || >=22}
+
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
@@ -8039,6 +8048,9 @@ packages:
 
   papaparse@5.5.4:
     resolution: {integrity: sha512-SwzWD9gl/ElwYLCI0nUja1mFJzjq2D8ziShfNBa7zCHzkOozeOGDwHWQ+tvCzEZcewecWZ5U7kUopDnG+DFYEQ==}
+
+  papaparse@5.6.0:
+    resolution: {integrity: sha512-N2vuNQAYGK1/4vs6HJX86+VYU6OkiSTgdJz3JQfTk1y51cFCO/U8gnaeTF4iNE4r57Tt0sV47dUua1/19pxO6Q==}
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -8855,6 +8867,10 @@ packages:
 
   smol-toml@1.7.1:
     resolution: {integrity: sha512-PPlsspAZ4jbMBu5DMFhfUGDQLu/vrL4SyBROVS37x8ynnVmFIs1VPBz1Co8Xks3TvpIaZXmU85y4DrQ+UyVFoQ==}
+    engines: {node: '>= 18'}
+
+  smol-toml@1.8.0:
+    resolution: {integrity: sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==}
     engines: {node: '>= 18'}
 
   sonic-boom@4.2.1:
@@ -16290,6 +16306,30 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  just-bash@3.4.2:
+    dependencies:
+      diff: 8.0.4
+      fast-xml-parser: 5.10.1
+      file-type: 21.3.4
+      ini: 6.0.0
+      minimatch: 10.2.6
+      modern-tar: 0.7.7
+      papaparse: 5.6.0
+      quickjs-emscripten: 0.32.0
+      re2js: 1.3.3
+      seek-bzip: 2.0.0
+      smol-toml: 1.8.0
+      sprintf-js: 1.1.3
+      sql.js: 1.14.1
+      turndown: 7.2.4
+      undici: 7.29.0
+      yaml: 2.9.0
+    optionalDependencies:
+      '@mongodb-js/zstd': 7.0.0
+      node-liblzma: 2.2.0
+    transitivePeerDependencies:
+      - supports-color
+
   katex@0.16.47:
     dependencies:
       commander: 8.3.0
@@ -16974,6 +17014,10 @@ snapshots:
     dependencies:
       brace-expansion: 5.0.9
 
+  minimatch@10.2.6:
+    dependencies:
+      brace-expansion: 5.0.9
+
   minimatch@3.1.5:
     dependencies:
       brace-expansion: 1.1.18
@@ -17328,6 +17372,8 @@ snapshots:
   package-manager-detector@1.8.0: {}
 
   papaparse@5.5.4: {}
+
+  papaparse@5.6.0: {}
 
   parent-module@1.0.1:
     dependencies:
@@ -18487,6 +18533,8 @@ snapshots:
   slash@3.0.0: {}
 
   smol-toml@1.7.1: {}
+
+  smol-toml@1.8.0: {}
 
   sonic-boom@4.2.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,12 +12,14 @@ packages:
 # runtime for the portability gate (scripts/portability-gate.mjs).
 allowBuilds:
   # zstd + lzma are just-bash's OPTIONAL native backends for its compressed-tar
-  # commands. just-bash is a devDependency (the workspace's bash tests) and
-  # nothing in the tree compresses an archive through it, so the native builds
-  # are denied rather than compiled — running two build scripts would widen the
-  # supply-chain surface for a code path with no caller. Kept rather than
-  # dropped because the packages remain in the install graph and strictDepBuilds
-  # fails a cold install that merely ignores them. Flip to true the day a
+  # commands. just-bash is a runtime dependency of @vendoai/harnesses (the shell
+  # tool) and nothing in the tree compresses an archive through it, so the native
+  # builds are denied rather than compiled — running two build scripts would
+  # widen the supply-chain surface for a code path with no caller. Kept rather
+  # than dropped because the packages remain in the install graph and
+  # strictDepBuilds fails a cold install that merely ignores them. Every
+  # consumer of the published packages inherits the same two — that is why
+  # docs-site/index.mdx tells them to deny both. Flip to true the day a
   # bash-native harness needs `tar -z`.
   '@mongodb-js/zstd': false
   cbor-extract: true


### PR DESCRIPTION
**Slice A of 4.** Stack, bottom → top:

- **A → `main`** ← you are here
- B → shell-a-engine (agent JavaScript)
- C → shell-b-js (PDF/xlsx/docx parsers)
- D → shell-c-parsers (files live with the work, and die with it)

Merges **once at the tip**, not per-PR.

## What this does

One `bash` tool on the existing guarded registry, backed by just-bash running in-process over the caller's own `WorkspaceFs`. Grep, sed, awk, jq, pipes and redirection over the user's real files — audited, graded `write`, host rules and kill switch apply, no new infra and no keys.

`/tmp` is an in-memory mount owned by the session, so a multi-step script keeps its intermediates and the workspace never sees them. One session per `turnId`, bounded at 32.

## Notes for review

- **just-bash loads through a mutable specifier, never a static import.** Its graph reaches `node:worker_threads`, `undici` and `sql.js`. This is not stylistic — a static import fails `scripts/portability-gate.mjs` Leg A. Portability gate is green, all legs.
- **`ShellLimits` carries two knobs, not the three the blueprint named.** `jsMemoryBytes` does not exist in just-bash 3.4.2 — the QuickJS ceiling is a compiled-in 64 MiB constant. Shipping a field nothing reads would be a lie in a public type.
- **`bash` deliberately carries no `vendo_` prefix** — it is the same `bash` every model already knows, and the name is what teaches it. The cost is that it falls outside the loadout's always-active exemption for our own tools, so it is named explicitly in `PROMPT_TAUGHT_TOOLS`.
- **`exec` catches filesystem `EACCES` at one boundary.** just-bash lets a filesystem rejection escape instead of making it an exit code, so an agent writing one bad path would crash the whole tool call. Six lines, one boundary.

## Known red — awaiting a product decision, do not "fix" in review

`@vendoai-fixtures/install-seam` fails with `[ERR_PNPM_IGNORED_BUILDS] @mongodb-js/zstd, node-liblzma`. just-bash declares those two as native `optionalDependencies` it never uses, and pnpm 11 defaults `strictDepBuilds: true`. The fixture is correctly reporting a real consumer's experience. Being decided separately.

## Proof

Seam test with no stub on either side: a real `POST /files` upload read back by a real `bash` call through the real guard-bound registry. Proven able to fail (shell unmounted → both tests red).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a guarded bash tool that runs in process over each user’s workspace for `vendo()` deployments. Previously there was no shell; now agents can run pipelines on real files with audited, graded writes and bounded output, without new infra.

- Scope and mount: Implemented in `@vendoai/harnesses/vendo` and composed in `@vendoai/vendo` only when the resident brain is `vendo()`. Withhold via `createVendo({ shell: false })`; not mounted for sandbox/machine harnesses. Named `bash` (no `vendo_`), added to `PROMPT_TAUGHT_TOOLS`, and exempted in the agent menu so loadout caps and curation never hide it.
- Sessions and concurrency: One session per `turnId` (max 32). Cache the open promise to avoid double workspaces; clear a rejected open so a store blip doesn’t wedge the turn. A per‑turn queue serializes exec and commit.
- Filesystem and isolation: `/tmp` is session‑owned in‑memory scratch capped at 32 MB and never persisted. Writes commit after each call. Out‑of‑mount writes surface as `EACCES` and return exit code 1. `/orgs` compare‑and‑swap conflicts return an error listing rejected paths; other writes that landed are preserved.
- Limits and output: Defaults to 30 s wall time and 1 MB combined output. stdout/stderr are clipped tail‑first, measured in JSON, to stay under the bridge’s 32k cap. Configure with `createVendo({ shell: { limits } })`.
- Portability and types: `just-bash` (pinned 3.x) is a runtime dependency loaded via a mutable specifier to avoid bundler resolution. `@vendoai/core` extends `FsStat` with upstream identity fields and asserts parity in tests.
- Rollout: `pnpm` 11 with `strictDepBuilds: true` fails on `just-bash`’s optional native deps. Deny their build scripts by adding to your `pnpm-workspace.yaml` allowBuilds: `@mongodb-js/zstd: false` and `node-liblzma: false` (docs updated). No network or package manager exists inside the shell.

<sup>Written for commit be810aae6886762e34bc435b971df90adbe3f6b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1615?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

