### PR TITLE
feat(shell): the agent can write and run JavaScript against the workspace

### DIFF
--- a/.changeset/shell-agent-javascript.md
+++ b/.changeset/shell-agent-javascript.md
@@ -1,0 +1,15 @@
+---
+"@vendoai/harnesses": minor
+---
+
+The shell can write and run JavaScript.
+
+`bash` now carries `js-exec`: the agent writes a script and runs it in a QuickJS
+sandbox on a worker thread — 64 MiB, 30 seconds, no network — with
+`require("node:fs")` bound to the SAME virtual workspace bash sees. That is the
+difference between "reshape this spreadsheet" being a page of `awk` and being
+five lines of the language the model writes best.
+
+It is a capability, not a flag: on a runtime with no `node:worker_threads` (edge,
+Workers) the shell is still the whole shell — bash, the coreutils, the parsers —
+and the tool simply does not advertise `js-exec` to the model.

--- a/packages/harnesses/src/vendo/shell/runtime.ts
+++ b/packages/harnesses/src/vendo/shell/runtime.ts
@@ -1,0 +1,21 @@
+/**
+ * Can this runtime host a worker thread?
+ *
+ * `js-exec` runs QuickJS inside `node:worker_threads` — the only part of the
+ * shell that is Node-only. Everywhere else (an edge runtime, a Worker) the shell
+ * is still the whole shell: bash, the coreutils, the parsers. So the answer is a
+ * capability question asked once, not a deployment flag anyone has to set.
+ *
+ * Asked through `process.getBuiltinModule` rather than a static import, for the
+ * same reason `dot-vendo.ts` reads `node:fs` that way: this module carries NO
+ * static Node import and therefore still loads and bundles for edge/Worker
+ * targets, where the accessor is simply absent.
+ */
+export function workerThreadsAvailable(): boolean {
+  try {
+    const proc = (globalThis as { process?: { getBuiltinModule?: (id: string) => unknown } }).process;
+    return proc?.getBuiltinModule?.("node:worker_threads") !== undefined;
+  } catch {
+    return false;
+  }
+}

--- a/packages/harnesses/src/vendo/shell/runtime.ts
+++ b/packages/harnesses/src/vendo/shell/runtime.ts
@@ -10,6 +10,13 @@
  * same reason `dot-vendo.ts` reads `node:fs` that way: this module carries NO
  * static Node import and therefore still loads and bundles for edge/Worker
  * targets, where the accessor is simply absent.
