### PR TITLE
feat(shell): the agent can read PDFs, spreadsheets and Word documents

### DIFF
--- a/.changeset/shell-parsers.md
+++ b/.changeset/shell-parsers.md
@@ -1,0 +1,17 @@
+---
+"@vendoai/harnesses": minor
+---
+
+The shell can open the formats people actually send.
+
+`pdftotext`, `xlsx2csv` and `docx2txt` are now commands inside the agent's shell.
+They write text to stdout, so they pipe into `grep`, `awk` and everything else —
+`pdftotext invoice.pdf | grep -o 'Total.*'` is one call, not a capability
+conversation. A PDF, a spreadsheet or a Word document dropped into chat stops
+being a file the agent can only name.
+
+They run in the host process against the same virtual filesystem the shell has
+(unpdf's serverless pdf.js, SheetJS Community Edition, and a zip read with
+fflate — no native code, no conversion service, no network), and each library
+loads the first time its format is actually parsed, so a deployment that never
+sees a PDF never pays for pdf.js.

--- a/packages/harnesses/package.json
+++ b/packages/harnesses/package.json
@@ -71,7 +71,10 @@
     "@vendoai/apps": "workspace:*",
     "@vendoai/core": "workspace:*",
     "@vendoai/guard": "workspace:*",
+    "fflate": "^0.8.3",
     "just-bash": "^3.4.2",
