### PR TITLE
fix(apps): a fault inside a handler no longer reads as the prop's own type

### DIFF
--- a/.changeset/a-fault-inside-a-handler-is-not-the-props-own-type.md
+++ b/.changeset/a-fault-inside-a-handler-is-not-the-props-own-type.md
@@ -1,0 +1,18 @@
+---
+"@vendoai/apps": patch
+---
+
+The checks floor stops re-describing a fault inside a callback as a fault in the
+prop that carries it. A type error in an `onClick` body or a table's slot arrow
+was anchored on the enclosing JSX attribute, so the refusal printed the prop's
+declared signature against a value that already matched it — `prop "columns" on
+<DataTable> takes a list of rows, but this value is a list of rows`. A sentence
+that contradicts itself has no repair that satisfies it, so a model reading it
+rewrites the one thing that was never wrong and is refused again, forever.
+
+The attribute-shaped sentence now requires the fault to be about the attribute:
+if a function boundary sits between the diagnostic and the attribute, the
+compiler's own sentence stands instead — `line 4: <Button> prop "onClick" Type
+'number' is not assignable to type 'string'.` A fault in a member of an inline
+object or array literal the prop really is (`columns={[{ key, label: 5 }]}`)
+still reads as the prop's own, because there it is.

--- a/packages/apps/src/server/checking/screen-program.ts
+++ b/packages/apps/src/server/checking/screen-program.ts
@@ -304,6 +304,16 @@ const attributeValueFinding = (
   where: string,
 ): Finding | undefined => {
   if (locus.prop === undefined || locus.element === undefined) return undefined;
+  // A fault inside a callback the prop CARRIES — a handler body, a slot arrow —
+  // is not a fault in the value the prop IS. The walk that found this attribute
+  // crosses function boundaries, so without this the sentence prints the prop's
+  // declared signature against a value that already matches it: `takes a list of
+  // rows, but this value is a list of rows`. A refusal that contradicts itself
+  // has no repair that satisfies it, so the model retries until it gives up.
+  // The compiler's own sentence names the real fault instead.
+  for (let at: TS.Node | undefined = locus.node; at !== undefined && !ts.isJsxAttribute(at); at = at.parent) {
+    if (ts.isArrowFunction(at) || ts.isFunctionExpression(at) || ts.isFunctionDeclaration(at)) return undefined;
+  }
   const attribute = locus.element.attributes.properties.find((property) =>
     ts.isJsxAttribute(property) && property.name.getText(file) === locus.prop);
   if (attribute === undefined || !ts.isJsxAttribute(attribute) || attribute.initializer === undefined) return undefined;

--- a/packages/apps/tests/checking/component-screen.test.ts
+++ b/packages/apps/tests/checking/component-screen.test.ts
@@ -1060,6 +1060,85 @@ export default function S() {
     expect(result.issues).toEqual([]);
     expect(result.ok).toBe(true);
   });
