### PR TITLE
fix(ui,apps,core,demo-bank): the last mile between working and usable (built apps)

### DIFF
--- a/.changeset/creations-last-mile.md
+++ b/.changeset/creations-last-mile.md
@@ -1,0 +1,7 @@
+---
+"@vendoai/core": minor
+"@vendoai/apps": minor
+"@vendoai/ui": minor
+---
+
+Built apps, last mile: a standing consent card a person can actually answer. An approval that was already waiting when the page loaded now raises its card on mount instead of only after — a build ask can outlive the tab that raised it, and the yes is meant to work whenever it lands, so an ask that only existed while you were watching was not a standing one. The card also says what it is asking: it reads the same plain-words ladder the approval card and its queue row read (the ask as a question, then every real input under it) rather than a bare tool label, it offers Deny beside Approve, and `vendo_app_build` joins the shared title table, so the consent moment reads "Build this app for real?" instead of "Vendo app build". Once the yes lands, the build's own status line reaches the person on that same surface — a detached build has no turn to stream into, and `useApp` now hands back the `status` the build window's poll was already receiving and discarding. A toast's hint moved under its text rather than beside its buttons, which is where it has to be to carry a sentence.

--- a/examples/demo-bank/src/app/layout.tsx
+++ b/examples/demo-bank/src/app/layout.tsx
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
 import type { Metadata } from "next"
 import { Inter } from "next/font/google"
 import { AppShell } from "@/components/shell/app-shell"
@@ -10,6 +12,12 @@ import "../../.vendo/fonts.css"
 
 const inter = Inter({ subsets: ["latin"], variable: "--font-inter" })
 
+// The SAME bytes, as text. A sealed bundle renders in an opaque-origin iframe
+// that the stylesheet import above can never reach, so the brand's @font-face
+// rules travel to it through the provider (posted in at render by
+// `sendFrameTheme`) or the app paints in the fallback stack.
+const vendoFonts = readFileSync(join(process.cwd(), ".vendo", "fonts.css"), "utf8")
+
 export const metadata: Metadata = {
   title: "Maple — Banking that keeps up.",
   description: "A modern bank account that actually understands your money.",
@@ -19,7 +27,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en" className={inter.variable}>
       <body className="min-h-screen bg-bg text-ink antialiased">
-        <VendoRoot>
+        <VendoRoot fonts={vendoFonts}>
           <AppShell>{children}</AppShell>
           <VendoLayer />
         </VendoRoot>

--- a/examples/demo-bank/src/app/vendo/apps/page.tsx
+++ b/examples/demo-bank/src/app/vendo/apps/page.tsx
@@ -4,7 +4,6 @@ import { useState, type FormEvent } from "react";
 import type { AppId } from "@vendoai/core";
 import { createVendoClient, hostComponentMap, useApp, useApps } from "@vendoai/ui";
 import { AppFrame } from "@vendoai/ui/tree";
-import { VendoRoot } from "@/components/vendo/VendoRoot";
 import { withBasePath } from "@/lib/base-path";
 import { mapleRegistry } from "@/vendo/registry";
 import { Card, CardContent } from "@/components/ui/card";
@@ -164,10 +163,9 @@ function AppsWorkspace() {
   );
 }
 
+// No <VendoRoot> of its own: `app/layout.tsx` already mounts one around every
+// page, and a nested provider is the one this page's surfaces actually read —
+// so it shadowed the layout's, brand fonts and all.
 export default function MapleAppsPage() {
-  return (
-    <VendoRoot>
-      <AppsWorkspace />
-    </VendoRoot>
-  );
+  return <AppsWorkspace />;
 }

