### PR TITLE
feat(vendo): give the screen agent a door out that only asks (built apps)

### DIFF
--- a/.changeset/creations-escalate-door.md
+++ b/.changeset/creations-escalate-door.md
@@ -1,0 +1,5 @@
+---
+"@vendoai/vendo": minor
+---
+
+Built apps: a chat ask that is bigger than a screen can reach the build lane again. The screen agent gets back a door out — one `escalate` hand carrying its own one-line reason — and all that hand does is raise the standing approval card: the person's yes is still the only thing that spends a machine. The door is offered only where a build machine is actually composed, so an escalation never ends in "this deployment has no build machine", and an assembly that simply failed still comes back as an honest failed receipt rather than a build proposal.

--- a/examples/demo-bank/src/components/vendo/VendoLayer.tsx
+++ b/examples/demo-bank/src/components/vendo/VendoLayer.tsx
@@ -3,7 +3,7 @@
 import { useEffect } from "react";
 import { withBasePath } from "@/lib/base-path";
 import { useVendoOverlay } from "@vendoai/ui";
-import { VendoOverlay, VendoPalette, VendoThread, type VendoCommand, type VendoThreadProps } from "@vendoai/ui/chrome";
+import { VendoOverlay, VendoPalette, VendoThread, VendoToasts, type VendoCommand, type VendoThreadProps } from "@vendoai/ui/chrome";
 import { MapleMark } from "@/components/ui/maple-mark";
 import { VendoWorkbench } from "@/components/vendo/workbench/VendoWorkbench";
 import { mapleScenarios } from "@/vendo/scenarios";