+ *
+ * The accessor itself landed in Node 20.16 / 22.3, so on the sliver of the
+ * `>=20` engines range below that this answers no while `node:worker_threads` is
+ * in fact there, and js-exec stays off. Deliberate: every alternative reaches for
+ * a static `node:` import or sniffs `process.versions`, and the first breaks the
+ * edge bundling this exists for while the second is a worse probe than the
+ * accessor. The floor is a repo-wide `engines` decision, not this module's.
  */
 export function workerThreadsAvailable(): boolean {
   try {

--- a/packages/harnesses/src/vendo/shell/tool.ts
+++ b/packages/harnesses/src/vendo/shell/tool.ts
@@ -16,21 +16,32 @@ import {
   type WorkspaceFs,
 } from "@vendoai/core";
 import { createShellSession, type ShellLimits, type ShellSession } from "./engine.js";
+import { workerThreadsAvailable } from "./runtime.js";
 
 const DRAFT_2020_12 = "https://json-schema.org/draft/2020-12/schema";
+
+/** Told once per process: the answer cannot change while it runs, and a probe
+ *  per descriptor call would be asked on every listing. */
+const JAVASCRIPT = workerThreadsAvailable();
+
+const DESCRIPTION =
+  "Run a bash command over this user's own files. You have a real shell — grep, sed, awk, jq, sort, "
+  + "cut, head, tail, wc, find, pipes and redirection all work — and the filesystem IS the user's "
+  + "workspace: /user/threads/<thread>/files holds what they dropped in THIS conversation, "
+  + "/user/apps/<app> holds an app's files, and /user/files is the shelf of things they asked you to "
+  + "keep. /tmp is scratch that lasts this conversation and is never saved. "
+  + (JAVASCRIPT
+    ? "For anything bash is awkward at, write JavaScript: `js-exec -c '<code>'` runs it in a sandbox with "
+      + "require(\"node:fs\") bound to this same filesystem. "
+    : "")
+  + "There is no network and no package manager: everything you need is already here. "
+  + "Prefer this over reading a file line by line — one command answers what twenty reads would.";
 
 const descriptors: ToolDescriptor[] = [
   {
     name: VENDO_BASH_TOOL,
     title: VENDO_TOOL_TITLES[VENDO_BASH_TOOL]!,
-    description:
-      "Run a bash command over this user's own files. You have a real shell — grep, sed, awk, jq, sort, "
-      + "cut, head, tail, wc, find, pipes and redirection all work — and the filesystem IS the user's "
-      + "workspace: /user/threads/<thread>/files holds what they dropped in THIS conversation, "
-      + "/user/apps/<app> holds an app's files, and /user/files is the shelf of things they asked you to "
-      + "keep. /tmp is scratch that lasts this conversation and is never saved. "
-      + "There is no network and no package manager: everything you need is already here. "
-      + "Prefer this over reading a file line by line — one command answers what twenty reads would.",
+    description: DESCRIPTION,
     inputSchema: {
       $schema: DRAFT_2020_12,
       type: "object",
@@ -126,6 +137,7 @@ export function createShellTools(
       workspace,
       session: createShellSession({
         workspace,
+        javascript: JAVASCRIPT,
         ...(config.limits === undefined ? {} : { limits: config.limits }),
       }),
       queue: Promise.resolve(),

--- a/packages/harnesses/tests/shell/engine.test.ts
+++ b/packages/harnesses/tests/shell/engine.test.ts
@@ -151,9 +151,15 @@ describe("the JavaScript hand", () => {
   it("has no network inside the script", async () => {
     const session = createShellSession({ workspace: await disk({}), javascript: true });
 
-    const result = await session.exec(`js-exec -c 'fetch("https://example.com").then(() => console.log("reached"))'`);
+    // AWAITED, not fire-and-forget: `fetch` IS defined in the sandbox, so an
+    // unawaited promise only proves the script exited before it settled — which
+    // it would do just as happily with the network working. What has to be proven
+    // is that the call is REFUSED, in the sandbox's own words.
+    const result = await session.exec(`js-exec -c 'await fetch("https://example.com"); console.log("reached")'`);
 
+    expect(result.exitCode).not.toBe(0);
     expect(result.stdout).not.toContain("reached");
+    expect(result.stderr).toContain("Network access not configured");
   });
 
   it("has no js-exec at all when it was not asked for", async () => {

--- a/packages/harnesses/tests/shell/engine.test.ts
+++ b/packages/harnesses/tests/shell/engine.test.ts
@@ -128,3 +128,40 @@ describe("one shell session over the workspace", () => {
     expect(result.stdout.length).toBeLessThan(4096);
   });
 });
+
+describe("the JavaScript hand", () => {
+  it("runs a script that reads the workspace and writes back to it", async () => {
+    const workspace = await disk({
+      "/user/threads/thr_1/files/rows.json": JSON.stringify([{ n: 3 }, { n: 4 }, { n: 5 }]),
+    });
+    const session = createShellSession({ workspace, javascript: true });
+
+    const result = await session.exec(
+      `js-exec -c 'const fs = require("node:fs");
+        const rows = JSON.parse(fs.readFileSync("/user/threads/thr_1/files/rows.json", "utf8"));
+        fs.writeFileSync("/user/threads/thr_1/files/total.txt", String(rows.reduce((a, r) => a + r.n, 0)));
+        console.log("done");'`,
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("done");
+    expect(await workspace.readFile("/user/threads/thr_1/files/total.txt")).toBe("12");
+  });
+
+  it("has no network inside the script", async () => {
+    const session = createShellSession({ workspace: await disk({}), javascript: true });
+
+    const result = await session.exec(`js-exec -c 'fetch("https://example.com").then(() => console.log("reached"))'`);
+
+    expect(result.stdout).not.toContain("reached");
+  });
+
+  it("has no js-exec at all when it was not asked for", async () => {
+    const session = createShellSession({ workspace: await disk({}) });
+
+    const result = await session.exec(`js-exec -c 'console.log(1)'`);
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain("js-exec");
+  });
+});

--- a/packages/harnesses/tests/shell/runtime.test.ts
+++ b/packages/harnesses/tests/shell/runtime.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Whether THIS runtime can host a worker thread. Asked through the runtime
+ * built-in accessor, so this module carries no static Node import and still
+ * bundles for an edge target.
+ */
+import { describe, expect, it } from "vitest";
+import { workerThreadsAvailable } from "../../src/vendo/shell/runtime.js";
+
+describe("the worker-thread probe", () => {
+  it("says yes under Node", () => {
+    expect(workerThreadsAvailable()).toBe(true);
+  });
+
+  it("says no where there is no Node built-in accessor at all", () => {
+    const proc = (globalThis as { process?: unknown }).process;
+    try {
+      delete (globalThis as { process?: unknown }).process;
+      expect(workerThreadsAvailable()).toBe(false);
+    } finally {
+      (globalThis as { process?: unknown }).process = proc;
+    }
+  });
+
+  it("says no where the accessor exists but the module does not", () => {
+    const proc = (globalThis as { process?: unknown }).process;
+    try {
+      (globalThis as { process?: unknown }).process = {
+        getBuiltinModule: (id: string) => (id === "node:worker_threads" ? undefined : {}),
+      };
+      expect(workerThreadsAvailable()).toBe(false);
+    } finally {
+      (globalThis as { process?: unknown }).process = proc;
+    }
+  });
+});

--- a/packages/harnesses/tests/shell/tool.test.ts
+++ b/packages/harnesses/tests/shell/tool.test.ts
@@ -225,3 +225,19 @@ describe("the session's lifetime", () => {
     expect((second as { output: { stdout: string } }).output.stdout).toBe("recovered\n");
   });
 });
+
+describe("the JavaScript hand, through the tool", () => {
+  it("is on under Node, and the description says so", async () => {
+    const workspace = workspaceDouble();
+    const registry = createShellTools(async () => workspace);
+
+    const [descriptor] = await registry.descriptors();
+    expect(descriptor?.description).toContain("js-exec");
+
+    const outcome = await registry.execute(
+      { id: "c9", tool: VENDO_BASH_TOOL, args: { command: `js-exec -c 'console.log(6 * 7)'` } },
+      ctx({ turnId: "trn_js" }),
+    );
+    expect((outcome as { output: { stdout: string } }).output.stdout).toContain("42");
+  });
+});

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,9 +7,10 @@ packages:
   - "genbench"
 
 # pnpm 9 ran every dependency build script; pnpm 11 (strictDepBuilds) requires
-# an explicit allowlist. These five are the deps with build scripts in the
-# tree — all allowed, preserving pnpm 9 behavior. workerd is miniflare's
-# runtime for the portability gate (scripts/portability-gate.mjs).
+# an explicit allowlist. These eight are the deps with build scripts in the
+# tree — six allowed, preserving pnpm 9 behavior, two denied (see below).
+# workerd is miniflare's runtime for the portability gate
+# (scripts/portability-gate.mjs).
 allowBuilds:
   # zstd + lzma are just-bash's OPTIONAL native backends for its compressed-tar
   # commands. just-bash is a runtime dependency of @vendoai/harnesses (the shell


### PR DESCRIPTION
**Slice B of 4.** Stack, bottom → top:

- A → `main` — #1615
- **B → shell-a-engine** ← you are here
- C → shell-b-js (PDF/xlsx/docx parsers)
- D → shell-c-parsers (files live with the work, and die with it)

Merges **once at the tip**, not per-PR. Review against A, not `main`.

## What this does

Turns on just-bash's `js-exec`, so the agent can write a real script and pipe into it: QuickJS in a Node worker thread, 64 MiB, 30 s, no network, with the script's `fs` bound to the same virtual disk bash sees. Both ceilings are just-bash's own defaults — the spec's numbers already — which is why nothing sets them.

On a runtime with no `node:worker_threads` (edge, Workers), `js-exec` is simply off and the shell still works: bash and the parsers, minus JavaScript.

## Notes for review

- **The probe uses `process.getBuiltinModule`**, matching `packages/vendo/src/dot-vendo.ts:31-33`, so this module carries no static Node import and still bundles for an edge target. Portability gate green.
- **One constant gates both the wiring and the description.** `const JAVASCRIPT = workerThreadsAvailable()` feeds `createShellSession({ javascript })` and the model-facing text, so the tool cannot advertise a capability it does not have.

## One correction to the approved plan, worth a look

The plan specified `js-exec '<code>'` in both the tests and the tool description. **That is wrong against the shipped library** — just-bash 3.4.2 reads a bare positional as a *file path*, so every such call returns `exitCode: 2`, `js-exec: can't open file '<your code>'`. Inline code requires `-c`. Shipping the plan's text verbatim would have taught the model a broken invocation in its own tool description. Corrected to `js-exec -c '<code>'` in both places; nothing else changed.

## Known red — inherited from A, awaiting a product decision

`@vendoai-fixtures/install-seam` — `[ERR_PNPM_IGNORED_BUILDS]`, see #1615.

## Proof

`js-exec` reads and writes the same disk as bash, offline. Proven able to fail: `javascript: false` → `expected 127 to be +0` (command not registered).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable JavaScript execution from the shell via `js-exec` when worker threads are available. Previously bash-only; now, on runtimes with `node:worker_threads`, the agent can run `js-exec -c '<code>'` against the same virtual workspace filesystem.

- Gate JavaScript with `workerThreadsAvailable()` using `process.getBuiltinModule` (no static `node:` imports). On runtimes without the accessor (edge/Workers and Node <20.16/<22.3), the probe returns false and `js-exec` stays off.
- Feed the same gate into `createShellSession({ javascript })` and the tool description so the tool only advertises `js-exec` where it can run.
- Sandbox: QuickJS in a worker thread, 64 MiB, 30 s, no network; `require("node:fs")` is bound to the workspace FS. Correct invocation is `js-exec -c '<code>'`.
- Tests cover workspace read/write, that awaited `fetch` is refused with a non-zero exit and sandbox error, absence of `js-exec` when JavaScript is off, and descriptor text including `js-exec` when on.
- Rollout: capability-based, no flags. On edge/Workers `js-exec` is absent and calls fail. Supports ENG-104 by making file transforms simple without external packages.

<sup>Written for commit 7de9683980d9f58934ffc2adb1949b9bd3e3fb92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1616?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