--- a/examples/demo-bank/src/components/vendo/VendoRoot.tsx
+++ b/examples/demo-bank/src/components/vendo/VendoRoot.tsx
@@ -27,8 +27,15 @@ const mapleToolMeta: ToolMetaMap = {
 
 export function VendoRoot({
   children,
+  fonts,
 }: {
   children: ReactNode;
+  /** The TEXT of `.vendo/fonts.css` (read server-side in `layout.tsx`), not a
+   *  stylesheet import: a sealed bundle renders in an opaque-origin iframe that
+   *  Maple's own stylesheets can never reach, so the brand's `@font-face` rules
+   *  are posted in at render (`sendFrameTheme`) or the app paints in the
+   *  fallback stack. */
+  fonts?: string;
 }) {
   const router = useRouter();
   return (
@@ -42,6 +49,7 @@ export function VendoRoot({
       // Without it the renderer paints `Unknown component "AreaChart"`.
       remixWiring={remixWiring}
       theme={mapleTheme}
+      {...(fonts === undefined ? {} : { fonts })}
       // No pin wiring: Maple's pages mount their own <VendoSlot>s, and a
       // mounted slot reports itself — so "Pin to dashboard" already knows
       // where it lands.

--- a/packages/apps/src/server/doors/build-door.ts
+++ b/packages/apps/src/server/doors/build-door.ts
@@ -9,7 +9,9 @@
  * Between the two, the app row says "offered, unanswered" and no box exists.
  */
 import {
+  VENDO_APP_BUILD_TOOL,
   VENDO_APP_FORMAT,
+  VENDO_TOOL_TITLES,
   VendoError,
   type AppBuildProposal,
   type AppBundle,
@@ -39,9 +41,12 @@ import type { AppsRuntime } from "../runtime/types.js";
  * an approval and hands back its card. The card STANDS — this door never waits
  * on it, so the harness's 90-second approval wait is not in this path at all.
  */
-const BUILD_TOOL = "vendo_app_build";
+const BUILD_TOOL = VENDO_APP_BUILD_TOOL;
 const buildDescriptor = (): ToolDescriptor => ({
   name: BUILD_TOOL,
+  // §3 consumer voice — the shared table, like every other Vendo descriptor.
+  // Without it the card asked the person to authorize "Vendo app build".
+  title: VENDO_TOOL_TITLES[BUILD_TOOL],
   description: "Build this app for real: a sandbox installs the packages it needs, writes and tests the code,"
     + " and the result is sealed. It spends a build machine, so it needs the person's yes.",
   inputSchema: {

--- a/packages/core/src/tools.ts
+++ b/packages/core/src/tools.ts
@@ -55,6 +55,17 @@ export const VENDO_AUTOMATE_TOOL = "vendo_automate";
 export const VENDO_APPS_PIN_TOOL = "vendo_apps_pin";
 export const VENDO_APPS_UNPIN_TOOL = "vendo_apps_unpin";
 
+/**
+ * The ask the BUILD door parks a standing card for (FINAL SPEC v1: no machine is
+ * spent without the person's explicit yes).
+ *
+ * No model is ever handed it — the door calls the guard with it directly — but
+ * the door that authors the descriptor and every surface that renders its card
+ * hold this string, and the card IS the consent moment, so it is named once here
+ * beside its title rather than spelled out on each side.
+ */
+export const VENDO_APP_BUILD_TOOL = "vendo_app_build";
+
 /** The read that makes those two callable: the slot ids the host's own pages
  *  have reported. Named here beside them because a model that invents a slot id
  *  aims a placement at a spot no page renders, and this is the only answer to
@@ -116,6 +127,10 @@ export const VENDO_TOOL_TITLES: Readonly<Record<string, string>> = {
   vendo_make: "Make you a screen",
   vendo_automate: "Set this to run on its own",
   vendo_apps_open: "Open the app",
+  // The one title a PERSON reads before anything is spent: this tool exists
+  // only to raise the consent card, and the card fell back to the prettified
+  // slug ("Vendo app build") on the one screen that has to be legible.
+  [VENDO_APP_BUILD_TOOL]: "Build this app for real",
   vendo_apps_reseed: "Refresh a remixed piece",
   vendo_apps_pin: "Pin the app to your page",
   vendo_apps_unpin: "Take the app off your page",

--- a/packages/ui/src/chrome/chrome-css.ts
+++ b/packages/ui/src/chrome/chrome-css.ts
@@ -1529,7 +1529,7 @@ html[data-vendo-dock] {
 .fl-toasts-view { border: 0; background: none; padding: 0; cursor: pointer;
   color: var(--vendo-accent); font: 600 12px/1.2 var(--vendo-font); }
 .fl-toasts-view:hover { text-decoration: underline; }
-.fl-toasts-hint { font-size: 11.5px; color: var(--vendo-fg-muted); }
+.fl-toasts-hint { font-size: 11.5px; line-height: 1.45; color: var(--vendo-fg-muted); }
 .fl-toasts-dismiss { margin-left: auto; border: 0; background: none; padding: 0 2px; cursor: pointer;
   color: var(--vendo-fg-muted); font: 600 12px/1 var(--vendo-font); }
 .fl-toasts-dismiss:hover { color: var(--vendo-fg); }

--- a/packages/ui/src/chrome/vendo-toasts.tsx
+++ b/packages/ui/src/chrome/vendo-toasts.tsx
@@ -8,13 +8,17 @@
       any code path; automations delivery wires through this).
     - `approvals` — opt-in polling of pending approvals: a NEWLY parked approval
       raises an approval-required toast, decidable in place. */
-import { useEffect, useRef, useSyncExternalStore, type ReactNode } from "react";
+import { VENDO_APP_BUILD_TOOL, type AppId } from "@vendoai/core";
+import { useEffect, useRef, useState, useSyncExternalStore, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { useVendoProvider } from "../context.js";
+import { useApp } from "../hooks/use-app.js";
 import { useApprovals } from "../hooks/use-approvals.js";
 import { themeCssVariables } from "../theme.js";
+import { consentAsk, toolPresentation } from "./build-beat.js";
+import { NOTE_SEPARATOR } from "./card-shell.js";
 import { ensureChromeStyles } from "./chrome-root.js";
-import { toolTitle } from "./humanize.js";
+import { fieldRows } from "./field-rows.js";
 
 export interface VendoToastAction {
   label: string;
@@ -130,51 +134,95 @@ function useToastQueue(): ToastRecord[] {
   return useSyncExternalStore(subscribe, () => queue, () => EMPTY);
 }
 
-/** Opt-in approval feed: raises a toast for every approval that parks AFTER
-    mount (the pre-existing backlog is the activity surface's to show, not a
-    toast storm on page load), and withdraws it once decided elsewhere. */
+/**
+ * FINAL SPEC v1 — "progress = chat status lines only", and for a build there is
+ * no chat left to say it in: the yes may land long after the turn that asked is
+ * gone, so the build runs detached with no stream to write to. Its own line
+ * therefore lands on the surface the yes was GIVEN on, from the same poll the
+ * forming card reads, and stands down the moment the app does.
+ */
+function BuildProgress({ appId }: { appId: AppId }) {
+  const { status, surface, error } = useApp(appId);
+  useEffect(() => {
+    // Nothing invented: silent until the lane speaks, gone once there is an app
+    // (or a reason there is not) — those speak for themselves on their own
+    // surfaces. The toast's own dismiss handle is the cleanup.
+    if (status === undefined || surface !== undefined || error !== undefined) return undefined;
+    return vendoToast({ text: status, durationMs: 0 });
+  }, [status, surface, error]);
+  return null;
+}
+
+/** Opt-in approval feed: a toast per approval waiting on the user, decidable in
+    place, withdrawn once decided anywhere.
+
+    IT SHOWS THE BACKLOG TOO. This took the asks present at mount as a baseline
+    and toasted only what arrived after — so a standing ask (a build's "spend a
+    machine?") stopped being answerable the moment the page reloaded, measured as
+    0 cards and 0 Approve buttons against an ask still pending on the wire. The
+    spec's whole shape is "the yes, WHENEVER", and an ask that only exists while
+    you are watching is not a standing one. Nothing here re-raises what a person
+    ANSWERED (`seen`, below, is what a dismissal respects, and a decided ask
+    leaves the pending list); what comes back is only what is still unanswered. */
 function ApprovalToasts({ pollMs }: { pollMs: number }) {
   const { tools } = useVendoProvider();
-  const { pending, isLoading, decide } = useApprovals({ pollMs });
-  // null until the first fetch settles — that first batch is baseline, not news.
-  const seenRef = useRef<Set<string> | null>(null);
+  const { pending, decide } = useApprovals({ pollMs });
+  const seenRef = useRef(new Set<string>());
   const dismissersRef = useRef(new Map<string, () => void>());
+  // The builds this person has just authorized here, so their progress has a
+  // surface. Not durable: a build already under way when the page loads speaks
+  // through the app's own embed, which is mounted where that app is.
+  const [builds, setBuilds] = useState<AppId[]>([]);
   useEffect(() => {
     const dismissers = dismissersRef.current;
-    if (seenRef.current === null) {
-      // The hook's initial [] (fetch still in flight) is not the baseline —
-      // waiting for it would toast the whole pre-existing backlog on load.
-      if (isLoading) return;
-      seenRef.current = new Set(pending.map(approval => approval.id));
-      return;
-    }
     const seen = seenRef.current;
     for (const approval of pending) {
       if (seen.has(approval.id) || dismissers.has(approval.id)) continue;
       seen.add(approval.id);
+      // Ruling 14's ONE plain-words ladder, the same one the approval card and
+      // its queue row read — so the toast cannot ask a different question from
+      // the card. It used to say the tool's LABEL and nothing else ("Waiting on
+      // you: Vendo app build"), which names no ask a person could weigh.
+      const meta = tools[approval.call.tool];
+      const ask = consentAsk(
+        approval.descriptor.risk,
+        toolPresentation(
+          approval.call.tool,
+          approval.call.args,
+          meta,
+          approval.descriptor.title,
+          approval.descriptor.inputSchema,
+        ),
+        fieldRows(approval.call.args, approval.descriptor.inputSchema, meta),
+        meta,
+      );
+      const settle = (approve: boolean) => () => {
+        void decide(approval.id, { approve }).then(() => {
+          dismissers.get(approval.id)?.();
+          dismissers.delete(approval.id);
+          const appId = (approval.call.args as { appId?: unknown }).appId;
+          if (approve && approval.call.tool === VENDO_APP_BUILD_TOOL && typeof appId === "string") {
+            setBuilds(current => [...current, appId as AppId]);
+          }
+        }).catch(() => {
+          // The decide failed — the approval is still parked server-side.
+          // Keep the toast so the buttons stay retryable, and un-see the id
+          // so a later poll can re-raise it once this card is gone.
+          seen.delete(approval.id);
+        });
+      };
       const dismiss = vendoToast({
         kind: "approval-required",
-        text: `Waiting on you: ${toolTitle(approval.call.tool, tools[approval.call.tool])}`,
-        // Not a destination: the library cannot know whether this host mounts
-        // a surface that shows the record. What IS true on every host is what
-        // approving MEANS — the same "Runs as you" the approval card and the
-        // morph toast say.
-        hint: "Runs as you once approved",
-        actions: [{
-          label: "Approve",
-          primary: true,
-          onAction: () => {
-            void decide(approval.id, { approve: true }).then(() => {
-              dismissers.get(approval.id)?.();
-              dismissers.delete(approval.id);
-            }).catch(() => {
-              // The decide failed — the approval is still parked server-side.
-              // Keep the toast so Approve stays retryable, and un-see the id
-              // so a later poll can re-raise it once this card is gone.
-              seen.delete(approval.id);
-            });
-          },
-        }],
+        text: `Waiting on you: ${ask.question}`,
+        // THE HONESTY LAW (card-shell.tsx) on the toast too: every real input
+        // the question does not already name, then what approving does.
+        hint: ask.notes.join(NOTE_SEPARATOR),
+        actions: [
+          { label: "Approve", primary: true, onAction: settle(true) },
+          // The × is a dismissal, not an answer, and a person being asked to
+          // spend a machine must be able to say no to it.
+          { label: "Deny", onAction: settle(false) },
+        ],
       });
       dismissers.set(approval.id, dismiss);
     }
@@ -186,12 +234,12 @@ function ApprovalToasts({ pollMs }: { pollMs: number }) {
         dismissers.delete(id);
       }
     }
-  }, [pending, isLoading, decide, tools]);
+  }, [pending, decide, tools]);
   useEffect(() => () => {
     for (const dismiss of dismissersRef.current.values()) dismiss();
     dismissersRef.current.clear();
   }, []);
-  return null;
+  return <>{builds.map(appId => <BuildProgress key={appId} appId={appId} />)}</>;
 }
 
 export interface VendoToastsProps {
@@ -259,6 +307,13 @@ export function VendoToasts({ placement = "bottom-right", approvals = false, pol
                 </span>
                 <div className="fl-toasts-body">
                   <div className="fl-toasts-text">{toast.text}</div>
+                  {/* Under the question, not beside the buttons. The hint used
+                      to ride the actions ROW, which is a centred flex line, so
+                      it read fine at five words ("Runs as you once approved")
+                      and folded into a tall column beside Approve the moment it
+                      carried a real ask. Its home is the body's own column —
+                      the same place the approval card puts the same line. */}
+                  {toast.hint !== undefined ? <div className="fl-toasts-hint">{toast.hint}</div> : null}
                   <div className="fl-toasts-actions">
                     {(toast.actions ?? []).map(action => (
                       <button
@@ -270,7 +325,6 @@ export function VendoToasts({ placement = "bottom-right", approvals = false, pol
                         {action.label}
                       </button>
                     ))}
-                    {toast.hint !== undefined ? <span className="fl-toasts-hint">{toast.hint}</span> : null}
                     <button type="button" className="fl-toasts-dismiss" aria-label="Dismiss notification" onClick={() => removeToast(toast.id)}>×</button>
                   </div>
                 </div>

--- a/packages/ui/src/hooks/use-app.ts
+++ b/packages/ui/src/hooks/use-app.ts
@@ -36,6 +36,11 @@ export interface AppOptions {
 export function useApp(appId: AppId, { enabled = true }: AppOptions = {}): {
   app: AppDocument | undefined;
   surface: OpenSurface | undefined;
+  /** What the build last said about itself while the surface is still pending
+   *  (`PendingSurface.status`) — the whole progress channel FINAL SPEC v1
+   *  allows. The poll below read it and threw it away, so a caller waiting on a
+   *  detached build had nothing to show but a spinner. */
+  status: string | undefined;
   error: Error | undefined;
   isLoading: boolean;
   call(ref: string, args: Json): Promise<ToolOutcome>;
@@ -46,6 +51,7 @@ export function useApp(appId: AppId, { enabled = true }: AppOptions = {}): {
   const { client } = useVendoProvider();
   const [app, setApp] = useState<AppDocument>();
   const [surface, setSurface] = useState<OpenSurface>();
+  const [status, setStatus] = useState<string>();
   const [error, setError] = useState<Error>();
   const [isLoading, setIsLoading] = useState(true);
   const generationRef = useRef(0);
@@ -69,6 +75,7 @@ export function useApp(appId: AppId, { enabled = true }: AppOptions = {}): {
         ]);
         if (!current()) return;
         if (nextSurface.kind === "pending") {
+          if (nextSurface.status !== undefined) setStatus(nextSurface.status);
           if (Date.now() >= deadline) {
             setError(new Error(`app ${appId} was still being generated when the build window ran out`));
             setIsLoading(false);
@@ -104,6 +111,7 @@ export function useApp(appId: AppId, { enabled = true }: AppOptions = {}): {
     loadedRef.current = false;
     setApp(undefined);
     setSurface(undefined);
+    setStatus(undefined);
     setError(undefined);
     // Nothing is loading while the surface is off, so say so rather than
     // leaving a consumer on a skeleton that will never resolve.
@@ -133,5 +141,5 @@ export function useApp(appId: AppId, { enabled = true }: AppOptions = {}): {
     [appId, client],
   );
 
-  return { app, surface, error, isLoading, call, edit, history, refresh };
+  return { app, surface, status, error, isLoading, call, edit, history, refresh };
 }

--- a/packages/ui/test/chrome/affordances-eng225.test.tsx
+++ b/packages/ui/test/chrome/affordances-eng225.test.tsx
@@ -123,6 +123,14 @@ describe("drag-drop attach + previews (ENG-225)", () => {
 });
 
 describe("toasts (ENG-225)", () => {
+  /** ⚠️ CONTRACT CHANGE (standing consent) — the stack shows EVERY ask waiting
+   *  on the user now, backlog included, so a bare "Approve" query is ambiguous.
+   *  This picks the button on the card for one named ask. */
+  const approveOn = (text: string) => within(
+    [...document.querySelectorAll<HTMLElement>(".fl-toasts-card")]
+      .find(card => card.textContent?.includes(text))!,
+  ).getByRole("button", { name: "Approve" });
+
   it("renders an imperative toast and dismisses it", async () => {
     const wire = await createWireServer();
     const client = createVendoClient({ baseUrl: wire.url });
@@ -192,16 +200,21 @@ describe("toasts (ENG-225)", () => {
     await wire.close();
   });
 
-  it("raises a toast for an approval that parks AFTER mount, not the backlog", async () => {
+  /** ⚠️ CONTRACT CHANGE (standing consent) — this asserted the OPPOSITE first
+   *  line: the backlog present at mount was baseline and must not toast. That
+   *  baseline is what made a standing ask unanswerable after a reload (0 cards
+   *  against an ask still pending on the wire), and FINAL SPEC v1's law is "the
+   *  yes, whenever". The rest of the test — one card per ask, no re-toast on a
+   *  poll tick, Approve decides and withdraws — is unchanged. */
+  it("raises a toast for every approval waiting on the user, backlog included", async () => {
     const wire = await createWireServer();
     const client = createVendoClient({ baseUrl: wire.url });
     render(<VendoProvider client={client}><VendoToasts approvals pollMs={40} /></VendoProvider>);
 
-    // The pre-existing approval is baseline — it must NOT toast.
-    await new Promise(resolve => setTimeout(resolve, 120));
-    expect(screen.queryByText(/Waiting on you:/)).toBeNull();
+    // The ask already pending when the page loaded is answerable here.
+    await screen.findByText(/Waiting on you:/);
 
-    // A newly parked approval does.
+    // A newly parked approval raises its own.
     wire.state.approvals.push({
       ...wire.state.approvals[0]!,
       id: "apr_2",
@@ -213,7 +226,7 @@ describe("toasts (ENG-225)", () => {
     expect(screen.getAllByText(/Waiting on you: Invoice delete/)).toHaveLength(1);
 
     // Approving from the toast decides it and withdraws the card.
-    fireEvent.click(screen.getByRole("button", { name: "Approve" }));
+    fireEvent.click(approveOn("Invoice delete"));
     await waitFor(() => expect(wire.state.approvals.some(item => item.id === "apr_2")).toBe(false));
     await waitFor(() => expect(screen.queryByText(/Waiting on you: Invoice delete/)).toBeNull());
     await wire.close();
@@ -236,7 +249,7 @@ describe("toasts (ENG-225)", () => {
 
     // The wire rejects the next decide (server 500 / dropped connection).
     wire.state.failures.push({ method: "POST", path: "/approvals/decide", code: "boom", message: "kaboom", status: 500 });
-    fireEvent.click(screen.getByRole("button", { name: "Approve" }));
+    fireEvent.click(approveOn("Invoice delete"));
     await waitFor(() => expect(
       wire.requests.filter(request => request.method === "POST" && request.path === "/approvals/decide"),
     ).toHaveLength(1));
@@ -246,7 +259,7 @@ describe("toasts (ENG-225)", () => {
     expect(screen.queryByText(/Waiting on you: Invoice delete/)).not.toBeNull();
 
     // The failure consumed, a second Approve decides it and withdraws the card.
-    fireEvent.click(screen.getByRole("button", { name: "Approve" }));
+    fireEvent.click(approveOn("Invoice delete"));
     await waitFor(() => expect(wire.state.approvals.some(item => item.id === "apr_2")).toBe(false));
     await waitFor(() => expect(screen.queryByText(/Waiting on you: Invoice delete/)).toBeNull());
     await wire.close();

--- a/packages/ui/test/chrome/standing-consent.test.tsx
+++ b/packages/ui/test/chrome/standing-consent.test.tsx
@@ -1,0 +1,116 @@
+// @vitest-environment jsdom
+/**
+ * The last mile of a STANDING consent (FINAL SPEC v1: "user's yes, whenever").
+ *
+ * A build ask outlives the tab that raised it, so the surface it lands on must
+ * show it on arrival AND on every later mount; it must say what it is asking so
+ * a person can weigh spending a machine; it must let them say no; and once they
+ * say yes, the build's own status line has to reach them — the detached build
+ * has no turn to stream into, so this surface is the whole progress channel.
+ */
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ApprovalRequest } from "@vendoai/core";
+import { afterEach, describe, expect, it } from "vitest";
+import { VendoProvider, createVendoClient } from "../../src/index.js";
+import { VendoToasts, dismissAllVendoToasts } from "../../src/chrome/index.js";
+import { createWireServer, fixtureApp } from "../wire-server.js";
+
+afterEach(() => {
+  cleanup();
+  act(() => dismissAllVendoToasts());
+});
+
+const BUILD_APP = "app_qr";
+const PROMPT = "A page with a scannable QR code";
+
+/** The ask the build door parks: `guard.check` on the build descriptor, with the
+ *  app id and the person's own words as its inputs (build-door.ts). */
+function buildAsk(base: ApprovalRequest): ApprovalRequest {
+  return {
+    ...base,
+    id: "apr_build",
+    call: { id: `call_build_${BUILD_APP}`, tool: "vendo_app_build", args: { appId: BUILD_APP, prompt: PROMPT } },
+    descriptor: {
+      name: "vendo_app_build",
+      title: "Build this app for real",
+      description: "Build this app for real: a sandbox installs the packages it needs.",
+      inputSchema: {
+        type: "object",
+        properties: { appId: { type: "string" }, prompt: { type: "string" } },
+        required: ["appId", "prompt"],
+      },
+      risk: "write",
+      confirmEach: true,
+    },
+  };
+}
+
+describe("a standing ask survives the tab it was raised in", () => {
+  it("surfaces an approval that was ALREADY pending at mount", async () => {
+    const wire = await createWireServer();
+    // The reload: the ask is on the wire before anything renders.
+    wire.state.approvals.push(buildAsk(wire.state.approvals[0]!));
+    const client = createVendoClient({ baseUrl: wire.url });
+    render(<VendoProvider client={client}><VendoToasts approvals pollMs={40} /></VendoProvider>);
+
+    await screen.findByText(/Build this app for real/);
+    expect(screen.getAllByRole("button", { name: "Approve" }).length).toBeGreaterThan(0);
+    await wire.close();
+  });
+});
+
+describe("the card says what it is asking, and takes no for an answer", () => {
+  it("carries the ask's own words — the person's request, not just a tool label", async () => {
+    const wire = await createWireServer();
+    wire.state.approvals.push(buildAsk(wire.state.approvals[0]!));
+    const client = createVendoClient({ baseUrl: wire.url });
+    render(<VendoProvider client={client}><VendoToasts approvals pollMs={40} /></VendoProvider>);
+
+    await screen.findByText(/Build this app for real/);
+    expect(screen.getByText(new RegExp(PROMPT))).toBeTruthy();
+    await wire.close();
+  });
+
+  it("offers Deny, and a denial is what reaches the wire", async () => {
+    const wire = await createWireServer();
+    wire.state.approvals.push(buildAsk(wire.state.approvals[0]!));
+    const client = createVendoClient({ baseUrl: wire.url });
+    render(<VendoProvider client={client}><VendoToasts approvals pollMs={40} /></VendoProvider>);
+
+    await screen.findByText(/Build this app for real/);
+    const cards = document.querySelectorAll(".fl-toasts-card");
+    const card = [...cards].find(item => item.textContent?.includes("Build this app for real"))!;
+    const deny = [...card.querySelectorAll("button")].find(button => button.textContent === "Deny")!;
+    expect(deny).toBeTruthy();
+    fireEvent.click(deny);
+
+    await waitFor(() => expect(wire.state.approvalResolutions.get("apr_build")).toEqual({ state: "declined" }));
+    await waitFor(() => expect(screen.queryByText(/Build this app for real/)).toBeNull());
+    await wire.close();
+  });
+});
+
+describe("progress reaches the person who said yes", () => {
+  it("shows the build's own status line once the yes lands, and drops it when the app does", async () => {
+    const wire = await createWireServer();
+    wire.state.approvals.push(buildAsk(wire.state.approvals[0]!));
+    // A building app: the row exists, and its flagged opens answer the build
+    // window's pending envelope carrying the lane's latest line.
+    wire.state.apps.push(fixtureApp(BUILD_APP, "QR code page"));
+    wire.state.pendingScreens.set(BUILD_APP, 3);
+    wire.state.buildStatus.set(BUILD_APP, "Starting a build machine…");
+    const client = createVendoClient({ baseUrl: wire.url });
+    render(<VendoProvider client={client}><VendoToasts approvals pollMs={40} /></VendoProvider>);
+
+    await screen.findByText(/Build this app for real/);
+    const cards = document.querySelectorAll(".fl-toasts-card");
+    const card = [...cards].find(item => item.textContent?.includes("Build this app for real"))!;
+    const approve = [...card.querySelectorAll("button")].find(button => button.textContent === "Approve")!;
+    fireEvent.click(approve);
+
+    await screen.findByText("Starting a build machine…");
+    // The app lands (pendingScreens runs out) and the progress line stands down.
+    await waitFor(() => expect(screen.queryByText("Starting a build machine…")).toBeNull(), { timeout: 10_000 });
+    await wire.close();
+  }, 20_000);
+});

--- a/packages/ui/test/wire-server.ts
+++ b/packages/ui/test/wire-server.ts
@@ -342,6 +342,10 @@ export async function createWireServer(options: WireServerOptions = {}) {
      *  screen, and "not ready yet" is the build window's pending, never a
      *  failure (persistence/open.ts, wire/apps.ts). */
     pendingScreens: new Map<string, number>(),
+    /** ⚠️ TEST EDIT (infrastructure) — the line a build last said about itself
+     *  (app id → `PendingSurface.status`), carried by the pending answers above.
+     *  The whole progress channel FINAL SPEC v1 allows. */
+    buildStatus: new Map<string, string>(),
     /** An app whose build LANDED and whose screen no longer opens (app id →
      *  reason): the placement is honestly "ready" and `open` still answers
      *  {kind:"failed"} — a stale app whose screen stopped compiling, which is
@@ -1315,8 +1319,9 @@ export async function createWireServer(options: WireServerOptions = {}) {
           const screenPolls = state.pendingScreens.get(id) ?? 0;
           if (screenPolls > 0) {
             state.pendingScreens.set(id, screenPolls - 1);
+            const label = state.buildStatus.get(id);
             return url.searchParams.get("pending") === "1"
-              ? json(response, { kind: "pending" })
+              ? json(response, { kind: "pending", ...(label === undefined ? {} : { status: label }) })
               : wireError(response, "not-found", `app ${id} has no screen yet`, 404);
           }
           const dead = state.deadScreens.get(id);


### PR DESCRIPTION
> Stacked on #1621. The stack merges once at the tip.

## What & why

An independent end-to-end proof on a **real Cloud box** confirmed the spine works: ask → standing card → Approve in 193ms → real box → npm install → sealed bundle (5 blobs, every one verified in Postgres as `sha256(bytes) == key`) → app renders with zero network from the frame and the exact CSP. **No box was claimed before the yes** — sandbox calls empty until Approve, first box request 144ms after.

It also found four gaps between "works" and "a person can use it". All four are closed here, each proven **red then green in a real browser** (`/home/ubuntu/proofs/last-mile/`).

## GAP 1 — a standing ask was unanswerable after a page reload — FIXED
Observed: ask still pending on the wire, **0 cards and 0 Approve buttons** in the DOM after reload. `vendo-toasts.tsx` took the backlog present at mount as a baseline and only toasted later arrivals.

That contradicts FINAL SPEC v1's own law — *"User's yes (**whenever**) starts the build"* — and a build ask is designed to outlive the tab that raised it.

Baseline deleted. **Why it existed:** its comment says load-time toast-storm, **not** respecting dismissals — and dismissals are held in a `seen` set for the life of a mount and were never persisted. So this re-raises nothing anyone answered, only what is genuinely still unanswered on the server.

**Accepted cost, stated plainly:** every pending ask now toasts on load. Two stack cleanly (see the 390px shots). Nine would fill the viewport. That is what the baseline was buying, and the spec's law outranks it.

## GAP 2 — progress never reached the person — PARTLY FIXED
A 13-minute build showed nothing; three progress screenshots were pixel-identical. `use-app` received the status from the poll and discarded it.

Now surfaced: `use-app.ts` returns the status the poll already had, and `BuildProgress` puts it on the same standing surface the yes was given on, withdrawing when the app lands. `pack.ts:104`'s refusal to mint an app-ref for an `awaiting-consent` receipt is **untouched** — that refusal is deliberate and correct.

**Honest limit:** this is not a literal `VendoAppEmbed` in the chat thread. After a detached build there is no live turn and no persisted part to hang one on; adding one needs a new stream channel, which the owner ruled out.

## GAP 3 — the card didn't say what it was asking — PARTLY FIXED
It read only "Waiting on you: Vendo app build" — no ask, no Deny. Someone was being asked to authorise spending a machine while told almost nothing.

Now reads the same `consentAsk` ladder the approval card reads, and offers **Deny** — reusing the identical `{approve:false}` decision `ApprovalCard` already sends. `vendo_app_build` was the one Vendo tool missing from `VENDO_TOOL_TITLES`; added, and the descriptor now authors its title from it.

**Not done: the spec's "~N min".** No duration constant exists that isn't a watchdog timeout, and `make-receipt.ts` law 5 says this moment is "a consent card, not a price quote". A number was not invented.

## GAP 4 — brand fonts never reached the frame — FIXED
Not a broken font path (that was proven with a negative control) — Maple simply passed no `fonts` prop. Now wired. Also removed the Apps page's nested `<VendoRoot>`, which shadowed the layout's provider so fonts could never have reached the frame there.

## Existing tests changed — two, both stated out loud
- `affordances-eng225.test.tsx`: its first assertion was literally *"the pre-existing approval is baseline — it must NOT toast"* — the exact behaviour GAP 1 removes. That producer is gone. Every other assertion in the test (one card per ask, no re-toast on a poll tick, Approve decides and withdraws) is unchanged. An `approveOn(text)` helper was added because two cards now legitimately render, making a bare `getByRole("Approve")` ambiguous.
- `wire-server.ts`: added a `buildStatus` map so the fake wire can answer `{kind:"pending", status}` like the real one. Added capability; **no assertion touched**.

## Evidence
`red/` — 0 cards / 0 Approve / 0 Deny after reload with the ask still pending; `document.fonts` count 0 in the frame.
`green/` — card after reload, closeup with the ask and Deny, the status line, the app open in Maple, Inter rendering inside the frame; `green-mobile/` at 390px; videos; the script; `gate.log`.
The status line is the **real** producer's — only the sandbox was faked, by hanging, so no machine was spent.

## Notes
`.vendo/tools.json` was dirtied twice by `pnpm build`'s `vendo sync` extracting the throwaway proof route; reverted both times, scaffold deleted before the final gate, verified clean after it.

Not done: `nameForUnbuilt` still cuts an app name at 60 chars mid-word. No existing helper is better (`fallbackAppName` cuts identically, `appRefTitleFromPrompt` caps at 80), so no naming system was invented.

Still live from the earlier proof and out of scope: `callHost` is absent from the published `@vendoai/ui` tarball, so a built app cannot reach host data until a release.

CI is the gate of record.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make standing consent for built apps usable end-to-end. Approval toasts now surface existing pending approvals on load, the consent card states the real ask and includes Deny, build progress reaches the person who approved, and brand fonts reach the sealed iframe.

- Approval toasts: previously only newly parked approvals toasted; now every pending approval toasts on mount and withdraws when decided. The toast shows the same consent ladder as the card, adds Deny, and moves the hint under the text.
- Build progress: previously discarded; `useApp` now returns `status` for pending surfaces, and `VendoToasts` shows the build’s status line after Approve until the app lands. Pre-consent app-ref minting remains blocked.
- Consent text: added `VENDO_APP_BUILD_TOOL` and its title to `VENDO_TOOL_TITLES`, and the build descriptor uses the shared title so the card reads “Build this app for real”.
- Fonts to iframe: `VendoProvider` accepts a `fonts` text prop; demo bank reads `.vendo/fonts.css` and passes it via `VendoRoot`. Removed the nested `VendoRoot` on the Apps page to avoid shadowing the layout provider.
- Tests and infra: updated toast expectations to include backlog and scoped Approve to a named card; added a standing-consent test; wire server now returns `{kind:"pending", status}` for builds; minor CSS line-height tweak for toast hints.

**Review and rollout**
- Update host apps to pass brand fonts to `VendoRoot` via the `fonts` prop if you want fonts inside sealed iframes.
- If you relied on “no backlog toasts,” update tests to expect a toast per pending approval and scope button queries to the targeted card.

<sup>Written for commit 8bea7d78241010f6b4b3262c7f0d51fabbf9db3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1622?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