@@ -71,6 +71,12 @@ export function VendoLayer() {
         hotkey={(event) => (event.metaKey || event.ctrlKey) && !event.shiftKey && event.key.toLowerCase() === "j"}
         onCommand={onCommand}
       />
+      {/* An approval that parks outside a live turn — a standing build ask —
+          has no in-thread card to land on, so this is the surface that shows
+          it. Bottom-LEFT: the launcher pill is pinned bottom-right and the
+          toast stack outranks its z-index, so the default corner would cover
+          Maple's front door. */}
+      <VendoToasts approvals placement="bottom-left" />
       {/* The harness workbench: dev-only diagnostics, docked beside the
           overlay. Renders nothing outside `next dev`. */}
       <VendoWorkbench />

--- a/packages/vendo/src/compose-apps.ts
+++ b/packages/vendo/src/compose-apps.ts
@@ -221,10 +221,18 @@ const appsHostSeams = (composition: VendoComposition): Partial<AppsConfig> => {
 
 /** THE SEAM (blueprint §1 point 2) — the screen agent in front of the
  *  conductor, joined here because composition is what holds every half. */
-const appsScreenSeam = (composition: VendoComposition, seams: AppsSeams): AppsConfig["screen"] => {
+const appsScreenSeam = (
+  composition: VendoComposition,
+  seams: AppsSeams,
+  build: NonNullable<AppsConfig["build"]>,
+): AppsConfig["screen"] => {
   const { inference, boundTools, briefing } = composition;
   const { screenWorkspace } = seams;
   return screenAssembler({
+      // The door out, from the very thing that would have to honour it: the
+      // loop is offered `escalate` only where a box can really be claimed after
+      // the person's yes, so an escalation never ends in "no build machine".
+      canBuild: build.available,
       // The SAME seats every other thinker runs on.
       models: inference.seats,
       // The SAME guard-bound registry. There is no second choke point.
@@ -280,7 +288,7 @@ const appsScreenSeam = (composition: VendoComposition, seams: AppsSeams): AppsCo
 
 /** THE OTHER SEAM — the build lane behind the escalations the screen agent
  *  refuses, joined here for the same reason and on the same terms. */
-const appsBuildSeam = (composition: VendoComposition, seams: AppsSeams): AppsConfig["build"] =>
+const appsBuildSeam = (composition: VendoComposition, seams: AppsSeams): NonNullable<AppsConfig["build"]> =>
   appBuilder({
     sandbox: composition.sandbox.adapter,
     // The SAME env a session box gets, and deliberately not `machineEnv`: that
@@ -421,11 +429,12 @@ export const composeApps = (composition: VendoComposition): Pick<VendoCompositio
     screenWorkspace,
     access,
   };
+  const build = appsBuildSeam(composition, seams);
   const apps = createApps({
     ...appsStoreSeams(composition, seams),
     ...appsHostSeams(composition),
-    screen: appsScreenSeam(composition, seams),
-    build: appsBuildSeam(composition, seams),
+    screen: appsScreenSeam(composition, seams, build),
+    build,
     ...appsTailSeams(composition, seams),
   } as AppsConfig);
   // Every contributed tool reaches the ONE registry here — the same `add` the

--- a/packages/vendo/src/screen-agent.ts
+++ b/packages/vendo/src/screen-agent.ts
@@ -169,6 +169,25 @@ export const SAVE_APP_TOOL = "save_app";
 export const EDIT_APP_TOOL = "edit_app";
 
 /**
+ * The door out of assembly (§4.5) — and it opens onto a QUESTION, never onto a
+ * machine.
+ *
+ * PR #1407 took this hand off the loadout so that the model could not spend a
+ * box by reaching for it, and that principle is untouched: all this hand does
+ * now is record one line, which the front door turns into a standing approval
+ * card (`build.propose`). The person's yes, whenever it lands, is still the only
+ * thing that starts a build. Without the hand the loop had no word for "this ask
+ * is bigger than a screen", so a real build was unreachable from chat at all —
+ * measured live 2026-08-24, an ask needing npm packages got a degraded screen
+ * and an apology.
+ *
+ * Never `vendo_`-prefixed: the loadout's `isAlwaysActive` would make it
+ * un-gateable, and this tool is the screen agent's own, not a product capability
+ * anybody else may reach.
+ */
+export const ESCALATE_TOOL = "escalate";
+
+/**
  * The two verbs that read an app which ALREADY EXISTS — on an EDIT and nowhere
  * else, because the loadout follows the task.
  *
@@ -306,6 +325,11 @@ export interface ScreenInput {
    *  row, `replayFrom` only for a re-seed). Absent on every other edit, whose
    *  first message stays the ask alone. See {@link startingSource}. */
   source?: string;
+  /** Is there a builder behind an escalation ({@link ScreenAssemblerDeps.canBuild})?
+   *  The door out is equipped only where the answer is yes: a deployment with no
+   *  sandbox cannot honour the offer, and `vendo_make` would answer the
+   *  escalation with a failed receipt naming the gap. Absent is no. */
+  canBuild?: boolean;
 }
 
 /** What one assembly run answers. `ScreenOutcome` plus the title an assembled
@@ -685,6 +709,25 @@ const surfaceNote = (viewport: ScreenInput["viewport"]): string => {
   cells truncate, a narrow frame keeps columns by \`priority\`, panes stack.`;
 };
 
+/** The door out, said only where a build could really follow it ({@link
+ *  ScreenInput.canBuild}) — an offer this deployment cannot honour would end in
+ *  a failed receipt naming a machine it has not got, which is worse than never
+ *  offering. The hand is equipped under exactly the same condition. */
+const doorOut = (input: ScreenInput): string => {
+  if (input.canBuild !== true) return "";
+  return `
+- **\`${ESCALATE_TOOL}\`** is the one door out. Writing one screen out of this
+  product's components is all you can do here; an ask that needs real code, its
+  own server, a package to install, or a surface these components cannot express
+  goes through it instead.
+  - It builds nothing by itself. It ASKS the person whether to have this built
+    for real, and their yes — whenever it comes — is what starts it.
+  - A view you could assemble does not keep an ask here: if part of it needs real
+    code, escalate the WHOLE ask.
+  - The builder gets the person's own words, so all you write is one plain
+    sentence saying what assembly cannot do.`;
+};
+
 /**
  * The environment correction, and only that.
  *
@@ -706,7 +749,7 @@ const environmentNote = (input: ScreenInput, wireable: readonly ToolListing[]): 
 - Never look for a tool that builds the app for you. There isn't one, and that is
   deliberate.${surfaceNote(input.viewport)}
 
-## Your two hands
+## Your hands
 
 - **\`${SAVE_APP_TOOL}\`** saves this app's whole file.
   - Every save that parses repaints the person's screen, so save as you go — a
@@ -726,7 +769,7 @@ const environmentNote = (input: ScreenInput, wireable: readonly ToolListing[]): 
   - Quote the text that goes in each \`find\`, write what replaces it in
     \`replace\`, and quote enough of it to match in exactly one place —
     everything the person is already looking at then stays where it is.
-  - It lands and is checked exactly like a save.
+  - It lands and is checked exactly like a save.${doorOut(input)}
 
 ## Your last words are what the person is told
 
@@ -1139,6 +1182,32 @@ export async function assembleScreen(
     },
   };
 
+  const escalate: HarnessHand = {
+    name: ESCALATE_TOOL,
+    description:
+      "Ask for this to be BUILT for real — a machine that installs packages, writes code and tests it. Use it "
+      + "when assembling a screen out of this product's components genuinely cannot serve the ask. It spends "
+      + "nothing and builds nothing by itself: the person is asked, and their yes is what starts the build. "
+      + "Their own ask is the builder's brief — say only why assembly cannot serve it. This ends your turn.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        why: { type: "string", description: "One plain sentence: what assembly cannot do here." },
+      },
+      required: ["why"],
+      additionalProperties: false,
+    },
+    execute: async (args) => {
+      const { why } = args as { why: string };
+      // The whole of the hand: one line recorded. What it becomes — a standing
+      // approval card, and a build only if the person says yes — is the front
+      // door's business (`make-tool.ts`'s escalate arm), which is what keeps
+      // this loop unable to spend a machine.
+      record.escalated = why;
+      return { asked: true };
+    },
+  };
+
   // The small loadout, resolved where the listings are: the assembly verbs by
   // name, plus the host's read tools so a query's real values can be learned when
   // a tool declares no shape. `vendo_make` is excluded by name — it is what called
@@ -1180,6 +1249,7 @@ export async function assembleScreen(
     },
   });
   loadout.push(acting(saveApp), acting(editApp));
+  if (input.canBuild === true) loadout.push(acting(escalate));
 
   const turn: Turn<VendoHarnessOptions> = {
     messages: [{
@@ -1467,6 +1537,16 @@ export interface ScreenAssemblerDeps {
    * write is never worth failing a screen the person can already see.
    */
   remember?: (appId: AppId, decisions: string, ctx: RunContext) => Promise<void>;
+  /**
+   * Is there a builder behind an escalation — `AppBuilder.available`, handed
+   * over by the composition that fills BOTH slots.
+   *
+   * Availability by construction, exactly as `servedProxyPath`'s presence used
+   * to say it (compose-apps.ts): the loop is offered the door out only where a
+   * box could really be claimed after the person's yes. Unfilled reads as no,
+   * which is what a deployment with no sandbox is.
+   */
+  canBuild?: () => boolean;
 }
 
 /**
@@ -1605,6 +1685,7 @@ export function screenAssembler(deps: ScreenAssemblerDeps): ScreenAssembler {
           ...(request.viewport === undefined ? {} : { viewport: request.viewport }),
           ...(pack === undefined ? {} : { briefing: renderBriefingPack(pack) }),
           ...(starting === undefined ? {} : { source: starting }),
+          ...(deps.canBuild?.() === true ? { canBuild: true } : {}),
         },
       );
       if (result.kind !== "assembled") return result;

--- a/packages/vendo/tests/screen-escalate-consent.seam.test.ts
+++ b/packages/vendo/tests/screen-escalate-consent.seam.test.ts
@@ -1,0 +1,224 @@
+/**
+ * THE DEAD SEAM — the screen agent's way of asking for a build, and where it
+ * lands.
+ *
+ * `RunRecord.escalated` was READ by the outcome gate and WRITTEN by nobody, so
+ * `screen.assemble()` could never answer `escalate`, `vendo_make`'s escalate arm
+ * was dead code, and no chat ask could reach the build lane at all. Live in
+ * Maple (2026-08-24) an ask that genuinely needed a real build produced a
+ * degraded screen and "this product's screen-building tool isn't that" — no
+ * card, no build, no box.
+ *
+ * So nothing on either side of that seam is faked here: a REAL composed
+ * deployment, the real front door, the real screen loop with its real loadout,
+ * the real build door and the REAL guard, whose parked ask IS the standing card.
+ * Two things are stand-ins, both of them the things a test cannot have: the
+ * MODEL (scripted, so the loadout is what is measured rather than a provider's
+ * mood) and the sandbox PROVIDER — a stub that refuses to hand out a machine,
+ * because the one thing this whole flow must not do before the person's yes is
+ * claim a box.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  VENDO_MAKE_TOOL,
+  type Principal,
+  type RunContext,
+  type ToolResult,
+} from "@vendoai/core";
+import { makeReceiptSchema } from "@vendoai/apps/contract";
+import type { SandboxAdapter } from "@vendoai/apps";
+import { defineHarness } from "@vendoai/harnesses";
+import { createStore, type VendoStore } from "@vendoai/store";
+import type { LanguageModel } from "ai";
+import { MockLanguageModelV3, simulateReadableStream } from "ai/test";
+import { afterEach, describe, expect, it } from "vitest";
+import { ESCALATE_TOOL, SAVE_APP_TOOL } from "../src/screen-agent.js";
+import { createVendo } from "../src/server.js";
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+const principal: Principal = { kind: "user", subject: "user_escalate" };
+const ctx: RunContext = { principal, venue: "chat", presence: "present", sessionId: "ses_escalate" };
+
+/** The ask a screen cannot serve — the one this whole lane exists for. */
+const ASK = "a QR code generator that really encodes my account details with the qrcode package";
+const WHY = "this needs a real npm package running real code, which a screen cannot do";
+
+/** Not a TSX module at all, so the gauntlet refuses it and the seam paints
+ *  nothing: an assembly FAILURE, which must never become a build proposal. */
+const BROKEN = "not a document at all";
+
+const ZERO_USAGE = {
+  inputTokens: { total: 0, noCache: 0, cacheRead: 0, cacheWrite: 0 },
+  outputTokens: { total: 0, text: 0, reasoning: 0 },
+} as const;
+
+type Chunk = Record<string, unknown>;
+
+const call = (toolName: string, input: unknown, toolCallId: string): Chunk[] => [
+  { type: "tool-call", toolCallId, toolName, input: JSON.stringify(input) },
+  { type: "finish", usage: ZERO_USAGE, finishReason: { unified: "tool-calls", raw: undefined } },
+];
+
+const speak = (text: string): Chunk[] => [
+  { type: "text-start", id: "t1" },
+  { type: "text-delta", id: "t1", delta: text },
+  { type: "text-end", id: "t1" },
+  { type: "finish", usage: ZERO_USAGE, finishReason: { unified: "stop", raw: undefined } },
+];
+
+/** A model that replays scripted turns and records WHICH TOOLS it was offered —
+ *  the only place a composed loadout is readable from outside the loop. */
+function scripted(turns: Chunk[][]): LanguageModel & { toolNamesPerCall: string[][] } {
+  const remaining = turns.map((turn) => [...turn]);
+  const toolNamesPerCall: string[][] = [];
+  const model = new MockLanguageModelV3({
+    doStream: async (request) => {
+      toolNamesPerCall.push((request.tools ?? []).map((tool) => tool.name));
+      const chunks = remaining.shift();
+      if (chunks === undefined) throw new Error("scripted model exhausted");
+      return { stream: simulateReadableStream({ chunks: chunks as never }) };
+    },
+  }) as unknown as LanguageModel & { toolNamesPerCall: string[][] };
+  model.toolNamesPerCall = toolNamesPerCall;
+  return model;
+}
+
+/** The sandbox slot filled by something that will not give a machine up. Its
+ *  PRESENCE is what makes `build.available()` true; every method is a tripwire,
+ *  because nothing in this file may reach a box. */
+const noBoxes = (): SandboxAdapter & { claims: number } => {
+  const adapter = {
+    claims: 0,
+    async create() {
+      adapter.claims += 1;
+      throw new Error("a box was claimed");
+    },
+    async resume() {
+      adapter.claims += 1;
+      throw new Error("a box was claimed");
+    },
+    async destroy() {},
+  };
+  return adapter as unknown as SandboxAdapter & { claims: number };
+};
+
+async function tempStore(): Promise<VendoStore> {
+  const dataDir = await mkdtemp(join(tmpdir(), "vendo-escalate-"));
+  const store = createStore({ dataDir });
+  cleanups.push(async () => {
+    await store.close();
+    await rm(dataDir, { recursive: true, force: true });
+  });
+  return store;
+}
+
+interface Walked {
+  receipt: ReturnType<typeof makeReceiptSchema.parse> | undefined;
+  result: ToolResult | undefined;
+  vendo: ReturnType<typeof createVendo>;
+  model: LanguageModel & { toolNamesPerCall: string[][] };
+  sandbox: ReturnType<typeof noBoxes>;
+}
+
+/** One real turn whose harness does what a calling agent does: ask `vendo_make`
+ *  in words, and hand back the receipt. */
+async function walk(options: { turns: Chunk[][]; sandbox?: boolean }): Promise<Walked> {
+  const store = await tempStore();
+  const model = scripted(options.turns);
+  const sandbox = noBoxes();
+  let result: ToolResult | undefined;
+  const harness = defineHarness({
+    name: "escalate-probe",
+    async *run(turn) {
+      result = await turn.tools.call(VENDO_MAKE_TOOL, { request: ASK });
+      yield { type: "text", delta: "ok" };
+    },
+  });
+  const vendo = createVendo({
+    models: { default: model },
+    principal: async () => principal,
+    store,
+    harness: harness as never,
+    ...(options.sandbox === false ? {} : { sandbox }),
+  } as Parameters<typeof createVendo>[0]);
+  const response = await vendo.handler(new Request("https://host.test/api/vendo/threads", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      threadId: "thr_escalate",
+      message: { id: "m1", role: "user", parts: [{ type: "text", text: ASK }] },
+    }),
+  }));
+  expect(response.status).toBe(200);
+  await response.text();
+  return {
+    receipt: result?.status === "ok" ? makeReceiptSchema.parse(result.output) : undefined,
+    result,
+    vendo,
+    model,
+    sandbox,
+  };
+}
+
+describe("a chat ask bigger than a screen reaches the build lane", () => {
+  it("lands as a standing card and an awaiting-consent receipt, with no box claimed", async () => {
+    const walked = await walk({
+      turns: [call(ESCALATE_TOOL, { why: WHY }, "c1"), speak("Asked about building it.")],
+    });
+
+    // THE DOOR IS ON THE LOADOUT — the fact that was missing.
+    expect(walked.model.toolNamesPerCall[0]).toContain(ESCALATE_TOOL);
+
+    // THE RECEIPT: the ask is alive and waiting on the person, not failed.
+    expect(walked.receipt?.status).toBe("awaiting-consent");
+
+    // THE STANDING CARD, on the real guard: one undecided ask for the build,
+    // carrying this app and the person's own words.
+    const pending = await walked.vendo.guard.approvals.pending(principal);
+    expect(pending.map((ask) => ask.call.tool)).toEqual(["vendo_app_build"]);
+    expect(pending[0]?.call.args).toMatchObject({ appId: walked.receipt?.id, prompt: ASK });
+
+    // THE ROW says "offered, unanswered" — and carries the model's own one line,
+    // which is what the person reads on the card.
+    const row = await walked.vendo.apps.get(walked.receipt!.id, ctx);
+    expect(row?.proposal).toMatchObject({ approvalId: pending[0]?.id, why: WHY });
+    expect(row?.building).toBeUndefined();
+
+    // NOTHING WAS SPENT. The turn ended with the sandbox untouched.
+    expect(walked.sandbox.claims).toBe(0);
+  }, 60_000);
+
+  it("does not offer the door where the deployment has no build machine", async () => {
+    // An offer nothing can honour is worse than no offer: the model is handed
+    // the door only where a box could actually be claimed after the yes.
+    const walked = await walk({
+      turns: [speak("Assembling a screen out of this product's components cannot serve that.")],
+      sandbox: false,
+    });
+
+    expect(walked.model.toolNamesPerCall[0]).not.toContain(ESCALATE_TOOL);
+    expect(walked.receipt?.status).toBe("failed");
+  }, 60_000);
+});
+
+describe("an assembly failure is not an escalation", () => {
+  it("stays a failed receipt: no card, no proposal, no box", async () => {
+    // The owner's line: escalation is the deliberate signal "this ask is bigger
+    // than a screen", never a fallback for "something went wrong". A sandbox IS
+    // composed here, so a proposal was available and was not taken.
+    const walked = await walk({
+      turns: [call(SAVE_APP_TOOL, { content: BROKEN }, "c1"), speak("saved")],
+    });
+
+    expect(walked.receipt?.status).toBe("failed");
+    expect(await walked.vendo.guard.approvals.pending(principal)).toEqual([]);
+    expect(await walked.vendo.apps.get(walked.receipt!.id, ctx)).toBeNull();
+    expect(walked.sandbox.claims).toBe(0);
+  }, 60_000);
+});


### PR DESCRIPTION
> Stacked on #1614. Review only the top commits; the stack merges once at the tip.

## What & why

**This is the change that makes the feature reachable at all.** A live proof on a real box found `RunRecord.escalated` was declared at `screen-agent.ts:787` and read at `:1291` — and **assigned nowhere in the repo**. The writer left the loadout in PR #1407 and no slice put it back, so `screen.assemble()` could never return `{kind:"escalate"}`, `make-tool`'s escalate arm was dead, and no chat ask could reach the build lane. Live in Maple: a degraded screen and "this product's screen-building tool isn't that" — no card, no build, no box.

## The shape, per the owner's ruling
An escalate-shaped signal in the screen agent's loadout **whose only effect is a proposal**: `kind:"escalate"` → `build.propose` → standing card. It spends nothing and asks the person.

This keeps PR #1407's principle literally intact — **the model never spends a machine** — while restoring the word the router needs. It is the consent-gated shape the spec approved: the TOOL raises the card when the ask exceeds Kit + host catalog.

**Restored, not reinvented:** the pre-#1407 hand was recovered from `f2860f5fc` and only its words rewritten, because all it does now is ask. Same `HarnessHand` mechanism as `save_app`/`edit_app`, wrapped in `acting()`, pushed onto `loadout`. Its `execute` does one thing: `record.escalated = why`.

**Gated on `build.available()`.** Precedent followed from the same composition file: `servedProxyPath` is supplied only when the deployment can produce one — "availability now means 'can actually produce a path', by construction" — after a host was once offered a lane it discovered was fake only *after* building a box. With no sandbox, the hand is absent from the loadout **and** from the brief. `make-tool.ts`'s `NO_MACHINE` arm remains the belt-and-braces answer for a host filling the `screen` slot itself.

**An assembly failure never proposes.** A failed assembly stays an honest failed receipt — escalation means "this ask is bigger than a screen", never "something went wrong".

## The seam test
`vendo/tests/screen-escalate-consent.seam.test.ts` (3). The defect was a DEAD SEAM — a field written by nobody and read by someone — so a faked screen agent would prove nothing. Real composed deployment, real front door, real screen loop, real loadout, real build door, real guard. Only the model is scripted; the sandbox is a stub whose every method throws, because its *presence* is what makes `available()` true.

Proves: an escalating run lands `awaiting-consent`, with one undecided `vendo_app_build` ask on the real guard carrying the app id and the ask verbatim, a row with `proposal.approvalId` and the model's own `why`, no `building`, and **zero sandbox claims**; a sandbox-less deployment is never offered the door; and an assembly failure with a sandbox composed stays a failed receipt — no card, no row, no box.

Each proven failable: dropping the assignment, pushing the hand unconditionally, and making a refused save answer `escalate` (the auto-propose the owner forbade) each redden the matching case.

## And the last mile: the card had nowhere to land
With the above, the ask reached the guard — and **nobody could press Approve**. `VendoToasts({ approvals })` (`ui/chrome/vendo-toasts.tsx:205`) is the durable surface for approvals that arrive outside a live turn, exactly what a standing build card is, and **no example host mounted it**.

`5477b3e` mounts it in Maple (7 lines, one file), beside the other app-wide Vendo chrome so it covers every page and cannot double-mount. `placement="bottom-left"` because the default `bottom-right` would lay the card over Maple's own launcher pill and the very badge announcing the ask.

**Proven in a real browser, red then green** (`/home/ubuntu/proofs/approval-card/`, real Chromium, real Postgres, real guard, nothing mocked):
- **RED, no mount:** ask on the wire `true`, cards in DOM `0`, Approve buttons `0`, still pending after 30s — defect A2c reproduced exactly.
- **GREEN:** card renders "Waiting on you: Vendo app build", `POST /approvals/decide → 200` captured at the network boundary, ask leaves the pending list, badge drops.

## Known, not fixed
- At ≤390px the approvals card is wide enough to overlap Maple's launcher — shipped CSS (`chrome-css.ts:1509`), untouched here.
- A test's prose in `vendo-make-matrix.e2e.test.ts` now says something false ("The screen agent carries no `escalate` hand"); its assertions still pass. Test-only reword for someone else.

CI is the gate of record.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the screen agent’s escalation path and surfaces standing build approvals. Previously `screen.assemble()` never set `RunRecord.escalated`, so asks larger than a screen could not reach the build lane; now the agent exposes an `escalate` hand that records a reason and raises a consent‑gated proposal, with no machine claimed until approval.

**Review focus**
- `@vendoai/vendo` `screen-agent.ts`: adds `ESCALATE_TOOL`, gates it on `canBuild`, and its `execute` only sets `record.escalated`.
- `@vendoai/vendo` `compose-apps.ts`: wires `build.available` into the screen seam as `canBuild`, ensuring `escalate` is offered only when a builder exists.
- `@vendoai/ui/chrome` usage in demo bank: mounts `VendoToasts` with `approvals` (`placement="bottom-left"`) to show standing cards.
- New seam test validates `awaiting-consent` receipts, a real `vendo_app_build` approval, gating when no sandbox, and zero sandbox claims.

**Rollout**
- Required: host apps must mount `VendoToasts` with `approvals` to surface pending build approvals.
- Deployments without a sandbox will not expose `escalate`; big asks return failed receipts instead.
- No API changes to existing senders; consent remains the only trigger for starting a build.

<sup>Written for commit 5477b3e25a9270a60403d32801b7ff667f1b6138. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