+
+  /**
+   * A fault INSIDE a callback a prop CARRIES is not a fault in the value the
+   * prop IS. The walk that finds the enclosing attribute crosses function
+   * boundaries, so a bad tool argument deep in an `onClick` arrow was
+   * re-described as a mismatch of `onClick` itself — printing the declared
+   * handler type against an arrow that already matches it. A sentence that
+   * contradicts itself has no repair that satisfies it, which is a retry loop
+   * that never converges rather than one bad message.
+   */
+  it("names the fault inside a handler, not the handler prop's own type", async () => {
+    const argument = await refusal(`import { Button, tools } from "@vendo/screen";
+
+export default function S() {
+  return <Button label="Cancel" onClick={() => tools.cancel_transfer({ id: 7 })} />;
+}
+`);
+
+    expect(argument.codes).toEqual(["types"]);
+    expect(argument.text).toContain("not assignable to type 'string'");
+    expect(argument.text).not.toContain('prop "onClick" on <Button> takes');
+
+    // …and the same for a fault that never leaves the handler's own body.
+    const body = await refusal(`import { Button } from "@vendo/screen";
+
+export default function S() {
+  return <Button label="Count" onClick={() => { const n: number = "x"; }} />;
+}
+`);
+
+    expect(body.codes).toEqual(["types"]);
+    expect(body.text).toContain("not assignable to type 'number'");
+    expect(body.text).not.toContain('prop "onClick" on <Button> takes');
+  });
+
+  it("names the fault inside a slot arrow, not the slot prop's own type", async () => {
+    const result = await checkComponentScreen({
+      source: `import { DataTable, Text, useQuery } from "@vendo/screen";
+
+export default function Ledger() {
+  const pending = useQuery("list_pending_transfers");
+  return (
+    <DataTable
+      rows={pending.data}
+      columns={[{ key: "recipient", label: "To", cell: (row) => { const cents: number = "x"; return <Text text={row.recipient + cents} />; } }]}
+    />
+  );
+}
+`,
+      hostTools: tools,
+      catalog: [...catalog, "DataTable"],
+      runQuery: async () => ROWS,
+    });
+
+    const text = result.issues.map(({ message }) => message).join("\n");
+    expect(text).toContain("not assignable to type 'number'");
+    expect(text).not.toContain('prop "columns" on <DataTable> takes');
+  });
+
+  /** The boundary of that rule. A member of an inline object or array literal
+   *  the prop IS also anchors below the attribute, and there the prop-shaped
+   *  sentence is the TRUE one: the value really is the wrong shape. Only a
+   *  function boundary tells the two apart. */
+  it("keeps the prop's own sentence where the fault is a member of the value itself", async () => {
+    const result = await checkComponentScreen({
+      source: `import { DataTable, useQuery } from "@vendo/screen";
+
+export default function Ledger() {
+  const pending = useQuery("list_pending_transfers");
+  return <DataTable rows={pending.data} columns={[{ key: "amount_cents", label: 5 }]} />;
+}
+`,
+      hostTools: tools,
+      catalog: [...catalog, "DataTable"],
+      runQuery: async () => ROWS,
+    });
+
+    expect(result.issues.map(({ message }) => message).join("\n")).toContain('prop "columns" on <DataTable> takes');
+  });
 });
 
 describe("stage 4 — it runs the screen for real", () => {


### PR DESCRIPTION
A screen the checks floor refuses is refused with a sentence a model has to
repair from. When the fault sits inside a callback a prop carries, that sentence
described the wrong thing — and described it in a way no edit could satisfy.

## The mechanism

`locusOf` (`packages/apps/src/server/checking/screen-program.ts:146`) walks
**every** parent of a diagnostic's deepest node looking for a `JsxAttribute`,
with no stop at function boundaries. A fault fifteen nodes deep inside an arrow
body is therefore attributed to the attribute the arrow happens to sit in.

`translate` (`:330`) then sees a `BAD_PROPS` code (2322/2741/2769/2739/2559) plus
a `locus.element` and calls `attributeValueFinding` (`:299`), which never asks
whether the diagnostic is *about* the attribute. It prints
`getContextualType(value)` — the prop's declared type — against
`getTypeAtLocation(value)` — the arrow's own, already-compatible type. The two
agree, so the sentence contradicts itself by construction:

```
prop "onClick" on <Button> takes (event?: { target: { value?: string; checked?: boolean; }…, but this value is () => Promise<any> — bind a value whose type matches the prop
prop "columns" on <DataTable> takes a list of rows, but this value is a list of rows — bind a value whose type matches the prop
```

There is no binding that satisfies "takes a list of rows, but this value is a
list of rows". The model rewrites the one thing that was never wrong, is refused
identically, and the retry loop cannot converge.

## The live evidence

Captured 2026-08-23 against `@vendoai` 0.39.0 (`keystone-demo`, Cloud gateway):
**37 rejections across 5 app ids**, seven distinct handler shapes tried, nothing
ever painted, 2.5 minutes of metered spend inside a single turn. Permanent
no-paint, not a slow path.

## The fix

One guard at the top of `attributeValueFinding`: walk from `locus.node` up
toward the `JsxAttribute`; if an `ArrowFunction`, `FunctionExpression` or
`FunctionDeclaration` sits between them, return `undefined` and let the finding
fall through to the compiler's own sentence (`screen-typecheck.ts:347`).

The function boundary is the discriminator, and it is the right one. A fault in
a member of an inline object or array literal the prop genuinely **is**
(`tones={{a: w}}`, `columns={[{key: 5}]}`) also anchors below the attribute, and
there the prop-shaped sentence is true and useful — those keep it. Ten lines,
additive, no behaviour removed.

After:

```
line 4: <Button> prop "onClick" Type 'number' is not assignable to type 'string'.
```

The locus is still named as a *location*; the *claim* is now the compiler's
honest one.

## Red, then green

Written test-first. Against the unguarded code, with the exact test text in this
PR:

```
 × stage 3 — the real compiler, with no DOM > names the fault inside a handler, not the handler prop's own type
 × stage 3 — the real compiler, with no DOM > names the fault inside a slot arrow, not the slot prop's own type
 ✓ stage 3 — the real compiler, with no DOM > keeps the prop's own sentence where the fault is a member of the value itself

AssertionError: expected 'line 4: prop "onClick" on <Button> ta…' to contain 'not assignable to type \'string\''
  Received: "line 4: prop "onClick" on <Button> takes (event?: { target: { value?: string; checked?: boolean; }…, but this value is () => Promise<any> — bind a value whose type matches the prop"

AssertionError: expected 'line 8: prop "columns" on <DataTable>…' to contain 'not assignable to type \'number\''
  Received: "line 8: prop "columns" on <DataTable> takes a list of rows, but this value is a list of rows — bind a value whose type matches the prop"

 Tests  2 failed | 1 passed | 100 skipped (103)
```

With the guard, the whole file: `Tests 103 passed (103)`.

Independently re-checked outside vitest, driving stage 3 directly with the live
`send_reminder({ id })` shapes from the incident capture:

```
== LIVE 1 — tool arg wrong type inside onClick == refused
   FLOOR: line 5: <Button> prop "onClick" Type 'number' is not assignable to type 'string'.
== LIVE 2 — body-local fault inside onClick == refused
   FLOOR: line 5: <Button> prop "onClick" Type 'string' is not assignable to type 'number'.
== CONTROL A — genuine attribute fault (identifier handler) == refused
   FLOOR: line 4: prop "onClick" on <Button> takes (event?: …, but this value is (id: string) => Promise<void> — bind a value whose type matches the prop
== CONTROL B — correct screen still passes == PASSES
```

## Test change — declared

This adds three cases to the existing
`packages/apps/tests/checking/component-screen.test.ts`, at the end of the
`stage 3 — the real compiler, with no DOM` block:

- **`names the fault inside a handler, not the handler prop's own type`** — a
  wrong-typed tool argument inside an `onClick` arrow, and a fault that never
  leaves the handler's own body.
- **`names the fault inside a slot arrow, not the slot prop's own type`** — the
  same class one container in, through a `DataTable` column's `cell` slot.
- **`keeps the prop's own sentence where the fault is a member of the value
  itself`** — the boundary. This one passes **before and after**; it exists so a
  future widening of the guard cannot silently trade one half of the rule for
  the other.

**No existing assertion was modified or deleted.** The pinned expectations at
`invents no repair where the event carries no value the receiver could take`
(the `onClick={cancel}` / `onChange={setRange}` pair) still pass untouched: both
write the handler as an identifier *outside* the attribute, so no function
boundary sits between the diagnostic and the attribute and the guard correctly
does not fire.

## Noted follow-ups — deliberately not in this PR

Both were identified during the diagnosis and left out to keep this the smallest
fix that closes the loop:

1. **`2322` is missing from `BAD_CALL`** (`screen-typecheck.ts:44`). Adding it
   would route more assignment errors through the payload-shaped translator.
2. **The `line 3: line 3` double prefix** (`screen-typecheck.ts:343`) — cosmetic;
   a reused sentence that states its own line gets the line prefixed again.

## Gate

`pnpm build` 22/22 · `@vendoai/apps` **1554 passed / 0 failed** (forced fresh, 142
files) · `pnpm typecheck` 44/44 · `pnpm lint` 4/4.

One unrelated pre-existing failure is worth naming so nobody hunts it here:
`packages/actions/tests/sync/split.test.ts` fails 2 tests **identically with and
without this change** — verified against a clean worktree at this branch's parent
commit. The `packages/vendo` CLI failures seen in a full local `test:affected`
run are load interference, not real: those four files pass 320/320 in isolation
both with and without this change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops misattributing faults inside handler or slot callbacks to the enclosing prop, eliminating contradictory “prop takes X, but value is X” refusals. Previously the walk crossed function boundaries and printed a prop-shaped sentence; now we fall back to the compiler’s own message unless the fault is about the attribute itself, fixing non-converging retries and no-paint loops.

- Adds a guard in attributeValueFinding (`packages/apps/src/server/checking/screen-program.ts`) to return undefined when a function boundary sits between the diagnostic node and the `JsxAttribute`, so the TypeScript sentence is used.
- Preserves prop-shaped sentences for errors in inline object/array members that the prop truly is.
- Adds three tests covering handler body, slot arrow, and the boundary case; no existing assertions changed.
- Patch release of `@vendoai/apps`. Supports ENG-104 by stabilizing the checks floor during fork-free onboarding and customize→deploy.

<sup>Written for commit e12ab42376fae83267d7d1830d1234dbe419f1dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1620?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

