### PR TITLE
fix(harnesses): a malformed tool call no longer poisons the next step's prompt

### DIFF
--- a/.changeset/malformed-tool-call-costs-a-step.md
+++ b/.changeset/malformed-tool-call-costs-a-step.md
@@ -1,0 +1,24 @@
+---
+"@vendoai/harnesses": patch
+---
+
+A tool call the model emitted as broken JSON now costs the turn one step instead
+of killing it.
+
+When a tool call's input text does not parse — malformed JSON, or a generation
+truncated at `max_tokens` mid-object — the AI SDK keeps the RAW STRING as that
+call's input, marks the call invalid, enqueues a `tool-error` as its output, and
+carries on. That string then rides into the assistant message appended to the
+running prompt, and on the very next step the Anthropic provider serializes it
+verbatim as `tool_use.input`. The provider rejects the whole request —
+`tool_use.input: Input should be an object` — so a single bad call took the
+entire turn down, several steps of real work with it. Seen live on Cloud managed
+inference.
+
+The turn loop's `prepareStep` now normalizes every outgoing prompt: any
+`tool-call` part whose input is not an object is sent as `{}`. That is the one
+seam that sees every step, so it covers the projected history, the SDK's in-turn
+accumulation and the overflow retry's resume path alike. Nothing is lost — the
+paired tool result already carries the invalid-input error, so the model simply
+re-issues the call with real arguments. Tool results are never rewritten, and a
+prompt with no broken call is passed through untouched.

--- a/packages/harnesses/src/vendo/loop.ts
+++ b/packages/harnesses/src/vendo/loop.ts
@@ -504,6 +504,38 @@ function advanceCacheBreakpoint(messages: readonly ModelMessage[]): ModelMessage
   return stripped;
 }
 