+    "unpdf": "^1.8.1",
+    "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
     "zod": "^3.25.0"
   },
   "peerDependencies": {

--- a/packages/harnesses/package.json
+++ b/packages/harnesses/package.json
@@ -88,8 +88,7 @@
     "@types/node": "^22.0.0",
     "ai": "6.0.28",
     "typescript": "^5.6.0",
-    "vitest": "^3.2.6",
-    "xlsx": "npm:@e965/xlsx@0.20.3"
+    "vitest": "^3.2.6"
   },
   "peerDependenciesMeta": {
     "@anthropic-ai/claude-agent-sdk": {

--- a/packages/harnesses/package.json
+++ b/packages/harnesses/package.json
@@ -68,13 +68,13 @@
   },
   "dependencies": {
     "@ai-sdk/anthropic": "3.0.12",
+    "@e965/xlsx": "0.20.3",
     "@vendoai/apps": "workspace:*",
     "@vendoai/core": "workspace:*",
     "@vendoai/guard": "workspace:*",
     "fflate": "^0.8.3",
     "just-bash": "^3.4.2",
     "unpdf": "^1.8.1",
-    "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
     "zod": "^3.25.0"
   },
   "peerDependencies": {
@@ -88,7 +88,8 @@
     "@types/node": "^22.0.0",
     "ai": "6.0.28",
     "typescript": "^5.6.0",
-    "vitest": "^3.2.6"
+    "vitest": "^3.2.6",
+    "xlsx": "npm:@e965/xlsx@0.20.3"
   },
   "peerDependenciesMeta": {
     "@anthropic-ai/claude-agent-sdk": {

--- a/packages/harnesses/src/vendo/shell/engine.ts
+++ b/packages/harnesses/src/vendo/shell/engine.ts
@@ -11,6 +11,7 @@
  */
 import type { IFileSystem } from "@vendoai/core";
 import type { Bash as BashInstance } from "just-bash";
+import { pdftotext } from "./parsers/pdftotext.js";
 
 /** One `bash` call's ceilings. Both map onto just-bash's own execution limits;
  *  everything else keeps just-bash's `normal` profile. */
@@ -85,6 +86,10 @@ export function createShellSession(opts: {
       // user's files actually have.
       cwd: "/user",
       javascript: opts.javascript === true,
+      // The binary formats a person actually drops into chat, as ordinary
+      // commands: they pipe, they redirect, and the agent needs no special
+      // vocabulary for them. Lazy, so their libraries load on first use.
+      customCommands: [pdftotext],
       executionLimits: {
         maxExecutionTimeMs: opts.limits?.maxExecutionTimeMs ?? DEFAULT_MAX_EXECUTION_TIME_MS,
         maxOutputSize: opts.limits?.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES,

--- a/packages/harnesses/src/vendo/shell/engine.ts
+++ b/packages/harnesses/src/vendo/shell/engine.ts
@@ -12,6 +12,7 @@
 import type { IFileSystem } from "@vendoai/core";
 import type { Bash as BashInstance } from "just-bash";
 import { pdftotext } from "./parsers/pdftotext.js";
+import { xlsx2csv } from "./parsers/xlsx2csv.js";
 
 /** One `bash` call's ceilings. Both map onto just-bash's own execution limits;
  *  everything else keeps just-bash's `normal` profile. */
@@ -89,7 +90,7 @@ export function createShellSession(opts: {
       // The binary formats a person actually drops into chat, as ordinary
       // commands: they pipe, they redirect, and the agent needs no special
       // vocabulary for them. Lazy, so their libraries load on first use.
-      customCommands: [pdftotext],
+      customCommands: [pdftotext, xlsx2csv],
       executionLimits: {
         maxExecutionTimeMs: opts.limits?.maxExecutionTimeMs ?? DEFAULT_MAX_EXECUTION_TIME_MS,
         maxOutputSize: opts.limits?.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES,

--- a/packages/harnesses/src/vendo/shell/engine.ts
+++ b/packages/harnesses/src/vendo/shell/engine.ts
@@ -11,6 +11,7 @@
  */
 import type { IFileSystem } from "@vendoai/core";
 import type { Bash as BashInstance } from "just-bash";
+import { docx2txt } from "./parsers/docx2txt.js";
 import { pdftotext } from "./parsers/pdftotext.js";
 import { xlsx2csv } from "./parsers/xlsx2csv.js";
 
@@ -90,7 +91,7 @@ export function createShellSession(opts: {
       // The binary formats a person actually drops into chat, as ordinary
       // commands: they pipe, they redirect, and the agent needs no special
       // vocabulary for them. Lazy, so their libraries load on first use.
-      customCommands: [pdftotext, xlsx2csv],
+      customCommands: [pdftotext, xlsx2csv, docx2txt],
       executionLimits: {
         maxExecutionTimeMs: opts.limits?.maxExecutionTimeMs ?? DEFAULT_MAX_EXECUTION_TIME_MS,
         maxOutputSize: opts.limits?.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES,

--- a/packages/harnesses/src/vendo/shell/parsers/docx2txt.ts
+++ b/packages/harnesses/src/vendo/shell/parsers/docx2txt.ts
@@ -21,21 +21,64 @@ type Fflate = typeof import("fflate");
 
 const NAME = "docx2txt";
 
-/** The five XML entities a `w:t` body may carry. Nothing else is escaped in
-    WordprocessingML text, so a table is the whole decoder. */
+/** What `word/document.xml` may inflate to. The upload cap bounds the FILE, and
+ *  a zip's ratio is unbounded: 150 KB of deflated zeros — comfortably under it —
+ *  carries 51 MB, and this shell runs in the host process, so that is the host's
+ *  memory. fflate inflates to the size the archive DECLARES, which makes the
+ *  declared size a sound gate and a free one: nothing is decompressed to learn
+ *  it. 32 MB matches what the session's whole `/tmp` may hold, so no document a
+ *  person can actually upload comes near it. */
+const MAX_DOCUMENT_BYTES = 32 * 1024 * 1024;
+
+/** The five named XML entities. Numeric references are legal in any XML and
+    plenty of .docx writers emit them, so they decode here too — left alone they
+    reach the agent as a literal `&#8212;`. */
 const ENTITIES: Readonly<Record<string, string>> = {
   "&amp;": "&", "&lt;": "<", "&gt;": ">", "&quot;": '"', "&apos;": "'",
 };
 
 const decode = (xml: string): string =>
-  xml.replace(/&(?:amp|lt|gt|quot|apos);/g, (entity) => ENTITIES[entity]!);
+  xml.replace(/&(?:#(\d+)|#[xX]([\dA-Fa-f]+)|amp|lt|gt|quot|apos);/g, (entity, decimal, hex) => {
+    if (decimal === undefined && hex === undefined) return ENTITIES[entity]!;
+    const code = decimal === undefined ? parseInt(hex, 16) : Number(decimal);
+    return code <= 0x10ffff ? String.fromCodePoint(code) : entity;
+  });
+
+/** Every tag that carries text, matched ONE AT A TIME. Matching `<w:t>…</w:t>`
+    as a single lazy pair is the trap: against openers that never close, each one
+    rescans to the end of the paragraph, so a malformed part costs O(n²) of
+    blocked event loop. Each alternative here stops at its own `>`, so the scan
+    is linear no matter what the bytes say.
+
+    `<w:tab/>` is EMPTY: a tab STOP is a `w:tab` in `w:pPr` carrying `w:val`, so
+    demanding the self-closing form keeps stops out of the text. */
+const CONTENT =
+  /(?<open><w:t(?:\s[^>]*)?>)|(?<shut><\/w:t>)|(?<tab><w:tab\s*\/>)|<w:(?:br|cr)\b[^>]*>/g;
+
+/** What one paragraph contributes, in document order. */
+function runsOf(paragraph: string): string[] {
+  const runs: string[] = [];
+  let textFrom = -1;
+  for (const match of paragraph.matchAll(CONTENT)) {
+    const { open, shut, tab } = match.groups!;
+    if (open !== undefined) textFrom = match.index! + open.length;
+    else if (shut === undefined) runs.push(tab === undefined ? "\n" : "\t");
+    else {
+      if (textFrom !== -1) runs.push(decode(paragraph.slice(textFrom, match.index!)));
+      textFrom = -1;
+    }
+  }
+  return runs;
+}
 
 /** The document's paragraphs, in order. */
 export function paragraphsOf(documentXml: string): string[] {
   const lines: string[] = [];
-  for (const paragraph of documentXml.match(/<w:p[ >][\s\S]*?<\/w:p>/g) ?? []) {
-    const runs = [...paragraph.matchAll(/<w:t(?:\s[^>]*)?>([\s\S]*?)<\/w:t>/g)]
-      .map((match) => decode(match[1]!));
+  // SPLIT on the opener rather than matching `<w:p …>…</w:p>` lazily, for the
+  // same reason {@link CONTENT} matches one tag at a time.
+  for (const chunk of documentXml.split(/<w:p[ >]/).slice(1)) {
+    const close = chunk.indexOf("</w:p>");
+    const runs = runsOf(close === -1 ? chunk : chunk.slice(0, close));
     // A paragraph with no text at all is a spacer, and a blank line between two
     // real ones is information — an empty run list is not.
     if (runs.length > 0) lines.push(runs.join(""));
@@ -55,7 +98,15 @@ export const docx2txt: LazyCommand = {
         const input = await inputBytes(NAME, args, ctx);
         if ("refusal" in input) return input.refusal;
         try {
-          const part = unzipSync(input.bytes, { filter: (file) => file.name === "word/document.xml" })["word/document.xml"];
+          const part = unzipSync(input.bytes, {
+            filter: (file) => {
+              if (file.name !== "word/document.xml") return false;
+              if (file.originalSize > MAX_DOCUMENT_BYTES) {
+                throw new Error(`word/document.xml declares ${file.originalSize} bytes`);
+              }
+              return true;
+            },
+          })["word/document.xml"];
           if (part === undefined) throw new Error("no word/document.xml inside");
           return { stdout: `${paragraphsOf(strFromU8(part)).join("\n")}\n`, stderr: "", exitCode: 0 };
         } catch (cause) {

--- a/packages/harnesses/src/vendo/shell/parsers/docx2txt.ts
+++ b/packages/harnesses/src/vendo/shell/parsers/docx2txt.ts
@@ -1,0 +1,67 @@
+/**
+ * `docx2txt <file>` — a Word document's text, one paragraph per line.
+ *
+ * A .docx is a zip with an XML part inside, so this is an unzip and a walk over
+ * `<w:t>` runs — no Word, no LibreOffice, no conversion service. `fflate` does
+ * the unzip (synchronous, zero dependencies); the extraction is a regex over the
+ * one element that holds text, and that is deliberate: a full XML parse would
+ * pull a parser in for a job whose whole grammar is "the text inside w:t,
+ * grouped by w:p".
+ *
+ * Runs of one paragraph are JOINED, never newline-separated: Word splits a
+ * sentence across runs at every formatting change, so a line per run would cut
+ * "Revenue rose 26%" into three.
+ */
+import type { Command, LazyCommand } from "just-bash";
+import { inputBytes, notThisFormat } from "./input.js";
+
+let FFLATE_SPECIFIER = "fflate";
+
+type Fflate = typeof import("fflate");
+
+const NAME = "docx2txt";
+
+/** The five XML entities a `w:t` body may carry. Nothing else is escaped in
+    WordprocessingML text, so a table is the whole decoder. */
+const ENTITIES: Readonly<Record<string, string>> = {
+  "&amp;": "&", "&lt;": "<", "&gt;": ">", "&quot;": '"', "&apos;": "'",
+};
+
+const decode = (xml: string): string =>
+  xml.replace(/&(?:amp|lt|gt|quot|apos);/g, (entity) => ENTITIES[entity]!);
+
+/** The document's paragraphs, in order. */
+export function paragraphsOf(documentXml: string): string[] {
+  const lines: string[] = [];
+  for (const paragraph of documentXml.match(/<w:p[ >][\s\S]*?<\/w:p>/g) ?? []) {
+    const runs = [...paragraph.matchAll(/<w:t(?:\s[^>]*)?>([\s\S]*?)<\/w:t>/g)]
+      .map((match) => decode(match[1]!));
+    // A paragraph with no text at all is a spacer, and a blank line between two
+    // real ones is information — an empty run list is not.
+    if (runs.length > 0) lines.push(runs.join(""));
+  }
+  return lines;
+}
+
+export const docx2txt: LazyCommand = {
+  name: NAME,
+  trusted: true,
+  async load(): Promise<Command> {
+    const { unzipSync, strFromU8 } = await import(/* webpackIgnore: true */ /* turbopackIgnore: true */ /* @vite-ignore */ FFLATE_SPECIFIER) as Fflate;
+    return {
+      name: NAME,
+      trusted: true,
+      async execute(args, ctx) {
+        const input = await inputBytes(NAME, args, ctx);
+        if ("refusal" in input) return input.refusal;
+        try {
+          const part = unzipSync(input.bytes, { filter: (file) => file.name === "word/document.xml" })["word/document.xml"];
+          if (part === undefined) throw new Error("no word/document.xml inside");
+          return { stdout: `${paragraphsOf(strFromU8(part)).join("\n")}\n`, stderr: "", exitCode: 0 };
+        } catch (cause) {
+          return notThisFormat(NAME, args[0]!, "Word document", cause);
+        }
+      },
+    };
+  },
+};

--- a/packages/harnesses/src/vendo/shell/parsers/input.ts
+++ b/packages/harnesses/src/vendo/shell/parsers/input.ts
@@ -1,0 +1,35 @@
+/**
+ * One file argument, resolved against the script's own cwd and read as bytes.
+ *
+ * The diagnostics are POSIX-shaped because bash PRINTS them: a parser that
+ * invented its own sentence would be the one command in the shell that does not
+ * sound like the shell.
+ */
+import type { ExecResult, ResolvedCommandContext } from "just-bash";
+
+export type Input = { bytes: Uint8Array } | { refusal: ExecResult };
+
+export async function inputBytes(
+  name: string,
+  args: string[],
+  ctx: ResolvedCommandContext,
+): Promise<Input> {
+  const target = args[0];
+  if (target === undefined || target.startsWith("-")) {
+    return { refusal: { stdout: "", stderr: `usage: ${name} <file>\n`, exitCode: 2 } };
+  }
+  try {
+    return { bytes: await ctx.fs.readFileBuffer(ctx.fs.resolvePath(ctx.cwd, target)) };
+  } catch {
+    return { refusal: { stdout: "", stderr: `${name}: ${target}: No such file or directory\n`, exitCode: 1 } };
+  }
+}
+
+/** What a parser says when the bytes are not the format it was handed. The
+    message names the format rather than echoing a library's internal error,
+    because the agent's next move is to tell the user what the file actually is. */
+export const notThisFormat = (name: string, target: string, format: string, cause: unknown): ExecResult => ({
+  stdout: "",
+  stderr: `${name}: ${target}: not a readable ${format} (${cause instanceof Error ? cause.message : String(cause)})\n`,
+  exitCode: 1,
+});

--- a/packages/harnesses/src/vendo/shell/parsers/input.ts
+++ b/packages/harnesses/src/vendo/shell/parsers/input.ts
@@ -20,8 +20,15 @@ export async function inputBytes(
   }
   try {
     return { bytes: await ctx.fs.readFileBuffer(ctx.fs.resolvePath(ctx.cwd, target)) };
-  } catch {
-    return { refusal: { stdout: "", stderr: `${name}: ${target}: No such file or directory\n`, exitCode: 1 } };
+  } catch (cause) {
+    // A directory is the one failure bash names differently, and the difference
+    // matters: told "no such file" an agent invents another path, told "is a
+    // directory" it lists it. Both filesystems carry the code in the MESSAGE and
+    // set no `code` property (`enoent`/`eisdir` in store's workspace-fs.ts).
+    const reason = cause instanceof Error && cause.message.startsWith("EISDIR")
+      ? "Is a directory"
+      : "No such file or directory";
+    return { refusal: { stdout: "", stderr: `${name}: ${target}: ${reason}\n`, exitCode: 1 } };
   }
 }
 

--- a/packages/harnesses/src/vendo/shell/parsers/pdftotext.ts
+++ b/packages/harnesses/src/vendo/shell/parsers/pdftotext.ts
@@ -1,0 +1,48 @@
+/**
+ * `pdftotext <file>` — a PDF's text, on stdout.
+ *
+ * LAZY on purpose: unpdf carries a serverless build of pdf.js (~1.6 MB) and most
+ * turns never touch a PDF, so it loads the first time one is actually parsed and
+ * never again. TRUSTED, because it runs in the HOST process against the same
+ * virtual filesystem the shell has — it is our code reading our bytes, not
+ * user JavaScript.
+ *
+ * Only stdout, deliberately: real `pdftotext` writes `<name>.txt` by default, and
+ * a command that silently creates a file is a command that surprises an agent
+ * mid-pipeline. Redirect it if you want a file.
+ */
+import type { Command, LazyCommand } from "just-bash";
+import { inputBytes, notThisFormat } from "./input.js";
+
+/** Mutable so no bundler statically resolves it — same containment as just-bash
+ *  in engine.ts, and the same reason: this module is reachable from the umbrella's
+ *  server entry, which must bundle for a Worker target. */
+let UNPDF_SPECIFIER = "unpdf";
+
+type Unpdf = typeof import("unpdf");
+
+const NAME = "pdftotext";
+
+export const pdftotext: LazyCommand = {
+  name: NAME,
+  trusted: true,
+  async load(): Promise<Command> {
+    const { extractText } = await import(/* webpackIgnore: true */ /* turbopackIgnore: true */ /* @vite-ignore */ UNPDF_SPECIFIER) as Unpdf;
+    return {
+      name: NAME,
+      trusted: true,
+      async execute(args, ctx) {
+        const input = await inputBytes(NAME, args, ctx);
+        if ("refusal" in input) return input.refusal;
+        try {
+          // Page by page, joined with the form feed real `pdftotext` uses, so
+          // "what is on page 3" is answerable with `awk` instead of guesswork.
+          const { text } = await extractText(input.bytes, { mergePages: false });
+          return { stdout: `${text.join("\n\f\n")}\n`, stderr: "", exitCode: 0 };
+        } catch (cause) {
+          return notThisFormat(NAME, args[0]!, "PDF", cause);
+        }
+      },
+    };
+  },
+};

--- a/packages/harnesses/src/vendo/shell/parsers/xlsx2csv.ts
+++ b/packages/harnesses/src/vendo/shell/parsers/xlsx2csv.ts
@@ -62,7 +62,12 @@ export const xlsx2csv: LazyCommand = {
           return notThisFormat(NAME, args[0]!, "spreadsheet", cause);
         }
         const wanted = args[1] ?? book.SheetNames[0];
-        const sheet = wanted === undefined ? undefined : book.Sheets[wanted];
+        // SheetNames, not a bare `Sheets[wanted]`: `xlsx2csv book.xlsx toString`
+        // would otherwise find Object.prototype's method and print an empty CSV
+        // with exit 0 instead of naming the sheets.
+        const sheet = wanted !== undefined && book.SheetNames.includes(wanted)
+          ? book.Sheets[wanted]
+          : undefined;
         if (sheet === undefined) {
           // Naming the sheets IS the fix: an agent told only "no" asks the user,
           // an agent told what exists picks the right one and carries on.

--- a/packages/harnesses/src/vendo/shell/parsers/xlsx2csv.ts
+++ b/packages/harnesses/src/vendo/shell/parsers/xlsx2csv.ts
@@ -5,15 +5,24 @@
  * stdout, `cut`, `awk`, `sort` and `jq -R` all work on it, which is the whole
  * reason the parsers are COMMANDS and not tools of their own.
  *
- * SheetJS Community Edition, pure JavaScript, synchronous, no native code. It
- * comes from the SheetJS CDN rather than npm — the registry copy is years stale.
+ * SheetJS Community Edition, pure JavaScript, synchronous, no native code.
  */
 import type { Command, LazyCommand } from "just-bash";
 import { inputBytes, notThisFormat } from "./input.js";
 
-let XLSX_SPECIFIER = "xlsx";
+/** `@e965/xlsx` is SheetJS CE republished on the public registry. SheetJS
+    itself ships only from its own CDN, and pnpm 11 (blockExoticSubdeps)
+    refuses a URL-resolved dependency reached through a dependency, so the CDN
+    tarball breaks every pnpm consumer; npm's stale `xlsx@0.18.5` carries
+    CVE-2023-30533 and CVE-2024-22363, both in this read path. The mirror is
+    one individual's account, so the EXACT pin is the control — npm forbids
+    replacing a published version, so a consumer can only get bytes we checked.
+    Re-verify on any bump (empty diff == identical to the official tarball):
+      diff <(curl -sL https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz \
+        | tar xzO package/xlsx.js) node_modules/@e965/xlsx/xlsx.js */
+let XLSX_SPECIFIER = "@e965/xlsx";
 
-type SheetJs = typeof import("xlsx");
+type SheetJs = typeof import("@e965/xlsx");
 
 const NAME = "xlsx2csv";
 

--- a/packages/harnesses/src/vendo/shell/parsers/xlsx2csv.ts
+++ b/packages/harnesses/src/vendo/shell/parsers/xlsx2csv.ts
@@ -1,0 +1,71 @@
+/**
+ * `xlsx2csv <file> [sheet]` — one sheet of a workbook, as CSV on stdout.
+ *
+ * CSV and not JSON because the rest of the shell speaks CSV: once it is on
+ * stdout, `cut`, `awk`, `sort` and `jq -R` all work on it, which is the whole
+ * reason the parsers are COMMANDS and not tools of their own.
+ *
+ * SheetJS Community Edition, pure JavaScript, synchronous, no native code. It
+ * comes from the SheetJS CDN rather than npm — the registry copy is years stale.
+ */
+import type { Command, LazyCommand } from "just-bash";
+import { inputBytes, notThisFormat } from "./input.js";
+
+let XLSX_SPECIFIER = "xlsx";
+
+type SheetJs = typeof import("xlsx");
+
+const NAME = "xlsx2csv";
+
+/** SheetJS never refuses. Handed bytes it does not recognise it falls back to
+    plain-text sniffing and hands back a one-cell "workbook", so `xlsx2csv
+    notes.txt` would exit 0 on nonsense — verified against 0.20.3, which even
+    accepts four random bytes. The gate is therefore ours, and it is the
+    container magic: every BINARY workbook SheetJS reads is a zip (xlsx, xlsb,
+    ods) or an OLE compound file (xls). The text formats it can also guess at
+    (csv, prn, sylk) are already the rest of the shell's job. */
+const WORKBOOK_MAGIC = [
+  [0x50, 0x4b], // "PK" — zip
+  [0xd0, 0xcf, 0x11, 0xe0], // OLE compound file
+];
+
+const isWorkbook = (bytes: Uint8Array): boolean =>
+  WORKBOOK_MAGIC.some((magic) => magic.every((byte, index) => bytes[index] === byte));
+
+export const xlsx2csv: LazyCommand = {
+  name: NAME,
+  trusted: true,
+  async load(): Promise<Command> {
+    const XLSX = await import(/* webpackIgnore: true */ /* turbopackIgnore: true */ /* @vite-ignore */ XLSX_SPECIFIER) as SheetJs;
+    return {
+      name: NAME,
+      trusted: true,
+      async execute(args, ctx) {
+        const input = await inputBytes(NAME, args, ctx);
+        if ("refusal" in input) return input.refusal;
+        if (!isWorkbook(input.bytes)) {
+          return notThisFormat(NAME, args[0]!, "spreadsheet", "not a zip or OLE workbook container");
+        }
+        let book: ReturnType<SheetJs["read"]>;
+        try {
+          book = XLSX.read(input.bytes, { type: "array" });
+        } catch (cause) {
+          return notThisFormat(NAME, args[0]!, "spreadsheet", cause);
+        }
+        const wanted = args[1] ?? book.SheetNames[0];
+        const sheet = wanted === undefined ? undefined : book.Sheets[wanted];
+        if (sheet === undefined) {
+          // Naming the sheets IS the fix: an agent told only "no" asks the user,
+          // an agent told what exists picks the right one and carries on.
+          return {
+            stdout: "",
+            stderr: `${NAME}: ${args[0]}: no sheet named ${JSON.stringify(wanted)};`
+              + ` this workbook has ${book.SheetNames.join(", ")}\n`,
+            exitCode: 1,
+          };
+        }
+        return { stdout: XLSX.utils.sheet_to_csv(sheet), stderr: "", exitCode: 0 };
+      },
+    };
+  },
+};

--- a/packages/harnesses/src/vendo/shell/tool.ts
+++ b/packages/harnesses/src/vendo/shell/tool.ts
@@ -30,6 +30,8 @@ const DESCRIPTION =
   + "workspace: /user/threads/<thread>/files holds what they dropped in THIS conversation, "
   + "/user/apps/<app> holds an app's files, and /user/files is the shelf of things they asked you to "
   + "keep. /tmp is scratch that lasts this conversation and is never saved. "
+  + "Binary formats are ordinary commands here: `pdftotext <file>`, `xlsx2csv <file> [sheet]` and "
+  + "`docx2txt <file>` each write text to stdout, so they pipe into grep, awk and the rest. "
   + (JAVASCRIPT
     ? "For anything bash is awkward at, write JavaScript: `js-exec -c '<code>'` runs it in a sandbox with "
       + "require(\"node:fs\") bound to this same filesystem. "

--- a/packages/harnesses/tests/shell/parsers.test.ts
+++ b/packages/harnesses/tests/shell/parsers.test.ts
@@ -84,7 +84,7 @@ describe("pdftotext", () => {
 describe("xlsx2csv", () => {
   /** A real workbook, written by the same library that will read it back. */
   const workbook = async (): Promise<Uint8Array> => {
-    const XLSX = await import("xlsx");
+    const XLSX = await import("@e965/xlsx");
     const book = XLSX.utils.book_new();
     XLSX.utils.book_append_sheet(
       book,

--- a/packages/harnesses/tests/shell/parsers.test.ts
+++ b/packages/harnesses/tests/shell/parsers.test.ts
@@ -1,0 +1,82 @@
+/**
+ * The three parsers, each against a REAL file of its format built right here.
+ * A fixture you can read is a fixture you can debug, and the libraries under
+ * test (pdf.js via unpdf, SheetJS, a zip) will not accept a fake.
+ */
+import { InMemoryFs } from "just-bash";
+import type { IFileSystem } from "@vendoai/core";
+import { describe, expect, it } from "vitest";
+import { createShellSession } from "../../src/vendo/shell/engine.js";
+
+/** A structurally valid one-page PDF with one line of Helvetica text. The xref
+    offsets are computed, not typed, so the file is always well-formed. */
+function minimalPdf(line: string): Uint8Array {
+  const stream = `BT /F1 12 Tf 20 100 Td (${line}) Tj ET`;
+  const objects = [
+    "<</Type/Catalog/Pages 2 0 R>>",
+    "<</Type/Pages/Kids[3 0 R]/Count 1>>",
+    "<</Type/Page/Parent 2 0 R/MediaBox[0 0 200 200]/Contents 4 0 R/Resources<</Font<</F1 5 0 R>>>>>>",
+    `<</Length ${stream.length}>>\nstream\n${stream}\nendstream`,
+    "<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>",
+  ];
+  let pdf = "%PDF-1.4\n";
+  const offsets: number[] = [];
+  for (const [index, body] of objects.entries()) {
+    offsets.push(pdf.length);
+    pdf += `${index + 1} 0 obj\n${body}\nendobj\n`;
+  }
+  const startxref = pdf.length;
+  pdf += `xref\n0 ${objects.length + 1}\n0000000000 65535 f \n`;
+  for (const offset of offsets) pdf += `${String(offset).padStart(10, "0")} 00000 n \n`;
+  pdf += `trailer\n<</Size ${objects.length + 1}/Root 1 0 R>>\nstartxref\n${startxref}\n%%EOF\n`;
+  return new TextEncoder().encode(pdf);
+}
+
+async function diskWith(files: Record<string, Uint8Array | string>): Promise<IFileSystem> {
+  const fs = new InMemoryFs();
+  for (const [path, content] of Object.entries(files)) {
+    await fs.mkdir(path.slice(0, path.lastIndexOf("/")), { recursive: true });
+    await fs.writeFile(path, content);
+  }
+  return fs as unknown as IFileSystem;
+}
+
+describe("pdftotext", () => {
+  it("reads the text out of a real PDF", async () => {
+    const workspace = await diskWith({ "/user/files/invoice.pdf": minimalPdf("Invoice 4210 total 980.00") });
+    const session = createShellSession({ workspace });
+
+    const result = await session.exec("pdftotext files/invoice.pdf");
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("Invoice 4210 total 980.00");
+  });
+
+  it("pipes, like every other command in the shell", async () => {
+    const workspace = await diskWith({ "/user/files/invoice.pdf": minimalPdf("Invoice 4210 total 980.00") });
+    const session = createShellSession({ workspace });
+
+    const result = await session.exec("pdftotext files/invoice.pdf | grep -o '4210'");
+
+    expect(result.stdout.trim()).toBe("4210");
+  });
+
+  it("says so when the file is not a PDF", async () => {
+    const workspace = await diskWith({ "/user/files/notes.txt": "just words\n" });
+    const session = createShellSession({ workspace });
+
+    const result = await session.exec("pdftotext files/notes.txt");
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("not a readable PDF");
+  });
+
+  it("says so when there is no file", async () => {
+    const session = createShellSession({ workspace: await diskWith({}) });
+
+    const result = await session.exec("pdftotext files/missing.pdf");
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("No such file or directory");
+  });
+});

--- a/packages/harnesses/tests/shell/parsers.test.ts
+++ b/packages/harnesses/tests/shell/parsers.test.ts
@@ -125,3 +125,56 @@ describe("xlsx2csv", () => {
     expect(result.stderr).toContain("not a readable spreadsheet");
   });
 });
+
+describe("docx2txt", () => {
+  /** A real .docx: a zip carrying the three parts Word requires. */
+  const document = async (paragraphs: string[]): Promise<Uint8Array> => {
+    const { zipSync, strToU8 } = await import("fflate");
+    const body = paragraphs
+      .map((text) => `<w:p><w:r><w:t xml:space="preserve">${text}</w:t></w:r></w:p>`)
+      .join("");
+    return zipSync({
+      "[Content_Types].xml":
+        strToU8(`<?xml version="1.0" encoding="UTF-8"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="xml" ContentType="application/xml"/><Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>`),
+      "_rels/.rels":
+        strToU8(`<?xml version="1.0" encoding="UTF-8"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/></Relationships>`),
+      "word/document.xml":
+        strToU8(`<?xml version="1.0" encoding="UTF-8"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>${body}</w:body></w:document>`),
+    });
+  };
+
+  it("reads the paragraphs out of a real .docx, one per line", async () => {
+    const workspace = await diskWith({
+      "/user/files/brief.docx": await document(["Quarterly brief", "Revenue rose 26% to 98,000."]),
+    });
+    const session = createShellSession({ workspace });
+
+    const result = await session.exec("docx2txt files/brief.docx");
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("Quarterly brief\nRevenue rose 26% to 98,000.\n");
+  });
+
+  it("keeps a paragraph whole when Word split it into runs", async () => {
+    const { zipSync, strToU8 } = await import("fflate");
+    const split = zipSync({
+      "word/document.xml": strToU8(
+        `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>`
+        + `<w:p><w:r><w:t xml:space="preserve">Revenue rose </w:t></w:r><w:r><w:t>26%</w:t></w:r></w:p>`
+        + `</w:body></w:document>`,
+      ),
+    });
+    const session = createShellSession({ workspace: await diskWith({ "/user/files/split.docx": split }) });
+
+    expect((await session.exec("docx2txt files/split.docx")).stdout).toBe("Revenue rose 26%\n");
+  });
+
+  it("says so when the file is not a .docx", async () => {
+    const session = createShellSession({ workspace: await diskWith({ "/user/files/notes.txt": "just words\n" }) });
+
+    const result = await session.exec("docx2txt files/notes.txt");
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("not a readable Word document");
+  });
+});

--- a/packages/harnesses/tests/shell/parsers.test.ts
+++ b/packages/harnesses/tests/shell/parsers.test.ts
@@ -80,3 +80,48 @@ describe("pdftotext", () => {
     expect(result.stderr).toContain("No such file or directory");
   });
 });
+
+describe("xlsx2csv", () => {
+  /** A real workbook, written by the same library that will read it back. */
+  const workbook = async (): Promise<Uint8Array> => {
+    const XLSX = await import("xlsx");
+    const book = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(
+      book,
+      XLSX.utils.aoa_to_sheet([["month", "revenue"], ["jan", 31000], ["feb", 39000]]),
+      "Revenue",
+    );
+    XLSX.utils.book_append_sheet(book, XLSX.utils.aoa_to_sheet([["note"], ["draft"]]), "Notes");
+    return new Uint8Array(XLSX.write(book, { type: "array", bookType: "xlsx" }) as ArrayBuffer);
+  };
+
+  it("turns the first sheet into CSV on stdout", async () => {
+    const session = createShellSession({ workspace: await diskWith({ "/user/files/q1.xlsx": await workbook() }) });
+
+    const result = await session.exec("xlsx2csv files/q1.xlsx");
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim().split("\n")).toEqual(["month,revenue", "jan,31000", "feb,39000"]);
+  });
+
+  it("takes a sheet by name, and lists them when the name is wrong", async () => {
+    const session = createShellSession({ workspace: await diskWith({ "/user/files/q1.xlsx": await workbook() }) });
+
+    expect((await session.exec("xlsx2csv files/q1.xlsx Notes")).stdout.trim().split("\n"))
+      .toEqual(["note", "draft"]);
+
+    const wrong = await session.exec("xlsx2csv files/q1.xlsx Nope");
+    expect(wrong.exitCode).toBe(1);
+    expect(wrong.stderr).toContain("Revenue");
+    expect(wrong.stderr).toContain("Notes");
+  });
+
+  it("says so when the file is not a workbook", async () => {
+    const session = createShellSession({ workspace: await diskWith({ "/user/files/notes.txt": "just words\n" }) });
+
+    const result = await session.exec("xlsx2csv files/notes.txt");
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("not a readable spreadsheet");
+  });
+});

--- a/packages/harnesses/tests/shell/parsers.test.ts
+++ b/packages/harnesses/tests/shell/parsers.test.ts
@@ -79,6 +79,16 @@ describe("pdftotext", () => {
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain("No such file or directory");
   });
+
+  it("says a directory is a directory, the way bash does", async () => {
+    const workspace = await diskWith({ "/user/files/reports/q1.pdf": minimalPdf("x") });
+    const session = createShellSession({ workspace });
+
+    const result = await session.exec("pdftotext files/reports");
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("Is a directory");
+  });
 });
 
 describe("xlsx2csv", () => {
@@ -123,6 +133,16 @@ describe("xlsx2csv", () => {
 
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain("not a readable spreadsheet");
+  });
+
+  it("treats a sheet named after an Object property as the missing sheet it is", async () => {
+    const session = createShellSession({ workspace: await diskWith({ "/user/files/q1.xlsx": await workbook() }) });
+
+    const result = await session.exec("xlsx2csv files/q1.xlsx toString");
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("no sheet named");
+    expect(result.stderr).toContain("Revenue");
   });
 });
 
@@ -176,5 +196,74 @@ describe("docx2txt", () => {
 
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain("not a readable Word document");
+  });
+
+  /** A .docx carrying exactly this `word/document.xml`, and nothing else. */
+  const docxWith = async (documentXml: string): Promise<Uint8Array> => {
+    const { zipSync, strToU8 } = await import("fflate");
+    return zipSync({ "word/document.xml": strToU8(documentXml) });
+  };
+
+  const body = (inner: string): string =>
+    `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>${inner}</w:body></w:document>`;
+
+  it("keeps the tab and the manual break Word put between two fields", async () => {
+    const docx = await docxWith(body(
+      `<w:p><w:r><w:t>Account</w:t></w:r><w:r><w:tab/></w:r><w:r><w:t>Balance</w:t></w:r>`
+      + `<w:r><w:br/></w:r><w:r><w:t>Due</w:t></w:r></w:p>`,
+    ));
+    const session = createShellSession({ workspace: await diskWith({ "/user/files/table.docx": docx }) });
+
+    expect((await session.exec("docx2txt files/table.docx")).stdout).toBe("Account\tBalance\nDue\n");
+  });
+
+  it("does not mistake a tab STOP in the paragraph's properties for a tab", async () => {
+    const docx = await docxWith(body(
+      `<w:p><w:pPr><w:tabs><w:tab w:val="left" w:pos="720"/></w:tabs></w:pPr>`
+      + `<w:r><w:t>Indented</w:t></w:r></w:p>`,
+    ));
+    const session = createShellSession({ workspace: await diskWith({ "/user/files/stops.docx": docx }) });
+
+    expect((await session.exec("docx2txt files/stops.docx")).stdout).toBe("Indented\n");
+  });
+
+  it("decodes the numeric character references XML allows, not just the named five", async () => {
+    const docx = await docxWith(body(`<w:p><w:r><w:t>Q1&#8212;Q2 &#x2014; &amp; up</w:t></w:r></w:p>`));
+    const session = createShellSession({ workspace: await diskWith({ "/user/files/refs.docx": docx }) });
+
+    expect((await session.exec("docx2txt files/refs.docx")).stdout).toBe("Q1—Q2 — & up\n");
+  });
+
+  it("refuses a part that only becomes huge once decompressed", async () => {
+    // 33 MB of zeros zips to a few KB: the upload cap bounds the FILE, and only
+    // the declared inflated size bounds what the host process has to hold.
+    const { zipSync } = await import("fflate");
+    const bomb = zipSync({ "word/document.xml": new Uint8Array(33 * 1024 * 1024) });
+    const session = createShellSession({ workspace: await diskWith({ "/user/files/bomb.docx": bomb }) });
+
+    const result = await session.exec("docx2txt files/bomb.docx");
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("not a readable Word document");
+  });
+
+  it("stays linear on a malformed part full of unclosed paragraph openers", async () => {
+    // A lazy `<w:p>…</w:p>` match rescans the remainder for EVERY opener, so this
+    // input costs minutes quadratically and milliseconds linearly. The test's own
+    // timeout is the detector — no inner stopwatch to go flaky under load.
+    const docx = await docxWith(body("<w:p >".repeat(200_000)));
+    const session = createShellSession({ workspace: await diskWith({ "/user/files/malformed.docx": docx }) });
+
+    expect((await session.exec("docx2txt files/malformed.docx")).exitCode).toBe(0);
+  });
+
+  it("stays linear on a paragraph full of unclosed text openers", async () => {
+    // The same quadratic trap one level down: a `<w:t>…</w:t>` pair matched as
+    // one lazy unit rescans to the end of the paragraph for every opener that
+    // never closes.
+    const docx = await docxWith(body(`<w:p >${"<w:t >".repeat(200_000)}</w:p>`));
+    const session = createShellSession({ workspace: await diskWith({ "/user/files/runs.docx": docx }) });
+
+    expect((await session.exec("docx2txt files/runs.docx")).exitCode).toBe(0);
   });
 });

--- a/packages/harnesses/tests/shell/tool.test.ts
+++ b/packages/harnesses/tests/shell/tool.test.ts
@@ -241,3 +241,13 @@ describe("the JavaScript hand, through the tool", () => {
     expect((outcome as { output: { stdout: string } }).output.stdout).toContain("42");
   });
 });
+
+describe("the parsers, announced", () => {
+  it("names all three in the description, so the model never guesses at a PDF", async () => {
+    const [descriptor] = await createShellTools(async () => workspaceDouble()).descriptors();
+
+    expect(descriptor?.description).toContain("pdftotext");
+    expect(descriptor?.description).toContain("xlsx2csv");
+    expect(descriptor?.description).toContain("docx2txt");
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1189,9 +1189,18 @@ importers:
       '@vendoai/guard':
         specifier: workspace:*
         version: link:../guard
+      fflate:
+        specifier: ^0.8.3
+        version: 0.8.3
       just-bash:
         specifier: ^3.4.2
         version: 3.4.2
+      unpdf:
+        specifier: ^1.8.1
+        version: 1.8.1
+      xlsx:
+        specifier: https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz
+        version: https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz
       zod:
         specifier: ^3.25.0
         version: 3.25.76
@@ -9361,6 +9370,15 @@ packages:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
 
+  unpdf@1.8.1:
+    resolution: {integrity: sha512-xkURhy2SoGpOIH0a1gLHNkASPIQYonadDJs2AQwPEfUakafeD9EA1WTWWsaR++gfTCXJpV27W7tU1nXuk82UKQ==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      '@napi-rs/canvas': ^0.1.69 || ^1.0.0
+    peerDependenciesMeta:
+      '@napi-rs/canvas':
+        optional: true
+
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
@@ -9618,6 +9636,12 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  xlsx@https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz:
+    resolution: {integrity: sha512-oLDq3jw7AcLqKWH2AhCpVTZl8mf6X2YReP+Neh0SJUzV/BdZYjth94tG5toiMB1PPrYtxOCfaoUCkvtuH+3AJA==, tarball: https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz}
+    version: 0.20.3
+    engines: {node: '>=0.8'}
+    hasBin: true
 
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
@@ -19094,6 +19118,8 @@ snapshots:
 
   universalify@2.0.1: {}
 
+  unpdf@1.8.1: {}
+
   unpipe@1.0.0: {}
 
   unplugin-utils@0.2.5:
@@ -19559,6 +19585,8 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.21.0: {}
+
+  xlsx@https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz: {}
 
   xml-name-validator@5.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1223,9 +1223,6 @@ importers:
       vitest:
         specifier: ^3.2.6
         version: 3.2.7(@types/debug@4.1.13)(@types/node@22.20.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
-      xlsx:
-        specifier: npm:@e965/xlsx@0.20.3
-        version: '@e965/xlsx@0.20.3'
 
   packages/knowledge:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1180,6 +1180,9 @@ importers:
       '@anthropic-ai/claude-agent-sdk':
         specifier: '>=0.3.0 <1'
         version: 0.3.214(@anthropic-ai/sdk@0.112.3(zod@3.25.76))(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(zod@3.25.76)
+      '@e965/xlsx':
+        specifier: 0.20.3
+        version: 0.20.3
       '@vendoai/apps':
         specifier: workspace:*
         version: link:../apps
@@ -1198,9 +1201,6 @@ importers:
       unpdf:
         specifier: ^1.8.1
         version: 1.8.1
-      xlsx:
-        specifier: https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz
-        version: https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz
       zod:
         specifier: ^3.25.0
         version: 3.25.76
@@ -1223,6 +1223,9 @@ importers:
       vitest:
         specifier: ^3.2.6
         version: 3.2.7(@types/debug@4.1.13)(@types/node@22.20.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
+      xlsx:
+        specifier: npm:@e965/xlsx@0.20.3
+        version: '@e965/xlsx@0.20.3'
 
   packages/knowledge:
     dependencies:
@@ -2243,6 +2246,11 @@ packages:
 
   '@duckdb/node-bindings@1.5.2-r.2':
     resolution: {integrity: sha512-A17A6pXB7SEBAm93POdmEG+f4vQWMSujUP8/hNUfDWjaqp4C5mUWFnyuBM4XiB4qyXXH3vbjis2TYsnxAN2xEQ==}
+
+  '@e965/xlsx@0.20.3':
+    resolution: {integrity: sha512-703RN/3OdsRD5mtse2HBX7Um7xwaP9tlswEG6svOtjqokXoX7rJdQj7DyabD2I+xk22RgaIIU+R6BHgkpZGB/w==}
+    engines: {node: '>=0.8'}
+    hasBin: true
 
   '@electric-sql/pglite@0.2.17':
     resolution: {integrity: sha512-qEpKRT2oUaWDH6tjRxLHjdzMqRUGYDnGZlKrnL4dJ77JVMcP2Hpo3NYnOSPKdZdeec57B6QPprCUFg0picx5Pw==}
@@ -9637,12 +9645,6 @@ packages:
       utf-8-validate:
         optional: true
 
-  xlsx@https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz:
-    resolution: {integrity: sha512-oLDq3jw7AcLqKWH2AhCpVTZl8mf6X2YReP+Neh0SJUzV/BdZYjth94tG5toiMB1PPrYtxOCfaoUCkvtuH+3AJA==, tarball: https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz}
-    version: 0.20.3
-    engines: {node: '>=0.8'}
-    hasBin: true
-
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
@@ -10645,6 +10647,8 @@ snapshots:
       '@duckdb/node-bindings-linux-x64-musl': 1.5.2-r.2
       '@duckdb/node-bindings-win32-arm64': 1.5.2-r.2
       '@duckdb/node-bindings-win32-x64': 1.5.2-r.2
+
+  '@e965/xlsx@0.20.3': {}
 
   '@electric-sql/pglite@0.2.17': {}
 
@@ -19585,8 +19589,6 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.21.0: {}
-
-  xlsx@https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz: {}
 
   xml-name-validator@5.0.0: {}
 


### PR DESCRIPTION
**Slice C of 4.** Stack, bottom → top:

- A → `main` — #1615
- B → shell-a-engine — #1616
- **C → shell-b-js** ← you are here
- D → shell-c-parsers

Merges **once at the tip**, not per-PR. Review against B, not `main`.

## What this does

Three trusted shell commands, running in the host process (not in QuickJS), on input already capped at 5 MB by the upload door:

- `pdftotext <file>` — unpdf
- `xlsx2csv <file> [sheet]` — SheetJS CE
- `docx2txt <file>` — fflate + minimal XML text extraction

Each is a `LazyCommand`, so unpdf's ~1.6 MB only loads the first time a PDF is actually parsed. Each library is reached through a mutable specifier, like just-bash — portability gate stays green (`@vendoai/harnesses` bundles for a Worker target, 224 modules).

## Two things worth a reviewer's attention

**1. SheetJS never throws on a non-spreadsheet.** The approved plan wrapped `XLSX.read` in a try/catch for the not-a-workbook case. That code can never fire: hand SheetJS `"just words\n"` or four random bytes and it text-sniffs and returns a one-cell workbook. `book.bookType` is not a usable discriminator either — it is undefined for genuine `.xls` and `.csv`. So the "says so when the file is not a workbook" test was passing a garbage file with `exitCode 0`. Replaced with a container-magic guard (`50 4b` zip, `d0 cf 11 e0` OLE) before the read.

**2. `xlsx` comes from `@e965/xlsx`, pinned exact, and that is deliberate.**
SheetJS stopped publishing to npm at 0.18.5 and ships Community Edition from its own CDN. We cannot depend on that URL: pnpm 11 defaults `blockExoticSubdeps: true` and refuses any URL-resolved dependency reached from inside a dependency, so `pnpm add @vendoai/vendo` failed outright for every pnpm user (npm, yarn and bun are unaffected).

npm's `xlsx@0.18.5` is not a fallback — CVE-2023-30533 (prototype pollution, CVSS 7.8) and CVE-2024-22363 (ReDoS, 7.5) both fire in exactly the read-a-workbook path this command uses; a 7 KB crafted file was measured hanging the parser for **106 seconds**. Both are fixed in 0.20.3.

`@e965/xlsx@0.20.3` is a registry republish of SheetJS CE 0.20.3. Verified before adoption: `xlsx.js` is byte-identical to the official CDN tarball (sha256 `fd159f1e…98cbfa`), 26 files each with only `README.md` and `package.json` differing, zero dependencies, no install scripts, Apache-2.0, npm SLSA provenance.

It is an unofficial mirror on an individual's account, so **the exact-version pin is the control** — npm forbids republishing an existing version, so a consumer can only ever receive the verified bytes. A re-verification command is recorded at `parsers/xlsx2csv.ts:21`; any future version bump re-runs it.

## Proof

Each parser is proven against a **real file of its format**, built in the test — a PDF with computed xref offsets parsed by real pdf.js, a workbook written by SheetJS and read back, a real zip built by fflate. No mocks. Proven able to fail: with `pdftotext` unregistered, all four of its tests go red with `expected 127 to be +0`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `pdftotext`, `xlsx2csv`, and `docx2txt` so the agent can read PDFs, spreadsheets, and Word documents and pipe their text into shell tools. Previously the shell could not open these files; now it streams text safely, with hardened parsing and POSIX-shaped diagnostics.

- Commands are trusted, run in the host process, are lazy-loaded, and write only to stdout: `pdftotext` uses `unpdf` and joins pages with form-feed; `xlsx2csv` uses `@e965/xlsx@0.20.3`; `docx2txt` uses `fflate`, parses linearly (no quadratic scans), decodes XML numeric entities, preserves `<w:tab/>` and line breaks, and caps `word/document.xml`’s declared size at 32 MB.
- `xlsx2csv`: guards on zip/OLE container magic before `XLSX.read`; selects sheets by name via `SheetNames` (avoids `Object.prototype` collisions); lists available sheets on mismatch.
- Shared behavior: one file arg; consistent exit codes; “not a readable <format>” errors; correct “Is a directory” vs “No such file or directory.”
- Updates the shell tool description to advertise the commands; adds integration tests against real PDFs, workbooks, and `.docx` files and asserts the commands are announced.

**Rollout**
- Ensure Node >= 22 for `unpdf`.
- Install dependencies to fetch `unpdf`, `@e965/xlsx`, and `fflate`.

<sup>Written for commit 682e9225bfbfb23b5e914786ee61d2ab18a88b4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

