### PR TITLE
feat(apps,core,ui,vendo): build progress lines and brand fonts at render (built apps)

### DIFF
--- a/.changeset/creations-progress-fonts.md
+++ b/.changeset/creations-progress-fonts.md
@@ -1,0 +1,8 @@
+---
+"@vendoai/vendo": minor
+"@vendoai/apps": minor
+"@vendoai/core": minor
+"@vendoai/ui": minor
+---
+
+Built apps: the build now says what it is doing, and a sealed bundle renders in the host's own font. `BuildRequest.onStatus` was emitted by the build lane and supplied by nobody, so a build narrated itself to no one; the door now writes the lane's latest line onto the app row (`AppDocument.buildStatus`) and the pending poll answers with it (`PendingSurface.status`), which the forming card reads in place of the generic "Building …". One label, replaced each time — no stream, no subscription, no new route — and a status write that fails never fails the build. Brand fonts now travel with the brand tokens at render: `sendFrameTheme` carries the host's `.vendo/fonts.css` faces into the frame, which installs them as its own sheet, and the bundle route's CSP gains `font-src data:` so an inlined face can load. The seal still holds nothing font-related, and the frame still makes no network request of any kind.

--- a/packages/apps/src/contract/wire-types.ts
+++ b/packages/apps/src/contract/wire-types.ts
@@ -58,6 +58,14 @@ export type OpenSurface =
 export interface PendingSurface {
   kind: "pending";
   /**
+   * What the build last said about itself (`AppDocument.buildStatus`) — one
+   * line, replaced each time, and the WHOLE of the progress channel FINAL SPEC
+   * v1 allows: no stream, no subscription, nothing held open. Absent until the
+   * lane speaks, and absent for a build that never does, in which case the
+   * embed keeps the label it already had.
+   */
+  status?: string;
+  /**
    * The app's tree AS IT FORMS, so the embed's existing poll paints stepped
    * assembly instead of a blind bar. GEOMETRY ONLY — node ids, component names
    * and nesting, tagged `streaming` — because a build's draft carries figures it

--- a/packages/apps/src/server/doors/build-door.ts
+++ b/packages/apps/src/server/doors/build-door.ts
@@ -76,11 +76,16 @@ export interface SealInput {
  * styles at all, which is the point: nothing is loaded, so nothing can be
  * injected from outside.
  *
+ * `font-src data:` is `img-src`'s trade, made twice for the same reason: brand
+ * fonts are injected AT RENDER as `data:` faces (`sendFrameTheme`), and a data
+ * URI is inline — it costs no request, so the zero-network guarantee is
+ * untouched. A scheme or an origin here would hand that guarantee back.
+ *
  * It is a HEADER and never a `<meta>` tag, because `frame-ancestors` — the half
  * that says only the host's own page may frame this — is ignored in meta.
  */
 export const BUNDLE_CSP = "default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline';"
-  + " img-src data:; frame-ancestors 'self'";
+  + " img-src data:; font-src data:; frame-ancestors 'self'";
 
 export const BUNDLE_HEADERS: Readonly<Record<string, string>> = {
   "content-type": "text/html; charset=utf-8",
@@ -172,7 +177,7 @@ export const createBuildDoor = (
     // existing compare-and-swap picks the head. The loser survives as the
     // history version appended below.
     const doc = await updateAppDocument(input.appId, (previous) => {
-      const { building: _building, proposal: _proposal, ...rest } = previous;
+      const { building: _building, buildStatus: _status, proposal: _proposal, ...rest } = previous;
       return { ...rest, ui: "bundle", bundle };
     });
     await history.append(input.appId, doc, {
@@ -271,7 +276,8 @@ export const createBuildDoor = (
         if (!alreadySealed) {
           return await markUnbuilt(appId, existing?.name ?? fallbackAppName(prompt), reason, ctx);
         }
-        await updateAppDocument(appId, ({ building: _building, proposal: _proposal, ...rest }) => rest);
+        await updateAppDocument(appId,
+          ({ building: _building, buildStatus: _status, proposal: _proposal, ...rest }) => rest);
       };
       if (!approved) return await refuse(BUILD_DECLINED);
       if (builder === undefined || !builder.available()) return await refuse(NO_MACHINE);
@@ -279,6 +285,35 @@ export const createBuildDoor = (
         const { proposal: _proposal, ...rest } = previous;
         return { ...rest, building: new Date().toISOString() };
       });
+      /**
+       * "Progress = chat status lines only" (FINAL SPEC v1), and this is the
+       * whole channel: the lane's latest line onto the row the poll already
+       * reads. No stream, no subscription, nothing held open.
+       *
+       * DETACHED AND INDEPENDENT — each label its own write, never chained
+       * behind the one before it. Chaining is the obvious way to guarantee the
+       * newest line wins, and it deadlocks: it moves the second write into the
+       * middle of the box's in-flight turn, where PGlite's single connection
+       * queues it forever (the deadlock `ops.ts`'s `txDb` note names). The
+       * order two labels seconds apart land in is worth nothing next to that,
+       * and the next label overwrites either way.
+       *
+       * It cannot fight the seal or a tombstone. Those bracket the build in
+       * time — `building` is stamped above and cleared by whichever of them
+       * lands — so a label that arrives after one of them finds `building`
+       * gone and writes nothing; `updateAppRow`'s own compare-and-swap
+       * arbitrates anything closer than that.
+       *
+       * And it cannot fail the build: a status is cosmetic, a build is not, so
+       * the write is detached and its failure swallowed. (`onStatus` is called
+       * unawaited by the lane but inside its try — a synchronous throw here
+       * WOULD be read as a failed build.)
+       */
+      const noteStatus = (label: string): void => {
+        void updateAppDocument(appId, (previous) => previous.building === undefined
+          ? previous
+          : { ...previous, buildStatus: label }).catch(() => undefined);
+      };
       /**
        * FROM HERE THE BUILD IS ON ITS OWN, and it has to be.
        *
@@ -306,6 +341,7 @@ export const createBuildDoor = (
           why,
           // Present on a RESEAL: the box starts from what this app already is.
           ...(doc.source === undefined ? {} : { source: doc.source }),
+          onStatus: noteStatus,
         }, ctx);
         if (outcome.kind === "failed") await refuse(outcome.why);
         else await seal({ appId, files: outcome.files, entry: outcome.entry });

--- a/packages/apps/src/server/persistence/open.ts
+++ b/packages/apps/src/server/persistence/open.ts
@@ -283,6 +283,10 @@ export const createAppOpener = (...args: Parameters<typeof serveOpenApp>): (
       throw new VendoError("not-found", `app ${app.id} is still being built`, { appId: app.id });
     }
     const tree = formingTreeOf(app.id);
-    return tree === undefined ? { kind: "pending" } : { kind: "pending", tree };
+    return {
+      kind: "pending",
+      ...(app.buildStatus === undefined ? {} : { status: app.buildStatus }),
+      ...(tree === undefined ? {} : { tree }),
+    };
   };
 };

--- a/packages/core/src/app-document.ts
+++ b/packages/core/src/app-document.ts
@@ -445,6 +445,13 @@ export interface AppDocument {
    */
   building?: IsoDateTime;
   /**
+   * The one line the build lane last said about itself, in the person's terms.
+   * A LABEL, never a log: the latest replaces the previous, because progress is
+   * chat status lines and the only reader is the pending poll's answer. Written
+   * only while `building` is set, and cleared with it.
+   */
+  buildStatus?: string;
+  /**
    * `building`'s half-step back: a build that has been OFFERED and not yet
    * answered. Server-written by the propose path and cleared by the decision,
    * so a document can never carry both this and `building`.
@@ -486,6 +493,7 @@ export const appDocumentSchema = z.object({
   forkedFrom: appIdSchema.optional(),
   buildFailed: appBuildFailureSchema.optional(),
   building: isoDateTimeSchema.optional(),
+  buildStatus: z.string().optional(),
   proposal: appBuildProposalSchema.optional(),
   memory: appMemorySchema.optional(),
   // Input widened for the same reason as {@link appSeedSchema}'s: a defaulted

--- a/packages/ui/src/chrome/embeds.tsx
+++ b/packages/ui/src/chrome/embeds.tsx
@@ -289,6 +289,10 @@ export function VendoAppEmbed({ refValue }: VendoAppEmbedProps) {
   // across polls that carry none, so a draft that stops painting for a beat
   // leaves the silhouette up instead of snapping back to the bare skeleton.
   const [forming, setForming] = useState<UIPayload>();
+  // "Progress = chat status lines only" (FINAL SPEC v1) — the build's own latest
+  // line, off the SAME poll. Held like the silhouette: a poll that carries none
+  // leaves the last line up rather than snapping back to the generic bar.
+  const [status, setStatus] = useState<string>();
 
   useEffect(() => {
     setActiveAppId(appId);
@@ -298,6 +302,7 @@ export function VendoAppEmbed({ refValue }: VendoAppEmbedProps) {
     setSurface(undefined);
     setFailed(undefined);
     setForming(undefined);
+    setStatus(undefined);
     const startedAt = Date.now();
     let cancelled = false;
     let done = false;
@@ -347,6 +352,7 @@ export function VendoAppEmbed({ refValue }: VendoAppEmbedProps) {
           resolveSurface(next);
           return;
         }
+        if (next.status !== undefined) setStatus(next.status);
         // Geometry only — the server ships no figure a repair round could
         // change (apps wire-types.ts), so this paints assembly, never a draft.
         if (next.tree !== undefined) setForming(next.tree);
@@ -380,6 +386,7 @@ export function VendoAppEmbed({ refValue }: VendoAppEmbedProps) {
     setSurface(undefined);
     setFailed(undefined);
     setForming(undefined);
+    setStatus(undefined);
     try {
       const created = await client.apps.create({ prompt });
       setActiveAppId(created.id);
@@ -403,7 +410,9 @@ export function VendoAppEmbed({ refValue }: VendoAppEmbedProps) {
         <div className="fl-appcard-bar" data-state={building ? "building" : "ready"}>
           <span className="fl-appcard-dot" aria-hidden="true" />
           <span className="fl-boot-labels fl-appcard-name">
-            <span className="fl-boot-building" aria-hidden={!building}>Building {title}…</span>
+            {/* The build's own line when it has one — same slot, same type, so
+                a status is a change of words and never of geometry. */}
+            <span className="fl-boot-building" aria-hidden={!building}>{status ?? `Building ${title}…`}</span>
             <span className="fl-boot-ready" aria-hidden={building}>{title}</span>
           </span>
           {/* The placement affordance, only once the view is READY — the same

--- a/packages/ui/src/embedded-runtime.ts
+++ b/packages/ui/src/embedded-runtime.ts
@@ -20,6 +20,7 @@
  * host configured.
  */
 import type { Json, ToolOutcome } from "@vendoai/core";
+import { ensureThemeFontStyles } from "./chrome/theme-fonts.js";
 import { normalizeViewportBlockCss } from "./tree/viewport-css.js";
 
 /** Post one message to the embedding host. Every message is stamped `vendo: true`
@@ -71,9 +72,16 @@ export function callHost(ref: string, args: Json = null): Promise<ToolOutcome> {
  */
 function receiveFromHost(event: MessageEvent): void {
   if (event.source !== parent) return;
-  const message = event.data as { vendo?: unknown; kind?: unknown; vars?: unknown; id?: unknown; outcome?: unknown } | null;
+  const message = event.data as
+    { vendo?: unknown; kind?: unknown; vars?: unknown; fonts?: unknown; id?: unknown; outcome?: unknown } | null;
   if (typeof message !== "object" || message === null || message.vendo !== true) return;
-  if (message.kind === "theme") applyThemeVars(message.vars);
+  if (message.kind === "theme") {
+    applyThemeVars(message.vars);
+    // The brand's own faces, as `data:` URIs — the family token names a font
+    // this document would otherwise have no bytes for. Same installer the
+    // chrome uses, so a surface that is its own document gets its own sheet.
+    if (typeof message.fonts === "string") ensureThemeFontStyles(message.fonts);
+  }
   if (message.kind === "result" && typeof message.id === "string") {
     awaiting.get(message.id)?.(message.outcome as ToolOutcome);
     awaiting.delete(message.id);

--- a/packages/ui/src/tree/frame-bridge.ts
+++ b/packages/ui/src/tree/frame-bridge.ts
@@ -60,11 +60,22 @@ export function replyToFrame(frame: HTMLIFrameElement | null, id: string, outcom
   postToFrame(frame, { kind: "result", id, outcome });
 }
 
-/** The host's brand tokens, injected AT RENDER — never baked into the seal, so
- *  one sealed bundle follows whatever palette the host is wearing today. */
-export function sendFrameTheme(frame: HTMLIFrameElement | null, vars: Record<string, string>): void {
+/**
+ * The host's brand tokens and font faces, injected AT RENDER — never baked into
+ * the seal, so one sealed bundle follows whatever palette the host is wearing
+ * today.
+ *
+ * `fonts` is the host's `.vendo/fonts.css` (`VendoContextValue.fonts`), whose
+ * faces sync already inlined as `data:` URIs. The family NAME alone is useless
+ * here: the frame has an opaque origin the host's stylesheet never reaches, so
+ * without the bytes the token resolves to whatever the frame happens to have.
+ * Absent, the token's own fallback stack is the whole answer — the route's CSP
+ * (`font-src data:`) blocks any face that would try to fetch anything.
+ */
+export function sendFrameTheme(frame: HTMLIFrameElement | null, vars: Record<string, string>, fonts?: string): void {
   postToFrame(frame, {
     kind: "theme",
     vars: Object.fromEntries(Object.entries(vars).filter(([name]) => VENDO_VAR.test(name))),
+    ...(fonts === undefined || fonts === "" ? {} : { fonts }),
   });
 }

--- a/packages/ui/src/tree/frames.tsx
+++ b/packages/ui/src/tree/frames.tsx
@@ -186,7 +186,7 @@ function BundleFrame({ appId, entry, onAction }: {
   entry: string;
   onAction: NonNullable<AppFrameProps["onAction"]>;
 }) {
-  const { client, theme } = useVendoProvider();
+  const { client, theme, fonts } = useVendoProvider();
   const frameRef = useRef<HTMLIFrameElement | null>(null);
   const vars = useMemo(() => themeCssVariables(theme), [theme]);
   useEffect(() => {
@@ -197,7 +197,7 @@ function BundleFrame({ appId, entry, onAction }: {
       // The handshake: a frame that has not booted has no listener yet, so the
       // tokens would land on nobody.
       if ((event.data as { vendo?: unknown; kind?: unknown } | null)?.kind === "booted" && isFromFrame(frame, event)) {
-        sendFrameTheme(frame, vars);
+        sendFrameTheme(frame, vars, fonts);
         return;
       }
       const call = readFrameCall(frame, event);
@@ -207,7 +207,7 @@ function BundleFrame({ appId, entry, onAction }: {
     };
     window.addEventListener("message", onMessage);
     return () => window.removeEventListener("message", onMessage);
-  }, [onAction, vars]);
+  }, [onAction, vars, fonts]);
   return (
     <iframe
       // The entry IS the content hash, so fresh bytes are a fresh frame.

--- a/packages/ui/test/tree/bundle-frame.test.tsx
+++ b/packages/ui/test/tree/bundle-frame.test.tsx
@@ -11,6 +11,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { act, cleanup, render, screen } from "@testing-library/react";
 import type { ToolOutcome } from "@vendoai/core";
+import { VendoProvider } from "../../src/context.js";
 import { AppFrame } from "../../src/tree/index.js";
 import { readFrameCall, replyToFrame, sendFrameTheme } from "../../src/tree/frame-bridge.js";
 
@@ -32,6 +33,8 @@ const posted = (source: Window | null, data: unknown) =>
 
 const CALL = { vendo: true, kind: "call", id: "c1", ref: "listAccounts", args: { limit: 2 } };
 const OK: ToolOutcome = { status: "ok", output: { rows: [] } };
+/** One `.vendo/fonts.css` face, as `vendo sync` inlines it. */
+const FACE = "@font-face{font-family:'Maple';src:url(data:font/woff2;base64,d09GMg==) format('woff2')}";
 
 describe("the frame bridge", () => {
   it("reads a well-formed call from the frame itself", () => {
@@ -111,6 +114,22 @@ describe("BundleFrame", () => {
     // Injected AT RENDER, never baked into the seal.
     expect(theme.vars["--vendo-font-family"]).toBeTypeOf("string");
     expect(Object.keys(theme.vars).every((name) => name.startsWith("--vendo-"))).toBe(true);
+  });
+
+  it("sends the host's own font faces with them, straight off the provider", () => {
+    render(
+      <VendoProvider fonts={FACE}>
+        <AppFrame surface={surface} appId="app_built" />
+      </VendoProvider>,
+    );
+    const frame = screen.getByTitle("Vendo app") as HTMLIFrameElement;
+    const post = vi.spyOn(frame.contentWindow!, "postMessage");
+
+    window.dispatchEvent(posted(frame.contentWindow, { vendo: true, kind: "booted" }));
+
+    const [theme] = post.mock.calls[0] as [{ fonts?: string }];
+    // `.vendo/fonts.css`, at render — the seal holds none of it.
+    expect(theme.fonts).toBe(FACE);
   });
 
   it("routes a frame call through onAction and posts the outcome back", async () => {

--- a/packages/ui/test/tree/frame-protocol.seam.test.ts
+++ b/packages/ui/test/tree/frame-protocol.seam.test.ts
@@ -17,10 +17,13 @@ import { readFrameCall, replyToFrame, sendFrameTheme } from "../../src/tree/fram
 afterEach(() => {
   document.body.innerHTML = "";
   document.documentElement.removeAttribute("style");
+  document.querySelector("style[data-vendo-fonts]")?.remove();
   vi.restoreAllMocks();
 });
 
 const OK: ToolOutcome = { status: "ok", output: { balance: 12 } };
+/** One `.vendo/fonts.css` face, as `vendo sync` inlines it. */
+const FACE = "@font-face{font-family:'Maple';src:url(data:font/woff2;base64,d09GMg==) format('woff2')}";
 
 /** jsdom's top window IS its own `parent`, so the inner half's listener accepts
  *  what this document dispatches — which is what a real host posts in. */
@@ -61,5 +64,35 @@ describe("the frame protocol, both real halves", () => {
 
     expect(document.documentElement.style.getPropertyValue("--vendo-color-accent")).toBe("#0a7");
     expect(document.documentElement.style.getPropertyValue("--host-private")).toBe("");
+  });
+
+  it("installs the host's data: font faces at render, beside the family token", () => {
+    startFrameProtocol(document.createElement("div"));
+    const frame = document.createElement("iframe");
+    document.body.appendChild(frame);
+    const out = vi.spyOn(frame.contentWindow!, "postMessage");
+
+    sendFrameTheme(frame, { "--vendo-font-family": "Maple, sans-serif" }, FACE);
+    toFrame(out.mock.calls[0]![0]);
+
+    // The BYTES, not the name: a sealed bundle renders in an opaque origin the
+    // host's own stylesheet never reaches, so "Maple" resolves to nothing
+    // unless the face travels with the token.
+    expect(document.querySelector("style[data-vendo-fonts]")?.textContent).toBe(FACE);
+    expect(document.body.style.fontFamily).toBe("var(--vendo-font-family, system-ui, sans-serif)");
+  });
+
+  it("falls back to the family token when the host has no face to send", () => {
+    startFrameProtocol(document.createElement("div"));
+    const frame = document.createElement("iframe");
+    document.body.appendChild(frame);
+    const out = vi.spyOn(frame.contentWindow!, "postMessage");
+
+    sendFrameTheme(frame, { "--vendo-font-family": "Maple, sans-serif" });
+    toFrame(out.mock.calls[0]![0]);
+
+    // No empty face and no broken load — the token is the whole answer.
+    expect(document.querySelector("style[data-vendo-fonts]")).toBeNull();
+    expect(document.documentElement.style.getPropertyValue("--vendo-font-family")).toBe("Maple, sans-serif");
   });
 });

--- a/packages/vendo/src/build-agent.ts
+++ b/packages/vendo/src/build-agent.ts
@@ -71,6 +71,14 @@ const diskDirectory = (appId: AppId): string => `${BOX_WORKSPACE_ROOT}${appDirec
  *  the brief tells the box to remove it if its own test does not pass. */
 const ENTRY = "dist/app.js";
 
+/** Everything this lane ever says about itself, in order — "progress = chat
+ *  status lines only" (FINAL SPEC v1). Named so the seam that reads them back
+ *  off the app row reads THESE rather than a copy of them. */
+export const BUILD_STATUS_LINES = [
+  "Starting a build machine…",
+  "Writing the code, installing what it needs, and testing it…",
+] as const;
+
 /** The one capability gap that is this seam's own to report, in the person's
  *  terms. Third person: it surfaces as a system notice. */
 const NO_SANDBOX = "This needs a real build machine, and this deployment has no sandbox adapter to boot one from.";
@@ -145,7 +153,7 @@ export function appBuilder(deps: AppBuilderDeps): AppBuilder {
       // Declared out here so the box is handed back even when the lane throws.
       let machine: Awaited<ReturnType<typeof boxMachine>> | undefined;
       try {
-        request.onStatus?.("Starting a build machine…");
+        request.onStatus?.(BUILD_STATUS_LINES[0]);
         machine = await boxMachine({
           sandbox,
           threadId: `build_${request.appId}`,
@@ -154,7 +162,7 @@ export function appBuilder(deps: AppBuilderDeps): AppBuilder {
           ...(deps.template === undefined ? {} : { template: deps.template }),
         });
         await machine.materialize(checkoutOf(request.source, directory));
-        request.onStatus?.("Writing the code, installing what it needs, and testing it…");
+        request.onStatus?.(BUILD_STATUS_LINES[1]);
         // No `toolDoor`: this box reaches none of the host's tools, so there is
         // nothing for it to act with and no credential to act under.
         await machine.send({

--- a/packages/vendo/tests/build-lane.test.ts
+++ b/packages/vendo/tests/build-lane.test.ts
@@ -43,7 +43,7 @@ import {
 import { createStore, type VendoStore } from "@vendoai/store";
 import * as kit from "@vendoai/ui/kit";
 import { afterEach, describe, expect, it } from "vitest";
-import { appBuilder, BUILD_ALLOWED_DOMAINS } from "../src/build-agent.js";
+import { appBuilder, BUILD_ALLOWED_DOMAINS, BUILD_STATUS_LINES } from "../src/build-agent.js";
 import { createVendo } from "../src/server.js";
 
 const encoder = new TextEncoder();
@@ -366,6 +366,106 @@ describe("approving comes straight back", () => {
 
     release();
     expect((await settled(harness))["ui"]).toBe("bundle");
+  });
+});
+
+describe("progress is chat status lines, and nothing more", () => {
+  /** Poll the REAL pending answer until the lane has said something. The write
+   *  is fire-and-forget by design, so it lands a beat after the label. */
+  const labelled = async (harness: Harness): Promise<Record<string, unknown>> => {
+    for (let attempt = 0; attempt < 400; attempt += 1) {
+      const surface = await harness.runtime.open(APP, ctx, { pending: true }) as Record<string, unknown>;
+      if (surface["status"] !== undefined) return surface;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    throw new Error("the pending poll never carried a status");
+  };
+
+  const heldBox = () => {
+    let started: () => void = () => undefined;
+    const inTheBox = new Promise<void>((resolve) => { started = resolve; });
+    let release: () => void = () => undefined;
+    const held = new Promise<void>((resolve) => { release = resolve; });
+    const sandbox = scriptedSandbox(async (input) => {
+      started();
+      await held;
+      buildsFine(input);
+    });
+    return { sandbox, inTheBox, release: () => release() };
+  };
+
+  it("the lane's own label reaches the pending poll, one line at a time", async () => {
+    const { sandbox, inTheBox, release } = heldBox();
+    const harness = setup(sandbox);
+
+    await decide(harness, await propose(harness));
+    await inTheBox;
+
+    // THE SEAM. `BuildRequest.onStatus` shipped emitted and unread: the real
+    // lane says these, the real row holds one, and the real pending answer —
+    // the one the embed already polls — is what carries it out.
+    const surface = await labelled(harness);
+    // ONE LABEL FIELD, not a log: a scalar `status` and nothing beside it.
+    expect(Object.keys(surface).sort()).toEqual(["kind", "status"]);
+    // …and the words are the LANE'S OWN, read off the lane rather than copied
+    // here: a rename there is a red test, never a build narrating a line
+    // nobody writes any more. Either of them, because the two writes are
+    // deliberately independent (build-door.ts) and race by design.
+    expect(BUILD_STATUS_LINES as readonly string[]).toContain(surface["status"]);
+
+    release();
+    // A label is build state, not app content: the seal takes it with the rest.
+    expect((await settled(harness))["buildStatus"]).toBeUndefined();
+  });
+
+  it("a status write the store refuses still leaves the build succeeding", async () => {
+    // Progress is cosmetic; the build is not. Only the status write is refused
+    // — the same row's own writes go through, so what is on trial is the
+    // failure of THIS write and nothing else.
+    const backing = memoryStoreAdapter();
+    let refused = 0;
+    const refusesLabels: StoreAdapter = {
+      ...backing,
+      records: (collection) => {
+        const records = backing.records(collection);
+        // The label write is the ONLY one refused, and it is told apart by the
+        // field it carries — so the row's own writes (`building`, the seal) land
+        // exactly as they always do.
+        if (collection !== "vendo_apps" || records.atomic === undefined) return records;
+        const atomic = records.atomic;
+        return {
+          ...records,
+          atomic: {
+            ...atomic,
+            compareAndSwap: async (input, revision) => {
+              if ((input.data as { doc?: { buildStatus?: unknown } }).doc?.buildStatus === undefined) {
+                return await atomic.compareAndSwap(input, revision);
+              }
+              refused += 1;
+              throw new Error("the store refused this write");
+            },
+          },
+        };
+      },
+    };
+    const { sandbox, inTheBox, release } = heldBox();
+    const harness = setup(sandbox, refusesLabels);
+
+    await decide(harness, await propose(harness));
+    // Held in the box, so the labels are written while the build is still
+    // running — a build that has already sealed writes no label at all, and
+    // this case would then pass on a lane that never tried.
+    await inTheBox;
+    for (let attempt = 0; refused === 0 && attempt < 400; attempt += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    expect(refused).toBeGreaterThan(0);
+
+    release();
+    const row = await settled(harness);
+    expect(row["ui"]).toBe("bundle");
+    expect(row["buildFailed"]).toBeUndefined();
+    expect(row["buildStatus"]).toBeUndefined();
   });
 });
 

--- a/packages/vendo/tests/bundle-route.seam.test.ts
+++ b/packages/vendo/tests/bundle-route.seam.test.ts
@@ -23,7 +23,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { createVendo, type Vendo } from "../src/server.js";
 
 const CSP = "default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline';"
-  + " img-src data:; frame-ancestors 'self'";
+  + " img-src data:; font-src data:; frame-ancestors 'self'";
 
 const ADA: Principal = { kind: "user", subject: "user_ada" };
 const APP = "app_built" as AppId;
@@ -97,6 +97,25 @@ describe("the sealed bundle's render seam", () => {
     expect(document_).not.toContain("<script src");
     // …and the bundle's own `</script>` did not end the script tag early.
     expect(document_.split("</script>")).toHaveLength(2);
+  });
+
+  it("lets a data: font face in and still no network out, and bakes no font into the seal", async () => {
+    const { vendo, bundle } = await setup();
+    const response = await get(vendo, `/apps/${APP}/bundle/${bundle.entry}`, ADA.subject);
+    const policy = response.headers.get("content-security-policy") ?? "";
+
+    // Brand fonts are injected AT RENDER as `data:` faces, which `default-src
+    // 'none'` blocks outright — so the policy has to name them, and inline is
+    // the only spelling it may name. A scheme or an origin here would hand the
+    // frame back the network the whole seal rests on not having.
+    expect(policy).toContain("font-src data:");
+    expect(policy).not.toMatch(/https?:|\/\//u);
+
+    // Nothing font-related is in the sealed bytes: the seal is content, the
+    // face is brand, and the two must never meet.
+    const document_ = await response.text();
+    expect(document_).not.toContain("@font-face");
+    expect(document_).not.toContain("font-family");
   });
 
   it("is viewer-scoped: a stranger gets not-found, never the bytes", async () => {


### PR DESCRIPTION
> Stacked on #1617. Review only the top commit; the stack merges once at the tip.

Two spec requirements that were unimplemented, both settled by owner ruling.

## 1. "Progress = chat status lines only"

`BuildRequest.onStatus` was *emitted* by the build lane and **supplied by nobody** — a dead seam. A prior lane parked it rather than invent a channel, correctly.

Built the smallest mechanism, exactly as ruled: **one label field on the app row, through the existing `updateAppRow` path, surfaced by the existing pending poll.** No new route, no stream, no subscription.

`AppDocument.buildStatus` ← written by `noteStatus` (`build-door.ts`), cleared with the rest of the build state → read out as `PendingSurface.status` by `open.ts` → rendered by the forming card (`ui/chrome/embeds.tsx`). The sanctioned bare-"building" fallback was **not** needed.

**Ordering.** The first cut serialized the two status writes behind the existing row queue so the newest line always won. That **deadlocked the composed build lane on every run** — it moves the second write into the middle of the box's in-flight turn, where PGlite's single connection queues it forever (the deadlock `store/src/ops.ts:304-307` already names). Each label is now its own independent write: the build's own writes bracket the labels in time, so a label outside that window writes nothing and `updateAppRow`'s CAS arbitrates anything closer. Two labels seconds apart landing out of order is a cosmetic non-risk next to a hung lane.

A failing status write can never fail a build — progress is cosmetic, the build is not.

**Seam test** (`vendo/tests/build-lane.test.ts`): the real `appBuilder` emits, the real door writes, the real `open(…, {pending:true})` reads — no stub between emitter and reader. Asserts the answer is `{kind, status}` and nothing else (one label, not a log), and that the words are the lane's own, imported from `BUILD_STATUS_LINES` rather than restated. A second case proves a refused status write still seals. Both redden when the wiring is removed.

## 2. Brand fonts at render

**Correction to the record:** the approved CSP did **not** already permit `data:` fonts. It had no `font-src` at all, and `default-src 'none'` blocks fonts outright. Delivering the ruling required adding the clause.

Final header, one clause added and nothing else:
```
default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data:; font-src data:; frame-ancestors 'self'
```
`data:` is inline, so **no request leaves the frame** — the zero-network guarantee is intact. It is the same trade already accepted one clause over for `img-src`.

`sendFrameTheme(frame, vars, fonts)` carries the host's faces; the frame installs them through the existing `ensureThemeFontStyles`; `BundleFrame` reads them off the provider. Nothing font-related is in the sealed bytes.

**Real font BYTES, not just names.** `vendo sync` already resolves brand families to inlined `data:font/woff2;base64,…` faces in `.vendo/fonts.css`, the provider already carries that text, and demo-bank ships 64KB of real Inter. The path is filled today, not merely ready.

**Browser proof with a negative control** — the real `bundleDocument` behind the real `BUNDLE_HEADERS`, in an `allow-scripts`-only opaque-origin frame, loaded demo-bank's real Inter face: `document.fonts` status `loaded`, zero CSP violations. With `font-src data:` removed, Chromium refused it verbatim: *"'font-src' was not explicitly set, so 'default-src' is used as a fallback. The action has been blocked"*. The clause is load-bearing, not cosmetic.

## Known, not fixed
- `build-lane.test.ts`'s last case returns while its detached lane is still writing to a store the `afterEach` then closes — benign today, but it is the window the deadlock above fell into, and a latent flake generator.
- `bundleDocument` is exported from `build-door.ts` but not from the package server index, while `BUNDLE_HEADERS` is.

CI is the gate of record.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows build progress as a single status line and renders sealed bundles with host brand fonts. Previously builds showed a generic “Building …” and bundles could not load fonts under the CSP.

- Progress line: the build lane now writes its latest status to `AppDocument.buildStatus`; the existing pending poll returns it as `PendingSurface.status`; the forming card in `@vendoai/ui` renders it instead of the generic label. One label at a time, no stream, no new routes, and a failed status write never fails the build. Writes are independent to avoid the prior deadlock risk.
- Fonts at render: `BUNDLE_CSP` adds `font-src data:` so inlined faces can load without network. `sendFrameTheme(frame, vars, fonts?)` now sends the host’s `.vendo/fonts.css` (data: woff2) into the frame, installed via the existing font sheet path. No font bytes enter the seal; if no faces are provided, the family token fallback remains.

<sup>Written for commit 02c37b7f7c8b4c332e0c76d6c449d4f22295c974. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