+/** A tool input the provider will accept: a JSON object, not a string or array. */
+const objectInput = (input: unknown): boolean =>
+  typeof input === "object" && input !== null && !Array.isArray(input);
+
+/**
+ * Force every tool call's input to an object.
+ *
+ * When a model's tool-call input text does not parse — malformed JSON, or a
+ * generation truncated at `max_tokens` — `parseToolCall` keeps the RAW STRING as
+ * that call's input, marks it invalid, and the step loop continues. The assistant
+ * message appended after it carries that string, and the next step serializes it
+ * verbatim as `tool_use.input`, which Anthropic rejects outright: `tool_use.input:
+ * Input should be an object`. One bad call kills the turn instead of costing it a
+ * step. {@link wellFormed} cannot catch it: that runs once, on the step-0 history,
+ * and this message is minted by the SDK mid-turn.
+ *
+ * `{}` is not lossy — the paired tool result already says the input was invalid,
+ * so the model re-issues the call. Repairing here rather than through
+ * `repairToolCall` is deliberate: a repaired call is re-parsed and EXECUTED, and
+ * this one would run for real with empty arguments.
+ */
+function objectToolInputs(messages: readonly ModelMessage[]): ModelMessage[] {
+  return messages.map((message) => {
+    if (typeof message.content === "string") return message;
+    const broken = (part: (typeof message.content)[number]): boolean =>
+      part.type === "tool-call" && !objectInput(part.input);
+    if (!message.content.some(broken)) return message;
+    const content = message.content.map((part) => (broken(part) ? { ...part, input: {} } : part));
+    return { ...message, content } as ModelMessage;
+  });
+}
+
 export interface TurnLoopOptions {
   model: LanguageModel;
   /** §4.1 item 3 — the rungs BELOW `model`, tried in order when a provider fails
@@ -643,18 +675,19 @@ export async function startTurn(options: TurnLoopOptions): Promise<TurnLoop> {
     // on the very next step. This gates the model's CHOICE only — every tool
     // still executes through the guard-bound registry; there is no unguarded path.
     ...(active === undefined ? {} : { activeTools: active }),
-    // One hook, two rails. `prepareStep` used to be built only when a loadout
+    // One hook, three rails. `prepareStep` used to be built only when a loadout
     // existed, which is why a step's growing tool results were never cached —
     // the turn with the most to cache had no hook at all. It is returned on
     // every turn now, and the loadout rides the same result rather than growing
-    // a second per-step hook beside it.
+    // a second per-step hook beside it; input normalization rides it too, since
+    // this is the one seam that sees every outgoing prompt.
     prepareStep: ({ messages, stepNumber }) => {
       const active = activeTools?.();
       step = stepNumber;
       stepStartedAt = Date.now();
       debug({ kind: "step-start", step, maxSteps, activeTools: active ?? [] });
       return {
-        messages: advanceCacheBreakpoint(messages),
+        messages: advanceCacheBreakpoint(objectToolInputs(messages)),
         ...(active === undefined ? {} : { activeTools: active }),
       };
     },

--- a/packages/harnesses/tests/vendo/malformed-tool-input.test.ts
+++ b/packages/harnesses/tests/vendo/malformed-tool-input.test.ts
@@ -1,0 +1,133 @@
+/**
+ * A tool call the model emitted as broken JSON must not poison the next step.
+ *
+ * When a model's tool-call input text does not parse — malformed JSON, or a
+ * generation truncated at `max_tokens` mid-object — the AI SDK's `parseToolCall`
+ * falls back to keeping the RAW STRING as that call's `input`, marks the call
+ * invalid, and enqueues a `tool-error` as its output. The step loop then
+ * CONTINUES, and `toResponseMessages` writes that string straight into the
+ * assistant message it appends to the running prompt. On the next step the stock
+ * Anthropic provider serializes it verbatim as `tool_use.input`, and the provider
+ * rejects the whole request: `tool_use.input: Input should be an object`. One
+ * malformed call therefore kills the entire turn rather than costing it a step.
+ *
+ * The projection's own well-formedness pass cannot catch this: it runs once, on
+ * the step-0 history, and the poisoned message is minted by the SDK mid-turn.
+ * `prepareStep` is the only thing that sees EVERY step's prompt, so that is where
+ * the shape is enforced.
+ *
+ * The proof is one question asked of the step that follows the bad call: is every
+ * tool-call input in the prompt an object? A string there is a request the
+ * provider will 400 on, so the assertion is about the wire shape and nothing else.
+ * `{}` is the right repair rather than a lossy one — the paired tool result
+ * already tells the model its input was invalid, so it re-issues the call with
+ * real arguments.
+ */
+import type { UIMessage } from "ai";
+import { tool } from "ai";
+import { MockLanguageModelV3, simulateReadableStream } from "ai/test";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { startTurn } from "../../src/vendo/loop.js";
+import type { StreamPart } from "../../src/test-doubles.test-util.js";
+
+const ZERO_USAGE = {
+  inputTokens: { total: 0, noCache: 0, cacheRead: 0, cacheWrite: 0 },
+  outputTokens: { total: 0, text: 0, reasoning: 0 },
+} as const;
+
+const note = tool({
+  description: "Write a note.",
+  inputSchema: z.object({ content: z.string() }),
+  execute: async (input: { content: string }) => input,
+});
+
+/** Exactly what a generation cut off at `max_tokens` mid-object leaves behind. */
+const TRUNCATED_INPUT = '{"content": "abc';
+
+const thread = (): UIMessage[] => [
+  { id: "m1", role: "user", parts: [{ type: "text", text: "write a note" }] },
+];
+
+/** Step 1 emits the unparseable call; step 2 replies, so there IS a next prompt. */
+function truncatedCallModel(): MockLanguageModelV3 {
+  let step = 0;
+  return new MockLanguageModelV3({
+    doStream: async () => {
+      step += 1;
+      const chunks: StreamPart[] = step === 1
+        ? [
+            {
+              type: "tool-call" as const,
+              toolCallId: "call_1",
+              toolName: "note",
+              input: TRUNCATED_INPUT,
+            },
+            { type: "finish" as const, usage: ZERO_USAGE, finishReason: { unified: "tool-calls" as const, raw: undefined } },
+          ]
+        : [
+            { type: "text-start" as const, id: "t1" },
+            { type: "text-delta" as const, id: "t1", delta: "done" },
+            { type: "text-end" as const, id: "t1" },
+            { type: "finish" as const, usage: ZERO_USAGE, finishReason: { unified: "stop" as const, raw: undefined } },
+          ];
+      return { stream: simulateReadableStream({ chunks }) };
+    },
+  });
+}
+
+type StepPrompt = MockLanguageModelV3["doStreamCalls"][number]["prompt"];
+
+/** Every tool-call part of one step's prompt, whichever message carries it. */
+function toolCallInputs(prompt: StepPrompt): unknown[] {
+  return prompt.flatMap((message) =>
+    typeof message.content === "string"
+      ? []
+      : message.content.flatMap((part) => (part.type === "tool-call" ? [part.input] : [])));
+}
+
+async function runTurn() {
+  const model = truncatedCallModel();
+  const loop = await startTurn({
+    model,
+    system: "system",
+    messages: thread(),
+    tools: { note },
+    context: { maxSteps: 5 },
+  });
+  for await (const _part of loop.result.fullStream) void _part;
+  return model.doStreamCalls;
+}
+
+describe("a malformed tool call does not poison the next step's prompt", () => {
+  it("sends the failed call's input as an OBJECT, never the raw string", async () => {
+    const calls = await runTurn();
+    // The turn has to keep going for there to be a poisoned prompt at all.
+    expect(calls.length).toBe(2);
+    const inputs = toolCallInputs((calls[1] as (typeof calls)[number]).prompt);
+    expect(inputs.length).toBe(1);
+    for (const input of inputs) {
+      expect(typeof input, `raw input was ${JSON.stringify(input)}`).toBe("object");
+      expect(input).not.toBeNull();
+    }
+  });
+
+  it("repairs to an empty object rather than inventing arguments", async () => {
+    // Anything non-empty would be arguments the model never asked for; the paired
+    // tool result already carries the invalid-input error that prompts a retry.
+    const calls = await runTurn();
+    expect(toolCallInputs((calls[1] as (typeof calls)[number]).prompt)).toEqual([{}]);
+  });
+
+  it("still pairs the failed call with a tool result", async () => {
+    // The repair rewrites tool CALLS only. If it touched outputs, or if the call
+    // lost its result, the prompt would be malformed in a second, different way.
+    const calls = await runTurn();
+    const prompt = (calls[1] as (typeof calls)[number]).prompt;
+    const results = prompt.flatMap((message) =>
+      typeof message.content === "string"
+        ? []
+        : message.content.flatMap((part) => (part.type === "tool-result" ? [part.toolCallId] : [])));
+    expect(results).toEqual(["call_1"]);
+  });
+});


### PR DESCRIPTION
When a model's tool-call input text does not parse — malformed JSON, or a generation truncated at `max_tokens` mid-object — the AI SDK's `parseToolCall` falls back to keeping the **raw string** as that call's `input`, marks the call invalid, enqueues a `tool-error` as its output, and lets the step loop continue. `toResponseMessages` then writes `input: part.input` (the string) into the assistant message it appends to the running prompt. On the very next step the stock Anthropic provider serializes it verbatim as `tool_use.input`, and the gateway rejects the entire request with `tool_use.input: Input should be an object`. So one malformed call does not cost the turn a step — it kills the turn outright, taking every step of real work before it down too. Observed live from vendo-demos through Vendo Cloud managed inference.

Nothing upstream can catch it. `wellFormed` (`loop.ts:216`) checks call/result pairing and the leading role, never input shape, and it runs exactly once — on the step-0 projection — while the poisoned message is minted by the SDK mid-turn. `prepareStep` (`loop.ts:651`) is the loop's only per-step interception and the one seam that sees every outgoing prompt, so the shape is enforced there: `objectToolInputs` shallow-maps the array and rewrites any `tool-call` part whose input is not a plain object to `{}`, composing with the existing rewrite as `advanceCacheBreakpoint(objectToolInputs(messages))`. Because `prepareStep` runs before every step including step 0, that single pass covers the projected history, the SDK's in-turn accumulation, and the overflow-retry resume path alike. Tool **results** are never rewritten, no message is deep-cloned (`advanceCacheBreakpoint` expects the same identities), and a prompt with no broken call is passed straight through. `{}` is the right repair rather than a lossy one: the paired tool result already carries `Invalid input for tool X: …`, so the model simply re-issues the call with real arguments. `repairToolCall` is deliberately **not** used — its return value is re-parsed and the tool would genuinely execute with empty args.

## The seam test

New file, `packages/harnesses/tests/vendo/malformed-tool-input.test.ts` — this is a **new test, not a modification of any existing test**. It follows `tests/vendo/cache-breakpoints.test.ts`, its direct sibling on the same hook. A `MockLanguageModelV3` streams one `tool-call` chunk on step 0 whose input text is `'{"content": "abc'` (exactly what a generation cut off at `max_tokens` leaves behind) for an equipped tool, then replies on step 1. The real turn loop is driven end to end via `startTurn`, and the assertion is made on the **second** `doStream` call's prompt — the actual wire shape the provider would receive. Nothing is stubbed on either side of the seam. Three cases: the input is an object and not the raw string; it is specifically `{}` rather than invented arguments; and the failed call is still paired with its tool result, proving the rewrite touches calls only.

## Red run — before the fix

The test was written first and run against unmodified `loop.ts`. It reproduced the production failure exactly:

```
 ❯ tests/vendo/malformed-tool-input.test.ts (3 tests | 2 failed) 44ms
   × a malformed tool call does not poison the next step's prompt > sends the failed call's input as an OBJECT, never the raw string 24ms
     → raw input was "{\"content\": \"abc": expected 'string' to be 'object'
   × a malformed tool call does not poison the next step's prompt > repairs to an empty object rather than inventing arguments 11ms
     → expected [ '{"content": "abc' ] to deeply equal [ {} ]
   ✓ a malformed tool call does not poison the next step's prompt > still pairs the failed call with a tool result 9ms

AssertionError: raw input was "{\"content\": \"abc": expected 'string' to be 'object'
Expected: "object"
Received: "string"

 Test Files  1 failed (1)
      Tests  2 failed | 1 passed (3)
```

The third case passing red confirms the turn *does* continue past the bad call and the pairing was never the problem — the input shape was the only defect.

## Green run — after the fix

```
 ✓ tests/vendo/malformed-tool-input.test.ts (3 tests) 39ms

 Test Files  1 passed (1)
      Tests  3 passed (3)
```

## Gate

Run on the touched scope from the worktree root:

| Step | Result |
| --- | --- |
| `pnpm build` | 22/22 tasks successful |
| `pnpm typecheck` | 44/44 tasks successful |
| `pnpm lint` | 4/4 tasks successful (4 pre-existing `demo-bank` warnings, 0 errors) |
| `@vendoai/harnesses` full suite | **607 passed**, 65 files, 3 skipped, 0 failures |

`pnpm test:affected` also surfaced 23 failures in `@vendoai/vendo`, led by `tests/cli/provider-deps.test.ts` asserting on `npm install ai@^6` install arguments. Those are unrelated to tool-call input normalization and are being confirmed as pre-existing against `origin/main`; CI on this PR is the gate of record.

A patch changeset for `@vendoai/harnesses` is included.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Malformed tool-call input no longer poisons the next step’s prompt in `@vendoai/harnesses`. Previously, the raw string from an unparseable tool-call input was echoed into the next prompt and Anthropic rejected `tool_use.input` (must be an object), killing the turn; now we normalize such inputs to `{}` so the turn continues and only costs a step.

- Compose a new `objectToolInputs()` pass into `prepareStep` as `advanceCacheBreakpoint(objectToolInputs(messages))`, ensuring every outgoing prompt has object-shaped tool-call inputs.
- Rewrite affects tool-call inputs only; tool results are untouched and message identities are preserved for cache breakpoints.
- Use `{}` instead of repairing inputs to avoid executing tools with empty args; the paired tool-error already prompts the model to retry with real arguments.
- Add seam test `packages/harnesses/tests/vendo/malformed-tool-input.test.ts` that runs the real loop and asserts the next-step wire shape. No API changes or migrations.

<sup>Written for commit 0750f4f0de6e6906e9b37969fc85b2781cdeed6c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

