### PR TITLE
feat(files): files live where the work lives, and die with it

### DIFF
--- a/.changeset/files-live-where-work-lives.md
+++ b/.changeset/files-live-where-work-lives.md
@@ -1,0 +1,33 @@
+---
+"@vendoai/apps": minor
+"@vendoai/harnesses": minor
+"@vendoai/store": minor
+"@vendoai/ui": minor
+"@vendoai/vendo": minor
+---
+
+Files live where the work lives, and are really deleted when it is.
+
+A file dropped into chat used to go into one global drawer, live there forever,
+and belong to nothing. Now it belongs to the CONVERSATION: the upload lands in a
+staging area, and the turn that receives the message moves it to
+`/user/threads/<thread>/files/<name>` and rewrites the message before storing it,
+so the agent's shell finds it at a stable address and later turns on that thread
+still can. `/user/files` is now what its name always suggested — a keep-shelf for
+things the user asked you to save — and the three `vendo_user_files_*` tools say
+so, so the model stops shelving everything by reflex. Staged files that were never
+sent are swept by the next turn.
+
+Two real leaks close with it, both of which existed before this change:
+
+- Deleting a conversation deleted ONE row. Its messages stayed in
+  `vendo_thread_messages` forever, unreachable by any later erasure because the
+  join that identified them had gone with the row, and its harness state stayed
+  with them. The delete now runs the cascade that already existed — thread row,
+  messages and state in one transaction — and sweeps the conversation's files,
+  including the blobs behind them.
+- Deleting an app never touched its workspace files or their objects. It now runs
+  the store's own app cascade, which does.
+
+Nothing in the file model is harness-specific: a sandboxed harness materialises a
+conversation's files exactly as it materialises everything else, with no new code.

--- a/.changeset/shell-agent-javascript.md
+++ b/.changeset/shell-agent-javascript.md
@@ -1,0 +1,15 @@
+---
+"@vendoai/harnesses": minor
+---
+
+The shell can write and run JavaScript.
+
+`bash` now carries `js-exec`: the agent writes a script and runs it in a QuickJS
+sandbox on a worker thread — 64 MiB, 30 seconds, no network — with
+`require("node:fs")` bound to the SAME virtual workspace bash sees. That is the
+difference between "reshape this spreadsheet" being a page of `awk` and being
+five lines of the language the model writes best.
+
+It is a capability, not a flag: on a runtime with no `node:worker_threads` (edge,
+Workers) the shell is still the whole shell — bash, the coreutils, the parsers —
+and the tool simply does not advertise `js-exec` to the model.

--- a/.changeset/shell-bash-hands.md
+++ b/.changeset/shell-bash-hands.md
@@ -1,0 +1,29 @@
+---
+"@vendoai/core": minor
+"@vendoai/harnesses": minor
+"@vendoai/vendo": minor
+---
+
+The agent has hands: one real `bash` over the user's own files.
+
+Every deployment running the default `vendo()` harness — no keys, no config —
+now projects one more tool: `bash`. It is a full shell (grep, sed, awk, jq, sort,
+cut, find, pipes, redirection) running IN THIS PROCESS over the same per-user
+workspace the file drawer already lives in, so a dropped CSV is something the
+agent can actually work on instead of something it can only page through 200
+lines at a time. There is no machine to provision, no sandbox key, and no network
+or package manager inside the shell — the interpreter is
+[just-bash](https://www.npmjs.com/package/just-bash) and the filesystem is the
+store, so the mounts the workspace already enforces (`/user` and
+`/orgs/<org>` writable, `/host` read-only, everything else `EACCES`) are the whole
+containment story. Each session also gets an in-memory `/tmp` that lasts the
+conversation and is never saved.
+
+It rides the ONE guarded registry like every other tool: graded `write`, so the
+guard's rules, grants and approvals apply to it unchanged, and every call lands
+an audit row.
+
+`createVendo({ shell: false })` withholds it; `createVendo({ shell: { limits } })`
+moves its per-call wall clock (30 s) and output ceiling (1 MB). It composes for
+the resident brain only — a harness that thinks on a machine already has a real
+disk and reaches it its own way.

--- a/.changeset/shell-bash-hands.md
+++ b/.changeset/shell-bash-hands.md
@@ -1,5 +1,6 @@
 ---
 "@vendoai/core": minor
+"@vendoai/guard": minor
 "@vendoai/harnesses": minor
 "@vendoai/vendo": minor
 ---
@@ -20,8 +21,16 @@ containment story. Each session also gets an in-memory `/tmp` that lasts the
 conversation and is never saved.
 
 It rides the ONE guarded registry like every other tool: graded `write`, so the
-guard's rules, grants and approvals apply to it unchanged, and every call lands
-an audit row.
+host's rules, grants and the kill switch apply to it unchanged, and every call
+lands an audit row.
+
+One security default moves with it, and it is worth reading twice: the
+`cautious` preset no longer raises an approval card for `bash`. It is the only
+tool exempted, and only from the prompt — the `write` grade is exactly what keeps
+the audit row, the host's own rules and the kill switch over it. A shell that
+asked before every `wc -l` would be unusable in chat and simply cannot run in an
+automation, which has nobody to answer the card. A deployment that wants the
+confirmation back adds a rule of its own for `bash`, and it wins.
 
 `createVendo({ shell: false })` withholds it; `createVendo({ shell: { limits } })`
 moves its per-call wall clock (30 s) and output ceiling (1 MB). It composes for

--- a/.changeset/shell-parsers.md
+++ b/.changeset/shell-parsers.md
@@ -1,0 +1,17 @@
+---
+"@vendoai/harnesses": minor
+---
+
+The shell can open the formats people actually send.
+
+`pdftotext`, `xlsx2csv` and `docx2txt` are now commands inside the agent's shell.
+They write text to stdout, so they pipe into `grep`, `awk` and everything else —
+`pdftotext invoice.pdf | grep -o 'Total.*'` is one call, not a capability
+conversation. A PDF, a spreadsheet or a Word document dropped into chat stops
+being a file the agent can only name.
+
+They run in the host process against the same virtual filesystem the shell has
+(unpdf's serverless pdf.js, SheetJS Community Edition, and a zip read with
+fflate — no native code, no conversion service, no network), and each library
+loads the first time its format is actually parsed, so a deployment that never
+sees a PDF never pays for pdf.js.

--- a/docs-site/agents/index.mdx
+++ b/docs-site/agents/index.mdx
@@ -83,6 +83,20 @@ pointed at.
    Then run the version check — and every `npx vendo …` step below — from
    that same app directory.
 
+   On pnpm only: the install downloads everything and then exits 1 with
+   `Ignored build scripts: @mongodb-js/zstd, esbuild, node-liblzma`. None of
+   the three needs compiling. pnpm writes the names into `pnpm-workspace.yaml`
+   with a placeholder — set all three to `false` and install again. Do NOT run
+   `pnpm approve-builds` (it is interactive) or allow all builds.
+
+   ```yaml
+   # pnpm-workspace.yaml
+   allowBuilds:
+     '@mongodb-js/zstd': false
+     esbuild: false
+     node-liblzma: false
+   ```
+
    ONE package, and it is the umbrella. `@vendoai/vendo` carries every
    `@vendoai/vendo/*` subpath the files init writes import, and it carries the
    `vendo` binary into `node_modules/.bin` — which is what the version check

--- a/docs-site/index.mdx
+++ b/docs-site/index.mdx
@@ -51,7 +51,14 @@ No agent handy? Do it by hand. Three steps.
 
     </CodeGroup>
 
-    On pnpm the install ends with `Ignored build scripts: esbuild`. Nothing to approve — Vendo reaches esbuild through its Node API, which that script has nothing to do with.
+    On pnpm the install downloads everything and then exits 1 with `Ignored build scripts: @mongodb-js/zstd, esbuild, node-liblzma`. None of the three needs compiling — Vendo reaches esbuild through its Node API, which that script has nothing to do with, and the other two are the shell's optional native `tar` backends, behind guarded imports nothing calls. pnpm writes the three names into your `pnpm-workspace.yaml` with a placeholder; set all three to `false` and install again.
+
+    ```yaml pnpm-workspace.yaml
+    allowBuilds:
+      '@mongodb-js/zstd': false
+      esbuild: false
+      node-liblzma: false
+    ```
   </Step>
 
   <Step title="Run npx vendo init">

--- a/docs-site/reference/handler-options.mdx
+++ b/docs-site/reference/handler-options.mdx
@@ -86,6 +86,8 @@ A name string is pinnable per seat with `VENDO_MODEL`, `VENDO_MODEL_APPS`, `VEND
 
 Named presets: `"cautious"` lets reads run and asks before writes or destructive calls, `"readonly"` lets reads run and blocks everything else, `"autopilot"` runs everything.
 
+`"cautious"` makes one exception to that prompt: the agent's `bash` runs without asking. It is still graded `write`, so it takes an audit row per call and answers to your own rules and the kill switch — but an automation has nobody to answer an approval card, and a prompt here would mean the shell could never run unattended. Add your own rule for the `bash` tool to put the prompt back.
+
 `guard({ policy: {} })` reads the default `.vendo/policy.json`, which is what `vendo init` scaffolds. It reads fail-soft, so a missing file also auto-runs with no notice; keep the file in version control.
 
 Omitting the `guard` key entirely surfaces an unconfigured-policy notice in the shipped chrome. Past either breaker, a would-be auto-run parks for approval until the window clears.

--- a/docs-site/reference/handler-options.mdx
+++ b/docs-site/reference/handler-options.mdx
@@ -41,6 +41,7 @@ One key is required, an identity, as either `principal` or an `auth` preset. `oa
 | `profileDir` | The project root `.vendo/` is read under. Unset keeps the process cwd |
 | `fetch` | The fetch host route and OpenAPI bindings execute through. An explicit function always wins |
 | `profile` | The `.vendo/` pieces as in-memory compose-time inputs. See [below](#profile) |
+| `shell` | The agent's `bash` over the user's own files. On by default when the resident brain is `vendo()`; `false` withholds it, `{ limits }` moves its per-call wall clock and output ceiling |
 | `mcp` | Opens the MCP door. Off by default. See [below](#mcp) |
 | `oauth` | `HostOAuthAdapter` used by the door for session lookup and principal resolution. Required when `mcp` is on and `auth` supplies no oauth half |
 | `agent` | A whole agent built by `agent()`. This deployment adopts its harness, store, files adapter, sandbox, and instructions |

--- a/fixtures/install-seam/src/pack.ts
+++ b/fixtures/install-seam/src/pack.ts
@@ -117,11 +117,20 @@ export async function vendorInto(targetDir: string, packed: Packed): Promise<voi
   const overrides = packed.tarballs
     .map((tarball) => `  "${tarball.name}": "file:vendor/${tarball.fileName}"`)
     .join("\n");
-  // pnpm 11 fails an install whose dependencies carry unapproved build scripts.
-  // These two are the ones the umbrella's tree brings and genuinely needs
-  // (esbuild and sharp both fetch a platform binary in theirs), so a real
-  // stranger has to approve them too — noted rather than hidden.
-  const allowBuilds = ["esbuild", "sharp"].map((name) => `  ${name}: true`).join("\n");
+  // pnpm 11 fails an install whose dependencies carry unapproved build scripts,
+  // so a real stranger writes these same four entries — noted rather than hidden.
+  // esbuild and sharp are approved: both fetch a platform binary in theirs.
+  // zstd and lzma are DENIED — they are just-bash's optional native tar
+  // backends, behind guarded imports nothing calls, so `false` compiles neither
+  // and still satisfies strictDepBuilds. Consumers meet the same two denials in
+  // docs-site/index.mdx; changing this line without changing that one would
+  // green the seam while every real install still exits 1.
+  const allowBuilds = [
+    "'@mongodb-js/zstd': false",
+    "esbuild: true",
+    "node-liblzma: false",
+    "sharp: true",
+  ].map((entry) => `  ${entry}`).join("\n");
   await fs.writeFile(
     path.join(targetDir, "pnpm-workspace.yaml"),
     `overrides:\n${overrides}\nallowBuilds:\n${allowBuilds}\n`,

--- a/packages/apps/src/server/doors/apps-surface.ts
+++ b/packages/apps/src/server/doors/apps-surface.ts
@@ -217,6 +217,15 @@ export const createAppsSurface = (
       await egressApprovals.clearForApp(appId);
       await parkedActions.clearForApp(appId);
       await engine.delete(APPS_COLLECTION, appId);
+      // The app's workspace documents and the blobs behind them. Everything
+      // above this line clears a drawer this package owns; `/user/apps/<id>/…`
+      // and `/orgs/<org>/apps/<id>/…` belong to the WORKSPACE, and only the
+      // store's own cascade can reach the blobs those rows point at (a `rm`
+      // leaves them: history is append-only and becomes the pointer). Called
+      // after the row so the cascade's own "app row first, then its data" order
+      // is preserved — `eraseAppData` needs no app row and re-deleting an absent
+      // one is a zero-count no-op.
+      await config.ops?.lifecycle.erase({ appId });
       // A deleted app can never mount again, so its placement rows are dead
       // weight — and a row with no app record reads as a build in flight, which
       // would park a skeleton in the slot until the build window elapsed and

--- a/packages/apps/tests/delete-erases-workspace.test.ts
+++ b/packages/apps/tests/delete-erases-workspace.test.ts
@@ -1,0 +1,48 @@
+/**
+ * The app cascade's LAST mile. `eraseStore().byApp` already destroys an app's
+ * workspace rows, its history and its blobs, and is tested against a real
+ * database in `@vendoai/store` — what was missing is anyone calling it. That
+ * call is what this proves, with its exact target.
+ */
+import { engineOverAdapter, VENDO_APP_FORMAT, type RunContext, type StoreOps, type ToolRegistry } from "@vendoai/core";
+import { describe, expect, it, vi } from "vitest";
+import type { AppDocument } from "../src/contract/index.js";
+import { createApps } from "../src/server/index.js";
+import { guardFixture } from "../src/server/testing/guard-fixture.js";
+import { memoryStore } from "../src/server/testing/memory-store.js";
+import { seedAppRow } from "../src/server/testing/seed-app-row.js";
+
+const tools: ToolRegistry = {
+  async descriptors() { return []; },
+  async execute() { return { status: "error", error: { code: "not-found", message: "no fixture tools" } }; },
+};
+
+const ctx: RunContext = {
+  principal: { kind: "user", subject: "user_delete" },
+  venue: "app",
+  presence: "present",
+  sessionId: "session_delete",
+};
+
+const app: AppDocument = {
+  format: VENDO_APP_FORMAT,
+  id: "app_erase",
+  name: "Erase Me",
+  description: "An app whose workspace files must go with it",
+  ui: "tree",
+  components: {},
+};
+
+describe("deleting an app", () => {
+  it("erases the app's workspace files and blobs through the store's own cascade", async () => {
+    const store = memoryStore();
+    const erase = vi.fn(async () => ({}));
+    const ops = { lifecycle: { erase, promote: async () => {} } } as unknown as StoreOps;
+    const runtime = createApps({ store, ops, guard: guardFixture(), tools, catalog: [] });
+    await seedAppRow(engineOverAdapter(store), app, ctx.principal.subject);
+
+    await runtime.delete(app.id, ctx);
+
+    expect(erase).toHaveBeenCalledWith({ appId: app.id });
+  });
+});

--- a/packages/core/src/filesystem.ts
+++ b/packages/core/src/filesystem.ts
@@ -52,6 +52,10 @@ export interface FsStat {
   mode: number;
   size: number;
   mtime: Date;
+  /** Stable filesystem identity when the backend can expose it safely. */
+  dev?: number | bigint;
+  ino?: number | bigint;
+  identity?: string;
 }
 
 export interface MkdirOptions {

--- a/packages/core/src/tools.ts
+++ b/packages/core/src/tools.ts
@@ -214,6 +214,8 @@ export type GradedRiskLabel = "read" | "write" | "destructive";
  *  The name lives in core because two sides read it and a security-relevant
  *  name with two definitions drifts silently: the registry that implements it,
  *  and the loop that ends a turn on it. */
+export const ASK_USER_TOOL = "ask_user";
+
 /** The agent's hands over the user's own files: one shell, in this process,
  *  over the workspace (spec 2026-08-23 §1). Named here for `ASK_USER_TOOL`'s
  *  reason — the registry that implements it lives in `@vendoai/harnesses` and the
@@ -225,10 +227,9 @@ export type GradedRiskLabel = "read" | "write" | "destructive";
  *  knows from every other agent harness, and the name is what teaches it. The
  *  cost of leaving the `vendo_` prefix behind is that it is not covered by the
  *  loadout's always-active exemption for our own tools, so composition names it
- *  explicitly (`PROMPT_TAUGHT_TOOLS`). */
+ *  explicitly (`PROMPT_TAUGHT_TOOLS`) and the agent-menu projection exempts it
+ *  beside the connector four (`withAgentMenu`). */
 export const VENDO_BASH_TOOL = "bash";
-
-export const ASK_USER_TOOL = "ask_user";
 
 /** The connector dispatcher — the one tool whose real action is an ARGUMENT
  *  rather than its name, because a single

--- a/packages/core/src/tools.ts
+++ b/packages/core/src/tools.ts
@@ -127,6 +127,7 @@ export const VENDO_TOOL_TITLES: Readonly<Record<string, string>> = {
   vendo_user_files_list: "See the files you shared",
   vendo_user_files_read: "Read a file you shared",
   vendo_user_files_put: "Save a file to your files",
+  bash: "Work on your files",
   vendo_text_me: "Text me",
   // The verbs and `ask_user` authored these titles inline first; they moved here
   // verbatim so the CLIENT can say them too — a live browser proof caught a verb
@@ -213,6 +214,20 @@ export type GradedRiskLabel = "read" | "write" | "destructive";
  *  The name lives in core because two sides read it and a security-relevant
  *  name with two definitions drifts silently: the registry that implements it,
  *  and the loop that ends a turn on it. */
+/** The agent's hands over the user's own files: one shell, in this process,
+ *  over the workspace (spec 2026-08-23 §1). Named here for `ASK_USER_TOOL`'s
+ *  reason — the registry that implements it lives in `@vendoai/harnesses` and the
+ *  composition that mounts it lives in `@vendoai/vendo`, and a tool name with two
+ *  spellings is a tool the guard grades under one and the loadout exempts under
+ *  the other.
+ *
+ *  Deliberately NOT `vendo_bash`: this is the same `bash` every model already
+ *  knows from every other agent harness, and the name is what teaches it. The
+ *  cost of leaving the `vendo_` prefix behind is that it is not covered by the
+ *  loadout's always-active exemption for our own tools, so composition names it
+ *  explicitly (`PROMPT_TAUGHT_TOOLS`). */
+export const VENDO_BASH_TOOL = "bash";
+
 export const ASK_USER_TOOL = "ask_user";
 
 /** The connector dispatcher — the one tool whose real action is an ARGUMENT

--- a/packages/core/tests/bash-tool-name.test.ts
+++ b/packages/core/tests/bash-tool-name.test.ts
@@ -1,0 +1,14 @@
+/**
+ * The shell's name and its human title live in core for the reason every other
+ * `vendo_*` name does: two sides read them — the registry in `@vendoai/harnesses`
+ * that implements the tool, and the surfaces that show it to a person.
+ */
+import { describe, expect, it } from "vitest";
+import { VENDO_BASH_TOOL, VENDO_TOOL_TITLES } from "../src/tools.js";
+
+describe("the shell tool's name", () => {
+  it("is `bash`, and has a title a person can read", () => {
+    expect(VENDO_BASH_TOOL).toBe("bash");
+    expect(VENDO_TOOL_TITLES[VENDO_BASH_TOOL]).toBe("Work on your files");
+  });
+});

--- a/packages/core/tests/filesystem-parity.test.ts
+++ b/packages/core/tests/filesystem-parity.test.ts
@@ -1,27 +1,33 @@
 /**
  * `FsStat` is VENDORED from just-bash (`dist/fs/interface.d.ts`), and the
  * vendoring is only worth anything if it stays identical. A type has no runtime
- * to assert on, so the assertion is a structural one the compiler makes and this
- * test merely names: a stat carrying upstream's identity fields must satisfy
- * ours.
+ * to assert on, so the assertion is a structural one the compiler makes —
+ * against UPSTREAM's own declaration, not a literal maintained by hand here,
+ * which would keep passing through any drift on their side.
  */
+import { InMemoryFs, type FsStat as UpstreamFsStat } from "just-bash";
 import { describe, expect, it } from "vitest";
 import type { FsStat } from "../src/filesystem.js";
 
-describe("the vendored FsStat", () => {
-  it("accepts upstream's optional identity fields", () => {
-    const stat: FsStat = {
-      isFile: true,
-      isDirectory: false,
-      isSymbolicLink: false,
-      mode: 0o644,
-      size: 3,
-      mtime: new Date(0),
-      dev: 1,
-      ino: 2n,
-      identity: "inode:2",
-    };
+/** Identical, for a structural type, is assignable BOTH ways: a renamed field, a
+ *  widened member, or a key that became required breaks one direction or the
+ *  other, and `pnpm typecheck` is where it says so. */
+type Assignable<A, B> = A extends B ? true : never;
+export const upstreamSatisfiesOurs: Assignable<UpstreamFsStat, FsStat> = true;
+export const oursSatisfiesUpstream: Assignable<FsStat, UpstreamFsStat> = true;
 
-    expect(stat.identity).toBe("inode:2");
+describe("the vendored FsStat", () => {
+  it("accepts what upstream's own filesystem hands back", async () => {
+    const fs = new InMemoryFs();
+    await fs.writeFile("/ledger.csv", "jan\n");
+
+    // The annotation IS the seam: upstream's real `stat()` return type has to
+    // flow into our vendored one, and the values below are upstream's real ones.
+    const stat: FsStat = await fs.stat("/ledger.csv");
+
+    expect(stat.isFile).toBe(true);
+    expect(stat.isDirectory).toBe(false);
+    expect(stat.size).toBe(4);
+    expect(stat.mtime).toBeInstanceOf(Date);
   });
 });

--- a/packages/core/tests/filesystem-parity.test.ts
+++ b/packages/core/tests/filesystem-parity.test.ts
@@ -1,0 +1,27 @@
+/**
+ * `FsStat` is VENDORED from just-bash (`dist/fs/interface.d.ts`), and the
+ * vendoring is only worth anything if it stays identical. A type has no runtime
+ * to assert on, so the assertion is a structural one the compiler makes and this
+ * test merely names: a stat carrying upstream's identity fields must satisfy
+ * ours.
+ */
+import { describe, expect, it } from "vitest";
+import type { FsStat } from "../src/filesystem.js";
+
+describe("the vendored FsStat", () => {
+  it("accepts upstream's optional identity fields", () => {
+    const stat: FsStat = {
+      isFile: true,
+      isDirectory: false,
+      isSymbolicLink: false,
+      mode: 0o644,
+      size: 3,
+      mtime: new Date(0),
+      dev: 1,
+      ino: 2n,
+      identity: "inode:2",
+    };
+
+    expect(stat.identity).toBe("inode:2");
+  });
+});

--- a/packages/guard/src/policy.ts
+++ b/packages/guard/src/policy.ts
@@ -1,4 +1,4 @@
-import { VendoError } from "@vendoai/core";
+import { VENDO_BASH_TOOL, VendoError } from "@vendoai/core";
 import type { PolicyConfig, PolicyConfigObject, PolicyFile, PolicyPresetName, PolicyRule } from "./types.js";
 import { policyFileSchema } from "./types.js";
 
@@ -17,6 +17,14 @@ const POLICY_PRESET_RULES: Record<PolicyPresetName, PolicyRule[]> = {
   cautious: [
     { match: { risk: "destructive" }, action: "ask" },
     { match: { risk: "ungraded" }, action: "ask" },
+    // The shell is graded `write` DELIBERATELY and stays that way — the grade is
+    // what buys the audit row per call, the host's own rules and the kill
+    // switch. What its spec removes is the PROMPT: an automation has nobody to
+    // answer an approval card, so a `write → ask` that caught this tool would
+    // mean it cannot run unattended at all. First-match-wins, so the exemption
+    // has to sit above the write rule; a host who wants the friction back says
+    // so with their own rule for this tool.
+    { match: { tool: VENDO_BASH_TOOL }, action: "run" },
     { match: { risk: "write" }, action: "ask" },
     { match: { risk: "read" }, action: "run" },
   ],

--- a/packages/guard/test/policy.test.ts
+++ b/packages/guard/test/policy.test.ts
@@ -1,4 +1,4 @@
-import { VENDO_POLICY_FORMAT, VendoError } from "@vendoai/core";
+import { VENDO_BASH_TOOL, VENDO_POLICY_FORMAT, VendoError } from "@vendoai/core";
 import type { GuardDecision } from "@vendoai/core";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -407,5 +407,73 @@ describe("policy files, rules, directions, and code", () => {
 
     await expect(threw.check(call(edit.name), edit, context())).resolves.toMatchObject({ action: "ask" });
     await expect(invalid.check(call(edit.name), edit, context())).resolves.toMatchObject({ action: "ask" });
+  });
+});
+
+describe("the shell raises no approval card, and keeps everything its write grade buys", () => {
+  const shell = descriptor("write", { name: VENDO_BASH_TOOL });
+  const shellCall = (id = "call_1"): ReturnType<typeof call> =>
+    call(VENDO_BASH_TOOL, { command: "wc -l files/ledger.csv" }, id);
+
+  it("runs a bash call instead of asking, under the default policy", async () => {
+    const guard = createGuard({ store: createMemoryStore(), policy: "cautious" });
+
+    await expect(guard.check(shellCall(), shell, context())).resolves.toMatchObject({
+      action: "run",
+      decidedBy: "rule",
+    });
+  });
+
+  it("still asks for another write-graded tool — the exemption is not a hole in the write rule", async () => {
+    const guard = createGuard({ store: createMemoryStore(), policy: "cautious" });
+    const write = descriptor("write");
+
+    await expect(guard.check(call(write.name), write, context())).resolves.toMatchObject({
+      action: "ask",
+      decidedBy: "rule",
+    });
+  });
+
+  it("lets a host put the prompt back with their own rule", async () => {
+    const guard = createGuard({
+      store: createMemoryStore(),
+      policy: { rules: [{ match: { tool: VENDO_BASH_TOOL }, action: "ask" }] },
+    });
+
+    await expect(guard.check(shellCall(), shell, context())).resolves.toMatchObject({
+      action: "ask",
+      decidedBy: "rule",
+    });
+  });
+
+  it("lands an audit row for every bash call, prompt or no prompt", async () => {
+    const store = createMemoryStore();
+    const guard = createGuard({ store, policy: "cautious" });
+    const tools = new FixtureTools([shell]);
+    const bound = guard.bind(tools);
+
+    await expect(bound.execute(shellCall("call_1"), context())).resolves.toMatchObject({ status: "ok" });
+    await expect(bound.execute(shellCall("call_2"), context())).resolves.toMatchObject({ status: "ok" });
+
+    const { events } = await guard.audit.query({ principal: alice });
+    expect(events.filter((event) => event.kind === "tool-call" && event.tool === VENDO_BASH_TOOL))
+      .toMatchObject([
+        { risk: "write", outcome: "ok", decidedBy: "rule" },
+        { risk: "write", outcome: "ok", decidedBy: "rule" },
+      ]);
+  });
+
+  it("still stops a bash call at the kill switch", async () => {
+    const guard = createGuard({ store: createMemoryStore(), policy: "cautious" });
+    const tools = new FixtureTools([shell]);
+    const bound = guard.bind(tools);
+
+    await guard.freeze("ops_yousef");
+
+    await expect(bound.execute(shellCall(), context())).resolves.toMatchObject({
+      status: "blocked",
+      reason: "vendo is frozen — nothing runs until it is unfrozen",
+    });
+    expect(tools.executions).toHaveLength(0);
   });
 });

--- a/packages/harnesses/package.json
+++ b/packages/harnesses/package.json
@@ -71,7 +71,10 @@
     "@vendoai/apps": "workspace:*",
     "@vendoai/core": "workspace:*",
     "@vendoai/guard": "workspace:*",
+    "fflate": "^0.8.3",
     "just-bash": "^3.4.2",
+    "unpdf": "^1.8.1",
+    "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
     "zod": "^3.25.0"
   },
   "peerDependencies": {

--- a/packages/harnesses/package.json
+++ b/packages/harnesses/package.json
@@ -71,6 +71,7 @@
     "@vendoai/apps": "workspace:*",
     "@vendoai/core": "workspace:*",
     "@vendoai/guard": "workspace:*",
+    "just-bash": "^3.4.2",
     "zod": "^3.25.0"
   },
   "peerDependencies": {
@@ -83,7 +84,6 @@
     "@ai-sdk/openai-compatible": "2.0.9",
     "@types/node": "^22.0.0",
     "ai": "6.0.28",
-    "just-bash": "^3.1.0",
     "typescript": "^5.6.0",
     "vitest": "^3.2.6"
   },

--- a/packages/harnesses/package.json
+++ b/packages/harnesses/package.json
@@ -88,8 +88,7 @@
     "@types/node": "^22.0.0",
     "ai": "6.0.28",
     "typescript": "^5.6.0",
-    "vitest": "^3.2.6",
-    "xlsx": "npm:@e965/xlsx@0.20.3"
+    "vitest": "^3.2.6"
   },
   "peerDependenciesMeta": {
     "@anthropic-ai/claude-agent-sdk": {

--- a/packages/harnesses/package.json
+++ b/packages/harnesses/package.json
@@ -68,13 +68,13 @@
   },
   "dependencies": {
     "@ai-sdk/anthropic": "3.0.12",
+    "@e965/xlsx": "0.20.3",
     "@vendoai/apps": "workspace:*",
     "@vendoai/core": "workspace:*",
     "@vendoai/guard": "workspace:*",
     "fflate": "^0.8.3",
     "just-bash": "^3.4.2",
     "unpdf": "^1.8.1",
-    "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
     "zod": "^3.25.0"
   },
   "peerDependencies": {
@@ -88,7 +88,8 @@
     "@types/node": "^22.0.0",
     "ai": "6.0.28",
     "typescript": "^5.6.0",
-    "vitest": "^3.2.6"
+    "vitest": "^3.2.6",
+    "xlsx": "npm:@e965/xlsx@0.20.3"
   },
   "peerDependenciesMeta": {
     "@anthropic-ai/claude-agent-sdk": {

--- a/packages/harnesses/src/vendo/index.ts
+++ b/packages/harnesses/src/vendo/index.ts
@@ -43,3 +43,16 @@ export {
 // surface the failure.
 export { isContextOverflow } from "./overflow.js";
 export { failoverModel, type ResolvedModel } from "./failover.js";
+// The shell — `vendo()`'s hands over the user's own files. It lives inside this
+// harness's directory and leaves through this subpath because it IS this
+// harness's hand: a sandbox harness has a machine and reaches a disk its own
+// way, and the umbrella mounts these tools only when the resident brain is
+// `vendo()` (compose-tools.ts).
+export {
+  createShellSession,
+  DEFAULT_MAX_EXECUTION_TIME_MS,
+  DEFAULT_MAX_OUTPUT_BYTES,
+  type ShellLimits,
+  type ShellSession,
+} from "./shell/engine.js";
+export { createShellTools } from "./shell/tool.js";

--- a/packages/harnesses/src/vendo/shell/engine.ts
+++ b/packages/harnesses/src/vendo/shell/engine.ts
@@ -43,8 +43,10 @@ const TMP_MAX_BYTES = 32 * 1024 * 1024;
 
 /** Routed through a mutable binding so NO bundler ever statically resolves the
  *  interpreter. just-bash's graph reaches `node:worker_threads`, `undici` and
- *  `sql.js`, and it `import()`s two packages that are not its dependencies at
- *  all (`@mongodb-js/zstd`, `node-liblzma`) — esbuild hard-fails a Worker build
+ *  `sql.js`, and it `import()`s the two native packages it declares as
+ *  `optionalDependencies` (`@mongodb-js/zstd`, `node-liblzma`) — installed on a
+ *  consumer's disk, which is why their build scripts have to be denied
+ *  (pnpm-workspace.yaml), and unbundleable, so esbuild hard-fails a Worker build
  *  on those two, which is `scripts/portability-gate.mjs` Leg A. Same containment,
  *  and the same reasoning, as the optional e2b SDK
  *  (`packages/apps/src/server/escalation/e2b/index.ts`); a `let` is what defeats

--- a/packages/harnesses/src/vendo/shell/engine.ts
+++ b/packages/harnesses/src/vendo/shell/engine.ts
@@ -11,6 +11,7 @@
  */
 import type { IFileSystem } from "@vendoai/core";
 import type { Bash as BashInstance } from "just-bash";
+import { pdftotext } from "./parsers/pdftotext.js";
 
 /** One `bash` call's ceilings. Both map onto just-bash's own execution limits;
  *  everything else keeps just-bash's `normal` profile. */
@@ -85,6 +86,10 @@ export function createShellSession(opts: {
       // user's files actually have.
       cwd: "/user",
       javascript: opts.javascript === true,
+      // The binary formats a person actually drops into chat, as ordinary
+      // commands: they pipe, they redirect, and the agent needs no special
+      // vocabulary for them. Lazy, so their libraries load on first use.
+      customCommands: [pdftotext],
       executionLimits: {
         maxExecutionTimeMs: opts.limits?.maxExecutionTimeMs ?? DEFAULT_MAX_EXECUTION_TIME_MS,
         maxOutputSize: opts.limits?.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES,

--- a/packages/harnesses/src/vendo/shell/engine.ts
+++ b/packages/harnesses/src/vendo/shell/engine.ts
@@ -33,6 +33,13 @@ export const DEFAULT_MAX_EXECUTION_TIME_MS = 30_000;
  *  a script may legitimately produce a lot and pipe it into `tail`; the cap is
  *  what the MODEL sees, this is what the SHELL may make. */
 export const DEFAULT_MAX_OUTPUT_BYTES = 1_000_000;
+/** What the whole session's `/tmp` may hold. `maxOutputBytes` bounds ONE
+ *  redirect and nothing bounded the session, so a turn that kept appending grew
+ *  this in-process filesystem without limit. Not a `ShellLimits` knob: it is
+ *  memory this process has to survive, not a ceiling a deployment tunes — 32× the
+ *  default per-call output, and 6× the 5 MB an upload may be, so a script can
+ *  still hold several copies of the largest file a person can drop. */
+const TMP_MAX_BYTES = 32 * 1024 * 1024;
 
 /** Routed through a mutable binding so NO bundler ever statically resolves the
  *  interpreter. just-bash's graph reaches `node:worker_threads`, `undici` and
@@ -69,7 +76,7 @@ export function createShellSession(opts: {
     // an intermediate is a shell that can only run one-liners. In memory, and
     // owned by the session, so it lasts exactly as long as the turn does.
     const fs = new MountableFs({ base: opts.workspace });
-    fs.mount("/tmp", new InMemoryFs());
+    fs.mount("/tmp", new InMemoryFs(undefined, { maxTotalBytes: TMP_MAX_BYTES }));
     return new Bash({
       fs,
       // The person's own mount, so the paths the agent types are the paths the

--- a/packages/harnesses/src/vendo/shell/engine.ts
+++ b/packages/harnesses/src/vendo/shell/engine.ts
@@ -1,0 +1,95 @@
+/**
+ * The agent's hands: ONE bash session over one caller's workspace, in this
+ * process, with no machine anywhere.
+ *
+ * The disk is the caller's own `WorkspaceFs` — the store, wearing just-bash's
+ * `IFileSystem` (build contract §3.2) — so a script reads and writes exactly the
+ * files that person already has, under exactly the mounts §3.1 froze
+ * (`/user`, `/orgs/<org>` rw, `/host` ro). There is no path argument to escape
+ * with and no host disk to reach: a write outside the mounts is `EACCES` from
+ * the filesystem itself, not from a check bolted on here.
+ */
+import type { IFileSystem } from "@vendoai/core";
+import type { Bash as BashInstance } from "just-bash";
+
+/** One `bash` call's ceilings. Both map onto just-bash's own execution limits;
+ *  everything else keeps just-bash's `normal` profile. */
+export interface ShellLimits {
+  /** Wall clock for ONE call, in milliseconds. */
+  maxExecutionTimeMs?: number;
+  /** Total stdout + stderr bytes one call may produce. */
+  maxOutputBytes?: number;
+}
+
+/** What a turn holds: a shell that keeps its filesystem between calls. */
+export interface ShellSession {
+  exec(command: string): Promise<{ stdout: string; stderr: string; exitCode: number }>;
+}
+
+/** A turn is a person waiting, so the default is the length of a person's
+ *  patience rather than just-bash's compatibility-oriented hour. */
+export const DEFAULT_MAX_EXECUTION_TIME_MS = 30_000;
+/** Generous next to the 32 000-char tool-output cap the bridge applies, because
+ *  a script may legitimately produce a lot and pipe it into `tail`; the cap is
+ *  what the MODEL sees, this is what the SHELL may make. */
+export const DEFAULT_MAX_OUTPUT_BYTES = 1_000_000;
+
+/** Routed through a mutable binding so NO bundler ever statically resolves the
+ *  interpreter. just-bash's graph reaches `node:worker_threads`, `undici` and
+ *  `sql.js`, and it `import()`s two packages that are not its dependencies at
+ *  all (`@mongodb-js/zstd`, `node-liblzma`) — esbuild hard-fails a Worker build
+ *  on those two, which is `scripts/portability-gate.mjs` Leg A. Same containment,
+ *  and the same reasoning, as the optional e2b SDK
+ *  (`packages/apps/src/server/escalation/e2b/index.ts`); a `let` is what defeats
+ *  esbuild's constant folding. */
+let JUST_BASH_SPECIFIER = "just-bash";
+
+type JustBash = typeof import("just-bash");
+
+const loadJustBash = async (): Promise<JustBash> =>
+  await import(/* webpackIgnore: true */ /* turbopackIgnore: true */ /* @vite-ignore */ JUST_BASH_SPECIFIER) as JustBash;
+
+/**
+ * One session, one workspace. The interpreter boots on the FIRST call and is
+ * kept: booting it costs a module load, and a turn that runs three commands
+ * should pay that once.
+ */
+export function createShellSession(opts: {
+  workspace: IFileSystem;
+  limits?: ShellLimits;
+  javascript?: boolean;
+}): ShellSession {
+  let booting: Promise<BashInstance> | undefined;
+
+  const boot = async (): Promise<BashInstance> => {
+    const { Bash, InMemoryFs, MountableFs } = await loadJustBash();
+    // `/tmp` is the one place a script may scribble that is NOT the person's
+    // workspace. It has to exist: the workspace holds `/user`, `/orgs/<org>` and
+    // `/host` and answers EACCES everywhere else, and a shell with nowhere to put
+    // an intermediate is a shell that can only run one-liners. In memory, and
+    // owned by the session, so it lasts exactly as long as the turn does.
+    const fs = new MountableFs({ base: opts.workspace });
+    fs.mount("/tmp", new InMemoryFs());
+    return new Bash({
+      fs,
+      // The person's own mount, so the paths the agent types are the paths the
+      // user's files actually have.
+      cwd: "/user",
+      javascript: opts.javascript === true,
+      executionLimits: {
+        maxExecutionTimeMs: opts.limits?.maxExecutionTimeMs ?? DEFAULT_MAX_EXECUTION_TIME_MS,
+        maxOutputSize: opts.limits?.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES,
+      },
+      // Network is off by definition: just-bash registers curl/wget only when a
+      // `network` or `fetch` option is passed, and neither is.
+    });
+  };
+
+  return {
+    async exec(command) {
+      const bash = await (booting ??= boot());
+      const { stdout, stderr, exitCode } = await bash.exec(command);
+      return { stdout, stderr, exitCode };
+    },
+  };
+}

--- a/packages/harnesses/src/vendo/shell/engine.ts
+++ b/packages/harnesses/src/vendo/shell/engine.ts
@@ -139,8 +139,15 @@ export function createShellSession(opts: {
 
   return {
     async exec(command) {
-      const bash = await (booting ??= boot());
       try {
+        if (booting === undefined) {
+          booting = boot();
+          // A REJECTED boot is not cached: the libraries load bundler-blind on
+          // first use, and one blink there must not answer every later call in
+          // the turn with the same stale failure (same as `open`, tool.ts:179).
+          void booting.catch(() => { booting = undefined; });
+        }
+        const bash = await booting;
         const { stdout, stderr, exitCode } = await bash.exec(command);
         return { stdout, stderr, exitCode };
       } catch (error) {
@@ -149,7 +156,9 @@ export function createShellSession(opts: {
         // `exec` instead of turning it into an exit code. A path the person's own
         // filesystem refused is an ordinary shell failure, not a broken tool call:
         // the model has to READ it and pick another path, which it cannot do if
-        // the turn dies instead.
+        // the turn dies instead. A boot that fails is inside the same boundary
+        // for the same reason: an unloadable library is a shell that is down, not
+        // a tool call that is broken.
         return { stdout: "", stderr: `${(error as Error).message}\n`, exitCode: 1 };
       }
     },

--- a/packages/harnesses/src/vendo/shell/engine.ts
+++ b/packages/harnesses/src/vendo/shell/engine.ts
@@ -12,6 +12,7 @@
 import type { IFileSystem } from "@vendoai/core";
 import type { Bash as BashInstance } from "just-bash";
 import { pdftotext } from "./parsers/pdftotext.js";
+import { xlsx2csv } from "./parsers/xlsx2csv.js";
 
 /** One `bash` call's ceilings. Both map onto just-bash's own execution limits;
  *  everything else keeps just-bash's `normal` profile. */
@@ -89,7 +90,7 @@ export function createShellSession(opts: {
       // The binary formats a person actually drops into chat, as ordinary
       // commands: they pipe, they redirect, and the agent needs no special
       // vocabulary for them. Lazy, so their libraries load on first use.
-      customCommands: [pdftotext],
+      customCommands: [pdftotext, xlsx2csv],
       executionLimits: {
         maxExecutionTimeMs: opts.limits?.maxExecutionTimeMs ?? DEFAULT_MAX_EXECUTION_TIME_MS,
         maxOutputSize: opts.limits?.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES,

--- a/packages/harnesses/src/vendo/shell/engine.ts
+++ b/packages/harnesses/src/vendo/shell/engine.ts
@@ -9,8 +9,8 @@
  * with and no host disk to reach: a write outside the mounts is `EACCES` from
  * the filesystem itself, not from a check bolted on here.
  */
-import type { IFileSystem } from "@vendoai/core";
-import type { Bash as BashInstance } from "just-bash";
+import { log, type IFileSystem } from "@vendoai/core";
+import type { Bash as BashInstance, SecurityViolation } from "just-bash";
 import { docx2txt } from "./parsers/docx2txt.js";
 import { pdftotext } from "./parsers/pdftotext.js";
 import { xlsx2csv } from "./parsers/xlsx2csv.js";
@@ -47,6 +47,34 @@ const TMP_MAX_BYTES = 32 * 1024 * 1024;
 
 type JustBash = typeof import("just-bash");
 
+/** Violation types already reported, PROCESS-wide.
+ *
+ *  Process-wide rather than per session for two independent reasons. just-bash's
+ *  defense box is a process singleton whose `getInstance` THROWS a config
+ *  conflict unless every `Bash` in the process passes the identical
+ *  `onViolation` reference, so this has to be one stable function rather than a
+ *  per-session closure. And the volume: a host async tracker trips
+ *  `performance_timing`/`weak_ref` on nearly every promise the shell makes —
+ *  1294 times in one measured turn — so a line per violation is a line per
+ *  promise, which is noise an operator learns to filter. One line per type is
+ *  the whole signal: which host global the box touched, and that nothing was
+ *  blocked. It also bounds the recursion if the log sink itself trips a guard
+ *  (`process_stderr` is one), because the second trip is already reported. */
+const reportedViolations = new Set<string>();
+
+const reportViolation = (violation: SecurityViolation): void => {
+  if (reportedViolations.has(violation.type)) return;
+  reportedViolations.add(violation.type);
+  log({
+    code: "harnesses.shell-defense-audit",
+    level: "warn",
+    message: `[vendo] shell: host code reached ${violation.path} (${violation.type}) inside just-bash's `
+      + "main-thread box. AUDITED AND ALLOWED — this box is the secondary layer and does not block here; "
+      + "containment stays with the QuickJS worker's own defense layer, the workspace's permission mounts, "
+      + `and the guard. Further ${violation.type} violations this process are not logged.`,
+  });
+};
+
 /**
  * One session, one workspace. The interpreter boots on the FIRST call and is
  * kept: booting it costs a module load, and a turn that runs three commands
@@ -82,6 +110,28 @@ export function createShellSession(opts: {
         maxExecutionTimeMs: opts.limits?.maxExecutionTimeMs ?? DEFAULT_MAX_EXECUTION_TIME_MS,
         maxOutputSize: opts.limits?.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES,
       },
+      // just-bash's MAIN-THREAD box patches host globals while a command runs.
+      // Inside a HOST's process that is not containment, it is a crash: an
+      // async-hooks `init` callback the host installed (Next dev's React async
+      // tracker is one, an APM agent is another) fires on the box's own first
+      // promise, touches `performance.now()`/`new WeakRef()`, and the box
+      // throws — from `emitInitNative`, where Node treats any exception as
+      // fatal, so no try/catch of ours is even on the stack. The demo host's dev
+      // server died on the FIRST bash call, deterministically.
+      //
+      // So audit: report the violation, let it through. The box's only
+      // enforcement action inside a host process is "kill the host", which is
+      // worse than the intrusion it guards against, and it was never the layer
+      // that contains a script — `WorkerDefenseInDepth` inside the QuickJS
+      // worker is separate, always on, and untouched by this, as are the
+      // workspace's permission mounts, the guard's audit row and kill switch,
+      // and the absent network.
+      //
+      // Not `excludeViolationTypes`: that list names React's MINIFIED internals,
+      // so it breaks on their next release, and it would still not cover an APM
+      // agent reaching a different guarded global from the same kind of hook —
+      // the same structural failure, and that one can hit production.
+      defenseInDepth: { auditMode: true, onViolation: reportViolation },
       // Network is off by definition: just-bash registers curl/wget only when a
       // `network` or `fetch` option is passed, and neither is.
     });

--- a/packages/harnesses/src/vendo/shell/engine.ts
+++ b/packages/harnesses/src/vendo/shell/engine.ts
@@ -14,6 +14,7 @@ import type { Bash as BashInstance } from "just-bash";
 import { docx2txt } from "./parsers/docx2txt.js";
 import { pdftotext } from "./parsers/pdftotext.js";
 import { xlsx2csv } from "./parsers/xlsx2csv.js";
+import { importShellLibrary } from "./runtime.js";
 
 /** One `bash` call's ceilings. Both map onto just-bash's own execution limits;
  *  everything else keeps just-bash's `normal` profile. */
@@ -44,22 +45,7 @@ export const DEFAULT_MAX_OUTPUT_BYTES = 1_000_000;
  *  still hold several copies of the largest file a person can drop. */
 const TMP_MAX_BYTES = 32 * 1024 * 1024;
 
-/** Routed through a mutable binding so NO bundler ever statically resolves the
- *  interpreter. just-bash's graph reaches `node:worker_threads`, `undici` and
- *  `sql.js`, and it `import()`s the two native packages it declares as
- *  `optionalDependencies` (`@mongodb-js/zstd`, `node-liblzma`) — installed on a
- *  consumer's disk, which is why their build scripts have to be denied
- *  (pnpm-workspace.yaml), and unbundleable, so esbuild hard-fails a Worker build
- *  on those two, which is `scripts/portability-gate.mjs` Leg A. Same containment,
- *  and the same reasoning, as the optional e2b SDK
- *  (`packages/apps/src/server/escalation/e2b/index.ts`); a `let` is what defeats
- *  esbuild's constant folding. */
-let JUST_BASH_SPECIFIER = "just-bash";
-
 type JustBash = typeof import("just-bash");
-
-const loadJustBash = async (): Promise<JustBash> =>
-  await import(/* webpackIgnore: true */ /* turbopackIgnore: true */ /* @vite-ignore */ JUST_BASH_SPECIFIER) as JustBash;
 
 /**
  * One session, one workspace. The interpreter boots on the FIRST call and is
@@ -74,7 +60,7 @@ export function createShellSession(opts: {
   let booting: Promise<BashInstance> | undefined;
 
   const boot = async (): Promise<BashInstance> => {
-    const { Bash, InMemoryFs, MountableFs } = await loadJustBash();
+    const { Bash, InMemoryFs, MountableFs } = await importShellLibrary<JustBash>("just-bash");
     // `/tmp` is the one place a script may scribble that is NOT the person's
     // workspace. It has to exist: the workspace holds `/user`, `/orgs/<org>` and
     // `/host` and answers EACCES everywhere else, and a shell with nowhere to put

--- a/packages/harnesses/src/vendo/shell/engine.ts
+++ b/packages/harnesses/src/vendo/shell/engine.ts
@@ -88,8 +88,18 @@ export function createShellSession(opts: {
   return {
     async exec(command) {
       const bash = await (booting ??= boot());
-      const { stdout, stderr, exitCode } = await bash.exec(command);
-      return { stdout, stderr, exitCode };
+      try {
+        const { stdout, stderr, exitCode } = await bash.exec(command);
+        return { stdout, stderr, exitCode };
+      } catch (error) {
+        // The workspace refuses a write outside the caller's mounts by THROWING
+        // (`EACCES`, store/src/workspace-fs.ts:65), and just-bash lets that out of
+        // `exec` instead of turning it into an exit code. A path the person's own
+        // filesystem refused is an ordinary shell failure, not a broken tool call:
+        // the model has to READ it and pick another path, which it cannot do if
+        // the turn dies instead.
+        return { stdout: "", stderr: `${(error as Error).message}\n`, exitCode: 1 };
+      }
     },
   };
 }

--- a/packages/harnesses/src/vendo/shell/engine.ts
+++ b/packages/harnesses/src/vendo/shell/engine.ts
@@ -11,6 +11,7 @@
  */
 import type { IFileSystem } from "@vendoai/core";
 import type { Bash as BashInstance } from "just-bash";
+import { docx2txt } from "./parsers/docx2txt.js";
 import { pdftotext } from "./parsers/pdftotext.js";
 import { xlsx2csv } from "./parsers/xlsx2csv.js";
 
@@ -90,7 +91,7 @@ export function createShellSession(opts: {
       // The binary formats a person actually drops into chat, as ordinary
       // commands: they pipe, they redirect, and the agent needs no special
       // vocabulary for them. Lazy, so their libraries load on first use.
-      customCommands: [pdftotext, xlsx2csv],
+      customCommands: [pdftotext, xlsx2csv, docx2txt],
       executionLimits: {
         maxExecutionTimeMs: opts.limits?.maxExecutionTimeMs ?? DEFAULT_MAX_EXECUTION_TIME_MS,
         maxOutputSize: opts.limits?.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES,

--- a/packages/harnesses/src/vendo/shell/parsers/docx2txt.ts
+++ b/packages/harnesses/src/vendo/shell/parsers/docx2txt.ts
@@ -21,21 +21,64 @@ type Fflate = typeof import("fflate");
 
 const NAME = "docx2txt";
 
-/** The five XML entities a `w:t` body may carry. Nothing else is escaped in
-    WordprocessingML text, so a table is the whole decoder. */
+/** What `word/document.xml` may inflate to. The upload cap bounds the FILE, and
+ *  a zip's ratio is unbounded: 150 KB of deflated zeros — comfortably under it —
+ *  carries 51 MB, and this shell runs in the host process, so that is the host's
+ *  memory. fflate inflates to the size the archive DECLARES, which makes the
+ *  declared size a sound gate and a free one: nothing is decompressed to learn
+ *  it. 32 MB matches what the session's whole `/tmp` may hold, so no document a
+ *  person can actually upload comes near it. */
+const MAX_DOCUMENT_BYTES = 32 * 1024 * 1024;
+
+/** The five named XML entities. Numeric references are legal in any XML and
+    plenty of .docx writers emit them, so they decode here too — left alone they
+    reach the agent as a literal `&#8212;`. */
 const ENTITIES: Readonly<Record<string, string>> = {
   "&amp;": "&", "&lt;": "<", "&gt;": ">", "&quot;": '"', "&apos;": "'",
 };
 
 const decode = (xml: string): string =>
-  xml.replace(/&(?:amp|lt|gt|quot|apos);/g, (entity) => ENTITIES[entity]!);
+  xml.replace(/&(?:#(\d+)|#[xX]([\dA-Fa-f]+)|amp|lt|gt|quot|apos);/g, (entity, decimal, hex) => {
+    if (decimal === undefined && hex === undefined) return ENTITIES[entity]!;
+    const code = decimal === undefined ? parseInt(hex, 16) : Number(decimal);
+    return code <= 0x10ffff ? String.fromCodePoint(code) : entity;
+  });
+
+/** Every tag that carries text, matched ONE AT A TIME. Matching `<w:t>…</w:t>`
+    as a single lazy pair is the trap: against openers that never close, each one
+    rescans to the end of the paragraph, so a malformed part costs O(n²) of
+    blocked event loop. Each alternative here stops at its own `>`, so the scan
+    is linear no matter what the bytes say.
+
+    `<w:tab/>` is EMPTY: a tab STOP is a `w:tab` in `w:pPr` carrying `w:val`, so
+    demanding the self-closing form keeps stops out of the text. */
+const CONTENT =
+  /(?<open><w:t(?:\s[^>]*)?>)|(?<shut><\/w:t>)|(?<tab><w:tab\s*\/>)|<w:(?:br|cr)\b[^>]*>/g;
+
+/** What one paragraph contributes, in document order. */
+function runsOf(paragraph: string): string[] {
+  const runs: string[] = [];
+  let textFrom = -1;
+  for (const match of paragraph.matchAll(CONTENT)) {
+    const { open, shut, tab } = match.groups!;
+    if (open !== undefined) textFrom = match.index! + open.length;
+    else if (shut === undefined) runs.push(tab === undefined ? "\n" : "\t");
+    else {
+      if (textFrom !== -1) runs.push(decode(paragraph.slice(textFrom, match.index!)));
+      textFrom = -1;
+    }
+  }
+  return runs;
+}
 
 /** The document's paragraphs, in order. */
 export function paragraphsOf(documentXml: string): string[] {
   const lines: string[] = [];
-  for (const paragraph of documentXml.match(/<w:p[ >][\s\S]*?<\/w:p>/g) ?? []) {
-    const runs = [...paragraph.matchAll(/<w:t(?:\s[^>]*)?>([\s\S]*?)<\/w:t>/g)]
-      .map((match) => decode(match[1]!));
+  // SPLIT on the opener rather than matching `<w:p …>…</w:p>` lazily, for the
+  // same reason {@link CONTENT} matches one tag at a time.
+  for (const chunk of documentXml.split(/<w:p[ >]/).slice(1)) {
+    const close = chunk.indexOf("</w:p>");
+    const runs = runsOf(close === -1 ? chunk : chunk.slice(0, close));
     // A paragraph with no text at all is a spacer, and a blank line between two
     // real ones is information — an empty run list is not.
     if (runs.length > 0) lines.push(runs.join(""));
@@ -55,7 +98,15 @@ export const docx2txt: LazyCommand = {
         const input = await inputBytes(NAME, args, ctx);
         if ("refusal" in input) return input.refusal;
         try {
-          const part = unzipSync(input.bytes, { filter: (file) => file.name === "word/document.xml" })["word/document.xml"];
+          const part = unzipSync(input.bytes, {
+            filter: (file) => {
+              if (file.name !== "word/document.xml") return false;
+              if (file.originalSize > MAX_DOCUMENT_BYTES) {
+                throw new Error(`word/document.xml declares ${file.originalSize} bytes`);
+              }
+              return true;
+            },
+          })["word/document.xml"];
           if (part === undefined) throw new Error("no word/document.xml inside");
           return { stdout: `${paragraphsOf(strFromU8(part)).join("\n")}\n`, stderr: "", exitCode: 0 };
         } catch (cause) {

--- a/packages/harnesses/src/vendo/shell/parsers/docx2txt.ts
+++ b/packages/harnesses/src/vendo/shell/parsers/docx2txt.ts
@@ -46,13 +46,17 @@ const decode = (xml: string): string =>
 /** Every tag that carries text, matched ONE AT A TIME. Matching `<w:t>…</w:t>`
     as a single lazy pair is the trap: against openers that never close, each one
     rescans to the end of the paragraph, so a malformed part costs O(n²) of
-    blocked event loop. Each alternative here stops at its own `>`, so the scan
-    is linear no matter what the bytes say.
+    blocked event loop. Each alternative here stops at the next `<` OR its own
+    `>`, so the scan is linear no matter what the bytes say — `[^>]*` alone is
+    not enough, because an opener whose `>` never arrives then scans to the end
+    of the part for EVERY opener, which is the same O(n²) one level deeper. `<`
+    cannot appear inside a tag in any well-formed XML (it is `&lt;` there), so
+    excluding it costs no real document a thing.
 
     `<w:tab/>` is EMPTY: a tab STOP is a `w:tab` in `w:pPr` carrying `w:val`, so
     demanding the self-closing form keeps stops out of the text. */
 const CONTENT =
-  /(?<open><w:t(?:\s[^>]*)?>)|(?<shut><\/w:t>)|(?<tab><w:tab\s*\/>)|<w:(?:br|cr)\b[^>]*>/g;
+  /(?<open><w:t(?:\s[^<>]*)?>)|(?<shut><\/w:t>)|(?<tab><w:tab\s*\/>)|<w:(?:br|cr)\b[^<>]*>/g;
 
 /** What one paragraph contributes, in document order. */
 function runsOf(paragraph: string): string[] {

--- a/packages/harnesses/src/vendo/shell/parsers/docx2txt.ts
+++ b/packages/harnesses/src/vendo/shell/parsers/docx2txt.ts
@@ -1,0 +1,67 @@
+/**
+ * `docx2txt <file>` — a Word document's text, one paragraph per line.
+ *
+ * A .docx is a zip with an XML part inside, so this is an unzip and a walk over
+ * `<w:t>` runs — no Word, no LibreOffice, no conversion service. `fflate` does
+ * the unzip (synchronous, zero dependencies); the extraction is a regex over the
+ * one element that holds text, and that is deliberate: a full XML parse would
+ * pull a parser in for a job whose whole grammar is "the text inside w:t,
+ * grouped by w:p".
+ *
+ * Runs of one paragraph are JOINED, never newline-separated: Word splits a
+ * sentence across runs at every formatting change, so a line per run would cut
+ * "Revenue rose 26%" into three.
+ */
+import type { Command, LazyCommand } from "just-bash";
+import { inputBytes, notThisFormat } from "./input.js";
+
+let FFLATE_SPECIFIER = "fflate";
+
+type Fflate = typeof import("fflate");
+
+const NAME = "docx2txt";
+
+/** The five XML entities a `w:t` body may carry. Nothing else is escaped in
+    WordprocessingML text, so a table is the whole decoder. */
+const ENTITIES: Readonly<Record<string, string>> = {
+  "&amp;": "&", "&lt;": "<", "&gt;": ">", "&quot;": '"', "&apos;": "'",
+};
+
+const decode = (xml: string): string =>
+  xml.replace(/&(?:amp|lt|gt|quot|apos);/g, (entity) => ENTITIES[entity]!);
+
+/** The document's paragraphs, in order. */
+export function paragraphsOf(documentXml: string): string[] {
+  const lines: string[] = [];
+  for (const paragraph of documentXml.match(/<w:p[ >][\s\S]*?<\/w:p>/g) ?? []) {
+    const runs = [...paragraph.matchAll(/<w:t(?:\s[^>]*)?>([\s\S]*?)<\/w:t>/g)]
+      .map((match) => decode(match[1]!));
+    // A paragraph with no text at all is a spacer, and a blank line between two
+    // real ones is information — an empty run list is not.
+    if (runs.length > 0) lines.push(runs.join(""));
+  }
+  return lines;
+}
+
+export const docx2txt: LazyCommand = {
+  name: NAME,
+  trusted: true,
+  async load(): Promise<Command> {
+    const { unzipSync, strFromU8 } = await import(/* webpackIgnore: true */ /* turbopackIgnore: true */ /* @vite-ignore */ FFLATE_SPECIFIER) as Fflate;
+    return {
+      name: NAME,
+      trusted: true,
+      async execute(args, ctx) {
+        const input = await inputBytes(NAME, args, ctx);
+        if ("refusal" in input) return input.refusal;
+        try {
+          const part = unzipSync(input.bytes, { filter: (file) => file.name === "word/document.xml" })["word/document.xml"];
+          if (part === undefined) throw new Error("no word/document.xml inside");
+          return { stdout: `${paragraphsOf(strFromU8(part)).join("\n")}\n`, stderr: "", exitCode: 0 };
+        } catch (cause) {
+          return notThisFormat(NAME, args[0]!, "Word document", cause);
+        }
+      },
+    };
+  },
+};

--- a/packages/harnesses/src/vendo/shell/parsers/docx2txt.ts
+++ b/packages/harnesses/src/vendo/shell/parsers/docx2txt.ts
@@ -13,9 +13,8 @@
  * "Revenue rose 26%" into three.
  */
 import type { Command, LazyCommand } from "just-bash";
+import { importShellLibrary } from "../runtime.js";
 import { inputBytes, notThisFormat } from "./input.js";
-
-let FFLATE_SPECIFIER = "fflate";
 
 type Fflate = typeof import("fflate");
 
@@ -90,7 +89,7 @@ export const docx2txt: LazyCommand = {
   name: NAME,
   trusted: true,
   async load(): Promise<Command> {
-    const { unzipSync, strFromU8 } = await import(/* webpackIgnore: true */ /* turbopackIgnore: true */ /* @vite-ignore */ FFLATE_SPECIFIER) as Fflate;
+    const { unzipSync, strFromU8 } = await importShellLibrary<Fflate>("fflate");
     return {
       name: NAME,
       trusted: true,

--- a/packages/harnesses/src/vendo/shell/parsers/input.ts
+++ b/packages/harnesses/src/vendo/shell/parsers/input.ts
@@ -1,0 +1,35 @@
+/**
+ * One file argument, resolved against the script's own cwd and read as bytes.
+ *
+ * The diagnostics are POSIX-shaped because bash PRINTS them: a parser that
+ * invented its own sentence would be the one command in the shell that does not
+ * sound like the shell.
+ */
+import type { ExecResult, ResolvedCommandContext } from "just-bash";
+
+export type Input = { bytes: Uint8Array } | { refusal: ExecResult };
+
+export async function inputBytes(
+  name: string,
+  args: string[],
+  ctx: ResolvedCommandContext,
+): Promise<Input> {
+  const target = args[0];
+  if (target === undefined || target.startsWith("-")) {
+    return { refusal: { stdout: "", stderr: `usage: ${name} <file>\n`, exitCode: 2 } };
+  }
+  try {
+    return { bytes: await ctx.fs.readFileBuffer(ctx.fs.resolvePath(ctx.cwd, target)) };
+  } catch {
+    return { refusal: { stdout: "", stderr: `${name}: ${target}: No such file or directory\n`, exitCode: 1 } };
+  }
+}
+
+/** What a parser says when the bytes are not the format it was handed. The
+    message names the format rather than echoing a library's internal error,
+    because the agent's next move is to tell the user what the file actually is. */
+export const notThisFormat = (name: string, target: string, format: string, cause: unknown): ExecResult => ({
+  stdout: "",
+  stderr: `${name}: ${target}: not a readable ${format} (${cause instanceof Error ? cause.message : String(cause)})\n`,
+  exitCode: 1,
+});

--- a/packages/harnesses/src/vendo/shell/parsers/input.ts
+++ b/packages/harnesses/src/vendo/shell/parsers/input.ts
@@ -20,8 +20,15 @@ export async function inputBytes(
   }
   try {
     return { bytes: await ctx.fs.readFileBuffer(ctx.fs.resolvePath(ctx.cwd, target)) };
-  } catch {
-    return { refusal: { stdout: "", stderr: `${name}: ${target}: No such file or directory\n`, exitCode: 1 } };
+  } catch (cause) {
+    // A directory is the one failure bash names differently, and the difference
+    // matters: told "no such file" an agent invents another path, told "is a
+    // directory" it lists it. Both filesystems carry the code in the MESSAGE and
+    // set no `code` property (`enoent`/`eisdir` in store's workspace-fs.ts).
+    const reason = cause instanceof Error && cause.message.startsWith("EISDIR")
+      ? "Is a directory"
+      : "No such file or directory";
+    return { refusal: { stdout: "", stderr: `${name}: ${target}: ${reason}\n`, exitCode: 1 } };
   }
 }
 

--- a/packages/harnesses/src/vendo/shell/parsers/pdftotext.ts
+++ b/packages/harnesses/src/vendo/shell/parsers/pdftotext.ts
@@ -1,0 +1,48 @@
+/**
+ * `pdftotext <file>` — a PDF's text, on stdout.
+ *
+ * LAZY on purpose: unpdf carries a serverless build of pdf.js (~1.6 MB) and most
+ * turns never touch a PDF, so it loads the first time one is actually parsed and
+ * never again. TRUSTED, because it runs in the HOST process against the same
+ * virtual filesystem the shell has — it is our code reading our bytes, not
+ * user JavaScript.
+ *
+ * Only stdout, deliberately: real `pdftotext` writes `<name>.txt` by default, and
+ * a command that silently creates a file is a command that surprises an agent
+ * mid-pipeline. Redirect it if you want a file.
+ */
+import type { Command, LazyCommand } from "just-bash";
+import { inputBytes, notThisFormat } from "./input.js";
+
+/** Mutable so no bundler statically resolves it — same containment as just-bash
+ *  in engine.ts, and the same reason: this module is reachable from the umbrella's
+ *  server entry, which must bundle for a Worker target. */
+let UNPDF_SPECIFIER = "unpdf";
+
+type Unpdf = typeof import("unpdf");
+
+const NAME = "pdftotext";
+
+export const pdftotext: LazyCommand = {
+  name: NAME,
+  trusted: true,
+  async load(): Promise<Command> {
+    const { extractText } = await import(/* webpackIgnore: true */ /* turbopackIgnore: true */ /* @vite-ignore */ UNPDF_SPECIFIER) as Unpdf;
+    return {
+      name: NAME,
+      trusted: true,
+      async execute(args, ctx) {
+        const input = await inputBytes(NAME, args, ctx);
+        if ("refusal" in input) return input.refusal;
+        try {
+          // Page by page, joined with the form feed real `pdftotext` uses, so
+          // "what is on page 3" is answerable with `awk` instead of guesswork.
+          const { text } = await extractText(input.bytes, { mergePages: false });
+          return { stdout: `${text.join("\n\f\n")}\n`, stderr: "", exitCode: 0 };
+        } catch (cause) {
+          return notThisFormat(NAME, args[0]!, "PDF", cause);
+        }
+      },
+    };
+  },
+};

--- a/packages/harnesses/src/vendo/shell/parsers/pdftotext.ts
+++ b/packages/harnesses/src/vendo/shell/parsers/pdftotext.ts
@@ -12,12 +12,8 @@
  * mid-pipeline. Redirect it if you want a file.
  */
 import type { Command, LazyCommand } from "just-bash";
+import { importShellLibrary } from "../runtime.js";
 import { inputBytes, notThisFormat } from "./input.js";
-
-/** Mutable so no bundler statically resolves it — same containment as just-bash
- *  in engine.ts, and the same reason: this module is reachable from the umbrella's
- *  server entry, which must bundle for a Worker target. */
-let UNPDF_SPECIFIER = "unpdf";
 
 type Unpdf = typeof import("unpdf");
 
@@ -27,7 +23,7 @@ export const pdftotext: LazyCommand = {
   name: NAME,
   trusted: true,
   async load(): Promise<Command> {
-    const { extractText } = await import(/* webpackIgnore: true */ /* turbopackIgnore: true */ /* @vite-ignore */ UNPDF_SPECIFIER) as Unpdf;
+    const { extractText } = await importShellLibrary<Unpdf>("unpdf");
     return {
       name: NAME,
       trusted: true,

--- a/packages/harnesses/src/vendo/shell/parsers/xlsx2csv.ts
+++ b/packages/harnesses/src/vendo/shell/parsers/xlsx2csv.ts
@@ -62,7 +62,12 @@ export const xlsx2csv: LazyCommand = {
           return notThisFormat(NAME, args[0]!, "spreadsheet", cause);
         }
         const wanted = args[1] ?? book.SheetNames[0];
-        const sheet = wanted === undefined ? undefined : book.Sheets[wanted];
+        // SheetNames, not a bare `Sheets[wanted]`: `xlsx2csv book.xlsx toString`
+        // would otherwise find Object.prototype's method and print an empty CSV
+        // with exit 0 instead of naming the sheets.
+        const sheet = wanted !== undefined && book.SheetNames.includes(wanted)
+          ? book.Sheets[wanted]
+          : undefined;
         if (sheet === undefined) {
           // Naming the sheets IS the fix: an agent told only "no" asks the user,
           // an agent told what exists picks the right one and carries on.

--- a/packages/harnesses/src/vendo/shell/parsers/xlsx2csv.ts
+++ b/packages/harnesses/src/vendo/shell/parsers/xlsx2csv.ts
@@ -8,6 +8,7 @@
  * SheetJS Community Edition, pure JavaScript, synchronous, no native code.
  */
 import type { Command, LazyCommand } from "just-bash";
+import { importShellLibrary } from "../runtime.js";
 import { inputBytes, notThisFormat } from "./input.js";
 
 /** `@e965/xlsx` is SheetJS CE republished on the public registry. SheetJS
@@ -20,8 +21,6 @@ import { inputBytes, notThisFormat } from "./input.js";
     Re-verify on any bump (empty diff == identical to the official tarball):
       diff <(curl -sL https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz \
         | tar xzO package/xlsx.js) node_modules/@e965/xlsx/xlsx.js */
-let XLSX_SPECIFIER = "@e965/xlsx";
-
 type SheetJs = typeof import("@e965/xlsx");
 
 const NAME = "xlsx2csv";
@@ -45,7 +44,7 @@ export const xlsx2csv: LazyCommand = {
   name: NAME,
   trusted: true,
   async load(): Promise<Command> {
-    const XLSX = await import(/* webpackIgnore: true */ /* turbopackIgnore: true */ /* @vite-ignore */ XLSX_SPECIFIER) as SheetJs;
+    const XLSX = await importShellLibrary<SheetJs>("@e965/xlsx");
     return {
       name: NAME,
       trusted: true,

--- a/packages/harnesses/src/vendo/shell/parsers/xlsx2csv.ts
+++ b/packages/harnesses/src/vendo/shell/parsers/xlsx2csv.ts
@@ -5,15 +5,24 @@
  * stdout, `cut`, `awk`, `sort` and `jq -R` all work on it, which is the whole
  * reason the parsers are COMMANDS and not tools of their own.
  *
- * SheetJS Community Edition, pure JavaScript, synchronous, no native code. It
- * comes from the SheetJS CDN rather than npm — the registry copy is years stale.
+ * SheetJS Community Edition, pure JavaScript, synchronous, no native code.
  */
 import type { Command, LazyCommand } from "just-bash";
 import { inputBytes, notThisFormat } from "./input.js";
 
-let XLSX_SPECIFIER = "xlsx";
+/** `@e965/xlsx` is SheetJS CE republished on the public registry. SheetJS
+    itself ships only from its own CDN, and pnpm 11 (blockExoticSubdeps)
+    refuses a URL-resolved dependency reached through a dependency, so the CDN
+    tarball breaks every pnpm consumer; npm's stale `xlsx@0.18.5` carries
+    CVE-2023-30533 and CVE-2024-22363, both in this read path. The mirror is
+    one individual's account, so the EXACT pin is the control — npm forbids
+    replacing a published version, so a consumer can only get bytes we checked.
+    Re-verify on any bump (empty diff == identical to the official tarball):
+      diff <(curl -sL https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz \
+        | tar xzO package/xlsx.js) node_modules/@e965/xlsx/xlsx.js */
+let XLSX_SPECIFIER = "@e965/xlsx";
 
-type SheetJs = typeof import("xlsx");
+type SheetJs = typeof import("@e965/xlsx");
 
 const NAME = "xlsx2csv";
 

--- a/packages/harnesses/src/vendo/shell/parsers/xlsx2csv.ts
+++ b/packages/harnesses/src/vendo/shell/parsers/xlsx2csv.ts
@@ -77,7 +77,10 @@ export const xlsx2csv: LazyCommand = {
             exitCode: 1,
           };
         }
-        return { stdout: XLSX.utils.sheet_to_csv(sheet), stderr: "", exitCode: 0 };
+        // Terminated, like the other parsers and like every text stream a shell
+        // produces: `sheet_to_csv` stops after the last row, and an unterminated
+        // last line makes `wc -l` and `tail` undercount the sheet by one.
+        return { stdout: `${XLSX.utils.sheet_to_csv(sheet)}\n`, stderr: "", exitCode: 0 };
       },
     };
   },

--- a/packages/harnesses/src/vendo/shell/parsers/xlsx2csv.ts
+++ b/packages/harnesses/src/vendo/shell/parsers/xlsx2csv.ts
@@ -1,0 +1,71 @@
+/**
+ * `xlsx2csv <file> [sheet]` — one sheet of a workbook, as CSV on stdout.
+ *
+ * CSV and not JSON because the rest of the shell speaks CSV: once it is on
+ * stdout, `cut`, `awk`, `sort` and `jq -R` all work on it, which is the whole
+ * reason the parsers are COMMANDS and not tools of their own.
+ *
+ * SheetJS Community Edition, pure JavaScript, synchronous, no native code. It
+ * comes from the SheetJS CDN rather than npm — the registry copy is years stale.
+ */
+import type { Command, LazyCommand } from "just-bash";
+import { inputBytes, notThisFormat } from "./input.js";
+
+let XLSX_SPECIFIER = "xlsx";
+
+type SheetJs = typeof import("xlsx");
+
+const NAME = "xlsx2csv";
+
+/** SheetJS never refuses. Handed bytes it does not recognise it falls back to
+    plain-text sniffing and hands back a one-cell "workbook", so `xlsx2csv
+    notes.txt` would exit 0 on nonsense — verified against 0.20.3, which even
+    accepts four random bytes. The gate is therefore ours, and it is the
+    container magic: every BINARY workbook SheetJS reads is a zip (xlsx, xlsb,
+    ods) or an OLE compound file (xls). The text formats it can also guess at
+    (csv, prn, sylk) are already the rest of the shell's job. */
+const WORKBOOK_MAGIC = [
+  [0x50, 0x4b], // "PK" — zip
+  [0xd0, 0xcf, 0x11, 0xe0], // OLE compound file
+];
+
+const isWorkbook = (bytes: Uint8Array): boolean =>
+  WORKBOOK_MAGIC.some((magic) => magic.every((byte, index) => bytes[index] === byte));
+
+export const xlsx2csv: LazyCommand = {
+  name: NAME,
+  trusted: true,
+  async load(): Promise<Command> {
+    const XLSX = await import(/* webpackIgnore: true */ /* turbopackIgnore: true */ /* @vite-ignore */ XLSX_SPECIFIER) as SheetJs;
+    return {
+      name: NAME,
+      trusted: true,
+      async execute(args, ctx) {
+        const input = await inputBytes(NAME, args, ctx);
+        if ("refusal" in input) return input.refusal;
+        if (!isWorkbook(input.bytes)) {
+          return notThisFormat(NAME, args[0]!, "spreadsheet", "not a zip or OLE workbook container");
+        }
+        let book: ReturnType<SheetJs["read"]>;
+        try {
+          book = XLSX.read(input.bytes, { type: "array" });
+        } catch (cause) {
+          return notThisFormat(NAME, args[0]!, "spreadsheet", cause);
+        }
+        const wanted = args[1] ?? book.SheetNames[0];
+        const sheet = wanted === undefined ? undefined : book.Sheets[wanted];
+        if (sheet === undefined) {
+          // Naming the sheets IS the fix: an agent told only "no" asks the user,
+          // an agent told what exists picks the right one and carries on.
+          return {
+            stdout: "",
+            stderr: `${NAME}: ${args[0]}: no sheet named ${JSON.stringify(wanted)};`
+              + ` this workbook has ${book.SheetNames.join(", ")}\n`,
+            exitCode: 1,
+          };
+        }
+        return { stdout: XLSX.utils.sheet_to_csv(sheet), stderr: "", exitCode: 0 };
+      },
+    };
+  },
+};

--- a/packages/harnesses/src/vendo/shell/runtime.ts
+++ b/packages/harnesses/src/vendo/shell/runtime.ts
@@ -1,0 +1,21 @@
+/**
+ * Can this runtime host a worker thread?
+ *
+ * `js-exec` runs QuickJS inside `node:worker_threads` — the only part of the
+ * shell that is Node-only. Everywhere else (an edge runtime, a Worker) the shell
+ * is still the whole shell: bash, the coreutils, the parsers. So the answer is a
+ * capability question asked once, not a deployment flag anyone has to set.
+ *
+ * Asked through `process.getBuiltinModule` rather than a static import, for the
+ * same reason `dot-vendo.ts` reads `node:fs` that way: this module carries NO
+ * static Node import and therefore still loads and bundles for edge/Worker
+ * targets, where the accessor is simply absent.
+ */
+export function workerThreadsAvailable(): boolean {
+  try {
+    const proc = (globalThis as { process?: { getBuiltinModule?: (id: string) => unknown } }).process;
+    return proc?.getBuiltinModule?.("node:worker_threads") !== undefined;
+  } catch {
+    return false;
+  }
+}

--- a/packages/harnesses/src/vendo/shell/runtime.ts
+++ b/packages/harnesses/src/vendo/shell/runtime.ts
@@ -10,6 +10,13 @@
  * same reason `dot-vendo.ts` reads `node:fs` that way: this module carries NO
  * static Node import and therefore still loads and bundles for edge/Worker
  * targets, where the accessor is simply absent.
+ *
+ * The accessor itself landed in Node 20.16 / 22.3, so on the sliver of the
+ * `>=20` engines range below that this answers no while `node:worker_threads` is
+ * in fact there, and js-exec stays off. Deliberate: every alternative reaches for
+ * a static `node:` import or sniffs `process.versions`, and the first breaks the
+ * edge bundling this exists for while the second is a worse probe than the
+ * accessor. The floor is a repo-wide `engines` decision, not this module's.
  */
 export function workerThreadsAvailable(): boolean {
   try {

--- a/packages/harnesses/src/vendo/shell/runtime.ts
+++ b/packages/harnesses/src/vendo/shell/runtime.ts
@@ -1,4 +1,9 @@
 /**
+ * The two things the shell has to ask the RUNTIME instead of assuming: whether
+ * it can host a worker thread, and where its own libraries actually live.
+ */
+
+/**
  * Can this runtime host a worker thread?
  *
  * `js-exec` runs QuickJS inside `node:worker_threads` — the only part of the
@@ -25,4 +30,54 @@ export function workerThreadsAvailable(): boolean {
   } catch {
     return false;
   }
+}
+
+/** A bare import, made from wherever THIS FILE physically is.
+ *
+ *  @internal Exported only so the copy of this module on disk can be called by a
+ *  bundled copy of it — see importShellLibrary, which is the one to call. */
+export const importFromHere = async (specifier: string): Promise<unknown> =>
+  await import(/* webpackIgnore: true */ /* turbopackIgnore: true */ /* @vite-ignore */ specifier);
+
+/**
+ * Load one of the shell's own libraries — just-bash and the three parser
+ * libraries — through the copy of this module that is really on disk.
+ *
+ * These imports have to stay bundler-blind: just-bash's graph reaches
+ * `node:worker_threads`, `undici` and `sql.js`, and it `import()`s the two
+ * native packages it declares as `optionalDependencies` (`@mongodb-js/zstd`,
+ * `node-liblzma`) — installed on a consumer's disk, which is why their build
+ * scripts have to be denied (pnpm-workspace.yaml), and unbundleable, so esbuild
+ * hard-fails a Worker build on those two: Leg A of
+ * `scripts/portability-gate.mjs`. Same containment, and the same reasoning, as
+ * the optional e2b SDK (`packages/apps/src/server/escalation/e2b/index.ts`).
+ *
+ * But bundler-blind means the bundler emits a bare `import("just-bash")` into a
+ * chunk that sits in the HOST APP's directory, and Node resolves a bare
+ * specifier relative to the importing FILE. All four are dependencies of
+ * @vendoai/harnesses alone, so pnpm keeps them in THIS package's node_modules,
+ * invisible from there: every shell call answered ERR_MODULE_NOT_FOUND in a real
+ * app while the tests, which import from inside this package, stayed green.
+ *
+ * So hop home first. Bundlers rewrite `import.meta.url` to the ORIGINAL
+ * module's path (Turbopack's ImportMetaBinding, webpack's module resource), so
+ * importing it loads this file from where it actually lives — beside its own
+ * node_modules, in this monorepo and in a consumer's install alike — and the
+ * bare import above then resolves the way it always meant to. Unbundled, the hop
+ * lands on this very module and costs a cache hit.
+ *
+ * The hop, not a resolved absolute path: `createRequire(import.meta.url).resolve`
+ * answers with the package's CJS entry, and just-bash's CJS bundle has no
+ * `import.meta.url` to bootstrap its QuickJS worker from, so `js-exec` dies
+ * there with "Invalid URL" while every other command looks fine.
+ *
+ * Where the recorded URL is not loadable at all (an esbuild/Worker bundle, whose
+ * `import.meta.url` is the bundle itself) the bare specifier is all there is.
+ */
+export async function importShellLibrary<T>(specifier: string): Promise<T> {
+  const onDisk = await import(
+    /* webpackIgnore: true */ /* turbopackIgnore: true */ /* @vite-ignore */
+    import.meta.url
+  ).catch(() => ({})) as { importFromHere?: typeof importFromHere };
+  return await (onDisk.importFromHere ?? importFromHere)(specifier) as T;
 }

--- a/packages/harnesses/src/vendo/shell/tool.ts
+++ b/packages/harnesses/src/vendo/shell/tool.ts
@@ -30,6 +30,8 @@ const DESCRIPTION =
   + "workspace: /user/threads/<thread>/files holds what they dropped in THIS conversation, "
   + "/user/apps/<app> holds an app's files, and /user/files is the shelf of things they asked you to "
   + "keep. /tmp is scratch that lasts this conversation and is never saved. "
+  + "Binary formats are ordinary commands here: `pdftotext <file>`, `xlsx2csv <file> [sheet]` and "
+  + "`docx2txt <file>` each write text to stdout, so they pipe into grep, awk and the rest. "
   + (JAVASCRIPT
     ? "For anything bash is awkward at, write JavaScript: `js-exec -c '<code>'` runs it in a sandbox with "
       + "require(\"node:fs\") bound to this same filesystem. "

--- a/packages/harnesses/src/vendo/shell/tool.ts
+++ b/packages/harnesses/src/vendo/shell/tool.ts
@@ -45,6 +45,28 @@ const descriptors: ToolDescriptor[] = [
 const ok = (output: Record<string, unknown>): ToolOutcome => ({ status: "ok", output: output as never });
 const fail = (code: string, message: string): ToolOutcome => ({ status: "error", error: { code, message } });
 
+/** What ONE stream may hand back. Half the bridge's 32 000-char cap, so stdout
+ *  and stderr together can never reach it: `capOutcome` does not clip, it
+ *  REPLACES the whole result with a preview string, which would throw away the
+ *  exit code and the stderr a failing command is diagnosed from. Clipping is the
+ *  shell's own job, and it keeps the TAIL — the end of a long output is where a
+ *  script's answer and its error both live. */
+const MAX_STREAM_CHARS = 16_000;
+
+const note = (dropped: number): string =>
+  `[clipped] ${dropped} earlier characters dropped; `
+  + `re-run with head/tail/grep to see them.\n`;
+
+const clip = (text: string): string => {
+  if (text.length <= MAX_STREAM_CHARS) return text;
+  // The note is INSIDE the budget, not on top of it — the cap is what one stream
+  // may hand back in TOTAL, and half the bridge's is only headroom if the note
+  // counts. Reserved against `text.length`, the largest the drop can ever be, so
+  // the digits are never underestimated and the result never exceeds the cap.
+  const kept = MAX_STREAM_CHARS - note(text.length).length;
+  return note(text.length - kept) + text.slice(text.length - kept);
+};
+
 export function createShellTools(
   open: (principal: Principal) => Promise<WorkspaceFs>,
   config: { limits?: ShellLimits } = {},
@@ -66,7 +88,7 @@ export function createShellTools(
       });
       const result = await session.exec(args.command);
       await workspace.commit();
-      return ok({ stdout: result.stdout, stderr: result.stderr, exitCode: result.exitCode });
+      return ok({ stdout: clip(result.stdout), stderr: clip(result.stderr), exitCode: result.exitCode });
     },
   };
 }

--- a/packages/harnesses/src/vendo/shell/tool.ts
+++ b/packages/harnesses/src/vendo/shell/tool.ts
@@ -16,21 +16,32 @@ import {
   type WorkspaceFs,
 } from "@vendoai/core";
 import { createShellSession, type ShellLimits, type ShellSession } from "./engine.js";
+import { workerThreadsAvailable } from "./runtime.js";
 
 const DRAFT_2020_12 = "https://json-schema.org/draft/2020-12/schema";
+
+/** Told once per process: the answer cannot change while it runs, and a probe
+ *  per descriptor call would be asked on every listing. */
+const JAVASCRIPT = workerThreadsAvailable();
+
+const DESCRIPTION =
+  "Run a bash command over this user's own files. You have a real shell — grep, sed, awk, jq, sort, "
+  + "cut, head, tail, wc, find, pipes and redirection all work — and the filesystem IS the user's "
+  + "workspace: /user/threads/<thread>/files holds what they dropped in THIS conversation, "
+  + "/user/apps/<app> holds an app's files, and /user/files is the shelf of things they asked you to "
+  + "keep. /tmp is scratch that lasts this conversation and is never saved. "
+  + (JAVASCRIPT
+    ? "For anything bash is awkward at, write JavaScript: `js-exec -c '<code>'` runs it in a sandbox with "
+      + "require(\"node:fs\") bound to this same filesystem. "
+    : "")
+  + "There is no network and no package manager: everything you need is already here. "
+  + "Prefer this over reading a file line by line — one command answers what twenty reads would.";
 
 const descriptors: ToolDescriptor[] = [
   {
     name: VENDO_BASH_TOOL,
     title: VENDO_TOOL_TITLES[VENDO_BASH_TOOL]!,
-    description:
-      "Run a bash command over this user's own files. You have a real shell — grep, sed, awk, jq, sort, "
-      + "cut, head, tail, wc, find, pipes and redirection all work — and the filesystem IS the user's "
-      + "workspace: /user/threads/<thread>/files holds what they dropped in THIS conversation, "
-      + "/user/apps/<app> holds an app's files, and /user/files is the shelf of things they asked you to "
-      + "keep. /tmp is scratch that lasts this conversation and is never saved. "
-      + "There is no network and no package manager: everything you need is already here. "
-      + "Prefer this over reading a file line by line — one command answers what twenty reads would.",
+    description: DESCRIPTION,
     inputSchema: {
       $schema: DRAFT_2020_12,
       type: "object",
@@ -126,6 +137,7 @@ export function createShellTools(
       workspace,
       session: createShellSession({
         workspace,
+        javascript: JAVASCRIPT,
         ...(config.limits === undefined ? {} : { limits: config.limits }),
       }),
       queue: Promise.resolve(),

--- a/packages/harnesses/src/vendo/shell/tool.ts
+++ b/packages/harnesses/src/vendo/shell/tool.ts
@@ -159,6 +159,13 @@ export function createShellTools(
         // `/tmp` and staged writes are then unreachable.
         opening = openTurn(ctx.principal);
         live.set(key, opening);
+        // A REJECTED open is not cached, though: the store blinking once must
+        // not wedge the rest of the turn. Guarded on identity so a turn that was
+        // evicted and re-opened keeps its newer entry.
+        const failed = opening;
+        void failed.catch(() => {
+          if (live.get(key) === failed) live.delete(key);
+        });
       }
       const turn = await opening;
       const run = turn.queue.then(async () => ({
@@ -168,12 +175,16 @@ export function createShellTools(
       turn.queue = run.catch(() => undefined);
       const { result, committed } = await run;
       if (committed.status === "conflict") {
-        // `/orgs` is compare-and-swap: the command ran, and nothing it wrote was
-        // kept. Saying `ok` here would tell the model a durable write happened.
+        // `/orgs` is compare-and-swap and a commit batches PER OWNER
+        // (store/src/workspace-fs.ts:592-595), so the losing swap is the only
+        // thing rolled back — the same command's `/user` writes DID land. Saying
+        // `ok` would hide the lost write; saying nothing was saved would send the
+        // model to re-run a command that already half-applied.
         return fail(
           "conflict",
-          `Someone else changed ${committed.paths.join(", ")} while this ran, so none of this command's `
-          + `writes were saved. Re-read those paths and run it again.`,
+          `Someone else changed ${committed.paths.join(", ")} while this ran, so the writes to those `
+          + `paths were rejected. Anything this command wrote elsewhere DID land. Re-read those paths `
+          + `and redo only that part.`,
         );
       }
       return ok({ stdout: clip(result.stdout), stderr: clip(result.stderr), exitCode: result.exitCode });

--- a/packages/harnesses/src/vendo/shell/tool.ts
+++ b/packages/harnesses/src/vendo/shell/tool.ts
@@ -1,0 +1,72 @@
+/**
+ * The shell's hand on the ONE registry.
+ *
+ * Modelled on the drawer's tools (`@vendoai/vendo` user-files.ts): a
+ * `ToolRegistry` whose descriptor carries its own `risk`, whose every call opens
+ * the workspace for `ctx.principal` and NOBODY else, and which commits what the
+ * call wrote before answering. There is no subject argument to get wrong.
+ */
+import {
+  VENDO_BASH_TOOL,
+  VENDO_TOOL_TITLES,
+  type Principal,
+  type ToolDescriptor,
+  type ToolOutcome,
+  type ToolRegistry,
+  type WorkspaceFs,
+} from "@vendoai/core";
+import { createShellSession, type ShellLimits, type ShellSession } from "./engine.js";
+
+const DRAFT_2020_12 = "https://json-schema.org/draft/2020-12/schema";
+
+const descriptors: ToolDescriptor[] = [
+  {
+    name: VENDO_BASH_TOOL,
+    title: VENDO_TOOL_TITLES[VENDO_BASH_TOOL]!,
+    description:
+      "Run a bash command over this user's own files. You have a real shell — grep, sed, awk, jq, sort, "
+      + "cut, head, tail, wc, find, pipes and redirection all work — and the filesystem IS the user's "
+      + "workspace: /user/threads/<thread>/files holds what they dropped in THIS conversation, "
+      + "/user/apps/<app> holds an app's files, and /user/files is the shelf of things they asked you to "
+      + "keep. /tmp is scratch that lasts this conversation and is never saved. "
+      + "There is no network and no package manager: everything you need is already here. "
+      + "Prefer this over reading a file line by line — one command answers what twenty reads would.",
+    inputSchema: {
+      $schema: DRAFT_2020_12,
+      type: "object",
+      properties: { command: { type: "string", minLength: 1 } },
+      required: ["command"],
+      additionalProperties: false,
+    },
+    risk: "write",
+  },
+];
+
+const ok = (output: Record<string, unknown>): ToolOutcome => ({ status: "ok", output: output as never });
+const fail = (code: string, message: string): ToolOutcome => ({ status: "error", error: { code, message } });
+
+export function createShellTools(
+  open: (principal: Principal) => Promise<WorkspaceFs>,
+  config: { limits?: ShellLimits } = {},
+): ToolRegistry {
+  return {
+    async descriptors() {
+      return structuredClone(descriptors);
+    },
+    async execute(call, ctx): Promise<ToolOutcome> {
+      if (call.tool !== VENDO_BASH_TOOL) return fail("not-found", `Unknown tool: ${call.tool}`);
+      const args = (call.args ?? {}) as { command?: unknown };
+      if (typeof args.command !== "string" || args.command.trim() === "") {
+        return fail("validation", "command must be the shell command to run, as a single string");
+      }
+      const workspace = await open(ctx.principal);
+      const session: ShellSession = createShellSession({
+        workspace,
+        ...(config.limits === undefined ? {} : { limits: config.limits }),
+      });
+      const result = await session.exec(args.command);
+      await workspace.commit();
+      return ok({ stdout: result.stdout, stderr: result.stderr, exitCode: result.exitCode });
+    },
+  };
+}

--- a/packages/harnesses/src/vendo/shell/tool.ts
+++ b/packages/harnesses/src/vendo/shell/tool.ts
@@ -45,26 +45,57 @@ const descriptors: ToolDescriptor[] = [
 const ok = (output: Record<string, unknown>): ToolOutcome => ({ status: "ok", output: output as never });
 const fail = (code: string, message: string): ToolOutcome => ({ status: "error", error: { code, message } });
 
-/** What ONE stream may hand back. Half the bridge's 32 000-char cap, so stdout
- *  and stderr together can never reach it: `capOutcome` does not clip, it
- *  REPLACES the whole result with a preview string, which would throw away the
- *  exit code and the stderr a failing command is diagnosed from. Clipping is the
- *  shell's own job, and it keeps the TAIL — the end of a long output is where a
- *  script's answer and its error both live. */
-const MAX_STREAM_CHARS = 16_000;
+/** The bridge's default `toolOutputCap`, mirrored because the layering forbids
+ *  importing `@vendoai/vendo`'s `DEFAULT_TOOL_OUTPUT_CAP` from here. `capOutcome`
+ *  does not clip at it, it REPLACES the whole result with a preview string,
+ *  throwing away the exit code and the stderr a failing command is diagnosed
+ *  from — so the shell stays under it itself. */
+const BRIDGE_CAP_CHARS = 32_000;
+
+/** `{"stdout":"…","stderr":"…","exitCode":0}` — the keys and punctuation the two
+ *  streams sit inside, which `JSON.stringify` weighs too. */
+const ENVELOPE_CHARS = 64;
+
+/** What ONE stream may hand back, so BOTH plus the envelope stay under the cap.
+ *  Clipping keeps the TAIL — the end of a long output is where a script's answer
+ *  and its error both live.
+ *
+ *  Counted in JSON characters, not raw ones: `capOutcome` weighs
+ *  `JSON.stringify(output)`, where a newline costs two characters and a control
+ *  byte six, so a raw budget let an all-newline stream (`cut` over empty fields,
+ *  a bare `find`) reach the very cap this exists to stay under. */
+const MAX_STREAM_JSON_CHARS = (BRIDGE_CAP_CHARS - ENVELOPE_CHARS) / 2;
+
+/** What `text` costs inside a JSON string, quotes excluded. */
+const jsonLength = (text: string): number => JSON.stringify(text).length - 2;
 
 const note = (dropped: number): string =>
   `[clipped] ${dropped} earlier characters dropped; `
   + `re-run with head/tail/grep to see them.\n`;
 
+/** The longest TAIL of `text` that fits `budget` JSON characters. Spent
+ *  character by character from the end, because escaping is per character and
+ *  the end is the half worth keeping. */
+const tail = (text: string, budget: number): string => {
+  let spent = 0;
+  let start = text.length;
+  while (start > 0) {
+    const cost = jsonLength(text[start - 1]!);
+    if (spent + cost > budget) break;
+    spent += cost;
+    start -= 1;
+  }
+  return text.slice(start);
+};
+
 const clip = (text: string): string => {
-  if (text.length <= MAX_STREAM_CHARS) return text;
+  if (jsonLength(text) <= MAX_STREAM_JSON_CHARS) return text;
   // The note is INSIDE the budget, not on top of it — the cap is what one stream
   // may hand back in TOTAL, and half the bridge's is only headroom if the note
   // counts. Reserved against `text.length`, the largest the drop can ever be, so
   // the digits are never underestimated and the result never exceeds the cap.
-  const kept = MAX_STREAM_CHARS - note(text.length).length;
-  return note(text.length - kept) + text.slice(text.length - kept);
+  const kept = tail(text, MAX_STREAM_JSON_CHARS - jsonLength(note(text.length)));
+  return note(text.length - kept.length) + kept;
 };
 
 /** Sessions outlive a call and nothing here is told a turn ended, so the cache is
@@ -73,11 +104,34 @@ const clip = (text: string): string => {
  *  which is the one thing in the session that was never durable anyway. */
 const MAX_LIVE_SESSIONS = 32;
 
+interface Turn {
+  session: ShellSession;
+  workspace: WorkspaceFs;
+  /** This turn's calls run ONE at a time. A model may emit two `bash` calls in a
+   *  single step and the AI SDK runs those together, and they share a workspace
+   *  whose writes STAGE until `commit()` — two in flight over one staging area is
+   *  one call committing the other's half-written files. */
+  queue: Promise<unknown>;
+}
+
 export function createShellTools(
   open: (principal: Principal) => Promise<WorkspaceFs>,
   config: { limits?: ShellLimits } = {},
 ): ToolRegistry {
-  const live = new Map<string, { session: ShellSession; workspace: WorkspaceFs }>();
+  const live = new Map<string, Promise<Turn>>();
+
+  const openTurn = async (principal: Principal): Promise<Turn> => {
+    const workspace = await open(principal);
+    return {
+      workspace,
+      session: createShellSession({
+        workspace,
+        ...(config.limits === undefined ? {} : { limits: config.limits }),
+      }),
+      queue: Promise.resolve(),
+    };
+  };
+
   return {
     async descriptors() {
       return structuredClone(descriptors);
@@ -88,6 +142,7 @@ export function createShellTools(
       if (typeof args.command !== "string" || args.command.trim() === "") {
         return fail("validation", "command must be the shell command to run, as a single string");
       }
+      const command = args.command;
       // ONE session per TURN: `/tmp` is where a multi-step script keeps its
       // intermediates, and a fresh interpreter per call would throw them away
       // between `sort > /tmp/x` and `cat /tmp/x`. Keyed on `turnId` because that
@@ -95,21 +150,32 @@ export function createShellTools(
       // going"; a run with no turn (a webhook, a schedule fire) falls back to its
       // session so it is at least not sharing with anyone else.
       const key = ctx.turnId ?? `session:${ctx.principal.subject}:${ctx.sessionId}`;
-      let held = live.get(key);
-      if (held === undefined) {
+      let opening = live.get(key);
+      if (opening === undefined) {
         if (live.size >= MAX_LIVE_SESSIONS) live.delete(live.keys().next().value!);
-        const workspace = await open(ctx.principal);
-        held = {
-          workspace,
-          session: createShellSession({
-            workspace,
-            ...(config.limits === undefined ? {} : { limits: config.limits }),
-          }),
-        };
-        live.set(key, held);
+        // The PROMISE is cached, before anything is awaited. A check-then-set
+        // around `open` lets a second concurrent call for the same turn find
+        // nothing, build a second workspace, and overwrite the first — whose
+        // `/tmp` and staged writes are then unreachable.
+        opening = openTurn(ctx.principal);
+        live.set(key, opening);
       }
-      const result = await held.session.exec(args.command);
-      await held.workspace.commit();
+      const turn = await opening;
+      const run = turn.queue.then(async () => ({
+        result: await turn.session.exec(command),
+        committed: await turn.workspace.commit(),
+      }));
+      turn.queue = run.catch(() => undefined);
+      const { result, committed } = await run;
+      if (committed.status === "conflict") {
+        // `/orgs` is compare-and-swap: the command ran, and nothing it wrote was
+        // kept. Saying `ok` here would tell the model a durable write happened.
+        return fail(
+          "conflict",
+          `Someone else changed ${committed.paths.join(", ")} while this ran, so none of this command's `
+          + `writes were saved. Re-read those paths and run it again.`,
+        );
+      }
       return ok({ stdout: clip(result.stdout), stderr: clip(result.stderr), exitCode: result.exitCode });
     },
   };

--- a/packages/harnesses/src/vendo/shell/tool.ts
+++ b/packages/harnesses/src/vendo/shell/tool.ts
@@ -67,10 +67,17 @@ const clip = (text: string): string => {
   return note(text.length - kept) + text.slice(text.length - kept);
 };
 
+/** Sessions outlive a call and nothing here is told a turn ended, so the cache is
+ *  BOUNDED rather than swept: the oldest entry leaves when a new one would be the
+ *  33rd. A turn evicted early re-opens on its next call and loses only `/tmp`,
+ *  which is the one thing in the session that was never durable anyway. */
+const MAX_LIVE_SESSIONS = 32;
+
 export function createShellTools(
   open: (principal: Principal) => Promise<WorkspaceFs>,
   config: { limits?: ShellLimits } = {},
 ): ToolRegistry {
+  const live = new Map<string, { session: ShellSession; workspace: WorkspaceFs }>();
   return {
     async descriptors() {
       return structuredClone(descriptors);
@@ -81,13 +88,28 @@ export function createShellTools(
       if (typeof args.command !== "string" || args.command.trim() === "") {
         return fail("validation", "command must be the shell command to run, as a single string");
       }
-      const workspace = await open(ctx.principal);
-      const session: ShellSession = createShellSession({
-        workspace,
-        ...(config.limits === undefined ? {} : { limits: config.limits }),
-      });
-      const result = await session.exec(args.command);
-      await workspace.commit();
+      // ONE session per TURN: `/tmp` is where a multi-step script keeps its
+      // intermediates, and a fresh interpreter per call would throw them away
+      // between `sort > /tmp/x` and `cat /tmp/x`. Keyed on `turnId` because that
+      // is the only thing a tool call carries meaning "same conversation, still
+      // going"; a run with no turn (a webhook, a schedule fire) falls back to its
+      // session so it is at least not sharing with anyone else.
+      const key = ctx.turnId ?? `session:${ctx.principal.subject}:${ctx.sessionId}`;
+      let held = live.get(key);
+      if (held === undefined) {
+        if (live.size >= MAX_LIVE_SESSIONS) live.delete(live.keys().next().value!);
+        const workspace = await open(ctx.principal);
+        held = {
+          workspace,
+          session: createShellSession({
+            workspace,
+            ...(config.limits === undefined ? {} : { limits: config.limits }),
+          }),
+        };
+        live.set(key, held);
+      }
+      const result = await held.session.exec(args.command);
+      await held.workspace.commit();
       return ok({ stdout: clip(result.stdout), stderr: clip(result.stderr), exitCode: result.exitCode });
     },
   };

--- a/packages/harnesses/src/vendo/shell/tool.ts
+++ b/packages/harnesses/src/vendo/shell/tool.ts
@@ -30,6 +30,9 @@ const DESCRIPTION =
   + "workspace: /user/threads/<thread>/files holds what they dropped in THIS conversation, "
   + "/user/apps/<app> holds an app's files, and /user/files is the shelf of things they asked you to "
   + "keep. /tmp is scratch that lasts this conversation and is never saved. "
+  + "When you build an app OUT OF a file the user dropped, `cp` it into "
+  + "/user/apps/<app>/ first and parse it there: a conversation's files are deleted with the "
+  + "conversation, and an app must not depend on one. "
   + "Binary formats are ordinary commands here: `pdftotext <file>`, `xlsx2csv <file> [sheet]` and "
   + "`docx2txt <file>` each write text to stdout, so they pipe into grep, awk and the rest. "
   + (JAVASCRIPT

--- a/packages/harnesses/tests/materialize-file-model.test.ts
+++ b/packages/harnesses/tests/materialize-file-model.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Spec §10 — every harness shares ONE file model. A sandboxed harness already
+ * materialises whatever the workspace says the caller can see, so a conversation's
+ * files and a staged drop reach a box with no code here at all. This test is the
+ * DECISION, pinned: staging is deliberately NOT excluded the way `scratch` is,
+ * because a staged file is the file the user just handed the agent, and the turn
+ * sweeps it anyway.
+ *
+ * `SCRATCH` gates PERSISTENCE, not the checkout (materialize.ts:186,205): every
+ * in-mount path reaches the disk — the agent needs its scratch directory to
+ * exist — and scratch alone is barred from syncing home. So the decision shows up
+ * in the baseline, which is where "never-persisted junk" actually means something.
+ */
+import { describe, expect, it } from "vitest";
+import { checkoutWorkspace, emptyTree } from "../src/materialize.js";
+import { testWorkspace } from "../src/test-doubles.test-util.js";
+
+describe("what reaches a machine's disk", () => {
+  it("carries a thread's files and a staged drop, and still drops scratch", async () => {
+    const workspace = testWorkspace({
+      "/user/threads/thr_1/files/ledger.csv": "jan,31000\n",
+      "/user/uploads/9f2a1c04-report.pdf": "%PDF-1.4\n",
+      "/user/files/kept.csv": "feb,39000\n",
+      "/user/scratch/junk.txt": "throwaway\n",
+    });
+
+    const tree = emptyTree();
+    const laid = await checkoutWorkspace(workspace, tree, true);
+    const paths = laid.files.map((file) => file.path);
+
+    // Nothing is excluded from the disk itself — the frozen line.
+    expect(paths).toContain("/user/threads/thr_1/files/ledger.csv");
+    expect(paths).toContain("/user/uploads/9f2a1c04-report.pdf");
+    expect(paths).toContain("/user/files/kept.csv");
+    expect(paths).toContain("/user/scratch/junk.txt");
+
+    // And the decision: a staged drop persists home like any real file, while
+    // scratch — and only scratch — is barred from ever coming back.
+    expect([...tree.hashes.keys()]).toContain("/user/uploads/9f2a1c04-report.pdf");
+    expect([...tree.hashes.keys()]).toContain("/user/threads/thr_1/files/ledger.csv");
+    expect([...tree.hashes.keys()]).toContain("/user/files/kept.csv");
+    expect([...tree.hashes.keys()]).not.toContain("/user/scratch/junk.txt");
+  });
+});

--- a/packages/harnesses/tests/shell/barrel.test.ts
+++ b/packages/harnesses/tests/shell/barrel.test.ts
@@ -1,0 +1,14 @@
+/**
+ * The shell is `vendo()`'s hand, so it leaves this package where the rest of
+ * that harness's knobs do — `@vendoai/harnesses/vendo`. A sandbox harness
+ * (`claudeCode()`) never imports it and must never see it.
+ */
+import { describe, expect, it } from "vitest";
+import * as vendoSubpath from "../../src/vendo/index.js";
+
+describe("the vendo subpath", () => {
+  it("exports the shell's tool factory and its limits type", () => {
+    expect(typeof vendoSubpath.createShellTools).toBe("function");
+    expect(typeof vendoSubpath.createShellSession).toBe("function");
+  });
+});

--- a/packages/harnesses/tests/shell/boot-failure.test.ts
+++ b/packages/harnesses/tests/shell/boot-failure.test.ts
@@ -1,0 +1,66 @@
+/**
+ * A shell that cannot BOOT, over the real engine.
+ *
+ * Its own file because the seam is a module: the shell loads its libraries
+ * bundler-blind at first use, so a load failure can only be injected by
+ * replacing `runtime.js`, and `vi.mock` is file-wide. Everything the assertions
+ * touch is real — the engine, just-bash, the filesystem, the retry.
+ */
+import { InMemoryFs } from "just-bash";
+import type { IFileSystem } from "@vendoai/core";
+import { describe, expect, it, vi } from "vitest";
+
+/** Set for the next library load only, then cleared — a blink, not a break. */
+let blink = false;
+
+vi.mock("../../src/vendo/shell/runtime.js", async (importOriginal) => {
+  const real = await importOriginal<typeof import("../../src/vendo/shell/runtime.js")>();
+  return {
+    ...real,
+    importShellLibrary: async (specifier: string) => {
+      if (!blink) return await real.importShellLibrary(specifier);
+      blink = false;
+      // The sentence Node itself produces when a bundled chunk cannot see this
+      // package's node_modules — the failure this really hit in a host app.
+      throw new Error(`Cannot find package '${specifier}' imported from /host/.next/chunk.js`);
+    },
+  };
+});
+
+// Imported AFTER the mock declaration; `vi.mock` is hoisted, so `engine.ts`
+// binds the double.
+const { createShellSession } = await import("../../src/vendo/shell/engine.js");
+
+const disk = async (files: Record<string, string>): Promise<IFileSystem> => {
+  const fs = new InMemoryFs();
+  for (const [path, content] of Object.entries(files)) {
+    await fs.mkdir(path.slice(0, path.lastIndexOf("/")), { recursive: true });
+    await fs.writeFile(path, content);
+  }
+  return fs as unknown as IFileSystem;
+};
+
+describe("a shell whose interpreter will not load", () => {
+  it("reports the failure the model can read instead of throwing out of the call", async () => {
+    const session = createShellSession({ workspace: await disk({ "/user/files/a.txt": "hi\n" }) });
+    blink = true;
+
+    const result = await session.exec("cat files/a.txt");
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain("Cannot find package 'just-bash'");
+    expect(result.stdout).toBe("");
+  });
+
+  it("does not cache the failure, so the next call in the same turn still works", async () => {
+    const session = createShellSession({ workspace: await disk({ "/user/files/a.txt": "hi\n" }) });
+    blink = true;
+    expect((await session.exec("cat files/a.txt")).exitCode).not.toBe(0);
+
+    // Same session. A cached rejection would answer with the boot error forever.
+    const result = await session.exec("cat files/a.txt");
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("hi\n");
+  });
+});

--- a/packages/harnesses/tests/shell/engine.test.ts
+++ b/packages/harnesses/tests/shell/engine.test.ts
@@ -75,6 +75,32 @@ describe("one shell session over the workspace", () => {
     const result = await createShellSession({ workspace }).exec("echo pwned > /etc/passwd");
 
     expect(result.exitCode).not.toBe(0);
+    // The workspace's OWN sentence, verbatim — a non-zero exit alone would also
+    // be satisfied by an engine that swallowed the EACCES and failed some other
+    // way, which is the opposite of the non-interference this proves.
+    expect(result.stderr).toContain("EACCES: permission denied, open '/etc/passwd'");
+  });
+
+  it("bounds that /tmp across the whole session, not just one call", async () => {
+    // `maxOutputBytes` bounds ONE redirect (`redirection: total output size
+    // exceeded`); nothing bounded the SESSION, so a turn that kept appending grew
+    // `/tmp` without limit — 200 MB over 400 calls, measured. Raised here so the
+    // ceiling is reached in a handful of copies rather than sixty appends.
+    const session = createShellSession({ workspace: await disk({}), limits: { maxOutputBytes: 8_000_000 } });
+    const repeat = (path: string, times: number): string => Array.from({ length: times }, () => path).join(" ");
+    expect((await session.exec(`printf 'x%.0s' $(seq 1 100000) > /tmp/kb100`)).exitCode).toBe(0);
+    expect((await session.exec(`cat ${repeat("/tmp/kb100", 10)} > /tmp/mb1`)).exitCode).toBe(0);
+    expect((await session.exec(`cat ${repeat("/tmp/mb1", 5)} > /tmp/mb5`)).exitCode).toBe(0);
+
+    let last = { exitCode: 0, stderr: "" };
+    for (let copy = 0; copy < 8 && last.exitCode === 0; copy += 1) {
+      // Each copy has to be its OWN bytes: `cp` alone shares one hard-link
+      // buffer, so eight identical copies retain what one does.
+      last = await session.exec(`cp /tmp/mb5 /tmp/copy${copy} && echo ${copy} >> /tmp/copy${copy}`);
+    }
+
+    expect(last.exitCode).not.toBe(0);
+    expect(last.stderr).toContain("ENOSPC");
   });
 
   it("stops a command that will not stop", async () => {

--- a/packages/harnesses/tests/shell/engine.test.ts
+++ b/packages/harnesses/tests/shell/engine.test.ts
@@ -76,4 +76,29 @@ describe("one shell session over the workspace", () => {
 
     expect(result.exitCode).not.toBe(0);
   });
+
+  it("stops a command that will not stop", async () => {
+    const session = createShellSession({
+      workspace: await disk({}),
+      limits: { maxExecutionTimeMs: 250 },
+    });
+
+    const result = await session.exec("while true; do echo spin > /dev/null; done");
+
+    expect(result.exitCode).not.toBe(0);
+  });
+
+  it("stops a command that will not stop TALKING", async () => {
+    const session = createShellSession({
+      workspace: await disk({}),
+      limits: { maxOutputBytes: 512 },
+    });
+
+    // `seq`, not `yes`: just-bash 3.4.2 ships no `yes`, and in a pipeline the
+    // `command not found` is invisible — the exit code is `head`'s 0.
+    const result = await session.exec("seq 1 100000");
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout.length).toBeLessThan(4096);
+  });
 });

--- a/packages/harnesses/tests/shell/engine.test.ts
+++ b/packages/harnesses/tests/shell/engine.test.ts
@@ -45,4 +45,35 @@ describe("one shell session over the workspace", () => {
     expect(result.exitCode).not.toBe(0);
     expect(result.stderr).toContain("No such file or directory");
   });
+
+  it("gives the session a writable /tmp the workspace never sees", async () => {
+    const workspace = await disk({ "/user/files/a.txt": "one\ntwo\n" });
+    const session = createShellSession({ workspace });
+
+    const wrote = await session.exec("sort files/a.txt > /tmp/sorted.txt");
+    expect(wrote.exitCode).toBe(0);
+    // Same session, second call: the scratch is still there.
+    expect((await session.exec("cat /tmp/sorted.txt")).stdout).toBe("one\ntwo\n");
+    // And it is NOT in the workspace — nothing to commit, nothing to leak.
+    expect(await workspace.exists("/tmp/sorted.txt")).toBe(false);
+  });
+
+  it("refuses a write outside the mounts, because the filesystem does", async () => {
+    // The refusal is the WORKSPACE's, never the engine's — `WorkspaceStoreFs`
+    // raises EACCES outside the caller's mounts (store/src/workspace-fs.ts:229),
+    // and this module deliberately bolts no check of its own on top. So the base
+    // here is one that refuses, and what this proves is the engine's
+    // non-interference: it surfaces the filesystem's EACCES rather than routing
+    // around it. A bare `InMemoryFs` has no mounts and would assert nothing.
+    const workspace = await disk({});
+    const mounted = workspace.writeFile.bind(workspace);
+    workspace.writeFile = async (path, data) => {
+      if (!path.startsWith("/user/")) throw new Error(`EACCES: permission denied, open '${path}'`);
+      return await mounted(path, data);
+    };
+
+    const result = await createShellSession({ workspace }).exec("echo pwned > /etc/passwd");
+
+    expect(result.exitCode).not.toBe(0);
+  });
 });

--- a/packages/harnesses/tests/shell/engine.test.ts
+++ b/packages/harnesses/tests/shell/engine.test.ts
@@ -1,0 +1,48 @@
+/**
+ * The engine, over a REAL just-bash filesystem — the same interface a
+ * `WorkspaceFs` satisfies, so what passes here is what a turn gets.
+ */
+import { InMemoryFs } from "just-bash";
+import type { IFileSystem } from "@vendoai/core";
+import { describe, expect, it } from "vitest";
+import { createShellSession } from "../../src/vendo/shell/engine.js";
+
+const disk = async (files: Record<string, string>): Promise<IFileSystem> => {
+  const fs = new InMemoryFs();
+  for (const [path, content] of Object.entries(files)) {
+    await fs.mkdir(path.slice(0, path.lastIndexOf("/")), { recursive: true });
+    await fs.writeFile(path, content);
+  }
+  return fs as unknown as IFileSystem;
+};
+
+describe("one shell session over the workspace", () => {
+  it("greps a file the workspace holds", async () => {
+    const workspace = await disk({
+      "/user/threads/thr_1/files/ledger.csv": "month,revenue\njan,31000\nfeb,39000\n",
+    });
+    const session = createShellSession({ workspace });
+
+    const result = await session.exec("grep -c , threads/thr_1/files/ledger.csv");
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe("3");
+    expect(result.stderr).toBe("");
+  });
+
+  it("starts in /user, so the agent's paths are the user's paths", async () => {
+    const session = createShellSession({ workspace: await disk({ "/user/files/a.txt": "hi\n" }) });
+
+    expect((await session.exec("pwd")).stdout.trim()).toBe("/user");
+    expect((await session.exec("cat files/a.txt")).stdout).toBe("hi\n");
+  });
+
+  it("reports a failing command instead of throwing", async () => {
+    const session = createShellSession({ workspace: await disk({}) });
+
+    const result = await session.exec("cat /user/nope.txt");
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain("No such file or directory");
+  });
+});

--- a/packages/harnesses/tests/shell/engine.test.ts
+++ b/packages/harnesses/tests/shell/engine.test.ts
@@ -151,9 +151,15 @@ describe("the JavaScript hand", () => {
   it("has no network inside the script", async () => {
     const session = createShellSession({ workspace: await disk({}), javascript: true });
 
-    const result = await session.exec(`js-exec -c 'fetch("https://example.com").then(() => console.log("reached"))'`);
+    // AWAITED, not fire-and-forget: `fetch` IS defined in the sandbox, so an
+    // unawaited promise only proves the script exited before it settled — which
+    // it would do just as happily with the network working. What has to be proven
+    // is that the call is REFUSED, in the sandbox's own words.
+    const result = await session.exec(`js-exec -c 'await fetch("https://example.com"); console.log("reached")'`);
 
+    expect(result.exitCode).not.toBe(0);
     expect(result.stdout).not.toContain("reached");
+    expect(result.stderr).toContain("Network access not configured");
   });
 
   it("has no js-exec at all when it was not asked for", async () => {

--- a/packages/harnesses/tests/shell/engine.test.ts
+++ b/packages/harnesses/tests/shell/engine.test.ts
@@ -128,3 +128,40 @@ describe("one shell session over the workspace", () => {
     expect(result.stdout.length).toBeLessThan(4096);
   });
 });
+
+describe("the JavaScript hand", () => {
+  it("runs a script that reads the workspace and writes back to it", async () => {
+    const workspace = await disk({
+      "/user/threads/thr_1/files/rows.json": JSON.stringify([{ n: 3 }, { n: 4 }, { n: 5 }]),
+    });
+    const session = createShellSession({ workspace, javascript: true });
+
+    const result = await session.exec(
+      `js-exec -c 'const fs = require("node:fs");
+        const rows = JSON.parse(fs.readFileSync("/user/threads/thr_1/files/rows.json", "utf8"));
+        fs.writeFileSync("/user/threads/thr_1/files/total.txt", String(rows.reduce((a, r) => a + r.n, 0)));
+        console.log("done");'`,
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("done");
+    expect(await workspace.readFile("/user/threads/thr_1/files/total.txt")).toBe("12");
+  });
+
+  it("has no network inside the script", async () => {
+    const session = createShellSession({ workspace: await disk({}), javascript: true });
+
+    const result = await session.exec(`js-exec -c 'fetch("https://example.com").then(() => console.log("reached"))'`);
+
+    expect(result.stdout).not.toContain("reached");
+  });
+
+  it("has no js-exec at all when it was not asked for", async () => {
+    const session = createShellSession({ workspace: await disk({}) });
+
+    const result = await session.exec(`js-exec -c 'console.log(1)'`);
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain("js-exec");
+  });
+});

--- a/packages/harnesses/tests/shell/host-async-hooks.e2e.test.ts
+++ b/packages/harnesses/tests/shell/host-async-hooks.e2e.test.ts
@@ -1,0 +1,120 @@
+/**
+ * The shell, inside a host process that watches its own promises.
+ *
+ * just-bash's MAIN-THREAD defense box patches host globals for the duration of a
+ * command. A host that has installed an async-hooks `init` callback — Next dev's
+ * React async tracker is the one that bit us — sees that callback fire on the
+ * box's own first promise, inside the box, where `performance.now()` and
+ * `new WeakRef()` are guarded. The box throws, and it throws from
+ * `emitInitNative`, which Node treats as unrecoverable: no try/catch of ours is
+ * even on the stack. The host's dev server died on the FIRST bash call, every
+ * time, and the engine's own tests could not see it because a test runner
+ * installs no such hook.
+ *
+ * So this runs the built shell in a subprocess that installs one, and asserts
+ * the process lives. In a subprocess because the failure mode being pinned is
+ * `process._fatalException` — in-process it would take the vitest worker with
+ * it, which is a crashed run rather than a red test.
+ */
+import { execFileSync, spawnSync } from "node:child_process";
+import { rm, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const PACKAGE_DIR = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const SHELL_DIST = join(PACKAGE_DIR, "dist", "vendo", "shell");
+
+/** Next's dev tracker, reduced to the one object literal its crash stacks point
+ *  at (next-server/app-page-turbo.runtime.dev.js): a `performance.now()`, a
+ *  `WeakRef` on the resource, and a captured stack. */
+const PROBE = `
+import { createHook } from "node:async_hooks";
+import { InMemoryFs } from "just-bash";
+import { createShellSession } from "./engine.js";
+
+let inits = 0;
+createHook({
+  init(_id, _type, _trigger, resource) {
+    inits += 1;
+    void {
+      start: globalThis.performance.now(),
+      promise: new WeakRef(resource),
+      stack: new Error().stack,
+    };
+  },
+}).enable();
+
+const workspace = new InMemoryFs();
+await workspace.mkdir("/user/files", { recursive: true });
+await workspace.writeFile("/user/files/rows.txt", "a\\nb\\nc\\n");
+
+const session = createShellSession({ workspace, javascript: true });
+const bash = await session.exec("wc -l < files/rows.txt");
+const jsExec = await session.exec("js-exec -c 'console.log(6 * 7)'");
+// A SECOND session in the same process: just-bash's defense box is a process
+// singleton that refuses two Bash instances whose resolved config differs, down
+// to the identity of the onViolation callback.
+const second = await createShellSession({ workspace }).exec("echo second-session");
+
+process.stdout.write(JSON.stringify({ inits, bash, jsExec, second }));
+// js-exec parks its QuickJS worker for the next call; a probe that has said
+// everything it has to say exits rather than waiting for it.
+process.exit(0);
+`;
+
+let probe: { status: number | null; stdout: string; stderr: string };
+let out: {
+  inits: number;
+  bash: { stdout: string; exitCode: number };
+  jsExec: { stdout: string; exitCode: number };
+  second: { stdout: string; exitCode: number };
+};
+
+/** Written INTO the built dist, so its bare imports resolve the way a host's
+ *  would; removed after, so the build output is left as tsc emitted it. */
+const SCRIPT = join(SHELL_DIST, "async-hooks-probe.mjs");
+
+afterAll(async () => { await rm(SCRIPT, { force: true }); });
+
+beforeAll(async () => {
+  // The built dist is what a host actually loads, and it is what `pnpm build`
+  // emits — same command, so this never tests a stale copy.
+  execFileSync("npx", ["tsc", "-p", "tsconfig.json"], { cwd: PACKAGE_DIR, stdio: "pipe" });
+  await writeFile(SCRIPT, PROBE);
+  probe = spawnSync(process.execPath, [SCRIPT], {
+    cwd: PACKAGE_DIR,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  out = probe.status === 0 ? JSON.parse(probe.stdout) as typeof out : ({} as typeof out);
+}, 300_000);
+
+describe("the shell under a host's async-hooks init callback", () => {
+  it("leaves the host process alive", () => {
+    // The whole defect, in one assertion: this exited 9 short of `status === 0`
+    // with `SecurityViolationError: globalThis.performance.now is blocked`.
+    expect({ status: probe.status, fatal: /SecurityViolationError/.test(probe.stderr) })
+      .toEqual({ status: 0, fatal: false });
+  });
+
+  it("ran every command, with the host's hook firing throughout", () => {
+    expect(out.bash).toMatchObject({ stdout: "3\n", exitCode: 0 });
+    expect(out.jsExec).toMatchObject({ stdout: "42\n", exitCode: 0 });
+    expect(out.inits).toBeGreaterThan(100);
+  });
+
+  it("lets a second session run in the same process", () => {
+    expect(out.second).toMatchObject({ stdout: "second-session\n", exitCode: 0 });
+  });
+
+  it("tells the operator once per violation type, not once per violation", () => {
+    // ~1294 violations in one measured turn: a line each is a line per promise.
+    // The count is the assertion — the audit is only useful if it is readable.
+    const lines = probe.stderr.split("\n").filter((line) => line.includes("[vendo] shell:"));
+    expect(lines.length).toBeGreaterThan(0);
+    expect(new Set(lines).size).toBe(lines.length);
+    expect(lines.join("\n")).toContain("performance_timing");
+    expect(lines.join("\n")).toContain("ALLOWED");
+  });
+});

--- a/packages/harnesses/tests/shell/host-resolution.e2e.test.ts
+++ b/packages/harnesses/tests/shell/host-resolution.e2e.test.ts
@@ -21,11 +21,11 @@
  * so this can never pass by accident.
  */
 import { execFileSync } from "node:child_process";
-import { cp, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { cp, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 const PACKAGE_DIR = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const SHELL_DIST = join(PACKAGE_DIR, "dist", "vendo", "shell");
@@ -76,14 +76,26 @@ process.exit(0);
 type Result = { stdout?: string; stderr?: string; exitCode?: number; error?: string };
 
 let probed: { bare: Record<string, string> } & Record<string, Result>;
+/** A full copy of the shell dist per run, so it is removed rather than left
+ *  in the OS temp directory. */
+let chunk: string;
+
+afterAll(async () => { await rm(chunk, { recursive: true, force: true }); });
 
 beforeAll(async () => {
   // The built dist is what a host actually loads, and it is what tsc emits for
   // `pnpm build` — same command, so this never tests a stale copy.
   execFileSync("npx", ["tsc", "-p", "tsconfig.json"], { cwd: PACKAGE_DIR, stdio: "pipe" });
-  const chunk = await mkdtemp(join(tmpdir(), "vendo-host-chunk-"));
+  chunk = await mkdtemp(join(tmpdir(), "vendo-host-chunk-"));
   await cp(SHELL_DIST, chunk, { recursive: true });
   await writeFile(join(chunk, "package.json"), '{"type":"module"}\n');
+  // A bundler INLINES an ordinary sibling like @vendoai/core into the chunk; the
+  // four above are the only imports left bare, because they alone are
+  // bundler-blind. Modelling core as bare too would fail this fixture for a
+  // reason no host has. So the chunk gets core, and nothing else — the first
+  // assertion below still proves the four are genuinely dead here.
+  await mkdir(join(chunk, "node_modules", "@vendoai"), { recursive: true });
+  await symlink(join(PACKAGE_DIR, "..", "core"), join(chunk, "node_modules", "@vendoai", "core"), "dir");
   const runtime = join(chunk, "runtime.js");
   await writeFile(runtime, (await readFile(runtime, "utf8")).replaceAll(
     "import.meta.url",

--- a/packages/harnesses/tests/shell/host-resolution.e2e.test.ts
+++ b/packages/harnesses/tests/shell/host-resolution.e2e.test.ts
@@ -1,0 +1,135 @@
+/**
+ * The shell, run from where the PRODUCT runs it.
+ *
+ * just-bash and the three parser libraries are dependencies of this package
+ * alone, so pnpm keeps them in this package's own node_modules. Every other test
+ * in this directory runs from inside this package, where a bare
+ * `import("just-bash")` therefore resolves — which is precisely why they all
+ * stayed green while the shell was dead in every real host: the shell's imports
+ * are deliberately bundler-blind (see importShellLibrary), so a bundler emits
+ * them into a chunk that sits in the HOST APP's directory, and Node resolves a
+ * bare specifier relative to the importing FILE.
+ *
+ * So this runs the BUILT shell out of a directory that cannot see those
+ * libraries, left exactly as Turbopack and webpack leave it: the code is
+ * relocated, while `import.meta.url` still names the original module (Turbopack
+ * emits `file://${resolveAbsolutePath("packages/harnesses/dist/…")}` for it;
+ * webpack substitutes the module's own resource URL). Under a plain `node`
+ * subprocess, never the test runner's module graph — vitest resolves against
+ * this package's root, which would hand back the very illusion this test exists
+ * to break. The first assertion is that a bare specifier really is dead there,
+ * so this can never pass by accident.
+ */
+import { execFileSync } from "node:child_process";
+import { cp, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { beforeAll, describe, expect, it } from "vitest";
+
+const PACKAGE_DIR = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const SHELL_DIST = join(PACKAGE_DIR, "dist", "vendo", "shell");
+const LIBRARIES = ["just-bash", "unpdf", "@e965/xlsx", "fflate"];
+
+/** The whole run, in the relocated chunk's own process. Every command is caught
+ *  so a library that fails to load reports as a result instead of a dead pipe. */
+const PROBE = (justBashUrl: string): string => `
+import { createShellSession } from "./engine.js";
+
+const bare = {};
+for (const specifier of ${JSON.stringify(LIBRARIES)}) {
+  try {
+    await import(specifier);
+    bare[specifier] = "resolved";
+  } catch (error) {
+    bare[specifier] = error.code ?? String(error);
+  }
+}
+
+const { InMemoryFs } = await import(${JSON.stringify(justBashUrl)});
+const workspace = new InMemoryFs();
+await workspace.mkdir("/user/files", { recursive: true });
+await workspace.writeFile("/user/files/notes.txt", "plain text, not a document\\n");
+const session = createShellSession({ workspace, javascript: true });
+
+const run = async (command) => {
+  try {
+    return await session.exec(command);
+  } catch (error) {
+    return { error: error?.message ?? String(error) };
+  }
+};
+
+process.stdout.write(JSON.stringify({
+  bare,
+  bash: await run("echo shell-alive"),
+  jsExec: await run("js-exec -c 'console.log(6 * 7)'"),
+  pdftotext: await run("pdftotext files/notes.txt"),
+  xlsx2csv: await run("xlsx2csv files/notes.txt"),
+  docx2txt: await run("docx2txt files/notes.txt"),
+}));
+// js-exec leaves its QuickJS worker parked for the next call, so a probe that
+// has said everything it has to say exits rather than waiting for it.
+process.exit(0);
+`;
+
+type Result = { stdout?: string; stderr?: string; exitCode?: number; error?: string };
+
+let probed: { bare: Record<string, string> } & Record<string, Result>;
+
+beforeAll(async () => {
+  // The built dist is what a host actually loads, and it is what tsc emits for
+  // `pnpm build` — same command, so this never tests a stale copy.
+  execFileSync("npx", ["tsc", "-p", "tsconfig.json"], { cwd: PACKAGE_DIR, stdio: "pipe" });
+  const chunk = await mkdtemp(join(tmpdir(), "vendo-host-chunk-"));
+  await cp(SHELL_DIST, chunk, { recursive: true });
+  await writeFile(join(chunk, "package.json"), '{"type":"module"}\n');
+  const runtime = join(chunk, "runtime.js");
+  await writeFile(runtime, (await readFile(runtime, "utf8")).replaceAll(
+    "import.meta.url",
+    JSON.stringify(pathToFileURL(join(SHELL_DIST, "runtime.js")).href),
+  ));
+  const justBash = execFileSync(
+    process.execPath,
+    ["-e", 'process.stdout.write(require.resolve("just-bash"))'],
+    { cwd: PACKAGE_DIR, encoding: "utf8" },
+  );
+  await writeFile(join(chunk, "probe.mjs"), PROBE(pathToFileURL(justBash).href));
+  probed = JSON.parse(execFileSync(process.execPath, [join(chunk, "probe.mjs")], {
+    cwd: chunk,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  })) as typeof probed;
+}, 300_000);
+
+describe("the shell's libraries, from a chunk in the host app's directory", () => {
+  it("is a directory where every bare specifier is genuinely dead", () => {
+    expect(probed.bare).toEqual(Object.fromEntries(
+      LIBRARIES.map((specifier) => [specifier, "ERR_MODULE_NOT_FOUND"]),
+    ));
+  });
+
+  it("runs bash there anyway", () => {
+    expect(probed.bash).toMatchObject({ stdout: "shell-alive\n", exitCode: 0 });
+  });
+
+  // just-bash's ESM entry, specifically: its CJS bundle has no `import.meta.url`
+  // to bootstrap the QuickJS worker from, so js-exec — and only js-exec — dies
+  // with "Invalid URL" if the load ever picks up the require condition.
+  it("runs js-exec there, so it is the ESM build that loaded", () => {
+    expect(probed.jsExec).toMatchObject({ stdout: "42\n", exitCode: 0 });
+  });
+
+  // Wrong bytes on purpose: each parser's OWN refusal is the proof its library
+  // loaded and ran. A library that never loaded takes the command down instead.
+  it.each([
+    ["pdftotext", "PDF"],
+    ["xlsx2csv", "spreadsheet"],
+    ["docx2txt", "Word document"],
+  ])("loads %s's library there", (command, format) => {
+    expect(probed[command]).toMatchObject({
+      exitCode: 1,
+      stderr: expect.stringContaining(`${command}: files/notes.txt: not a readable ${format}`) as unknown as string,
+    });
+  });
+});

--- a/packages/harnesses/tests/shell/parsers.test.ts
+++ b/packages/harnesses/tests/shell/parsers.test.ts
@@ -114,6 +114,14 @@ describe("xlsx2csv", () => {
     expect(result.stdout.trim().split("\n")).toEqual(["month,revenue", "jan,31000", "feb,39000"]);
   });
 
+  it("terminates the CSV with a newline, so `wc -l` counts every row", async () => {
+    const session = createShellSession({ workspace: await diskWith({ "/user/files/q1.xlsx": await workbook() }) });
+
+    expect((await session.exec("xlsx2csv files/q1.xlsx")).stdout)
+      .toBe("month,revenue\njan,31000\nfeb,39000\n");
+    expect((await session.exec("xlsx2csv files/q1.xlsx | wc -l")).stdout.trim()).toBe("3");
+  });
+
   it("takes a sheet by name, and lists them when the name is wrong", async () => {
     const session = createShellSession({ workspace: await diskWith({ "/user/files/q1.xlsx": await workbook() }) });
 

--- a/packages/harnesses/tests/shell/parsers.test.ts
+++ b/packages/harnesses/tests/shell/parsers.test.ts
@@ -274,4 +274,14 @@ describe("docx2txt", () => {
 
     expect((await session.exec("docx2txt files/runs.docx")).exitCode).toBe(0);
   });
+
+  it("stays linear when the text openers never reach their own '>'", async () => {
+    // One level deeper again: the opener alternative itself scans for `>`, so
+    // openers with no `>` anywhere after them make EVERY one of them scan to the
+    // end of the part. Only stopping that scan at the next `<` keeps it linear.
+    const docx = await docxWith(body(`<w:p >${"<w:t ".repeat(200_000)}</w:p>`));
+    const session = createShellSession({ workspace: await diskWith({ "/user/files/open.docx": docx }) });
+
+    expect((await session.exec("docx2txt files/open.docx")).exitCode).toBe(0);
+  });
 });

--- a/packages/harnesses/tests/shell/parsers.test.ts
+++ b/packages/harnesses/tests/shell/parsers.test.ts
@@ -84,7 +84,7 @@ describe("pdftotext", () => {
 describe("xlsx2csv", () => {
   /** A real workbook, written by the same library that will read it back. */
   const workbook = async (): Promise<Uint8Array> => {
-    const XLSX = await import("xlsx");
+    const XLSX = await import("@e965/xlsx");
     const book = XLSX.utils.book_new();
     XLSX.utils.book_append_sheet(
       book,

--- a/packages/harnesses/tests/shell/parsers.test.ts
+++ b/packages/harnesses/tests/shell/parsers.test.ts
@@ -1,0 +1,82 @@
+/**
+ * The three parsers, each against a REAL file of its format built right here.
+ * A fixture you can read is a fixture you can debug, and the libraries under
+ * test (pdf.js via unpdf, SheetJS, a zip) will not accept a fake.
+ */
+import { InMemoryFs } from "just-bash";
+import type { IFileSystem } from "@vendoai/core";
+import { describe, expect, it } from "vitest";
+import { createShellSession } from "../../src/vendo/shell/engine.js";
+
+/** A structurally valid one-page PDF with one line of Helvetica text. The xref
+    offsets are computed, not typed, so the file is always well-formed. */
+function minimalPdf(line: string): Uint8Array {
+  const stream = `BT /F1 12 Tf 20 100 Td (${line}) Tj ET`;
+  const objects = [
+    "<</Type/Catalog/Pages 2 0 R>>",
+    "<</Type/Pages/Kids[3 0 R]/Count 1>>",
+    "<</Type/Page/Parent 2 0 R/MediaBox[0 0 200 200]/Contents 4 0 R/Resources<</Font<</F1 5 0 R>>>>>>",
+    `<</Length ${stream.length}>>\nstream\n${stream}\nendstream`,
+    "<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>",
+  ];
+  let pdf = "%PDF-1.4\n";
+  const offsets: number[] = [];
+  for (const [index, body] of objects.entries()) {
+    offsets.push(pdf.length);
+    pdf += `${index + 1} 0 obj\n${body}\nendobj\n`;
+  }
+  const startxref = pdf.length;
+  pdf += `xref\n0 ${objects.length + 1}\n0000000000 65535 f \n`;
+  for (const offset of offsets) pdf += `${String(offset).padStart(10, "0")} 00000 n \n`;
+  pdf += `trailer\n<</Size ${objects.length + 1}/Root 1 0 R>>\nstartxref\n${startxref}\n%%EOF\n`;
+  return new TextEncoder().encode(pdf);
+}
+
+async function diskWith(files: Record<string, Uint8Array | string>): Promise<IFileSystem> {
+  const fs = new InMemoryFs();
+  for (const [path, content] of Object.entries(files)) {
+    await fs.mkdir(path.slice(0, path.lastIndexOf("/")), { recursive: true });
+    await fs.writeFile(path, content);
+  }
+  return fs as unknown as IFileSystem;
+}
+
+describe("pdftotext", () => {
+  it("reads the text out of a real PDF", async () => {
+    const workspace = await diskWith({ "/user/files/invoice.pdf": minimalPdf("Invoice 4210 total 980.00") });
+    const session = createShellSession({ workspace });
+
+    const result = await session.exec("pdftotext files/invoice.pdf");
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("Invoice 4210 total 980.00");
+  });
+
+  it("pipes, like every other command in the shell", async () => {
+    const workspace = await diskWith({ "/user/files/invoice.pdf": minimalPdf("Invoice 4210 total 980.00") });
+    const session = createShellSession({ workspace });
+
+    const result = await session.exec("pdftotext files/invoice.pdf | grep -o '4210'");
+
+    expect(result.stdout.trim()).toBe("4210");
+  });
+
+  it("says so when the file is not a PDF", async () => {
+    const workspace = await diskWith({ "/user/files/notes.txt": "just words\n" });
+    const session = createShellSession({ workspace });
+
+    const result = await session.exec("pdftotext files/notes.txt");
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("not a readable PDF");
+  });
+
+  it("says so when there is no file", async () => {
+    const session = createShellSession({ workspace: await diskWith({}) });
+
+    const result = await session.exec("pdftotext files/missing.pdf");
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("No such file or directory");
+  });
+});

--- a/packages/harnesses/tests/shell/parsers.test.ts
+++ b/packages/harnesses/tests/shell/parsers.test.ts
@@ -125,3 +125,56 @@ describe("xlsx2csv", () => {
     expect(result.stderr).toContain("not a readable spreadsheet");
   });
 });
+
+describe("docx2txt", () => {
+  /** A real .docx: a zip carrying the three parts Word requires. */
+  const document = async (paragraphs: string[]): Promise<Uint8Array> => {
+    const { zipSync, strToU8 } = await import("fflate");
+    const body = paragraphs
+      .map((text) => `<w:p><w:r><w:t xml:space="preserve">${text}</w:t></w:r></w:p>`)
+      .join("");
+    return zipSync({
+      "[Content_Types].xml":
+        strToU8(`<?xml version="1.0" encoding="UTF-8"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="xml" ContentType="application/xml"/><Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>`),
+      "_rels/.rels":
+        strToU8(`<?xml version="1.0" encoding="UTF-8"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/></Relationships>`),
+      "word/document.xml":
+        strToU8(`<?xml version="1.0" encoding="UTF-8"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>${body}</w:body></w:document>`),
+    });
+  };
+
+  it("reads the paragraphs out of a real .docx, one per line", async () => {
+    const workspace = await diskWith({
+      "/user/files/brief.docx": await document(["Quarterly brief", "Revenue rose 26% to 98,000."]),
+    });
+    const session = createShellSession({ workspace });
+
+    const result = await session.exec("docx2txt files/brief.docx");
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("Quarterly brief\nRevenue rose 26% to 98,000.\n");
+  });
+
+  it("keeps a paragraph whole when Word split it into runs", async () => {
+    const { zipSync, strToU8 } = await import("fflate");
+    const split = zipSync({
+      "word/document.xml": strToU8(
+        `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>`
+        + `<w:p><w:r><w:t xml:space="preserve">Revenue rose </w:t></w:r><w:r><w:t>26%</w:t></w:r></w:p>`
+        + `</w:body></w:document>`,
+      ),
+    });
+    const session = createShellSession({ workspace: await diskWith({ "/user/files/split.docx": split }) });
+
+    expect((await session.exec("docx2txt files/split.docx")).stdout).toBe("Revenue rose 26%\n");
+  });
+
+  it("says so when the file is not a .docx", async () => {
+    const session = createShellSession({ workspace: await diskWith({ "/user/files/notes.txt": "just words\n" }) });
+
+    const result = await session.exec("docx2txt files/notes.txt");
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("not a readable Word document");
+  });
+});

--- a/packages/harnesses/tests/shell/parsers.test.ts
+++ b/packages/harnesses/tests/shell/parsers.test.ts
@@ -80,3 +80,48 @@ describe("pdftotext", () => {
     expect(result.stderr).toContain("No such file or directory");
   });
 });
+
+describe("xlsx2csv", () => {
+  /** A real workbook, written by the same library that will read it back. */
+  const workbook = async (): Promise<Uint8Array> => {
+    const XLSX = await import("xlsx");
+    const book = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(
+      book,
+      XLSX.utils.aoa_to_sheet([["month", "revenue"], ["jan", 31000], ["feb", 39000]]),
+      "Revenue",
+    );
+    XLSX.utils.book_append_sheet(book, XLSX.utils.aoa_to_sheet([["note"], ["draft"]]), "Notes");
+    return new Uint8Array(XLSX.write(book, { type: "array", bookType: "xlsx" }) as ArrayBuffer);
+  };
+
+  it("turns the first sheet into CSV on stdout", async () => {
+    const session = createShellSession({ workspace: await diskWith({ "/user/files/q1.xlsx": await workbook() }) });
+
+    const result = await session.exec("xlsx2csv files/q1.xlsx");
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim().split("\n")).toEqual(["month,revenue", "jan,31000", "feb,39000"]);
+  });
+
+  it("takes a sheet by name, and lists them when the name is wrong", async () => {
+    const session = createShellSession({ workspace: await diskWith({ "/user/files/q1.xlsx": await workbook() }) });
+
+    expect((await session.exec("xlsx2csv files/q1.xlsx Notes")).stdout.trim().split("\n"))
+      .toEqual(["note", "draft"]);
+
+    const wrong = await session.exec("xlsx2csv files/q1.xlsx Nope");
+    expect(wrong.exitCode).toBe(1);
+    expect(wrong.stderr).toContain("Revenue");
+    expect(wrong.stderr).toContain("Notes");
+  });
+
+  it("says so when the file is not a workbook", async () => {
+    const session = createShellSession({ workspace: await diskWith({ "/user/files/notes.txt": "just words\n" }) });
+
+    const result = await session.exec("xlsx2csv files/notes.txt");
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("not a readable spreadsheet");
+  });
+});

--- a/packages/harnesses/tests/shell/parsers.test.ts
+++ b/packages/harnesses/tests/shell/parsers.test.ts
@@ -79,6 +79,16 @@ describe("pdftotext", () => {
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain("No such file or directory");
   });
+
+  it("says a directory is a directory, the way bash does", async () => {
+    const workspace = await diskWith({ "/user/files/reports/q1.pdf": minimalPdf("x") });
+    const session = createShellSession({ workspace });
+
+    const result = await session.exec("pdftotext files/reports");
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("Is a directory");
+  });
 });
 
 describe("xlsx2csv", () => {
@@ -123,6 +133,16 @@ describe("xlsx2csv", () => {
 
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain("not a readable spreadsheet");
+  });
+
+  it("treats a sheet named after an Object property as the missing sheet it is", async () => {
+    const session = createShellSession({ workspace: await diskWith({ "/user/files/q1.xlsx": await workbook() }) });
+
+    const result = await session.exec("xlsx2csv files/q1.xlsx toString");
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("no sheet named");
+    expect(result.stderr).toContain("Revenue");
   });
 });
 
@@ -176,5 +196,74 @@ describe("docx2txt", () => {
 
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain("not a readable Word document");
+  });
+
+  /** A .docx carrying exactly this `word/document.xml`, and nothing else. */
+  const docxWith = async (documentXml: string): Promise<Uint8Array> => {
+    const { zipSync, strToU8 } = await import("fflate");
+    return zipSync({ "word/document.xml": strToU8(documentXml) });
+  };
+
+  const body = (inner: string): string =>
+    `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>${inner}</w:body></w:document>`;
+
+  it("keeps the tab and the manual break Word put between two fields", async () => {
+    const docx = await docxWith(body(
+      `<w:p><w:r><w:t>Account</w:t></w:r><w:r><w:tab/></w:r><w:r><w:t>Balance</w:t></w:r>`
+      + `<w:r><w:br/></w:r><w:r><w:t>Due</w:t></w:r></w:p>`,
+    ));
+    const session = createShellSession({ workspace: await diskWith({ "/user/files/table.docx": docx }) });
+
+    expect((await session.exec("docx2txt files/table.docx")).stdout).toBe("Account\tBalance\nDue\n");
+  });
+
+  it("does not mistake a tab STOP in the paragraph's properties for a tab", async () => {
+    const docx = await docxWith(body(
+      `<w:p><w:pPr><w:tabs><w:tab w:val="left" w:pos="720"/></w:tabs></w:pPr>`
+      + `<w:r><w:t>Indented</w:t></w:r></w:p>`,
+    ));
+    const session = createShellSession({ workspace: await diskWith({ "/user/files/stops.docx": docx }) });
+
+    expect((await session.exec("docx2txt files/stops.docx")).stdout).toBe("Indented\n");
+  });
+
+  it("decodes the numeric character references XML allows, not just the named five", async () => {
+    const docx = await docxWith(body(`<w:p><w:r><w:t>Q1&#8212;Q2 &#x2014; &amp; up</w:t></w:r></w:p>`));
+    const session = createShellSession({ workspace: await diskWith({ "/user/files/refs.docx": docx }) });
+
+    expect((await session.exec("docx2txt files/refs.docx")).stdout).toBe("Q1—Q2 — & up\n");
+  });
+
+  it("refuses a part that only becomes huge once decompressed", async () => {
+    // 33 MB of zeros zips to a few KB: the upload cap bounds the FILE, and only
+    // the declared inflated size bounds what the host process has to hold.
+    const { zipSync } = await import("fflate");
+    const bomb = zipSync({ "word/document.xml": new Uint8Array(33 * 1024 * 1024) });
+    const session = createShellSession({ workspace: await diskWith({ "/user/files/bomb.docx": bomb }) });
+
+    const result = await session.exec("docx2txt files/bomb.docx");
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("not a readable Word document");
+  });
+
+  it("stays linear on a malformed part full of unclosed paragraph openers", async () => {
+    // A lazy `<w:p>…</w:p>` match rescans the remainder for EVERY opener, so this
+    // input costs minutes quadratically and milliseconds linearly. The test's own
+    // timeout is the detector — no inner stopwatch to go flaky under load.
+    const docx = await docxWith(body("<w:p >".repeat(200_000)));
+    const session = createShellSession({ workspace: await diskWith({ "/user/files/malformed.docx": docx }) });
+
+    expect((await session.exec("docx2txt files/malformed.docx")).exitCode).toBe(0);
+  });
+
+  it("stays linear on a paragraph full of unclosed text openers", async () => {
+    // The same quadratic trap one level down: a `<w:t>…</w:t>` pair matched as
+    // one lazy unit rescans to the end of the paragraph for every opener that
+    // never closes.
+    const docx = await docxWith(body(`<w:p >${"<w:t >".repeat(200_000)}</w:p>`));
+    const session = createShellSession({ workspace: await diskWith({ "/user/files/runs.docx": docx }) });
+
+    expect((await session.exec("docx2txt files/runs.docx")).exitCode).toBe(0);
   });
 });

--- a/packages/harnesses/tests/shell/runtime.test.ts
+++ b/packages/harnesses/tests/shell/runtime.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Whether THIS runtime can host a worker thread. Asked through the runtime
+ * built-in accessor, so this module carries no static Node import and still
+ * bundles for an edge target.
+ */
+import { describe, expect, it } from "vitest";
+import { workerThreadsAvailable } from "../../src/vendo/shell/runtime.js";
+
+describe("the worker-thread probe", () => {
+  it("says yes under Node", () => {
+    expect(workerThreadsAvailable()).toBe(true);
+  });
+
+  it("says no where there is no Node built-in accessor at all", () => {
+    const proc = (globalThis as { process?: unknown }).process;
+    try {
+      delete (globalThis as { process?: unknown }).process;
+      expect(workerThreadsAvailable()).toBe(false);
+    } finally {
+      (globalThis as { process?: unknown }).process = proc;
+    }
+  });
+
+  it("says no where the accessor exists but the module does not", () => {
+    const proc = (globalThis as { process?: unknown }).process;
+    try {
+      (globalThis as { process?: unknown }).process = {
+        getBuiltinModule: (id: string) => (id === "node:worker_threads" ? undefined : {}),
+      };
+      expect(workerThreadsAvailable()).toBe(false);
+    } finally {
+      (globalThis as { process?: unknown }).process = proc;
+    }
+  });
+});

--- a/packages/harnesses/tests/shell/tool.test.ts
+++ b/packages/harnesses/tests/shell/tool.test.ts
@@ -107,3 +107,35 @@ describe("a very talkative command", () => {
     expect(JSON.stringify((outcome as { output: unknown }).output).length).toBeLessThan(32_000);
   });
 });
+
+describe("the session's lifetime", () => {
+  it("keeps /tmp across calls in ONE turn", async () => {
+    const workspace = workspaceDouble();
+    const registry = createShellTools(async () => workspace);
+    const turn = ctx({ turnId: "trn_same" });
+
+    await registry.execute({ id: "c5", tool: VENDO_BASH_TOOL, args: { command: "echo kept > /tmp/note" } }, turn);
+    const second = await registry.execute(
+      { id: "c6", tool: VENDO_BASH_TOOL, args: { command: "cat /tmp/note" } },
+      turn,
+    );
+
+    expect((second as { output: { stdout: string } }).output.stdout).toBe("kept\n");
+  });
+
+  it("does NOT carry /tmp into another turn", async () => {
+    const workspace = workspaceDouble();
+    const registry = createShellTools(async () => workspace);
+
+    await registry.execute(
+      { id: "c7", tool: VENDO_BASH_TOOL, args: { command: "echo leaked > /tmp/note" } },
+      ctx({ turnId: "trn_one" }),
+    );
+    const other = await registry.execute(
+      { id: "c8", tool: VENDO_BASH_TOOL, args: { command: "cat /tmp/note" } },
+      ctx({ turnId: "trn_two" }),
+    );
+
+    expect((other as { output: { exitCode: number } }).output.exitCode).not.toBe(0);
+  });
+});

--- a/packages/harnesses/tests/shell/tool.test.ts
+++ b/packages/harnesses/tests/shell/tool.test.ts
@@ -251,3 +251,12 @@ describe("the parsers, announced", () => {
     expect(descriptor?.description).toContain("docx2txt");
   });
 });
+
+describe("what the shell says about apps", () => {
+  it("tells the model to copy a file into the app it is building from it", async () => {
+    const [descriptor] = await createShellTools(async () => workspaceDouble()).descriptors();
+
+    expect(descriptor?.description).toContain("/user/apps/");
+    expect(descriptor?.description).toContain("cp");
+  });
+});

--- a/packages/harnesses/tests/shell/tool.test.ts
+++ b/packages/harnesses/tests/shell/tool.test.ts
@@ -57,3 +57,34 @@ describe("the shell tool's descriptor", () => {
       .toMatchObject({ status: "error", error: { code: "validation" } });
   });
 });
+
+describe("the shell tool's hands", () => {
+  it("reads a file the workspace holds and answers with the shell's three outputs", async () => {
+    const workspace = workspaceDouble();
+    await workspace.mkdir("/user/files", { recursive: true });
+    await workspace.writeFile("/user/files/ledger.csv", "month,revenue\njan,31000\n");
+    const registry = createShellTools(async () => workspace);
+
+    const outcome = await registry.execute(
+      { id: "c2", tool: VENDO_BASH_TOOL, args: { command: "cut -d, -f2 files/ledger.csv | tail -1" } },
+      ctx(),
+    );
+
+    expect(outcome).toMatchObject({ status: "ok", output: { exitCode: 0, stderr: "" } });
+    expect((outcome as { output: { stdout: string } }).output.stdout.trim()).toBe("31000");
+  });
+
+  it("commits what the call wrote, so the next turn sees it", async () => {
+    const workspace = workspaceDouble();
+    await workspace.mkdir("/user/files", { recursive: true });
+    const registry = createShellTools(async () => workspace);
+
+    await registry.execute(
+      { id: "c3", tool: VENDO_BASH_TOOL, args: { command: "echo 'jan,31000' > files/out.csv" } },
+      ctx(),
+    );
+
+    expect(await workspace.readFile("/user/files/out.csv")).toBe("jan,31000\n");
+    expect(workspace.commits).toBe(1);
+  });
+});

--- a/packages/harnesses/tests/shell/tool.test.ts
+++ b/packages/harnesses/tests/shell/tool.test.ts
@@ -88,3 +88,22 @@ describe("the shell tool's hands", () => {
     expect(workspace.commits).toBe(1);
   });
 });
+
+describe("a very talkative command", () => {
+  it("comes back clipped, and says so, instead of tripping the bridge's cap", async () => {
+    const workspace = workspaceDouble();
+    const registry = createShellTools(async () => workspace);
+
+    // `seq`, not `yes`: just-bash 3.4.2 ships no `yes`. ~48 900 chars — well over
+    // the 16 000-char clip, well under the 1 MB default output ceiling.
+    const outcome = await registry.execute(
+      { id: "c4", tool: VENDO_BASH_TOOL, args: { command: "seq 1 10000" } },
+      ctx(),
+    );
+
+    const { stdout } = (outcome as { output: { stdout: string } }).output;
+    expect(stdout.length).toBeLessThanOrEqual(16_000);
+    expect(stdout).toContain("[clipped]");
+    expect(JSON.stringify((outcome as { output: unknown }).output).length).toBeLessThan(32_000);
+  });
+});

--- a/packages/harnesses/tests/shell/tool.test.ts
+++ b/packages/harnesses/tests/shell/tool.test.ts
@@ -99,7 +99,14 @@ describe("the shell tool's hands", () => {
     );
 
     expect(outcome).toMatchObject({ status: "error", error: { code: "conflict" } });
-    expect((outcome as { error: { message: string } }).error.message).toContain("/orgs/acme/files/ledger.csv");
+    const { message } = (outcome as { error: { message: string } }).error;
+    expect(message).toContain("/orgs/acme/files/ledger.csv");
+    // A commit batches PER OWNER (store/src/workspace-fs.ts:592-595), so a lost
+    // `/orgs` swap does NOT take the same command's `/user` writes down with it.
+    // Saying nothing was saved would send the model to re-run a command that
+    // already half-landed.
+    expect(message).not.toContain("none of this command");
+    expect(message).toContain("elsewhere");
   });
 });
 
@@ -192,5 +199,29 @@ describe("the session's lifetime", () => {
 
     expect(opened).toBe(1);
     expect((second as { output: { stdout: string } }).output.stdout).toBe("one\n");
+  });
+
+  it("does not poison the turn when opening the workspace fails once", async () => {
+    const workspace = workspaceDouble();
+    let attempt = 0;
+    const registry = createShellTools(async () => {
+      attempt += 1;
+      if (attempt === 1) throw new Error("store unreachable");
+      return workspace;
+    });
+    const turn = ctx({ turnId: "trn_flaky" });
+
+    await expect(registry.execute(
+      { id: "c13", tool: VENDO_BASH_TOOL, args: { command: "echo hi" } },
+      turn,
+    )).rejects.toThrow("store unreachable");
+    // Caching the PROMISE is what fixes the open race; caching a REJECTED one
+    // would wedge the rest of the turn on a blip the store already recovered from.
+    const second = await registry.execute(
+      { id: "c14", tool: VENDO_BASH_TOOL, args: { command: "echo recovered" } },
+      turn,
+    );
+
+    expect((second as { output: { stdout: string } }).output.stdout).toBe("recovered\n");
   });
 });

--- a/packages/harnesses/tests/shell/tool.test.ts
+++ b/packages/harnesses/tests/shell/tool.test.ts
@@ -225,3 +225,19 @@ describe("the session's lifetime", () => {
     expect((second as { output: { stdout: string } }).output.stdout).toBe("recovered\n");
   });
 });
+
+describe("the JavaScript hand, through the tool", () => {
+  it("is on under Node, and the description says so", async () => {
+    const workspace = workspaceDouble();
+    const registry = createShellTools(async () => workspace);
+
+    const [descriptor] = await registry.descriptors();
+    expect(descriptor?.description).toContain("js-exec");
+
+    const outcome = await registry.execute(
+      { id: "c9", tool: VENDO_BASH_TOOL, args: { command: `js-exec -c 'console.log(6 * 7)'` } },
+      ctx({ turnId: "trn_js" }),
+    );
+    expect((outcome as { output: { stdout: string } }).output.stdout).toContain("42");
+  });
+});

--- a/packages/harnesses/tests/shell/tool.test.ts
+++ b/packages/harnesses/tests/shell/tool.test.ts
@@ -241,3 +241,13 @@ describe("the JavaScript hand, through the tool", () => {
     expect((outcome as { output: { stdout: string } }).output.stdout).toContain("42");
   });
 });
+
+describe("the parsers, announced", () => {
+  it("names all three in the description, so the model never guesses at a PDF", async () => {
+    const [descriptor] = await createShellTools(async () => workspaceDouble()).descriptors();
+
+    expect(descriptor?.description).toContain("pdftotext");
+    expect(descriptor?.description).toContain("xlsx2csv");
+    expect(descriptor?.description).toContain("docx2txt");
+  });
+});

--- a/packages/harnesses/tests/shell/tool.test.ts
+++ b/packages/harnesses/tests/shell/tool.test.ts
@@ -1,0 +1,59 @@
+/**
+ * The shell on the ONE registry — guarded, audited and projected exactly like a
+ * host tool, with no privileged side door. The descriptor IS the guard story:
+ * `guard.bind` keys off `risk`.
+ */
+import { InMemoryFs } from "just-bash";
+import { VENDO_BASH_TOOL, type Principal, type RunContext, type WorkspaceFs } from "@vendoai/core";
+import { describe, expect, it } from "vitest";
+import { createShellTools } from "../../src/vendo/shell/tool.js";
+
+const principal: Principal = { kind: "user", subject: "user_shell" };
+
+const ctx = (overrides: Partial<RunContext> = {}): RunContext => ({
+  principal,
+  venue: "chat",
+  presence: "present",
+  sessionId: "s_shell",
+  ...overrides,
+});
+
+/** A workspace double that is a REAL just-bash filesystem plus the one method
+    the façade adds — so nothing about the bash half is faked. */
+const workspaceDouble = (): WorkspaceFs & { commits: number } => {
+  const fs = new InMemoryFs() as unknown as WorkspaceFs & { commits: number };
+  fs.commits = 0;
+  fs.commit = async () => {
+    fs.commits += 1;
+    return { status: "ok", changed: [] };
+  };
+  return fs;
+};
+
+describe("the shell tool's descriptor", () => {
+  it("is one tool called bash, graded write", async () => {
+    const registry = createShellTools(async () => workspaceDouble());
+
+    const [descriptor, ...rest] = await registry.descriptors();
+
+    expect(rest).toEqual([]);
+    expect(descriptor?.name).toBe(VENDO_BASH_TOOL);
+    expect(descriptor?.title).toBe("Work on your files");
+    expect(descriptor?.risk).toBe("write");
+    expect(descriptor?.inputSchema).toMatchObject({
+      type: "object",
+      properties: { command: { type: "string" } },
+      required: ["command"],
+      additionalProperties: false,
+    });
+  });
+
+  it("refuses a call that is not this tool, and a call with no command", async () => {
+    const registry = createShellTools(async () => workspaceDouble());
+
+    expect(await registry.execute({ id: "c0", tool: "nope", args: {} }, ctx()))
+      .toMatchObject({ status: "error", error: { code: "not-found" } });
+    expect(await registry.execute({ id: "c1", tool: VENDO_BASH_TOOL, args: {} }, ctx()))
+      .toMatchObject({ status: "error", error: { code: "validation" } });
+  });
+});

--- a/packages/harnesses/tests/shell/tool.test.ts
+++ b/packages/harnesses/tests/shell/tool.test.ts
@@ -87,6 +87,20 @@ describe("the shell tool's hands", () => {
     expect(await workspace.readFile("/user/files/out.csv")).toBe("jan,31000\n");
     expect(workspace.commits).toBe(1);
   });
+
+  it("says the write did NOT land when the workspace answers conflict", async () => {
+    const workspace = workspaceDouble();
+    workspace.commit = async () => ({ status: "conflict", paths: ["/orgs/acme/files/ledger.csv"] });
+    const registry = createShellTools(async () => workspace);
+
+    const outcome = await registry.execute(
+      { id: "c9", tool: VENDO_BASH_TOOL, args: { command: "echo 'jan,31000' > /tmp/out.csv" } },
+      ctx(),
+    );
+
+    expect(outcome).toMatchObject({ status: "error", error: { code: "conflict" } });
+    expect((outcome as { error: { message: string } }).error.message).toContain("/orgs/acme/files/ledger.csv");
+  });
 });
 
 describe("a very talkative command", () => {
@@ -95,7 +109,7 @@ describe("a very talkative command", () => {
     const registry = createShellTools(async () => workspace);
 
     // `seq`, not `yes`: just-bash 3.4.2 ships no `yes`. ~48 900 chars — well over
-    // the 16 000-char clip, well under the 1 MB default output ceiling.
+    // the clip, well under the 1 MB default output ceiling.
     const outcome = await registry.execute(
       { id: "c4", tool: VENDO_BASH_TOOL, args: { command: "seq 1 10000" } },
       ctx(),
@@ -105,6 +119,25 @@ describe("a very talkative command", () => {
     expect(stdout.length).toBeLessThanOrEqual(16_000);
     expect(stdout).toContain("[clipped]");
     expect(JSON.stringify((outcome as { output: unknown }).output).length).toBeLessThan(32_000);
+  });
+
+  it("keeps stdout AND stderr together under the bridge's cap, escaping and all", async () => {
+    const workspace = workspaceDouble();
+    const registry = createShellTools(async () => workspace);
+
+    // Both streams full of the one character JSON doubles. Raw, each is 30 000
+    // characters; in the JSON `capOutcome` weighs, each is 60 000, so a
+    // raw-character budget hands the bridge far more than it caps at.
+    const blanks = `awk 'BEGIN{for(i=0;i<30000;i++)print ""}'`;
+    const outcome = await registry.execute(
+      { id: "c10", tool: VENDO_BASH_TOOL, args: { command: `${blanks}; ${blanks} >&2` } },
+      ctx(),
+    );
+
+    const { stdout, stderr } = (outcome as { output: { stdout: string; stderr: string } }).output;
+    expect(stdout).toContain("[clipped]");
+    expect(stderr).toContain("[clipped]");
+    expect(JSON.stringify((outcome as { output: unknown }).output).length).toBeLessThanOrEqual(32_000);
   });
 });
 
@@ -127,7 +160,7 @@ describe("the session's lifetime", () => {
     const workspace = workspaceDouble();
     const registry = createShellTools(async () => workspace);
 
-    await registry.execute(
+    const wrote = await registry.execute(
       { id: "c7", tool: VENDO_BASH_TOOL, args: { command: "echo leaked > /tmp/note" } },
       ctx({ turnId: "trn_one" }),
     );
@@ -136,6 +169,28 @@ describe("the session's lifetime", () => {
       ctx({ turnId: "trn_two" }),
     );
 
+    // The write has to have LANDED, or the second turn's failure proves nothing
+    // but that nobody ever wrote the file.
+    expect((wrote as { output: { exitCode: number } }).output.exitCode).toBe(0);
     expect((other as { output: { exitCode: number } }).output.exitCode).not.toBe(0);
+  });
+
+  it("opens ONE workspace for a turn whose two calls arrive together", async () => {
+    const workspace = workspaceDouble();
+    let opened = 0;
+    const registry = createShellTools(async () => {
+      opened += 1;
+      return workspace;
+    });
+    const turn = ctx({ turnId: "trn_parallel" });
+
+    // What the AI SDK does with two tool calls in one step: both at once.
+    const [, second] = await Promise.all([
+      registry.execute({ id: "c11", tool: VENDO_BASH_TOOL, args: { command: "echo one > /tmp/shared" } }, turn),
+      registry.execute({ id: "c12", tool: VENDO_BASH_TOOL, args: { command: "cat /tmp/shared" } }, turn),
+    ]);
+
+    expect(opened).toBe(1);
+    expect((second as { output: { stdout: string } }).output.stdout).toBe("one\n");
   });
 });

--- a/packages/store/src/erase.ts
+++ b/packages/store/src/erase.ts
@@ -107,6 +107,12 @@ export function eraseStore(store: VendoStore, options: { files: FilesAdapter }):
       (Threads, approvals and — since v11 — runs have no app axis: the subject
       selector covers them, through their automation in the runs' case.) */
   byApp(appId: string): Promise<EraseReport>;
+  /** Erase ONE conversation's files: the workspace rows under
+      `/user/threads/<id>`, their history, and the blobs those rows were the only
+      pointer to. Its transcript, its messages and its harness state are a
+      DIFFERENT cascade (`transcripts.deleteThread`, one transaction) — this is
+      only the half that lives in the workspace and behind the files adapter. */
+  byThread(threadId: string): Promise<EraseReport>;
 } {
   const db = dbFor(store);
   // Workspace content past the inline cap lives behind the files adapter, and
@@ -331,6 +337,24 @@ export function eraseStore(store: VendoStore, options: { files: FilesAdapter }):
       const user = `/user/apps/${escapeLike(appId)}`;
       const org = `/orgs/%/apps/${escapeLike(appId)}`;
       const anchors = [`${user}/%`, user, `${org}/%`, org];
+      const where = anchors.map((_, index) => `path LIKE $${index + 1} ESCAPE '\\'`).join(" OR ");
+      await delWorkspace(report, "vendo_workspace_files", where, anchors);
+      await delWorkspace(report, "vendo_workspace_history", where, anchors);
+      return report;
+    },
+
+    async byThread(threadId) {
+      if (typeof threadId !== "string" || threadId === "") {
+        invalid("erase threadId must be a non-empty string");
+      }
+      const report = emptyReport();
+      // Build contract §3.1 puts a conversation's files at
+      // `/user/threads/<id>/…` with the id verbatim, so they are addressable
+      // without knowing whose workspace holds them — the same property `byApp`
+      // relies on. Two patterns, for `byApp`'s reason: the subtree, and the
+      // subtree's own root row at exactly `/user/threads/<id>`.
+      const root = `/user/threads/${escapeLike(threadId)}`;
+      const anchors = [`${root}/%`, root];
       const where = anchors.map((_, index) => `path LIKE $${index + 1} ESCAPE '\\'`).join(" OR ");
       await delWorkspace(report, "vendo_workspace_files", where, anchors);
       await delWorkspace(report, "vendo_workspace_history", where, anchors);

--- a/packages/store/src/erase.ts
+++ b/packages/store/src/erase.ts
@@ -113,6 +113,17 @@ export function eraseStore(store: VendoStore, options: { files: FilesAdapter }):
       DIFFERENT cascade (`transcripts.deleteThread`, one transaction) — this is
       only the half that lives in the workspace and behind the files adapter. */
   byThread(threadId: string): Promise<EraseReport>;
+  /** Erase ONE workspace path and everything under it, for ONE owner: the live
+      rows, their history, and the blobs those rows were the only pointer to.
+      The owner is required because `/user/**` means a different file in every
+      subject's workspace — the other selectors here carry the tenant in the path
+      (`/user/threads/<id>`, `/user/apps/<id>`) and this one cannot.
+
+      It exists for the staging waypoint (`/user/uploads/**`), which is neither a
+      thread nor an app and so is reachable by no other axis, while both ways a
+      file leaves staging — the turn's re-home and the janitor's sweep — only
+      tombstone it, leaving the object behind under that unreachable address. */
+  byWorkspacePath(owner: string, path: string): Promise<EraseReport>;
 } {
   const db = dbFor(store);
   // Workspace content past the inline cap lives behind the files adapter, and
@@ -358,6 +369,28 @@ export function eraseStore(store: VendoStore, options: { files: FilesAdapter }):
       const where = anchors.map((_, index) => `path LIKE $${index + 1} ESCAPE '\\'`).join(" OR ");
       await delWorkspace(report, "vendo_workspace_files", where, anchors);
       await delWorkspace(report, "vendo_workspace_history", where, anchors);
+      return report;
+    },
+
+    async byWorkspacePath(owner, path) {
+      if (typeof owner !== "string" || owner === "") {
+        invalid("erase workspace owner must be a non-empty string");
+      }
+      if (typeof path !== "string" || !path.startsWith("/")) {
+        invalid("erase workspace path must be absolute");
+      }
+      const report = emptyReport();
+      // Two patterns, for `byApp`'s reason: the subtree, and a row at exactly
+      // the prefix. The trailing slash is what keeps `/user/uploads-archive`
+      // out of a sweep of `/user/uploads`.
+      const root = escapeLike(path);
+      const anchors = [`${root}/%`, root];
+      const where = `owner = $1 AND (`
+        + anchors.map((_, index) => `path LIKE $${index + 2} ESCAPE '\\'`).join(" OR ")
+        + `)`;
+      const params = [owner, ...anchors];
+      await delWorkspace(report, "vendo_workspace_files", where, params);
+      await delWorkspace(report, "vendo_workspace_history", where, params);
       return report;
     },
   };

--- a/packages/store/src/workspace-fs.ts
+++ b/packages/store/src/workspace-fs.ts
@@ -56,6 +56,8 @@ const enotempty = (op: string, path: string): Error =>
   new Error(`ENOTEMPTY: directory not empty, ${op} '${path}'`);
 const eexist = (op: string, path: string): Error =>
   new Error(`EEXIST: file already exists, ${op} '${path}'`);
+const einval = (op: string, path: string): Error =>
+  new Error(`EINVAL: invalid argument, ${op} '${path}'`);
 /** The workspace is exactly the mounts §3.1 names. A write anywhere else is a
     mistake — `/User/apps/...`, `/user/../x`, `/etc/passwd`, or an org the host
     did not assert this request — and silently accepting it would lose the data
@@ -451,7 +453,14 @@ export class WorkspaceStoreFs implements WorkspaceFs {
     // Moving a path onto itself is a no-op, and it has to be checked here: the
     // copy below stages the bytes at `from`, and the delete then drops the very
     // path the copy just staged, so the file would disappear.
-    if (from === normalizePath(dest)) return;
+    const to = normalizePath(dest);
+    if (from === to) return;
+    // A destination INSIDE the source is the same trap, wearing a whole tree:
+    // the copy stages the children under `to`, and the recursive delete then
+    // drops everything with the source's prefix — the copies included. An error
+    // rather than a silent skip, because unlike the identity case nothing the
+    // caller asked for happened; `rename(2)` answers EINVAL here too.
+    if (under(to, from)) throw einval("rename", src);
     await this.cp(src, dest, { recursive: true });
     await this.rm(from, { recursive: true });
   }

--- a/packages/store/src/workspace-fs.ts
+++ b/packages/store/src/workspace-fs.ts
@@ -448,6 +448,10 @@ export class WorkspaceStoreFs implements WorkspaceFs {
   async mv(src: string, dest: string): Promise<void> {
     const from = normalizePath(src);
     this.assertWritable("rename", from);
+    // Moving a path onto itself is a no-op, and it has to be checked here: the
+    // copy below stages the bytes at `from`, and the delete then drops the very
+    // path the copy just staged, so the file would disappear.
+    if (from === normalizePath(dest)) return;
     await this.cp(src, dest, { recursive: true });
     await this.rm(from, { recursive: true });
   }

--- a/packages/store/tests/erase-thread.test.ts
+++ b/packages/store/tests/erase-thread.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Erasing one conversation's files: the rows, their history, and the blobs those
+ * rows were the only pointer to. The blob half is the point — a `rm` through the
+ * façade leaves the object behind, because history is append-only.
+ */
+import type { FilesAdapter, Principal } from "@vendoai/core";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { backends, type MadeBackend } from "../src/backends.test-util.js";
+import { eraseStore } from "../src/erase.js";
+import { workspaceStore } from "../src/workspace.js";
+
+const user: Principal = { kind: "user", subject: "user_erase_thread" };
+/** Past the inline cap, so the content lands behind the files adapter and the
+    row carries a `blob_ref` — which is the whole thing being proved. */
+const BIG = new Uint8Array(200_000).fill(7);
+
+function bucket(): FilesAdapter & { keys: () => string[] } {
+  const blobs = new Map<string, Uint8Array>();
+  return {
+    put: async (key, value) => void blobs.set(key, value),
+    get: async (key) => {
+      const value = blobs.get(key);
+      return value === undefined ? undefined : { bytes: value };
+    },
+    delete: async (key) => void blobs.delete(key),
+    keys: () => [...blobs.keys()],
+  };
+}
+
+for (const backend of backends()) {
+  describe(`${backend.name} erase.byThread`, () => {
+    let made: MadeBackend;
+
+    beforeAll(async () => {
+      made = await backend.make();
+      await made.store.ensureSchema();
+    });
+    afterAll(async () => { if (made) await made.cleanup(); });
+
+    it("destroys a thread's files, their history and their blobs — and nothing else", async () => {
+      const files = bucket();
+      const workspace = workspaceStore(made.store, { files });
+      const seed = await workspace.open(user);
+      await seed.writeFile("/user/threads/thr_gone/files/scan.pdf", BIG);
+      await seed.writeFile("/user/threads/thr_kept/files/scan.pdf", BIG);
+      await seed.writeFile("/user/files/shelf.csv", "jan,31000\n");
+      await seed.commit();
+      // A second revision, so there is a history row holding a blob too.
+      const again = await workspace.open(user);
+      await again.writeFile("/user/threads/thr_gone/files/scan.pdf", new Uint8Array(200_000).fill(9));
+      await again.commit();
+      expect(files.keys().length).toBeGreaterThanOrEqual(3);
+
+      const report = await eraseStore(made.store, { files }).byThread("thr_gone");
+
+      expect(report.vendo_workspace_files).toBe(1);
+      expect(report.vendo_workspace_history).toBeGreaterThanOrEqual(1);
+      // The other conversation and the shelf are untouched.
+      const after = await workspace.open(user);
+      expect(await after.exists("/user/threads/thr_gone/files/scan.pdf")).toBe(false);
+      expect(await after.exists("/user/threads/thr_kept/files/scan.pdf")).toBe(true);
+      expect(await after.readFile("/user/files/shelf.csv")).toBe("jan,31000\n");
+      // And exactly one blob survives: the other thread's.
+      expect(files.keys()).toHaveLength(1);
+    });
+  });
+}

--- a/packages/store/tests/workspace.erase.test.ts
+++ b/packages/store/tests/workspace.erase.test.ts
@@ -172,6 +172,64 @@ for (const backend of backends()) {
       expect(await workspaceBlobs()).toBe(before);
     });
 
+    // The staging waypoint (`/user/uploads/**`) is neither a thread nor an app,
+    // so no other axis here reaches it — and both ways a file LEAVES staging
+    // only tombstone it: the row moves to history with its `blob_ref` intact and
+    // the object stays. Without a path axis the bucket keeps that object forever.
+    it("erases one workspace path, its history and its blobs, for that owner only", async () => {
+      const mine: Principal = { kind: "user", subject: "user_ws_path" };
+      const theirs: Principal = { kind: "user", subject: "user_ws_path_other" };
+      const path = "/user/uploads/abcd1234-scan.pdf";
+      const big = "z".repeat(WORKSPACE_INLINE_MAX_BYTES + 1);
+      // Two revisions, so a history row holds a blob ref as well as the live one.
+      await seed(made.store, mine, path, [big, `${big}!`]);
+      // The SAME path in another subject's workspace. `/user/**` is per-owner, so
+      // a path-keyed erase that ignored the owner would cross tenants.
+      await seed(made.store, theirs, path, [big]);
+      const before = await workspaceBlobs();
+
+      const report = await eraseStore(made.store, { files: storeFiles(made.store) })
+        .byWorkspacePath(mine.subject, path);
+
+      expect(report.vendo_workspace_files).toBe(1);
+      expect(report.vendo_workspace_history).toBe(1);
+      expect(await count("vendo_workspace_files", "owner = $1", [mine.subject])).toBe(0);
+      expect(await count("vendo_workspace_history", "owner = $1", [mine.subject])).toBe(0);
+      // The live object and the superseded one both go.
+      expect(await workspaceBlobs()).toBe(before - 2);
+      // ...and the other subject's identical path is untouched.
+      expect(await count("vendo_workspace_files", "owner = $1", [theirs.subject])).toBe(1);
+    });
+
+    it("erases everything under a workspace path, and the path's own row", async () => {
+      // Two anchors, for `byThread`'s reason: the subtree, and a row at exactly
+      // the prefix. A slash-suffixed LIKE alone never matches the second.
+      const owner: Principal = { kind: "user", subject: "user_ws_path_tree" };
+      await seed(made.store, owner, "/user/uploads/one.csv", ["first"]);
+      await seed(made.store, owner, "/user/uploads/nested/two.csv", ["second"]);
+      // A sibling whose name merely STARTS with the prefix must survive.
+      await seed(made.store, owner, "/user/uploads-archive/three.csv", ["spared"]);
+      // The prefix's own row goes in behind the façade, which refuses to write
+      // through a path that is already a directory.
+      await made.sql(
+        "INSERT INTO vendo_workspace_files (path, owner, content, bytes) VALUES ($1, $2, $3, $4)",
+        ["/user/uploads", owner.subject, "the prefix, as a row", 20],
+      );
+
+      const report = await eraseStore(made.store, { files: storeFiles(made.store) })
+        .byWorkspacePath(owner.subject, "/user/uploads");
+
+      expect(report.vendo_workspace_files).toBe(3);
+      expect(await count("vendo_workspace_files", "path = '/user/uploads-archive/three.csv'", [])).toBe(1);
+    });
+
+    it("refuses a workspace path that is not absolute", async () => {
+      const erase = eraseStore(made.store, { files: storeFiles(made.store) });
+      for (const path of ["", "user/uploads", "relative.csv"]) {
+        await expect(erase.byWorkspacePath("user_ws_path_bad", path)).rejects.toThrow(/absolute/);
+      }
+    });
+
     // F15 (verifier): keys derived from owner+path+revision were guessable
     // across tenants. A blob key is now a random id; the row is the only pointer.
     it("mints unguessable blob keys that carry no owner or path", async () => {

--- a/packages/store/tests/workspace.test.ts
+++ b/packages/store/tests/workspace.test.ts
@@ -1,4 +1,4 @@
-import { VendoError, type Principal } from "@vendoai/core";
+import { VendoError, type FilesAdapter, type Principal } from "@vendoai/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { backends, type MadeBackend } from "../src/backends.test-util.js";
 import { FILES_STORE_MAX_BYTES } from "../src/files-store.js";
@@ -508,6 +508,129 @@ for (const backend of backends()) {
 
       // Every workspace blob is still pointed at by some row.
       expect(await reachable()).toBe(orphansBefore);
+    });
+
+    // `mv` is the façade's rename, and it had no coverage at all — while the
+    // re-homing of a dropped chat file rides it (vendo/harness-turn.ts's
+    // rehomeStagedFiles) and so does bash's own `mv`.
+    describe("mv", () => {
+      /** A host's own bucket, so blob-backed content is really placed. */
+      const bucket = (): FilesAdapter => {
+        const held = new Map<string, Uint8Array>();
+        return {
+          async put(key, bytes) { held.set(key, bytes); },
+          async get(key) {
+            const bytes = held.get(key);
+            return bytes === undefined ? undefined : { bytes };
+          },
+          async delete(key) { held.delete(key); },
+        };
+      };
+
+      it("puts the bytes at the destination and leaves nothing at the source", async () => {
+        const workspace = workspaceStore(made.store, { files: bucket() });
+        const from = "/user/files/before.bin";
+        const to = "/user/files/after.bin";
+        // Past the inline cap, so the content is an object, not a text column.
+        const bytes = new Uint8Array(WORKSPACE_INLINE_MAX_BYTES + 1).fill(9);
+
+        const first = await workspace.open(user);
+        await first.writeFile(from, bytes);
+        await first.commit();
+
+        const moving = await workspace.open(user);
+        await moving.mv(from, to);
+        // Visible to the moving turn before it commits, both ways round.
+        expect(await moving.exists(to)).toBe(true);
+        expect(await moving.exists(from)).toBe(false);
+        await moving.commit();
+
+        // ...and to the NEXT turn, through the store.
+        const next = await workspace.open(user);
+        expect(await next.exists(from)).toBe(false);
+        expect(Buffer.compare(Buffer.from(await next.readFileBuffer(to)), Buffer.from(bytes))).toBe(0);
+        expect(await rowsFor(from)).toEqual([]);
+      });
+
+      it("moves bytes the turn only staged, with no row to relocate", async () => {
+        const workspace = workspaceStore(made.store, { files: bucket() });
+        const fs = await workspace.open(user);
+        await fs.writeFile("/user/scratch/draft.md", "written and moved in one turn");
+        await fs.mv("/user/scratch/draft.md", "/user/memory/kept.md");
+        await fs.commit();
+
+        const next = await workspace.open(user);
+        expect(await next.readFile("/user/memory/kept.md")).toBe("written and moved in one turn");
+        expect(await next.exists("/user/scratch/draft.md")).toBe(false);
+      });
+
+      it("overwrites an existing destination, as every mv does", async () => {
+        const workspace = workspaceStore(made.store, { files: bucket() });
+        const from = "/user/files/winner.txt";
+        const to = "/user/files/loser.txt";
+
+        const first = await workspace.open(user);
+        await first.writeFile(from, "the one that moves");
+        await first.writeFile(to, "the one that is replaced");
+        await first.commit();
+
+        const moving = await workspace.open(user);
+        await moving.mv(from, to);
+        await moving.commit();
+
+        const next = await workspace.open(user);
+        expect(await next.readFile(to)).toBe("the one that moves");
+        expect(await next.exists(from)).toBe(false);
+      });
+
+      it("keeps the file when the source and the destination are the same path", async () => {
+        const workspace = workspaceStore(made.store, { files: bucket() });
+        const path = "/user/files/self.txt";
+        const first = await workspace.open(user);
+        await first.writeFile(path, "still here");
+        await first.commit();
+
+        const moving = await workspace.open(user);
+        await moving.mv(path, path);
+        await moving.commit();
+
+        // A copy-then-delete drops the file: the copy stages it, the delete
+        // removes the very path it was staged at.
+        expect(await (await workspace.open(user)).readFile(path)).toBe("still here");
+      });
+
+      it("moves a directory with everything under it", async () => {
+        const workspace = workspaceStore(made.store, { files: bucket() });
+        const first = await workspace.open(user);
+        await first.writeFile("/user/files/box/a.txt", "a");
+        await first.writeFile("/user/files/box/deep/b.txt", "b");
+        await first.commit();
+
+        const moving = await workspace.open(user);
+        await moving.mv("/user/files/box", "/user/files/crate");
+        await moving.commit();
+
+        const next = await workspace.open(user);
+        expect(await next.readFile("/user/files/crate/a.txt")).toBe("a");
+        expect(await next.readFile("/user/files/crate/deep/b.txt")).toBe("b");
+        expect(await next.exists("/user/files/box")).toBe(false);
+      });
+
+      it("refuses a source that is not there, a read-only source and an unmounted destination", async () => {
+        const fs = await workspaceStore(made.store, { files: bucket() })
+          .open(user, { host: { "/host/skills/charting/SKILL.md": "read me" } });
+
+        await expect(fs.mv("/user/files/absent.txt", "/user/files/anywhere.txt"))
+          .rejects.toThrow(/ENOENT: no such file or directory/);
+        await expect(fs.mv("/host/skills/charting/SKILL.md", "/user/files/stolen.md"))
+          .rejects.toThrow(/EROFS: read-only file system/);
+
+        await fs.writeFile("/user/files/here.txt", "mine");
+        await expect(fs.mv("/user/files/here.txt", "/etc/passwd"))
+          .rejects.toThrow(/EACCES: permission denied/);
+        // The refused move left the source exactly where it was.
+        expect(await fs.readFile("/user/files/here.txt")).toBe("mine");
+      });
     });
 
     it("names the fix when a file passes the store-backed cap with no files adapter wired", async () => {

--- a/packages/store/tests/workspace.test.ts
+++ b/packages/store/tests/workspace.test.ts
@@ -616,6 +616,26 @@ for (const backend of backends()) {
         expect(await next.exists("/user/files/box")).toBe(false);
       });
 
+      it("refuses to move a directory into its own subtree, and keeps it", async () => {
+        // The same copy-then-delete that ate a self-move eats this one, only
+        // worse: the copy stages the children UNDER the destination, and the
+        // recursive delete then drops everything with the source's prefix —
+        // which now includes the copies. The tree is gone with no error.
+        const workspace = workspaceStore(made.store, { files: bucket() });
+        const first = await workspace.open(user);
+        await first.writeFile("/user/files/box/a.txt", "a");
+        await first.commit();
+
+        const moving = await workspace.open(user);
+        // POSIX `rename(2)` answers EINVAL here, and bash prints it verbatim;
+        // a silent no-op would tell the caller the move happened.
+        await expect(moving.mv("/user/files/box", "/user/files/box/inner"))
+          .rejects.toThrow(/EINVAL: invalid argument/);
+        await moving.commit();
+
+        expect(await (await workspace.open(user)).readFile("/user/files/box/a.txt")).toBe("a");
+      });
+
       it("refuses a source that is not there, a read-only source and an unmounted destination", async () => {
         const fs = await workspaceStore(made.store, { files: bucket() })
           .open(user, { host: { "/host/skills/charting/SKILL.md": "read me" } });

--- a/packages/ui/src/chrome/build-beat.tsx
+++ b/packages/ui/src/chrome/build-beat.tsx
@@ -102,9 +102,9 @@ const TARGET_FIELDS = ["recipient_name", "recipient", "payee", "to", "destinatio
  * safety the ruling exists to kill.
  */
 const CLASS_LINE: Record<string, string> = {
-  read: "This reads your data, as you.",
-  write: "This changes something in your account, as you.",
-  destructive: "This makes a change you can’t undo, as you.",
+  read: "This reads your data, and it runs as you.",
+  write: "This changes something in your account, and it runs as you.",
+  destructive: "This makes a change you can’t undo, and it runs as you.",
 };
 
 export function consentClassLine(risk: string): string {

--- a/packages/ui/src/chrome/thread/attachments.tsx
+++ b/packages/ui/src/chrome/thread/attachments.tsx
@@ -44,9 +44,11 @@ export function formatBytes(size: number): string {
 
 export type FilePart = Extract<UIMessage["parts"][number], { type: "file" }>;
 
-/** A part that names a file in the user's own files rather than carrying it.
-    The prefix is the workspace's frozen `/user/files` (build contract §3.1). */
-export const isSavedFile = (url: string): boolean => url.startsWith("/user/files/");
+/** A part that names a file the SERVER holds rather than carrying it: the
+    conversation's own files, a drop still in staging, or the keep-shelf. All
+    three live under §3.1's frozen `/user` mount, and nothing that carries its own
+    bytes ever does — a data:, blob: or https: url cannot start with a slash. */
+export const isSavedFile = (url: string): boolean => url.startsWith("/user/");
 
 /** A sent attachment in the transcript: images render as the designed
     `.fl-msg-img` thumbnail, anything else as a `.fl-msg-file` pill.

--- a/packages/ui/test/chrome/approval-and-notice.test.tsx
+++ b/packages/ui/test/chrome/approval-and-notice.test.tsx
@@ -63,7 +63,7 @@ describe("ApprovalCard and NoPolicyNotice exports", () => {
     expect(Array.from(notes.querySelectorAll("li")).map(item => item.textContent)).toEqual([
       "Invoice id: inv_42",
       " · Permanent: Yes",
-      " · This makes a change you can’t undo, as you.",
+      " · This makes a change you can’t undo, and it runs as you.",
       " · asked in an app",
     ]);
     // No amber and no pill: the grade is a machine affordance on the shell, and

--- a/packages/ui/test/chrome/approval-degraded.test.tsx
+++ b/packages/ui/test/chrome/approval-degraded.test.tsx
@@ -92,7 +92,7 @@ describe("degraded data never changes the card", () => {
     // humanized label (what the card's title always read) and the consequence
     // CLASS says what approving DOES — that half still never names the tool.
     expect(container.querySelector(".fl-approval-ask")!.textContent).toBe("Thing do?");
-    expect(notesOf(container)).toContain("This changes something in your account, as you.");
+    expect(notesOf(container)).toContain("This changes something in your account, and it runs as you.");
     expect(rowsOf(container)).toEqual([["Note", "hi"]]);
     // The prettified id, never the raw slug (ENG-216).
     expect(screen.queryByText("host_thing_do")).toBeNull();
@@ -313,14 +313,14 @@ describe("the plain-words line says what happens, not which tool", () => {
     const bare = show(money({ schema: false }));
     // The GRADE says what it does, not the name (Yousef's D1). This read "This
     // moves money, as you." only because the tool id contains "transfer".
-    expect(notesOf(bare)).toContain("This makes a change you can’t undo, as you.");
+    expect(notesOf(bare)).toContain("This makes a change you can’t undo, and it runs as you.");
     expect(does(bare)).not.toContain("Send money");
     expect(does(bare)).not.toContain("Vendo will run");
     cleanup();
     // A tool whose words name no known verb still never reads its own label
     // back at the person on the what-it-DOES half: the risk class carries it.
     const unknown = show(ask({ args: { note: "hi" } }));
-    expect(notesOf(unknown)).toContain("This changes something in your account, as you.");
+    expect(notesOf(unknown)).toContain("This changes something in your account, and it runs as you.");
     expect(does(unknown)).not.toContain("Thing do");
   });
 
@@ -339,7 +339,7 @@ describe("the plain-words line says what happens, not which tool", () => {
     } as Partial<ApprovalRequest>));
     expect(question(container)).toBe("Send money?");
     expect(question(container)).not.toContain("$1.99");
-    expect(notesOf(container)).toContain("This changes something in your account, as you.");
+    expect(notesOf(container)).toContain("This changes something in your account, and it runs as you.");
     // Never fold on uncertainty: both amounts stay in plain sight.
     expect(container.querySelector(".fl-approval-details")).toBeNull();
     expect(rowsOf(container)).toEqual([
@@ -363,7 +363,7 @@ describe("the plain-words line says what happens, not which tool", () => {
     );
     // "Send 5% to Acme Utilities?" was a real possible question here.
     expect(question(container)).toBe("Send money?");
-    expect(notesOf(container)).toContain("This changes something in your account, as you.");
+    expect(notesOf(container)).toContain("This changes something in your account, and it runs as you.");
     expect(rowsOf(container)).toEqual([["Rate", "5%"], ["Recipient name", "Acme Utilities"]]);
   });
 
@@ -382,7 +382,7 @@ describe("the plain-words line says what happens, not which tool", () => {
       descriptor: { name: "host_transferMoney", title: "Send money", description: "", inputSchema: {}, risk: "write" },
     } as Partial<ApprovalRequest>));
     expect(question(container)).toBe("Send money?");
-    expect(notesOf(container)).toContain("This changes something in your account, as you.");
+    expect(notesOf(container)).toContain("This changes something in your account, and it runs as you.");
     // Both amounts stay in plain sight, formatted, with nothing folded.
     expect(container.querySelector(".fl-approval-details")).toBeNull();
     expect(rowsOf(container)).toEqual([

--- a/packages/ui/test/chrome/approval-modal.test.tsx
+++ b/packages/ui/test/chrome/approval-modal.test.tsx
@@ -118,7 +118,7 @@ describe("the screen-initiated approval modal", () => {
       }));
       await waitFor(() => expect(ask()).toBe("Archive project?"));
       expect(rows()).toEqual(["Project: Orion", "Notify team: Yes"]);
-      expect(notes()).toEqual(["This makes a change you can’t undo, as you."]);
+      expect(notes()).toEqual(["This makes a change you can’t undo, and it runs as you."]);
     });
 
     it("lands focus on the dialog, never on Approve — the press that opened it must not spend the decision", async () => {

--- a/packages/ui/test/chrome/approval-money.test.tsx
+++ b/packages/ui/test/chrome/approval-money.test.tsx
@@ -77,7 +77,7 @@ function cardOf(approval: ApprovalRequest): { question: string; notes: string[] 
 
 /** The card's own venue note, last on every ask in this file. */
 const ASKED_HERE = "asked here in chat";
-const IRREVERSIBLE = "This makes a change you can’t undo, as you.";
+const IRREVERSIBLE = "This makes a change you can’t undo, and it runs as you.";
 
 const CENTS_SCHEMA: JsonSchema = {
   type: "object",

--- a/packages/ui/test/chrome/approval-notes-copy.test.tsx
+++ b/packages/ui/test/chrome/approval-notes-copy.test.tsx
@@ -31,7 +31,7 @@ const approval: ApprovalRequest = {
 const FACTS = [
   "Invoice id: inv_42",
   "Permanent: Yes",
-  "This makes a change you can’t undo, as you.",
+  "This makes a change you can’t undo, and it runs as you.",
   "asked in an app",
 ];
 
@@ -56,7 +56,7 @@ describe("the ask's quiet line, copied", () => {
     expect(Array.from(list.querySelectorAll("li")).map(item => item.textContent)).toEqual([
       "Invoice id: inv_42",
       " · Permanent: Yes",
-      " · This makes a change you can’t undo, as you.",
+      " · This makes a change you can’t undo, and it runs as you.",
       " · asked in an app",
     ]);
     // The WCAG 1.3.1 half: every child of the list is an item. A separator

--- a/packages/ui/test/chrome/attachment-paths.test.ts
+++ b/packages/ui/test/chrome/attachment-paths.test.ts
@@ -1,0 +1,22 @@
+/**
+ * A file part either CARRIES its bytes or NAMES where the server holds them.
+ * The pill's download link exists only in the first case, so the predicate has to
+ * recognise all three addresses — a thread's own files, a staged drop, and the
+ * keep-shelf — not just the one that existed when it was written.
+ */
+import { describe, expect, it } from "vitest";
+import { isSavedFile } from "../../src/chrome/thread/attachments.js";
+
+describe("which file parts the server holds", () => {
+  it("recognises every workspace address", () => {
+    expect(isSavedFile("/user/files/kept.csv")).toBe(true);
+    expect(isSavedFile("/user/uploads/9f2a1c04-ledger.csv")).toBe(true);
+    expect(isSavedFile("/user/threads/thr_abc/files/ledger.csv")).toBe(true);
+  });
+
+  it("still treats a part carrying its own bytes as downloadable", () => {
+    expect(isSavedFile("data:text/csv;base64,YQ==")).toBe(false);
+    expect(isSavedFile("blob:https://host.test/2f1c")).toBe(false);
+    expect(isSavedFile("https://cdn.test/a.csv")).toBe(false);
+  });
+});

--- a/packages/ui/test/chrome/consent-class-line.test.ts
+++ b/packages/ui/test/chrome/consent-class-line.test.ts
@@ -38,9 +38,9 @@ import { grantRowWord } from "../../src/chrome/grant-set-card.js";
 
 /** One sentence per grade, and the ungraded state is NOT one of the three. */
 const BY_GRADE = {
-  read: "This reads your data, as you.",
-  write: "This changes something in your account, as you.",
-  destructive: "This makes a change you can’t undo, as you.",
+  read: "This reads your data, and it runs as you.",
+  write: "This changes something in your account, and it runs as you.",
+  destructive: "This makes a change you can’t undo, and it runs as you.",
 } as const;
 
 const UNGRADED_LINE = "This hasn’t been checked, so we can’t say what it changes — it runs as you.";

--- a/packages/vendo/src/compose-harness.ts
+++ b/packages/vendo/src/compose-harness.ts
@@ -8,6 +8,7 @@ import { awayRunner } from "@vendoai/agents";
 import {
   CONNECTOR_DISCOVERY_TOOLS,
   VENDO_AUTOMATE_TOOL,
+  VENDO_BASH_TOOL,
   VENDO_MAKE_TOOL,
   type AgentRunner,
   type Harness,
@@ -48,10 +49,17 @@ import { registerTurnSteer } from "./turn-liveness.js";
  *  A name with nothing behind it costs nothing: `computeInitialLoadout` filters
  *  the turn's OWN listings through this set (tool-search.ts), so on a deployment
  *  that never opted into texts it simply never matches — no `channels` gate. */
-const PROMPT_TAUGHT_TOOLS: readonly string[] = [
+export const PROMPT_TAUGHT_TOOLS: readonly string[] = [
   VENDO_MAKE_TOOL,
   VENDO_AUTOMATE_TOOL,
   VENDO_TEXT_ME_TOOL,
+  // The shell has no `vendo_` prefix on purpose (it is the `bash` every model
+  // already knows), so it is not covered by the always-active exemption that
+  // prefix buys. Named here instead: a deployment past the loadout cap must not
+  // lose the one tool that opens the user's files. An entry with no matching
+  // listing costs nothing — a deployment with the shell withheld simply has
+  // nothing for this name to exempt.
+  VENDO_BASH_TOOL,
   ...CONNECTOR_DISCOVERY_TOOLS,
 ];
 

--- a/packages/vendo/src/compose-harness.ts
+++ b/packages/vendo/src/compose-harness.ts
@@ -323,6 +323,14 @@ const harnessDoorFor = (composition: VendoComposition): HarnessTurns => {
       await ready();
       return harnessTurns.putUserFile(input);
     },
+    stageUpload: async (input) => {
+      await ready();
+      return harnessTurns.stageUpload(input);
+    },
+    writeUserBytes: async (principal, path, content) => {
+      await ready();
+      return harnessTurns.writeUserBytes(principal, path, content);
+    },
     threads: {
       get: async (id, ctx) => {
         await ready();

--- a/packages/vendo/src/compose-harness.ts
+++ b/packages/vendo/src/compose-harness.ts
@@ -215,7 +215,7 @@ const harnessTurnDoorSeams = (
 const harnessTurnConfig = (
   composition: VendoComposition,
 ): Parameters<typeof createHarnessTurns>[0] => {
-  const { harness, sandbox, store, files, guard, boundTools, capability, catalog } = composition;
+  const { harness, sandbox, store, files, guard, boundTools, capability, catalog, ops } = composition;
   const { inference, system, toolSearch, capabilityMiss } = composition;
   const { serviceCatalog, toolOutputCap, connectGate, membershipsSeam } = composition;
   // The host's `surfaces.agent` menu, bound at the harness door's registry
@@ -234,6 +234,7 @@ const harnessTurnConfig = (
     // The SAME adapter the erase cascade deletes through (selectStore) — the
     // whole point of resolving it once.
     files,
+    ...(ops === undefined ? {} : { ops }),
     guard,
     tools: menuBoundTools,
     skills: capability.skills,

--- a/packages/vendo/src/compose-tools.ts
+++ b/packages/vendo/src/compose-tools.ts
@@ -5,6 +5,7 @@
  */
 import type { Connector } from "@vendoai/actions";
 import { consoleLogger, emitUsage, setLogger, setUsageSink, type Json } from "@vendoai/core";
+import { createShellTools } from "@vendoai/harnesses/vendo";
 import { createKnowledgeTools, knowledgeIndexResolver } from "@vendoai/knowledge";
 import { workspaceStore } from "@vendoai/store";
 import {
@@ -133,7 +134,7 @@ export const emitDeploymentBoot = (composition: VendoComposition): void => {
 export const composeTools = (composition: VendoComposition): Pick<VendoComposition,
   "toolOutputCap" | "catalogConnectors" | "serviceCatalog" | "knowledgeIndex"
   | "missSurface" | "missCapture"> => {
-  const { config, actions, store, resolvedConnectors, surfaceRoot } = composition;
+  const { config, actions, store, resolvedConnectors, surfaceRoot, composed } = composition;
   // One value, three readers: the agent's context, the harness bridge, and the
   // discovery registry — which bounds its own search under it rather than being
   // cut by it (the cap slices serialized JSON, so a search that reaches it loses
@@ -183,6 +184,26 @@ export const composeTools = (composition: VendoComposition): Pick<VendoCompositi
     async (principal) => await (drawer ??= workspaceStore(store, { files: composition.files })).open(principal),
     uploadCapOf(config),
   ));
+
+  // The shell (spec 2026-08-23 §1) — the RESIDENT brain's hands, on the same
+  // registry, guarded and audited like everything else.
+  //
+  // The condition is WHO THINKS, resolved from the same two slots
+  // compose-harness.ts resolves it from (`composed?.harness ?? config.harness`,
+  // then the `vendo()` default). It is re-derived here rather than read off
+  // `composition.harness` because this phase runs BEFORE composeHarness
+  // (compose-context.ts:323 vs :325) — and a brain that thinks on a MACHINE
+  // already has a real disk, so handing it a second, virtual one would be two
+  // filesystems disagreeing about the same files.
+  const brain = composed?.harness ?? config.harness;
+  const residentBrain = brain === undefined || brain.name === "vendo";
+  const shellLimits = typeof config.shell === "object" ? config.shell.limits : undefined;
+  if (config.shell !== false && residentBrain) {
+    actions.add(createShellTools(
+      async (principal) => await (drawer ??= workspaceStore(store, { files: composition.files })).open(principal),
+      shellLimits === undefined ? {} : { limits: shellLimits },
+    ));
+  }
 
   // Knowledge K1 — the tool exists exactly when an adapter is configured;
   // no adapter, no `vendo_knowledge_search` in any descriptor surface.

--- a/packages/vendo/src/config-keys.ts
+++ b/packages/vendo/src/config-keys.ts
@@ -59,6 +59,7 @@ export const CREATE_VENDO_CONFIG_KEYS = [
   "profileDir",
   "fetch",
   "profile",
+  "shell",
   "mcp",
   "oauth",
   "agent",

--- a/packages/vendo/src/harness-turn.ts
+++ b/packages/vendo/src/harness-turn.ts
@@ -79,7 +79,7 @@ import type { VendoToolSearchConfig } from "@vendoai/harnesses/vendo";
 import { createUIMessageStream, createUIMessageStreamResponse, type LanguageModel, type UIMessage } from "ai";
 import { discoveryRail } from "./prompt.js";
 import { finishActiveTurn } from "./turn-liveness.js";
-import { isUserFilePath, threadFilePath, threadFilesDir, uploadStagingPath, userFilePath, USER_UPLOADS } from "./user-files.js";
+import { isUserFilePath, MAX_LEAF_NAME, threadFilePath, threadFilesDir, uploadStagingPath, userFilePath, USER_UPLOADS } from "./user-files.js";
 import type { Limiter } from "./limits.js";
 
 export interface HarnessTurnsConfig {
@@ -500,7 +500,12 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
       // with one question: it reads the store's index AND this turn's own staged
       // moves (store/src/workspace-fs.ts:260). The common single-drop turn is
       // untouched.
-      if (await workspace.exists(to)) to = threadFilePath(threadId, from.slice(USER_UPLOADS.length + 1));
+      // That leaf is the name with staging's nine-character prefix in front of
+      // it, so a name near the door's own limit overshoots it — and the whole
+      // turn was refused rather than the second drop homed. The prefix is what
+      // makes it unique, so the overshoot comes off the END.
+      const staged = from.slice(USER_UPLOADS.length + 1);
+      if (await workspace.exists(to)) to = threadFilePath(threadId, staged.slice(0, MAX_LEAF_NAME));
       await workspace.mv(from, to);
       homes.set(from, to);
     }

--- a/packages/vendo/src/harness-turn.ts
+++ b/packages/vendo/src/harness-turn.ts
@@ -490,7 +490,14 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
       const from = (part as { url: string }).url;
       // The NAME is the part's, and it goes through the same leaf rule every
       // other door uses (`threadFilePath` throws on anything that is not one).
-      const to = threadFilePath(threadId, (part as { filename?: string }).filename ?? from.slice(from.indexOf("-") + 1));
+      let to = threadFilePath(threadId, (part as { filename?: string }).filename ?? from.slice(from.indexOf("-") + 1));
+      // ONE message can carry two drops of one name — the composer appends, and
+      // the staging door deliberately keeps them apart. Homing both on the name
+      // alone put the second move on top of the first, SILENTLY (a workspace
+      // move overwrites), and the same turn's staging erase then freed the
+      // loser's blob. So the second keeps the unique leaf staging already gave
+      // it; the common single-drop turn is untouched.
+      if ([...homes.values()].includes(to)) to = threadFilePath(threadId, from.slice(USER_UPLOADS.length + 1));
       await workspace.mv(from, to);
       homes.set(from, to);
     }
@@ -523,7 +530,12 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
     for (const name of await workspace.readdir(USER_UPLOADS)) {
       const path = `${USER_UPLOADS}/${name}`;
       if ((await workspace.stat(path)).mtime.getTime() >= cutoff) continue;
-      await workspace.rm(path);
+      // Recursive, because staging is not flat in practice: the agent's own
+      // shell mounts this workspace, so a `cp -r` can plant a subtree here, and
+      // a directory's `stat` answers the epoch — never spared by the cutoff. A
+      // bare `rm` then threw ENOTEMPTY on every later turn, before the model
+      // ran. `force`, because `readdir` and `rm` are two moments.
+      await workspace.rm(path, { recursive: true, force: true });
       await eraseStagedFile(ctx, path);
     }
   };

--- a/packages/vendo/src/harness-turn.ts
+++ b/packages/vendo/src/harness-turn.ts
@@ -491,13 +491,16 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
       // The NAME is the part's, and it goes through the same leaf rule every
       // other door uses (`threadFilePath` throws on anything that is not one).
       let to = threadFilePath(threadId, (part as { filename?: string }).filename ?? from.slice(from.indexOf("-") + 1));
-      // ONE message can carry two drops of one name — the composer appends, and
-      // the staging door deliberately keeps them apart. Homing both on the name
-      // alone put the second move on top of the first, SILENTLY (a workspace
-      // move overwrites), and the same turn's staging erase then freed the
-      // loser's blob. So the second keeps the unique leaf staging already gave
-      // it; the common single-drop turn is untouched.
-      if ([...homes.values()].includes(to)) to = threadFilePath(threadId, from.slice(USER_UPLOADS.length + 1));
+      // One name can arrive twice — twice in ONE message (the composer appends),
+      // or again on a LATER turn of a thread a person keeps coming back to. The
+      // staging door keeps the drops apart, but homing on the name alone put the
+      // second move on top of the first, SILENTLY (a workspace move overwrites),
+      // and the staging erase then freed the loser's blob. So the second keeps
+      // the unique leaf staging already gave it. `exists` covers both arrivals
+      // with one question: it reads the store's index AND this turn's own staged
+      // moves (store/src/workspace-fs.ts:260). The common single-drop turn is
+      // untouched.
+      if (await workspace.exists(to)) to = threadFilePath(threadId, from.slice(USER_UPLOADS.length + 1));
       await workspace.mv(from, to);
       homes.set(from, to);
     }

--- a/packages/vendo/src/harness-turn.ts
+++ b/packages/vendo/src/harness-turn.ts
@@ -478,6 +478,26 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
     } as UIMessage;
   };
 
+  /** How long a staged file may sit unclaimed. A person can upload, get
+   *  distracted, and send an hour later; six hours is far past that and far
+   *  short of storage anyone would notice. This is not retention — it is the
+   *  janitor for an address that is only ever a waypoint. */
+  const STRAY_MAX_AGE_MS = 6 * 60 * 60 * 1000;
+
+  /** Staging is a waypoint, so nothing may live there. Every turn sweeps what
+   *  this person left behind — a drop whose message was never sent, or one whose
+   *  turn died between the write and the move. Reads the path index the turn's
+   *  workspace already built, so it costs no round trip; the removals ride the
+   *  turn's own commit. */
+  const sweepStagedStrays = async (workspace: WorkspaceFs): Promise<void> => {
+    if (!await workspace.exists(USER_UPLOADS)) return;
+    const cutoff = Date.now() - STRAY_MAX_AGE_MS;
+    for (const name of await workspace.readdir(USER_UPLOADS)) {
+      const path = `${USER_UPLOADS}/${name}`;
+      if ((await workspace.stat(path)).mtime.getTime() < cutoff) await workspace.rm(path);
+    }
+  };
+
   /** The thread's harness-state slot, when this store can hold one. The slot
    *  carries a native session ref and vendo()'s searched-in loadout, so it has
    *  to die with the thread — a reused id must never inherit either (the
@@ -730,6 +750,9 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
         }),
       ]);
       timings.add("store", Date.now() - storeAt);
+      // §6 — the janitor for the waypoint. On the turn's own workspace and its
+      // own commit, so a sweep costs no extra open and no extra write.
+      await sweepStagedStrays(workspace);
       // §1.6 — the render seam, built for THIS turn's ctx and handed to the
       // runtime's generic `wrapWorkspace` slot: the runtime owns WHERE the wrap
       // happens and what `emit` writes to; composition owns WHAT wraps.

--- a/packages/vendo/src/harness-turn.ts
+++ b/packages/vendo/src/harness-turn.ts
@@ -443,6 +443,25 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
     repairInstruction,
   });
 
+  /** A file that LEAVES staging must leave the bucket with it.
+   *
+   *  Both exits — the re-home's `mv` and the janitor's `rm` — only tombstone:
+   *  the `/user/uploads/…` row moves to history with its `blob_ref` intact and
+   *  the object is deliberately kept (store/workspace-rows.ts: "the history row
+   *  is its pointer now"). Staging is neither a thread nor an app, so no other
+   *  erase axis reaches that address, and the object outlived deleting the
+   *  conversation — and would have outlived an erasure request.
+   *
+   *  Deliberately not wrapped: a bucket that refuses the delete is the leak
+   *  coming back, so it fails the turn rather than passing quietly. A store with
+   *  no SQL backend has no erase path at all — the same gap `sweepThreadFiles`
+   *  documents below. */
+  const eraseStagedFile = async (ctx: RunContext, path: string): Promise<void> => {
+    if (maybeDbFor(config.store) === undefined) return;
+    await eraseStore(config.store, { files: config.files })
+      .byWorkspacePath(ctx.principal.subject, path);
+  };
+
   /**
    * A dropped file belongs to the CONVERSATION, so the turn that receives it
    * moves it there and rewrites the part it arrived on.
@@ -476,6 +495,7 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
       homes.set(from, to);
     }
     await workspace.commit();
+    for (const from of homes.keys()) await eraseStagedFile(ctx, from);
     return {
       ...message,
       parts: message.parts.map((part) =>
@@ -494,14 +514,17 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
   /** Staging is a waypoint, so nothing may live there. Every turn sweeps what
    *  this person left behind — a drop whose message was never sent, or one whose
    *  turn died between the write and the move. Reads the path index the turn's
-   *  workspace already built, so it costs no round trip; the removals ride the
-   *  turn's own commit. */
-  const sweepStagedStrays = async (workspace: WorkspaceFs): Promise<void> => {
+   *  workspace already built, so FINDING a stray costs no round trip, and the
+   *  removals ride the turn's own commit; only a turn that actually sweeps
+   *  something pays for the erase that frees its object. */
+  const sweepStagedStrays = async (workspace: WorkspaceFs, ctx: RunContext): Promise<void> => {
     if (!await workspace.exists(USER_UPLOADS)) return;
     const cutoff = Date.now() - STRAY_MAX_AGE_MS;
     for (const name of await workspace.readdir(USER_UPLOADS)) {
       const path = `${USER_UPLOADS}/${name}`;
-      if ((await workspace.stat(path)).mtime.getTime() < cutoff) await workspace.rm(path);
+      if ((await workspace.stat(path)).mtime.getTime() >= cutoff) continue;
+      await workspace.rm(path);
+      await eraseStagedFile(ctx, path);
     }
   };
 
@@ -791,8 +814,9 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
       ]);
       timings.add("store", Date.now() - storeAt);
       // §6 — the janitor for the waypoint. On the turn's own workspace and its
-      // own commit, so a sweep costs no extra open and no extra write.
-      await sweepStagedStrays(workspace);
+      // own commit, so a turn with nothing to sweep costs no extra open and no
+      // extra write.
+      await sweepStagedStrays(workspace, input.ctx);
       // §1.6 — the render seam, built for THIS turn's ctx and handed to the
       // runtime's generic `wrapWorkspace` slot: the runtime owns WHERE the wrap
       // happens and what `emit` writes to; composition owns WHAT wraps.

--- a/packages/vendo/src/harness-turn.ts
+++ b/packages/vendo/src/harness-turn.ts
@@ -77,7 +77,7 @@ import type { VendoToolSearchConfig } from "@vendoai/harnesses/vendo";
 import { createUIMessageStream, createUIMessageStreamResponse, type LanguageModel, type UIMessage } from "ai";
 import { discoveryRail } from "./prompt.js";
 import { finishActiveTurn } from "./turn-liveness.js";
-import { isUserFilePath, userFilePath } from "./user-files.js";
+import { isUserFilePath, threadFilePath, uploadStagingPath, userFilePath, USER_UPLOADS } from "./user-files.js";
 import type { Limiter } from "./limits.js";
 
 export interface HarnessTurnsConfig {
@@ -269,6 +269,18 @@ export interface HarnessTurns {
     content: Uint8Array | string;
     contentType?: string;
   }): Promise<UploadedFile>;
+  /** The CHAT drop's landing pad. A dropped file is not a saved one — it belongs
+   *  to the conversation that is about to receive it, and the turn re-homes it
+   *  there. Until then it lives in staging under an address only the re-homer
+   *  and its sweep read. */
+  stageUpload(input: {
+    principal: Principal;
+    name: string;
+    content: Uint8Array | string;
+    contentType?: string;
+  }): Promise<UploadedFile>;
+  /** @internal The one write both file doors share. */
+  writeUserBytes(principal: Principal, path: string, content: Uint8Array | string): Promise<UploadedFile>;
   /** D6 — drop every thread a subject owns. */
   evictSubject(subject: string): Promise<void>;
 }
@@ -469,13 +481,20 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
     },
 
     async putUserFile(input) {
-      const path = userFilePath(input.name);
-      const bytes = typeof input.content === "string"
-        ? new TextEncoder().encode(input.content)
-        : input.content;
-      // The user's OWN mount and nothing else: no host projection to build and
-      // no org mounts to assert, because a drawer write addresses one subject.
-      const workspace = await sqlDoors().workspaces.open(input.principal);
+      return await this.writeUserBytes(input.principal, userFilePath(input.name), input.content);
+    },
+
+    async stageUpload(input) {
+      return await this.writeUserBytes(input.principal, uploadStagingPath(input.name), input.content);
+    },
+
+    /** The ONE server-side write both doors go through, so a shelved file and a
+     *  dropped one land the same way and differ only in their address. The
+     *  user's OWN mount and nothing else: no host projection to build and no org
+     *  mounts to assert, because this addresses one subject. */
+    async writeUserBytes(principal, path, content) {
+      const bytes = typeof content === "string" ? new TextEncoder().encode(content) : content;
+      const workspace = await sqlDoors().workspaces.open(principal);
       await workspace.writeFile(path, bytes);
       await workspace.commit();
       return { path, bytes: bytes.byteLength };

--- a/packages/vendo/src/harness-turn.ts
+++ b/packages/vendo/src/harness-turn.ts
@@ -436,6 +436,48 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
     repairInstruction,
   });
 
+  /**
+   * A dropped file belongs to the CONVERSATION, so the turn that receives it
+   * moves it there and rewrites the part it arrived on.
+   *
+   * It happens HERE, server-side at turn start, because this is the first moment
+   * both halves exist at once: the composer uploads before it sends (so a first
+   * turn's file is staged before any thread does), and the thread id is minted
+   * in this function. And it happens BEFORE the message is persisted, because a
+   * transcript that recorded the staging path would hold a pill pointing at
+   * something the next turn's sweep deletes.
+   *
+   * Identity is preserved when there is nothing to do: the overwhelming majority
+   * of turns carry no staged part, and they must cost exactly nothing.
+   */
+  const rehomeStagedFiles = async (
+    message: UIMessage,
+    threadId: ThreadId,
+    ctx: RunContext,
+  ): Promise<UIMessage> => {
+    const staged = message.parts.filter((part) =>
+      part.type === "file" && part.url.startsWith(`${USER_UPLOADS}/`));
+    if (staged.length === 0) return message;
+    const workspace = await sqlDoors().workspaces.open(ctx.principal);
+    const homes = new Map<string, string>();
+    for (const part of staged) {
+      const from = (part as { url: string }).url;
+      // The NAME is the part's, and it goes through the same leaf rule every
+      // other door uses (`threadFilePath` throws on anything that is not one).
+      const to = threadFilePath(threadId, (part as { filename?: string }).filename ?? from.slice(from.indexOf("-") + 1));
+      await workspace.mv(from, to);
+      homes.set(from, to);
+    }
+    await workspace.commit();
+    return {
+      ...message,
+      parts: message.parts.map((part) =>
+        part.type === "file" && homes.has(part.url)
+          ? { ...part, url: homes.get(part.url)! }
+          : part),
+    } as UIMessage;
+  };
+
   /** The thread's harness-state slot, when this store can hold one. The slot
    *  carries a native session ref and vendo()'s searched-in loadout, so it has
    *  to die with the thread — a reused id must never inherit either (the
@@ -559,6 +601,8 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
       // here exactly as it always was. Below the turn level there is no round
       // trip worth saving, so the old order stands.
       const opening = input[SERVER_AUTHORED] === true && given !== undefined && batched
+        // No re-home applies here: the only SERVER_AUTHORED caller (channel-turn)
+        // builds a message of text parts alone, so it can carry no staged drop.
         ? sqlDoors().transcript.upsertMany?.(input.ctx.principal, given, [input.message], {})
         : undefined;
       // A rejection is delivered where it is awaited below; this only keeps a
@@ -579,6 +623,11 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
       // derivation — and `thread.messages` is the canonical transcript read back
       // from `vendo_thread_messages`.
       const thread = await threads.resolve(batched ? threadId : given, input.ctx, loaded?.thread);
+      // §6 — the drop comes home before anything records where it was. Keyed on
+      // the RESOLVED id, not the speculatively minted one: unbatched, `resolve`
+      // mints the thread's real id itself, and a file homed under the other id
+      // would belong to no conversation at all.
+      const message = await rehomeStagedFiles(input.message, thread.id, input.ctx);
 
       // THE CONSTRAINT (lane A's verifier): `TurnRunInput.messages` is
       // STORE-SOURCED. The client contributes at most this one message, and
@@ -600,8 +649,8 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
       // carries a message this process authored, so there is no client copy to
       // check it against — and a gate run after the write could only report a
       // rewrite it had already let through.
-      if (opening === undefined) validateUpsert(thread.messages, input.message);
-      upsertMessage(thread.messages, input.message);
+      if (opening === undefined) validateUpsert(thread.messages, message);
+      upsertMessage(thread.messages, message);
 
       // Before the FIRST write, not after it. `threads.persist` goes through the
       // adapter seam and so succeeds even on a store that can keep neither the
@@ -656,7 +705,7 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
         // Already in flight since before the read, where it was allowed to be.
         opening
         ?? (fresh || batchAppend === undefined
-          ? threads.persist(thread, [input.message], { fresh })
+          ? threads.persist(thread, [message], { fresh })
           // No position is passed: the store assigns one while it holds the
           // thread row, so two turns racing on this conversation cannot claim
           // the same slot. An answer to a pending approval matches an existing
@@ -664,7 +713,7 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
           : transcript.upsertMany(
             input.ctx.principal,
             thread.id,
-            [input.message],
+            [message],
             { title: deriveTitle(thread.messages) },
           )),
         // §9.7 — the turn's façade mounts every org the wire asserted for this

--- a/packages/vendo/src/harness-turn.ts
+++ b/packages/vendo/src/harness-turn.ts
@@ -31,6 +31,7 @@ import {
   type RecordInput,
   type ResolvedModels,
   type RunContext,
+  type StoreOps,
   type ThreadId,
   type ToolRegistry,
   type WorkspaceFs,
@@ -50,6 +51,7 @@ import {
 } from "@vendoai/apps";
 import type { VendoGuard } from "@vendoai/guard";
 import {
+  eraseStore,
   harnessStateKey,
   harnessStateRow,
   harnessStateStore,
@@ -77,7 +79,7 @@ import type { VendoToolSearchConfig } from "@vendoai/harnesses/vendo";
 import { createUIMessageStream, createUIMessageStreamResponse, type LanguageModel, type UIMessage } from "ai";
 import { discoveryRail } from "./prompt.js";
 import { finishActiveTurn } from "./turn-liveness.js";
-import { isUserFilePath, threadFilePath, uploadStagingPath, userFilePath, USER_UPLOADS } from "./user-files.js";
+import { isUserFilePath, threadFilePath, threadFilesDir, uploadStagingPath, userFilePath, USER_UPLOADS } from "./user-files.js";
 import type { Limiter } from "./limits.js";
 
 export interface HarnessTurnsConfig {
@@ -89,6 +91,11 @@ export interface HarnessTurnsConfig {
   /** THE deployment's files adapter (`selectStore`), so workspace blobs are
    *  written where the erase cascade will look for them. */
   files: FilesAdapter;
+  /** THE deployment's named-operation surface (`selectStoreOps`), when it has
+   *  one. The delete cascade is its one caller here: `transcripts.deleteThread`
+   *  is a single transaction over three tables, and the row-at-a-time route it
+   *  replaces could only ever delete the first of them. */
+  ops?: StoreOps;
   guard: VendoGuard;
   /** The composed sandbox adapter (`selectSandbox`). A harness declaring
    *  `requires: { sandbox: true }` — `claudeCode()` — is constructed by the HOST
@@ -498,6 +505,26 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
     }
   };
 
+  /** A conversation's files go with the conversation.
+   *
+   *  A SQL-backed store erases the rows, their history AND the blobs those rows
+   *  were the only pointer to, in one pass (`eraseStore().byThread`). Every other
+   *  backend gets the façade's recursive delete, which removes the live rows and
+   *  leaves the history rows that hold the blob refs — the same residue a bare
+   *  `rm` leaves today, and the same follow-up. Both paths leave the person's
+   *  view identical; they differ only in what the bucket still holds. */
+  const sweepThreadFiles = async (id: ThreadId, ctx: RunContext): Promise<void> => {
+    if (maybeDbFor(config.store) !== undefined) {
+      await eraseStore(config.store, { files: config.files }).byThread(id);
+      return;
+    }
+    const workspace = await sqlDoors().workspaces.open(ctx.principal);
+    const dir = threadFilesDir(id);
+    if (!await workspace.exists(dir)) return;
+    await workspace.rm(dir, { recursive: true, force: true });
+    await workspace.commit();
+  };
+
   /** The thread's harness-state slot, when this store can hold one. The slot
    *  carries a native session ref and vendo()'s searched-in loadout, so it has
    *  to die with the thread — a reused id must never inherit either (the
@@ -517,8 +544,21 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
       get: (id, ctx) => threads.get(id, ctx),
       list: (ctx) => threads.list(ctx),
       delete: async (id, ctx) => {
-        await threads.delete(id, ctx);
-        await stateDoor()?.clear(id);
+        // Ownership stays the repository's law: `get` answers null for another
+        // subject's id, and an absent thread is a no-op — exactly as before.
+        if (await threads.get(id, ctx) === null) return;
+        // The REAL cascade. `transcripts.deleteThread` is thread row + message
+        // rows + harness state in ONE transaction (store/ops.ts:543-552, mirrored
+        // by the hosted store); the single-row delete it replaces left every
+        // message behind forever, unreachable by any later erase because the join
+        // that identified them went with the row.
+        if (config.ops === undefined) {
+          await threads.delete(id, ctx);
+          await stateDoor()?.clear(id);
+        } else {
+          await config.ops.transcripts.deleteThread(id);
+        }
+        await sweepThreadFiles(id, ctx);
       },
     },
 

--- a/packages/vendo/src/surface-menu.ts
+++ b/packages/vendo/src/surface-menu.ts
@@ -1,4 +1,4 @@
-import { CONNECTOR_DISCOVERY_TOOLS, type ToolRegistry } from "@vendoai/core";
+import { CONNECTOR_DISCOVERY_TOOLS, VENDO_BASH_TOOL, type ToolRegistry } from "@vendoai/core";
 import { VENDO_TOOL_PACK_PREFIX } from "./tool-pack.js";
 
 /**
@@ -56,12 +56,18 @@ export function memoizedSurfaceMenu(
  * four carry no prefix while the system prompt teaches them by name — filtering
  * them out is the uiaudit-2026-08-06 regression (a curated host lost
  * `request_connection` while the prompt kept teaching it).
+ *
+ * `bash` is exempt for exactly that second reason, and named for exactly that
+ * reason too: it is Vendo's own, the prompt teaches it, and it deliberately
+ * carries no `vendo_` prefix, so the prefix cannot cover it (the same gap
+ * `PROMPT_TAUGHT_TOOLS` closes on the loadout side). A deployment that does not
+ * want the shell says `shell: false`; a curated menu is not where it goes.
  */
 export function withAgentMenu(
   tools: ToolRegistry,
   menu: () => Promise<ReadonlySet<string> | undefined>,
 ): ToolRegistry {
-  const exempt: ReadonlySet<string> = new Set(CONNECTOR_DISCOVERY_TOOLS);
+  const exempt: ReadonlySet<string> = new Set([...CONNECTOR_DISCOVERY_TOOLS, VENDO_BASH_TOOL]);
   return {
     ...tools,
     async descriptors(ctx) {

--- a/packages/vendo/src/types.ts
+++ b/packages/vendo/src/types.ts
@@ -42,6 +42,7 @@ import type {
   VendoTheme,
 } from "@vendoai/apps/contract";
 import type { GuardRules, PolicyFile, VendoGuard } from "@vendoai/guard";
+import type { ShellLimits } from "@vendoai/harnesses/vendo";
 import type { HostOAuthAdapter } from "@vendoai/mcp";
 import type { VendoStore } from "@vendoai/store";
 import type { VendoAgentTools } from "./agent-tools.js";
@@ -423,6 +424,23 @@ export interface CreateVendoConfig {
       exchanges one of these keys plus a user id for a short-lived user-bound
       token at the door's token endpoint (rotation is listing both keys until
       the old one is out of use). */
+  /** The agent's hands over the user's own files (spec 2026-08-23 §1): one
+      in-process `bash` over the workspace, on the same guarded registry as
+      everything else. ON by default — a deployment's users drop files into chat
+      whether or not anyone configured anything, and an agent that cannot open
+      them is the whole problem this exists to fix.
+
+      `false` withholds the tool entirely. The object form keeps it and moves its
+      ceilings: `limits.maxExecutionTimeMs` (default 30 000) is one call's wall
+      clock, `limits.maxOutputBytes` (default 1 000 000) is how much one call may
+      produce before the shell stops it.
+
+      It rides the RESIDENT BRAIN, not the deployment: `vendo()` runs in this
+      process and has the workspace in hand, so the tool composes for it and for
+      an `agent()` that adopted it. A harness that thinks on a MACHINE
+      (`claudeCode()`) already has a real disk and reaches it its own way, so this
+      flag is silently irrelevant there rather than half-wired. */
+  shell?: boolean | { limits?: ShellLimits };
   mcp?: boolean | {
     baseUrl?: string;
     remoteAs?: { issuer: string; jwksUri?: string; audience: string };

--- a/packages/vendo/src/types.ts
+++ b/packages/vendo/src/types.ts
@@ -424,6 +424,12 @@ export interface CreateVendoConfig {
       exchanges one of these keys plus a user id for a short-lived user-bound
       token at the door's token endpoint (rotation is listing both keys until
       the old one is out of use). */
+  mcp?: boolean | {
+    baseUrl?: string;
+    remoteAs?: { issuer: string; jwksUri?: string; audience: string };
+    federation?: { secret: string };
+    serviceAuth?: { keys: readonly string[] };
+  };
   /** The agent's hands over the user's own files (spec 2026-08-23 §1): one
       in-process `bash` over the workspace, on the same guarded registry as
       everything else. ON by default — a deployment's users drop files into chat
@@ -441,12 +447,6 @@ export interface CreateVendoConfig {
       (`claudeCode()`) already has a real disk and reaches it its own way, so this
       flag is silently irrelevant there rather than half-wired. */
   shell?: boolean | { limits?: ShellLimits };
-  mcp?: boolean | {
-    baseUrl?: string;
-    remoteAs?: { issuer: string; jwksUri?: string; audience: string };
-    federation?: { secret: string };
-    serviceAuth?: { keys: readonly string[] };
-  };
   /** 10-mcp §3 plus its additive prebuilt flow — the host's session + identity seam. Threaded top-level like
       `actAs`/`principal` (the door is agnostic; the umbrella owns the shape).
       REQUIRED when `mcp` is true: the door cannot mint principals without it. */

--- a/packages/vendo/src/user-files.ts
+++ b/packages/vendo/src/user-files.ts
@@ -83,8 +83,13 @@ export function uploadStagingPath(name: string): string {
 }
 
 /** Everything one conversation owns. The delete cascade sweeps this whole
-    subtree, so nothing may live under it that should outlive the thread. */
-export const threadFilesDir = (threadId: ThreadId): string => `${USER_THREADS}/${threadId}`;
+    subtree, so nothing may live under it that should outlive the thread.
+
+    The id goes through the SAME rule as a name: it is a path segment like any
+    other, and the only shape the wire checks is `thr_` + `.+` (core ids.ts),
+    whose `.+` matches a slash. Without this a client-chosen id climbed out of
+    this mount — and took the delete cascade's recursive rm with it. */
+export const threadFilesDir = (threadId: ThreadId): string => `${USER_THREADS}/${leafName(threadId)}`;
 
 /** One file, homed with its conversation. */
 export const threadFilePath = (threadId: ThreadId, name: string): string =>

--- a/packages/vendo/src/user-files.ts
+++ b/packages/vendo/src/user-files.ts
@@ -57,14 +57,18 @@ export const isUserFilePath = (path: string): boolean =>
  * (b9392b92c): reject the segment rather than sanitize it, because the values
  * reaching here are steerable by end-user chat.
  */
+/** The longest leaf any door accepts. Named because the re-homer builds a leaf
+    out of one staging already prefixed and has to cut it to the same limit. */
+export const MAX_LEAF_NAME = 200;
+
 function leafName(name: string): string {
-  const bad = name.length === 0 || name.length > 200
+  const bad = name.length === 0 || name.length > MAX_LEAF_NAME
     || /[/\\]/.test(name) || name === "." || name === ".."
     || [...name].some((char) => char < " ");
   if (bad) {
     throw new VendoError(
       "validation",
-      `${JSON.stringify(name)} is not a file name. Send one name — no slashes, no control characters, at most 200 characters — and it lands in the user's files as exactly that.`,
+      `${JSON.stringify(name)} is not a file name. Send one name — no slashes, no control characters, at most ${MAX_LEAF_NAME} characters — and it lands in the user's files as exactly that.`,
     );
   }
   return name;

--- a/packages/vendo/src/user-files.ts
+++ b/packages/vendo/src/user-files.ts
@@ -13,6 +13,7 @@ import {
   VendoError,
   VENDO_TOOL_TITLES,
   type Principal,
+  type ThreadId,
   type ToolDescriptor,
   type ToolOutcome,
   type ToolRegistry,
@@ -25,21 +26,38 @@ import type { CreateVendoConfig } from "./types.js";
 /** §3.1's frozen drawer: per subject, and outliving every conversation. */
 export const USER_FILES = "/user/files";
 
-/** Does this message part address the drawer rather than carry bytes? */
-export const isUserFilePath = (path: string): boolean => path.startsWith(`${USER_FILES}/`);
+/** Where a dropped file LANDS, for the moments between `POST /files` and the
+    turn that claims it. A drop finishes before the conversation it belongs to
+    exists (the composer uploads pre-send, and a first turn's thread id is minted
+    server-side), so there has to be an address that means "received, not yet
+    homed". Nothing but the re-homer and its sweep ever reads it. */
+export const USER_UPLOADS = "/user/uploads";
+
+/** Where a file BELONGS once a turn has claimed it: with the conversation, like
+    a Claude Code project — so it is in reach of every later turn on that thread,
+    and it dies when the thread does. */
+export const USER_THREADS = "/user/threads";
+
+/** Does this message part address bytes the SERVER holds, rather than carry
+    them? All three addresses answer yes: the shelf, a staged drop, and a
+    conversation's own files. */
+export const isUserFilePath = (path: string): boolean =>
+  path.startsWith(`${USER_FILES}/`)
+  || path.startsWith(`${USER_UPLOADS}/`)
+  || path.startsWith(`${USER_THREADS}/`);
 
 /**
- * The ONE name check every door into the drawer shares, so a file lands and is
- * fetched at the same address by the same rule.
+ * The ONE name check every door into a user's files shares, so a file lands and
+ * is fetched at the same address by the same rule.
  *
  * A name is a FILE name, never a path. Refusing `/`, `\` and the `.`/`..`
- * dot-segments AT THE SOURCE is what contains the whole feature — the path is
- * built below from a name that provably carries no separator, so there is
+ * dot-segments AT THE SOURCE is what contains the whole feature — every path
+ * below is BUILT from a name that provably carries no separator, so there is
  * nothing to escape with. Same posture as the route-tool traversal fix
  * (b9392b92c): reject the segment rather than sanitize it, because the values
  * reaching here are steerable by end-user chat.
  */
-export function userFilePath(name: string): string {
+function leafName(name: string): string {
   const bad = name.length === 0 || name.length > 200
     || /[/\\]/.test(name) || name === "." || name === ".."
     || [...name].some((char) => char < " ");
@@ -49,8 +67,28 @@ export function userFilePath(name: string): string {
       `${JSON.stringify(name)} is not a file name. Send one name — no slashes, no control characters, at most 200 characters — and it lands in the user's files as exactly that.`,
     );
   }
-  return `${USER_FILES}/${name}`;
+  return name;
 }
+
+/** The keep-shelf's address. */
+export function userFilePath(name: string): string {
+  return `${USER_FILES}/${leafName(name)}`;
+}
+
+/** A staged drop's address. The random prefix is OURS, never the caller's: two
+    conversations may drop `report.pdf` in the same second and neither may
+    overwrite the other before its turn claims it. */
+export function uploadStagingPath(name: string): string {
+  return `${USER_UPLOADS}/${globalThis.crypto.randomUUID().slice(0, 8)}-${leafName(name)}`;
+}
+
+/** Everything one conversation owns. The delete cascade sweeps this whole
+    subtree, so nothing may live under it that should outlive the thread. */
+export const threadFilesDir = (threadId: ThreadId): string => `${USER_THREADS}/${threadId}`;
+
+/** One file, homed with its conversation. */
+export const threadFilePath = (threadId: ThreadId, name: string): string =>
+  `${threadFilesDir(threadId)}/files/${leafName(name)}`;
 
 /** What one caller may push into the drawer in one go by DEFAULT, and the same
     number at every door into it; `createVendo({ uploadMaxBytes })` moves it. It

--- a/packages/vendo/src/user-files.ts
+++ b/packages/vendo/src/user-files.ts
@@ -186,9 +186,10 @@ const descriptors: ToolDescriptor[] = [
     name: VENDO_USER_FILES_LIST_TOOL,
     title: VENDO_TOOL_TITLES[VENDO_USER_FILES_LIST_TOOL]!,
     description:
-      "List the files this user has shared with you. They are saved and stay available in EVERY conversation, "
-      + "not just the one they were dropped in — so call this whenever the user refers to something they gave "
-      + "you and you cannot see it in this conversation.",
+      "List the files this user has kept — their shelf, which outlives every conversation. "
+      + "This is NOT where a file they dropped into chat lives: that is in the conversation's own "
+      + "files, under /user/threads/<thread>/files, and the bash tool reads it directly. Call this "
+      + "when the user refers to something they told you to save.",
     inputSchema: { $schema: DRAFT_2020_12, type: "object", properties: {}, additionalProperties: false },
     risk: "read",
   },
@@ -196,12 +197,12 @@ const descriptors: ToolDescriptor[] = [
     name: VENDO_USER_FILES_READ_TOOL,
     title: VENDO_TOOL_TITLES[VENDO_USER_FILES_READ_TOOL]!,
     description:
-      "Read one of the files this user has shared with you, by its name. "
+      "Read one of the files this user has kept, by its name. "
       + `It comes back at most ${LINES_PER_READ} lines at a time: when the result says truncated, call again with `
       + "offset set to the nextOffset it gave you, and keep going until it stops. offset counts LINES from the "
       + "start of the file, never characters. "
-      + "A file that is not text — a PDF, an image, a spreadsheet workbook, a parquet or database file — answers "
-      + "with its type and size and no content: say what it is instead of guessing at what is inside it.",
+      + "For a file dropped into THIS conversation, or for anything that is not plain text, use bash instead — "
+      + "it reads the same workspace and can parse PDFs, spreadsheets and Word documents.",
     inputSchema: {
       $schema: DRAFT_2020_12,
       type: "object",
@@ -218,9 +219,12 @@ const descriptors: ToolDescriptor[] = [
     name: VENDO_USER_FILES_PUT_TOOL,
     title: VENDO_TOOL_TITLES[VENDO_USER_FILES_PUT_TOOL]!,
     description:
-      "Save a file into this user's own files, under a name. It stays available in EVERY conversation, and a "
-      + "file already saved under that name is replaced. Send text as content; send anything else base64-encoded "
-      + `with encoding set to base64. Any type can be SAVED, but only ${READABLE_EXTENSIONS} read back as text.`,
+      "Put a file on this user's shelf, under a name — for something they asked you to keep, so it is "
+      + "there in EVERY future conversation. A file already kept under that name is replaced. "
+      + "Do NOT use this to stash working files: anything you produce for THIS conversation belongs in "
+      + "/user/threads/<thread>/files, which bash writes to directly. "
+      + "Send text as content; send anything else base64-encoded with encoding set to base64. "
+      + `Any type can be SAVED, but only ${READABLE_EXTENSIONS} read back as text here.`,
     inputSchema: {
       $schema: DRAFT_2020_12,
       type: "object",

--- a/packages/vendo/src/wire/files.ts
+++ b/packages/vendo/src/wire/files.ts
@@ -36,7 +36,7 @@ export const fileRoutes: RouteEntry[] = [
     const bytes = new Uint8Array(await request.arrayBuffer());
     if (bytes.byteLength > max) throw overCap(name, bytes.byteLength, max, venue);
     const contentType = request.headers.get("content-type");
-    return json(await deps.harness.putUserFile({
+    return json(await deps.harness.stageUpload({
       principal: ctx.principal,
       name,
       content: bytes,

--- a/packages/vendo/src/wire/shared.ts
+++ b/packages/vendo/src/wire/shared.ts
@@ -93,7 +93,7 @@ export interface WireDeps {
       §3.3/§6), and a store that offers neither a SQL handle nor a StoreOps
       surface refuses THAT TURN, loudly, naming both options — where the old
       probe silently routed the whole deployment onto the legacy door. */
-  harness: Pick<HarnessTurns, "stream" | "threads" | "putUserFile">;
+  harness: Pick<HarnessTurns, "stream" | "threads" | "stageUpload">;
   guard: VendoGuard;
   /** Which optional subsystems this deployment mounted (`createVendo({ apps:
       false })` / `{ automations: false }`). An unmounted subsystem's routes are

--- a/packages/vendo/tests/rehome-uploads.seam.test.ts
+++ b/packages/vendo/tests/rehome-uploads.seam.test.ts
@@ -198,6 +198,41 @@ describe("a turn takes its files home", () => {
     expect(await readBack(vendo, stored[1]!.url!)).toBe("second\n");
   });
 
+  it("keeps both drops when the shared name is as long as the door allows", async () => {
+    // The unique fallback re-uses the STAGING leaf, which is the name plus a
+    // nine-character prefix — so a name near the 200-character door limit built
+    // a leaf past it, and `threadFilePath` refused the whole turn rather than
+    // homing the second drop.
+    const { vendo } = await compose();
+    const headers = await bearer();
+    const name = `${"ledger-".repeat(27)}rows.csv`;
+    expect(name).toHaveLength(197);
+    const first = await (await upload(vendo, name, bytes("first\n"), headers)).json() as { path: string };
+    const second = await (await upload(vendo, name, bytes("second\n"), headers)).json() as { path: string };
+
+    const message = {
+      id: "m1",
+      role: "user",
+      parts: [
+        { type: "file", mediaType: "text/csv", filename: name, url: first.path },
+        { type: "file", mediaType: "text/csv", filename: name, url: second.path },
+      ],
+    };
+    const response = await post(vendo, { threadId: "thr_long", message }, headers);
+    await response.text();
+    expect(response.status).toBe(200);
+
+    const thread = await (await vendo.handler(new Request(
+      "https://host.test/api/vendo/threads/thr_long",
+      { headers },
+    ))).json() as { messages: Array<{ parts: Array<{ type: string; url?: string }> }> };
+    const stored = thread.messages[0]!.parts.filter((part) => part.type === "file");
+    expect(stored).toHaveLength(2);
+    expect(stored[0]!.url).not.toBe(stored[1]!.url);
+    expect(await readBack(vendo, stored[0]!.url!)).toBe("first\n");
+    expect(await readBack(vendo, stored[1]!.url!)).toBe("second\n");
+  });
+
   it("keeps both drops when TWO TURNS of one thread carry the same name", async () => {
     // The same root cause one axis over: the within-message fix compared the
     // addresses THIS message was taking, which is empty on a later turn, so

--- a/packages/vendo/tests/rehome-uploads.seam.test.ts
+++ b/packages/vendo/tests/rehome-uploads.seam.test.ts
@@ -163,6 +163,41 @@ describe("a turn takes its files home", () => {
     expect(stored?.url).toBe(homed);
   });
 
+  it("keeps both drops when ONE message carries two files of the same name", async () => {
+    // The staging door mints a unique prefix per drop, so two `report.csv`s
+    // survive as two rows — but the home address was derived from the NAME
+    // alone, so the second move landed on the first and both pills then pointed
+    // at one file. Silent: a workspace move overwrites without complaint, and
+    // the loser's blob was released by the staging erase in the same turn.
+    const { vendo } = await compose();
+    const headers = await bearer();
+    const first = await (await upload(vendo, "report.csv", bytes("first\n"), headers)).json() as { path: string };
+    const second = await (await upload(vendo, "report.csv", bytes("second\n"), headers)).json() as { path: string };
+    expect(first.path).not.toBe(second.path);
+
+    const message = {
+      id: "m1",
+      role: "user",
+      parts: [
+        { type: "text", text: "compare these" },
+        { type: "file", mediaType: "text/csv", filename: "report.csv", url: first.path },
+        { type: "file", mediaType: "text/csv", filename: "report.csv", url: second.path },
+      ],
+    };
+    await (await post(vendo, { threadId: "thr_twins", message }, headers)).text();
+
+    const thread = await (await vendo.handler(new Request(
+      "https://host.test/api/vendo/threads/thr_twins",
+      { headers },
+    ))).json() as { messages: Array<{ parts: Array<{ type: string; url?: string }> }> };
+    const stored = thread.messages[0]!.parts.filter((part) => part.type === "file");
+    expect(stored).toHaveLength(2);
+    expect(stored[0]!.url).not.toBe(stored[1]!.url);
+    // Each pill still opens the bytes the person actually sent.
+    expect(await readBack(vendo, stored[0]!.url!)).toBe("first\n");
+    expect(await readBack(vendo, stored[1]!.url!)).toBe("second\n");
+  });
+
   it("homes a FIRST turn's drop under the id the server minted", async () => {
     const { vendo } = await compose();
     const headers = await bearer();
@@ -223,6 +258,29 @@ describe("staging does not accumulate", () => {
 
     await expect(readBack(vendo, stale)).rejects.toThrow();
     expect(await readBack(vendo, fresh)).toBe("y");
+  });
+
+  it("sweeps a nested stray the agent's own shell left behind", async () => {
+    // The upload door cannot make one — `leafName` refuses a separator. The
+    // SHELL can: this build mounts the whole workspace under the agent's bash,
+    // so `cp -r` into `/user/uploads/…` plants a subtree. A directory's `stat`
+    // answers the epoch, so it is never spared by the six-hour rule, and the
+    // sweep's non-recursive `rm` then threw ENOTEMPTY on EVERY later turn —
+    // before the model ran, so the whole thread 500'd for good.
+    const { vendo } = await compose();
+    const headers = await bearer();
+    const shell = await vendo.harness.workspace(principal);
+    await shell.writeFile("/user/uploads/scratch/notes.txt", "left behind");
+    await shell.commit();
+
+    const response = await post(vendo, {
+      threadId: "thr_nested_stray",
+      message: { id: "m1", role: "user", parts: [{ type: "text", text: "hello" }] },
+    }, headers);
+    await response.text();
+
+    expect(response.status).toBe(200);
+    await expect(readBack(vendo, "/user/uploads/scratch/notes.txt")).rejects.toThrow();
   });
 
   // The sweep removed the ROW and kept the OBJECT: `workspace.rm` tombstones,

--- a/packages/vendo/tests/rehome-uploads.seam.test.ts
+++ b/packages/vendo/tests/rehome-uploads.seam.test.ts
@@ -210,3 +210,29 @@ describe("staging does not accumulate", () => {
     expect(await readBack(vendo, fresh)).toBe("y");
   });
 });
+
+describe("what the model is handed", () => {
+  it("names a thread file and a shelf file alike, and still sends images inline", async () => {
+    const { vendo, seen } = await compose();
+    const headers = await bearer();
+    const { path: staged } = await (await upload(vendo, "ledger.csv", bytes("jan,31000\n"), headers)).json() as { path: string };
+
+    await (await post(vendo, {
+      threadId: "thr_refs",
+      message: {
+        id: "m1",
+        role: "user",
+        parts: [
+          { type: "text", text: "chart this" },
+          { type: "file", mediaType: "text/csv", filename: "ledger.csv", url: staged },
+          { type: "file", mediaType: "image/png", filename: "chart.png", url: "data:image/png;base64,aGVsbG8=" },
+        ],
+      },
+    }, headers)).text();
+
+    const prompt = seen[0]!;
+    expect(prompt).toContain("The user shared ledger.csv, saved at /user/threads/thr_refs/files/ledger.csv");
+    expect(prompt).not.toContain("text/csv");
+    expect(prompt).toContain("aGVsbG8=");
+  });
+});

--- a/packages/vendo/tests/rehome-uploads.seam.test.ts
+++ b/packages/vendo/tests/rehome-uploads.seam.test.ts
@@ -73,7 +73,7 @@ async function bearer(): Promise<Record<string, string>> {
   return (await mint(principal, grant))!.headers;
 }
 
-async function compose(files?: FilesAdapter): Promise<{ vendo: Vendo; seen: string[] }> {
+async function compose(files?: FilesAdapter): Promise<{ vendo: Vendo; seen: string[]; store: VendoStore }> {
   const dataDir = await mkdtemp(join(tmpdir(), "vendo-rehome-uploads-"));
   const store: VendoStore = createStore({ dataDir });
   cleanups.push(async () => {
@@ -87,7 +87,7 @@ async function compose(files?: FilesAdapter): Promise<{ vendo: Vendo; seen: stri
     store,
     ...(files === undefined ? {} : { files }),
   });
-  return { vendo, seen };
+  return { vendo, seen, store };
 }
 
 const upload = (
@@ -182,5 +182,31 @@ describe("a turn takes its files home", () => {
     }, headers)).text();
 
     expect(await readBack(vendo, "/user/files/kept.csv")).toBe("jan,31000\n");
+  });
+});
+
+describe("staging does not accumulate", () => {
+  it("sweeps a stale stray the user never sent, and spares a fresh one", async () => {
+    const { vendo, store } = await compose();
+    const headers = await bearer();
+    const { path: stale } = await (await upload(vendo, "abandoned.csv", bytes("x"), headers)).json() as { path: string };
+    // Age it past the window in the REAL row the sweep's `stat` reads. It cannot
+    // be done through `utimes`: the façade stages an mtime, and `commit` writes
+    // `updated_at = now` over it (store/workspace-rows.ts), so a staged mtime
+    // never survives the commit. Nothing else here is reached around.
+    await (store.raw() as { query: (q: string, p: unknown[]) => Promise<unknown> })
+      .query("UPDATE vendo_workspace_files SET updated_at = $2 WHERE path = $1", [
+        stale,
+        new Date(Date.now() - 7 * 60 * 60 * 1000).toISOString(),
+      ]);
+    const { path: fresh } = await (await upload(vendo, "pending.csv", bytes("y"), headers)).json() as { path: string };
+
+    await (await post(vendo, {
+      threadId: "thr_sweep",
+      message: { id: "m1", role: "user", parts: [{ type: "text", text: "hello" }] },
+    }, headers)).text();
+
+    await expect(readBack(vendo, stale)).rejects.toThrow();
+    expect(await readBack(vendo, fresh)).toBe("y");
   });
 });

--- a/packages/vendo/tests/rehome-uploads.seam.test.ts
+++ b/packages/vendo/tests/rehome-uploads.seam.test.ts
@@ -116,6 +116,21 @@ const post = (vendo: Vendo, body: unknown, headers: Record<string, string>): Pro
 
 const bytes = (text: string): Uint8Array => new TextEncoder().encode(text);
 
+/** A host's own bucket, in memory — a REAL FilesAdapter, so what the bucket
+    still holds is observed rather than assumed. */
+function bucket(): FilesAdapter & { keys: () => string[] } {
+  const blobs = new Map<string, Uint8Array>();
+  return {
+    put: async (key, value) => void blobs.set(key, value),
+    get: async (key) => {
+      const value = blobs.get(key);
+      return value === undefined ? undefined : { bytes: value };
+    },
+    delete: async (key) => void blobs.delete(key),
+    keys: () => [...blobs.keys()],
+  };
+}
+
 describe("a turn takes its files home", () => {
   it("moves a staged drop under the thread and rewrites the part BEFORE it is stored", async () => {
     const { vendo } = await compose();
@@ -208,6 +223,34 @@ describe("staging does not accumulate", () => {
 
     await expect(readBack(vendo, stale)).rejects.toThrow();
     expect(await readBack(vendo, fresh)).toBe("y");
+  });
+
+  // The sweep removed the ROW and kept the OBJECT: `workspace.rm` tombstones,
+  // so the row moved to history with its `blob_ref` intact, under an address no
+  // erase axis reaches. An upload nobody ever sent leaked its bytes forever.
+  it("frees the stale stray's object, not just its row", async () => {
+    const files = bucket();
+    const { vendo, store } = await compose(files);
+    const headers = await bearer();
+    // Past the inline cap, so the content is a real object in the host's bucket.
+    const big = new Uint8Array(200_000).fill(65);
+    const { path: stale } = await (await upload(vendo, "abandoned.pdf", big, headers, "application/pdf"))
+      .json() as { path: string };
+    expect(files.keys()).toHaveLength(1);
+
+    await (store.raw() as { query: (q: string, p: unknown[]) => Promise<unknown> })
+      .query("UPDATE vendo_workspace_files SET updated_at = $2 WHERE path = $1", [
+        stale,
+        new Date(Date.now() - 7 * 60 * 60 * 1000).toISOString(),
+      ]);
+
+    await (await post(vendo, {
+      threadId: "thr_sweep_object",
+      message: { id: "m1", role: "user", parts: [{ type: "text", text: "hello" }] },
+    }, headers)).text();
+
+    await expect(readBack(vendo, stale)).rejects.toThrow();
+    expect(files.keys()).toHaveLength(0);
   });
 });
 

--- a/packages/vendo/tests/rehome-uploads.seam.test.ts
+++ b/packages/vendo/tests/rehome-uploads.seam.test.ts
@@ -198,6 +198,41 @@ describe("a turn takes its files home", () => {
     expect(await readBack(vendo, stored[1]!.url!)).toBe("second\n");
   });
 
+  it("keeps both drops when TWO TURNS of one thread carry the same name", async () => {
+    // The same root cause one axis over: the within-message fix compared the
+    // addresses THIS message was taking, which is empty on a later turn, so
+    // turn 5's `report.csv` landed on turn 1's — and the staging erase then
+    // released the first's blob. Silent user data loss, in a thread a person
+    // keeps coming back to.
+    const { vendo } = await compose();
+    const headers = await bearer();
+
+    const fileMessage = (id: string, url: string) => ({
+      id,
+      role: "user",
+      parts: [{ type: "file", mediaType: "text/csv", filename: "report.csv", url }],
+    });
+
+    const first = await (await upload(vendo, "report.csv", bytes("january\n"), headers)).json() as { path: string };
+    await (await post(vendo, { threadId: "thr_return", message: fileMessage("m1", first.path) }, headers)).text();
+
+    const second = await (await upload(vendo, "report.csv", bytes("february\n"), headers)).json() as { path: string };
+    await (await post(vendo, { threadId: "thr_return", message: fileMessage("m2", second.path) }, headers)).text();
+
+    const thread = await (await vendo.handler(new Request(
+      "https://host.test/api/vendo/threads/thr_return",
+      { headers },
+    ))).json() as { messages: Array<{ id: string; parts: Array<{ type: string; url?: string }> }> };
+    const pills = thread.messages
+      .flatMap((message) => message.parts.filter((part) => part.type === "file"));
+
+    expect(pills).toHaveLength(2);
+    expect(pills[0]!.url).not.toBe(pills[1]!.url);
+    // Each turn's pill opens the bytes THAT turn carried.
+    expect(await readBack(vendo, pills[0]!.url!)).toBe("january\n");
+    expect(await readBack(vendo, pills[1]!.url!)).toBe("february\n");
+  });
+
   it("homes a FIRST turn's drop under the id the server minted", async () => {
     const { vendo } = await compose();
     const headers = await bearer();

--- a/packages/vendo/tests/rehome-uploads.seam.test.ts
+++ b/packages/vendo/tests/rehome-uploads.seam.test.ts
@@ -1,0 +1,186 @@
+/**
+ * SEAM: the turn takes its dropped files home.
+ *
+ * The REAL `POST /files` door writes, the REAL turn re-homes, and every read-back
+ * is a FRESH workspace open — no stub on either side, so the producer (the upload
+ * door) and the consumer (the turn) cannot agree with each other while both being
+ * wrong about where a conversation's bytes live.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { genericJwtPreset } from "@vendoai/actions/presets";
+import { UPLOAD_HEADER, type FilesAdapter, type PermissionGrant, type Principal } from "@vendoai/core";
+import { THREAD_ID_HEADER } from "@vendoai/harnesses";
+import { createStore, type VendoStore } from "@vendoai/store";
+import type { LanguageModel } from "ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { jwt } from "../src/auth-presets/jwt.js";
+import { createVendo, type Vendo } from "../src/server.js";
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+const SECRET = "vendo-rehome-uploads-seam-secret-with-entropy";
+const SUBJECT = "host_sam";
+const principal: Principal = { kind: "user", subject: SUBJECT };
+
+/** Records every prompt it is asked to think with, then says one line. */
+function recordingModel(seen: string[]): LanguageModel {
+  return {
+    specificationVersion: "v2",
+    provider: "probe",
+    modelId: "probe-v1",
+    supportedUrls: {},
+    async doStream(call: { prompt: unknown }) {
+      seen.push(JSON.stringify(call.prompt));
+      return {
+        stream: new ReadableStream({
+          start(controller) {
+            controller.enqueue({ type: "stream-start", warnings: [] });
+            controller.enqueue({ type: "text-start", id: "t1" });
+            controller.enqueue({ type: "text-delta", id: "t1", delta: "ok" });
+            controller.enqueue({ type: "text-end", id: "t1" });
+            controller.enqueue({
+              type: "finish",
+              finishReason: "stop",
+              usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+            });
+            controller.close();
+          },
+        }),
+      };
+    },
+  } as unknown as LanguageModel;
+}
+
+const grant: PermissionGrant = {
+  id: "grt_rehome_uploads_seam",
+  subject: SUBJECT,
+  tool: "host_profile",
+  descriptorHash: "sha256:rehome-uploads-seam",
+  scope: { kind: "tool" },
+  duration: "standing",
+  source: "automation",
+  grantedAt: "2026-08-18T00:00:00.000Z",
+};
+
+/** Mint a REAL host bearer the way the actions half does. */
+async function bearer(): Promise<Record<string, string>> {
+  const mint = genericJwtPreset({ secret: SECRET });
+  return (await mint(principal, grant))!.headers;
+}
+
+async function compose(files?: FilesAdapter): Promise<{ vendo: Vendo; seen: string[] }> {
+  const dataDir = await mkdtemp(join(tmpdir(), "vendo-rehome-uploads-"));
+  const store: VendoStore = createStore({ dataDir });
+  cleanups.push(async () => {
+    await store.close();
+    await rm(dataDir, { recursive: true, force: true });
+  });
+  const seen: string[] = [];
+  const vendo = createVendo({
+    models: { default: recordingModel(seen) },
+    auth: jwt({ secret: SECRET }),
+    store,
+    ...(files === undefined ? {} : { files }),
+  });
+  return { vendo, seen };
+}
+
+const upload = (
+  vendo: Vendo,
+  name: string,
+  body: Uint8Array,
+  headers: Record<string, string>,
+  contentType = "text/csv",
+): Promise<Response> =>
+  vendo.handler(new Request(`https://host.test/api/vendo/files?name=${encodeURIComponent(name)}`, {
+    method: "POST",
+    headers: { "content-type": contentType, [UPLOAD_HEADER]: "1", ...headers },
+    body: body as BodyInit,
+  }));
+
+/** The REAL read path, through a workspace opened AFTER the write. */
+const readBack = async (vendo: Vendo, path: string): Promise<string> =>
+  await (await vendo.harness.workspace(principal)).readFile(path);
+
+const post = (vendo: Vendo, body: unknown, headers: Record<string, string>): Promise<Response> =>
+  vendo.handler(new Request("https://host.test/api/vendo/threads", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  }));
+
+const bytes = (text: string): Uint8Array => new TextEncoder().encode(text);
+
+describe("a turn takes its files home", () => {
+  it("moves a staged drop under the thread and rewrites the part BEFORE it is stored", async () => {
+    const { vendo } = await compose();
+    const headers = await bearer();
+    const { path: staged } = await (await upload(vendo, "ledger.csv", bytes("jan,31000\n"), headers)).json() as { path: string };
+
+    const message = {
+      id: "m1",
+      role: "user",
+      parts: [
+        { type: "text", text: "what is in this?" },
+        { type: "file", mediaType: "text/csv", filename: "ledger.csv", url: staged },
+      ],
+    };
+    const response = await post(vendo, { threadId: "thr_home_1", message }, headers);
+    await response.text();
+
+    const homed = "/user/threads/thr_home_1/files/ledger.csv";
+    expect(await readBack(vendo, homed)).toBe("jan,31000\n");
+    // The staging copy is GONE — a move, not a copy.
+    await expect(readBack(vendo, staged)).rejects.toThrow();
+
+    // And the STORED transcript names the new home, not the staging path: the
+    // pill a person clicks tomorrow has to point somewhere that still exists.
+    const thread = await (await vendo.handler(new Request(
+      "https://host.test/api/vendo/threads/thr_home_1",
+      { headers },
+    ))).json() as { messages: Array<{ parts: Array<{ type: string; url?: string }> }> };
+    const stored = thread.messages[0]!.parts.find((part) => part.type === "file");
+    expect(stored?.url).toBe(homed);
+  });
+
+  it("homes a FIRST turn's drop under the id the server minted", async () => {
+    const { vendo } = await compose();
+    const headers = await bearer();
+    const { path: staged } = await (await upload(vendo, "notes.txt", bytes("hello"), headers)).json() as { path: string };
+
+    const response = await post(vendo, {
+      message: {
+        id: "m1",
+        role: "user",
+        parts: [{ type: "file", mediaType: "text/plain", filename: "notes.txt", url: staged }],
+      },
+    }, headers);
+    const threadId = response.headers.get(THREAD_ID_HEADER)!;
+    await response.text();
+
+    expect(threadId).toMatch(/^thr_/);
+    expect(await readBack(vendo, `/user/threads/${threadId}/files/notes.txt`)).toBe("hello");
+  });
+
+  it("leaves a shelf reference exactly where it is", async () => {
+    const { vendo } = await compose();
+    const headers = await bearer();
+    await vendo.putUserFile({ principal, name: "kept.csv", content: "jan,31000\n" });
+
+    await (await post(vendo, {
+      threadId: "thr_home_2",
+      message: {
+        id: "m1",
+        role: "user",
+        parts: [{ type: "file", mediaType: "text/csv", filename: "kept.csv", url: "/user/files/kept.csv" }],
+      },
+    }, headers)).text();
+
+    expect(await readBack(vendo, "/user/files/kept.csv")).toBe("jan,31000\n");
+  });
+});

--- a/packages/vendo/tests/shelf-semantics.test.ts
+++ b/packages/vendo/tests/shelf-semantics.test.ts
@@ -1,0 +1,32 @@
+/**
+ * The drawer was "everything the user ever gave you". It is now a SHELF: the
+ * things they asked to keep. The tools have to say so, or the model will keep
+ * putting every dropped file on it.
+ */
+import {
+  VENDO_USER_FILES_LIST_TOOL,
+  VENDO_USER_FILES_PUT_TOOL,
+  VENDO_USER_FILES_READ_TOOL,
+} from "../src/user-files.js";
+import { createUserFilesTools } from "../src/user-files.js";
+import { describe, expect, it } from "vitest";
+
+const descriptorsOf = async (): Promise<Record<string, string>> => {
+  const registry = createUserFilesTools(async () => { throw new Error("not opened"); },
+    { uploadMaxBytes: 1, files: "store" });
+  return Object.fromEntries((await registry.descriptors()).map((d) => [d.name, d.description]));
+};
+
+describe("the shelf's tools say what the shelf is", () => {
+  it("tells the model this is the keep-shelf, not the inbox", async () => {
+    const described = await descriptorsOf();
+
+    for (const name of [VENDO_USER_FILES_LIST_TOOL, VENDO_USER_FILES_READ_TOOL, VENDO_USER_FILES_PUT_TOOL]) {
+      expect(described[name], name).toContain("kept");
+    }
+    // The put tool is the one that must not be reached for by reflex.
+    expect(described[VENDO_USER_FILES_PUT_TOOL]).toContain("asked you to keep");
+    // And every one of them points at where a dropped file actually is.
+    expect(described[VENDO_USER_FILES_LIST_TOOL]).toContain("/user/threads/");
+  });
+});

--- a/packages/vendo/tests/shell-config.test.ts
+++ b/packages/vendo/tests/shell-config.test.ts
@@ -1,0 +1,16 @@
+/**
+ * The shell's config surface: the SAME shape `mcp` has — a boolean for the
+ * decision, an object for the decision plus its knobs. Default ON.
+ */
+import { describe, expect, it } from "vitest";
+import type { CreateVendoConfig } from "../src/types.js";
+
+describe("createVendo({ shell })", () => {
+  it("takes a boolean or an object carrying limits", () => {
+    const off: CreateVendoConfig["shell"] = false;
+    const on: CreateVendoConfig["shell"] = true;
+    const tuned: CreateVendoConfig["shell"] = { limits: { maxExecutionTimeMs: 5_000, maxOutputBytes: 4_096 } };
+
+    expect([off, on, tuned]).toHaveLength(3);
+  });
+});

--- a/packages/vendo/tests/shell-config.test.ts
+++ b/packages/vendo/tests/shell-config.test.ts
@@ -1,16 +1,33 @@
 /**
  * The shell's config surface: the SAME shape `mcp` has — a boolean for the
  * decision, an object for the decision plus its knobs. Default ON.
+ *
+ * A type has no runtime, so the shape's assertions are the compiler's and
+ * `tsc -p tsconfig.test.json` is where they bite. Each `@ts-expect-error` is
+ * itself an assertion: it fails the build the day the surface widens enough to
+ * accept what it refuses today.
  */
 import { describe, expect, it } from "vitest";
+import { CREATE_VENDO_CONFIG_KEYS } from "../src/config-keys.js";
 import type { CreateVendoConfig } from "../src/types.js";
 
-describe("createVendo({ shell })", () => {
-  it("takes a boolean or an object carrying limits", () => {
-    const off: CreateVendoConfig["shell"] = false;
-    const on: CreateVendoConfig["shell"] = true;
-    const tuned: CreateVendoConfig["shell"] = { limits: { maxExecutionTimeMs: 5_000, maxOutputBytes: 4_096 } };
+type Shell = CreateVendoConfig["shell"];
 
-    expect([off, on, tuned]).toHaveLength(3);
+export const off: Shell = false;
+export const on: Shell = true;
+export const tuned: Shell = { limits: { maxExecutionTimeMs: 5_000, maxOutputBytes: 4_096 } };
+
+// @ts-expect-error — `limits` is the only member; a near-miss must not pass silently.
+export const typo: Shell = { limit: { maxExecutionTimeMs: 5_000 } };
+// @ts-expect-error — the ceilings are a number of milliseconds and a number of bytes.
+export const wrongUnit: Shell = { limits: { maxExecutionTimeMs: "5s" } };
+// @ts-expect-error — two knobs, and only two: just-bash 3.4.2's QuickJS memory
+// ceiling is a compiled-in constant, so a `jsMemoryBytes` nothing could read
+// would be a lie in a public type.
+export const unimplementable: Shell = { limits: { jsMemoryBytes: 1_000_000 } };
+
+describe("createVendo({ shell })", () => {
+  it("is a key the closed config list accepts", () => {
+    expect(CREATE_VENDO_CONFIG_KEYS).toContain("shell");
   });
 });

--- a/packages/vendo/tests/shell-loadout.test.ts
+++ b/packages/vendo/tests/shell-loadout.test.ts
@@ -1,0 +1,9 @@
+import { VENDO_BASH_TOOL } from "@vendoai/core";
+import { describe, expect, it } from "vitest";
+import { PROMPT_TAUGHT_TOOLS } from "../src/compose-harness.js";
+
+describe("the shell and the loadout cap", () => {
+  it("is named as prompt-taught, so the cap never hides it", () => {
+    expect(PROMPT_TAUGHT_TOOLS).toContain(VENDO_BASH_TOOL);
+  });
+});

--- a/packages/vendo/tests/shell-mount.test.ts
+++ b/packages/vendo/tests/shell-mount.test.ts
@@ -1,0 +1,60 @@
+/**
+ * WHO gets hands. The shell is the resident brain's, so it composes for the
+ * default `vendo()` and for a host-constructed one, and NOT for a harness whose
+ * thinker lives on a machine.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { defineHarness } from "@vendoai/harnesses";
+import { VENDO_BASH_TOOL } from "@vendoai/core";
+import { createStore, type VendoStore } from "@vendoai/store";
+import { afterEach, describe, expect, it } from "vitest";
+import { createVendo, type Vendo } from "../src/server.js";
+import { vendo as vendoHarness } from "@vendoai/harnesses";
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+async function compose(extra: Record<string, unknown> = {}): Promise<Vendo> {
+  const dataDir = await mkdtemp(join(tmpdir(), "vendo-shell-mount-"));
+  const store: VendoStore = createStore({ dataDir });
+  cleanups.push(async () => {
+    await store.close();
+    await rm(dataDir, { recursive: true, force: true });
+  });
+  return createVendo({
+    store,
+    principal: async () => ({ kind: "user", subject: "dev" }),
+    ...extra,
+  } as never);
+}
+
+const names = async (deployment: Vendo): Promise<string[]> =>
+  (await deployment.guardedTools.descriptors()).map((descriptor) => descriptor.name);
+
+describe("who gets hands", () => {
+  it("mounts bash on a default deployment, with no keys and no config", async () => {
+    expect(await names(await compose())).toContain(VENDO_BASH_TOOL);
+  });
+
+  it("mounts bash for a HOST-constructed vendo() too", async () => {
+    expect(await names(await compose({ harness: vendoHarness() }))).toContain(VENDO_BASH_TOOL);
+  });
+
+  it("withholds bash from a harness that thinks somewhere else", async () => {
+    const elsewhere = defineHarness({
+      name: "elsewhere",
+      // eslint-disable-next-line require-yield
+      async *run() {},
+    });
+
+    expect(await names(await compose({ harness: elsewhere }))).not.toContain(VENDO_BASH_TOOL);
+  });
+
+  it("withholds bash when the host says shell: false", async () => {
+    expect(await names(await compose({ shell: false }))).not.toContain(VENDO_BASH_TOOL);
+  });
+});

--- a/packages/vendo/tests/shell-upload.seam.test.ts
+++ b/packages/vendo/tests/shell-upload.seam.test.ts
@@ -1,0 +1,121 @@
+/**
+ * SEAM: the upload door WRITES and the shell READS, with no stub between them.
+ *
+ * Both halves are the shipped ones — a real `POST /files` request through
+ * `vendo.handler`, and a real `bash` call through `vendo.guardedTools`, which is
+ * the same guard-bound registry a turn executes on. A harness that mocked either
+ * side could never catch the two disagreeing about where the bytes are.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { genericJwtPreset } from "@vendoai/actions/presets";
+import {
+  UPLOAD_HEADER,
+  VENDO_BASH_TOOL,
+  type PermissionGrant,
+  type Principal,
+  type RunContext,
+} from "@vendoai/core";
+import { createStore, type VendoStore } from "@vendoai/store";
+import { afterEach, describe, expect, it } from "vitest";
+import { jwt } from "../src/auth-presets/jwt.js";
+import { createVendo, type Vendo } from "../src/server.js";
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+const SECRET = "vendo-shell-seam-secret-with-entropy";
+const SUBJECT = "host_sam";
+const principal: Principal = { kind: "user", subject: SUBJECT };
+
+const grant: PermissionGrant = {
+  id: "grt_shell_seam",
+  subject: SUBJECT,
+  tool: "host_profile",
+  descriptorHash: "sha256:shell-seam",
+  scope: { kind: "tool" },
+  duration: "standing",
+  source: "automation",
+  grantedAt: "2026-08-23T00:00:00.000Z",
+};
+
+async function bearer(): Promise<Record<string, string>> {
+  const mint = genericJwtPreset({ secret: SECRET });
+  return (await mint(principal, grant))!.headers;
+}
+
+async function compose(): Promise<Vendo> {
+  const dataDir = await mkdtemp(join(tmpdir(), "vendo-shell-seam-"));
+  const store: VendoStore = createStore({ dataDir });
+  cleanups.push(async () => {
+    await store.close();
+    await rm(dataDir, { recursive: true, force: true });
+  });
+  return createVendo({ store, auth: jwt({ secret: SECRET }) });
+}
+
+const upload = (deployment: Vendo, name: string, body: string, headers: Record<string, string>) =>
+  deployment.handler(new Request(`https://host.test/api/vendo/files?name=${encodeURIComponent(name)}`, {
+    method: "POST",
+    headers: { "content-type": "text/csv", [UPLOAD_HEADER]: "1", ...headers },
+    body: new TextEncoder().encode(body) as BodyInit,
+  }));
+
+const ctx: RunContext = {
+  principal,
+  venue: "chat",
+  presence: "present",
+  sessionId: "s_shell_seam",
+  // `trn_` + exactly 32 hex (ids.ts:69) — the guard writes a real audit row for
+  // this call and `auditEventSchema` rejects anything else.
+  turnId: `trn_${"0".repeat(28)}5ea1`,
+};
+
+const run = async (deployment: Vendo, command: string): Promise<{ stdout: string; exitCode: number }> => {
+  const outcome = await deployment.guardedTools.execute(
+    { id: `call_${Math.random().toString(36).slice(2)}`, tool: VENDO_BASH_TOOL, args: { command } },
+    ctx,
+  );
+  expect(outcome.status).toBe("ok");
+  return (outcome as { output: { stdout: string; exitCode: number } }).output;
+};
+
+describe("SEAM — what the upload door writes, the shell reads", () => {
+  it("greps a file that arrived over the wire seconds earlier", async () => {
+    const deployment = await compose();
+    const headers = await bearer();
+    const response = await upload(
+      deployment,
+      "ledger.csv",
+      "month,revenue\njan,31000\nfeb,39000\nmar,28000\n",
+      headers,
+    );
+    const { path } = await response.json() as { path: string };
+
+    const counted = await run(deployment, `wc -l < ${path}`);
+    expect(counted.exitCode).toBe(0);
+    expect(counted.stdout.trim()).toBe("4");
+
+    // `awk`, not `bc`: just-bash 3.4.2 ships no `bc`.
+    const summed = await run(deployment, `tail -n +2 ${path} | cut -d, -f2 | awk '{t+=$1} END {print t}'`);
+    expect(summed.stdout.trim()).toBe("98000");
+  });
+
+  it("writes a file the workspace keeps, readable through the workspace door", async () => {
+    const deployment = await compose();
+    await upload(deployment, "ledger.csv", "month,revenue\njan,31000\nfeb,39000\n", await bearer());
+
+    const written = await run(
+      deployment,
+      "mkdir -p /user/files && tail -n +2 /user/files/ledger.csv | sort -t, -k2 -nr > /user/files/ranked.csv",
+    );
+    expect(written.exitCode).toBe(0);
+
+    // The REAL read path, through a workspace opened AFTER the tool call.
+    const workspace = await deployment.harness.workspace(principal);
+    expect(await workspace.readFile("/user/files/ranked.csv")).toBe("feb,39000\njan,31000\n");
+  });
+});

--- a/packages/vendo/tests/shell-upload.seam.test.ts
+++ b/packages/vendo/tests/shell-upload.seam.test.ts
@@ -106,11 +106,13 @@ describe("SEAM — what the upload door writes, the shell reads", () => {
 
   it("writes a file the workspace keeps, readable through the workspace door", async () => {
     const deployment = await compose();
-    await upload(deployment, "ledger.csv", "month,revenue\njan,31000\nfeb,39000\n", await bearer());
+    const uploaded = await upload(deployment, "ledger.csv", "month,revenue\njan,31000\nfeb,39000\n", await bearer());
+    const { path: staged } = await uploaded.json() as { path: string };
+    expect(staged).toMatch(/^\/user\/uploads\/[0-9a-f]{8}-ledger\.csv$/);
 
     const written = await run(
       deployment,
-      "mkdir -p /user/files && tail -n +2 /user/files/ledger.csv | sort -t, -k2 -nr > /user/files/ranked.csv",
+      `mkdir -p /user/files && tail -n +2 ${staged} | sort -t, -k2 -nr > /user/files/ranked.csv`,
     );
     expect(written.exitCode).toBe(0);
 

--- a/packages/vendo/tests/surface-menu.test.ts
+++ b/packages/vendo/tests/surface-menu.test.ts
@@ -1,5 +1,31 @@
+import { CONNECTOR_DISCOVERY_TOOLS, VENDO_BASH_TOOL, type ToolDescriptor, type ToolRegistry } from "@vendoai/core";
 import { describe, expect, it, vi } from "vitest";
-import { memoizedSurfaceMenu } from "../src/surface-menu.js";
+import { memoizedSurfaceMenu, withAgentMenu } from "../src/surface-menu.js";
+
+const listing = (...names: string[]): ToolRegistry => ({
+  async descriptors(): Promise<ToolDescriptor[]> {
+    return names.map((name) => ({ name, description: name, inputSchema: { type: "object" }, risk: "read" }));
+  },
+  async execute() {
+    return { status: "ok", output: {} as never };
+  },
+});
+
+describe("withAgentMenu", () => {
+  it("curates the host's surface and leaves Vendo's own plumbing alone", async () => {
+    const [discovery] = CONNECTOR_DISCOVERY_TOOLS;
+    const tools = listing("host_invoices", "host_payroll", "vendo_make", VENDO_BASH_TOOL, discovery!);
+
+    const curated = withAgentMenu(tools, async () => new Set(["host_invoices"]));
+
+    // `bash` carries no `vendo_` prefix — that is the whole point of its name —
+    // so the prefix exemption cannot cover it and it has to be named. Without
+    // that, a curated deployment loses the one tool that opens the user's files
+    // while the system prompt keeps teaching it.
+    expect((await curated.descriptors()).map(({ name }) => name))
+      .toEqual(["host_invoices", "vendo_make", VENDO_BASH_TOOL, discovery]);
+  });
+});
 
 describe("memoizedSurfaceMenu", () => {
   it("resolves once and reuses the answer", async () => {

--- a/packages/vendo/tests/thread-delete-cascade.seam.test.ts
+++ b/packages/vendo/tests/thread-delete-cascade.seam.test.ts
@@ -1,0 +1,134 @@
+/**
+ * SEAM: deleting a conversation deletes it. The REAL `DELETE /threads/:id` door
+ * runs against the REAL store, and the row counts are read straight out of the
+ * database afterwards — no stub on either side, so the door and the store cannot
+ * disagree about what "deleted" means.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { genericJwtPreset } from "@vendoai/actions/presets";
+import type { PermissionGrant, Principal } from "@vendoai/core";
+import { createStore, type VendoStore } from "@vendoai/store";
+import type { LanguageModel } from "ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { jwt } from "../src/auth-presets/jwt.js";
+import { createVendo, type Vendo } from "../src/server.js";
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+const SECRET = "vendo-thread-delete-seam-secret-with-entropy";
+const SUBJECT = "host_sam";
+const principal: Principal = { kind: "user", subject: SUBJECT };
+
+/** Says one line and stops — the delete is the subject here, not the thinking. */
+const quietModel = (): LanguageModel => ({
+  specificationVersion: "v2",
+  provider: "probe",
+  modelId: "probe-v1",
+  supportedUrls: {},
+  async doStream() {
+    return {
+      stream: new ReadableStream({
+        start(controller) {
+          controller.enqueue({ type: "stream-start", warnings: [] });
+          controller.enqueue({ type: "text-start", id: "t1" });
+          controller.enqueue({ type: "text-delta", id: "t1", delta: "ok" });
+          controller.enqueue({ type: "text-end", id: "t1" });
+          controller.enqueue({
+            type: "finish",
+            finishReason: "stop",
+            usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+          });
+          controller.close();
+        },
+      }),
+    };
+  },
+} as unknown as LanguageModel);
+
+const grant: PermissionGrant = {
+  id: "grt_thread_delete_seam",
+  subject: SUBJECT,
+  tool: "host_profile",
+  descriptorHash: "sha256:thread-delete-seam",
+  scope: { kind: "tool" },
+  duration: "standing",
+  source: "automation",
+  grantedAt: "2026-08-18T00:00:00.000Z",
+};
+
+async function bearer(): Promise<Record<string, string>> {
+  return (await genericJwtPreset({ secret: SECRET })(principal, grant))!.headers;
+}
+
+async function compose(): Promise<{ vendo: Vendo; store: VendoStore }> {
+  const dataDir = await mkdtemp(join(tmpdir(), "vendo-thread-delete-"));
+  const store: VendoStore = createStore({ dataDir });
+  cleanups.push(async () => {
+    await store.close();
+    await rm(dataDir, { recursive: true, force: true });
+  });
+  const vendo = createVendo({
+    models: { default: quietModel() },
+    auth: jwt({ secret: SECRET }),
+    store,
+  });
+  return { vendo, store };
+}
+
+const post = (vendo: Vendo, body: unknown, headers: Record<string, string>): Promise<Response> =>
+  vendo.handler(new Request("https://host.test/api/vendo/threads", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  }));
+
+describe("deleting a conversation deletes it", () => {
+  it("takes the messages and the harness state with the thread row", async () => {
+    const { vendo, store } = await compose();
+    const headers = await bearer();
+    await (await post(vendo, {
+      threadId: "thr_bye",
+      message: { id: "m1", role: "user", parts: [{ type: "text", text: "hello" }] },
+    }, headers)).text();
+
+    const rows = async (sql: string): Promise<number> =>
+      Number((await (store.raw() as { query: (q: string, p: unknown[]) => Promise<{ rows: Array<Record<string, unknown>> }> })
+        .query(sql, ["thr_bye"])).rows.length);
+    expect(await rows("SELECT id FROM vendo_thread_messages WHERE thread_id = $1")).toBeGreaterThan(0);
+
+    const response = await vendo.handler(new Request("https://host.test/api/vendo/threads/thr_bye", {
+      method: "DELETE",
+      // The wire's CSRF floor requires it on every mutation (server.ts:237-248).
+      headers: { "content-type": "application/json", ...headers },
+    }));
+
+    expect(response.status).toBe(200);
+    expect(await rows("SELECT id FROM vendo_threads WHERE id = $1")).toBe(0);
+    expect(await rows("SELECT id FROM vendo_thread_messages WHERE thread_id = $1")).toBe(0);
+  });
+
+  it("refuses to touch another subject's conversation", async () => {
+    const { vendo, store } = await compose();
+    await (await post(vendo, {
+      threadId: "thr_mine",
+      message: { id: "m1", role: "user", parts: [{ type: "text", text: "hello" }] },
+    }, await bearer())).text();
+
+    // A DIFFERENT subject's bearer, same thread id.
+    const other = genericJwtPreset({ secret: SECRET });
+    const otherHeaders = (await other({ kind: "user", subject: "host_mallory" }, { ...grant, subject: "host_mallory" }))!.headers;
+    await vendo.handler(new Request("https://host.test/api/vendo/threads/thr_mine", {
+      method: "DELETE",
+      headers: { "content-type": "application/json", ...otherHeaders },
+    }));
+
+    const kept = await (store.raw() as { query: (q: string, p: unknown[]) => Promise<{ rows: unknown[] }> })
+      .query("SELECT id FROM vendo_threads WHERE id = $1", ["thr_mine"]);
+    expect(kept.rows).toHaveLength(1);
+  });
+});

--- a/packages/vendo/tests/thread-files-lifecycle.seam.test.ts
+++ b/packages/vendo/tests/thread-files-lifecycle.seam.test.ts
@@ -1,0 +1,175 @@
+/**
+ * SEAM: a file's whole life, with no stub anywhere on it.
+ *
+ * A real `POST /files` upload → a real turn that re-homes it → a real `bash` call
+ * that reads it at the new address → a real `DELETE /threads/:id` → the rows AND
+ * the object in a real FilesAdapter, both checked afterwards. Each half is the
+ * shipped one; a fixture that mocked either end could not catch them disagreeing
+ * about where a conversation's bytes live.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { genericJwtPreset } from "@vendoai/actions/presets";
+import {
+  UPLOAD_HEADER,
+  VENDO_BASH_TOOL,
+  type FilesAdapter,
+  type PermissionGrant,
+  type Principal,
+  type RunContext,
+} from "@vendoai/core";
+import { createStore, type VendoStore } from "@vendoai/store";
+import type { LanguageModel } from "ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { jwt } from "../src/auth-presets/jwt.js";
+import { createVendo, type Vendo } from "../src/server.js";
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+const SECRET = "vendo-thread-files-seam-secret-with-entropy";
+const SUBJECT = "host_sam";
+const principal: Principal = { kind: "user", subject: SUBJECT };
+
+const grant: PermissionGrant = {
+  id: "grt_thread_files_seam",
+  subject: SUBJECT,
+  tool: "host_profile",
+  descriptorHash: "sha256:thread-files-seam",
+  scope: { kind: "tool" },
+  duration: "standing",
+  source: "automation",
+  grantedAt: "2026-08-23T00:00:00.000Z",
+};
+
+async function bearer(): Promise<Record<string, string>> {
+  return (await genericJwtPreset({ secret: SECRET })(principal, grant))!.headers;
+}
+
+/** A host's own bucket, in memory — a REAL FilesAdapter, so the blob half of the
+    cascade is observed rather than assumed. */
+function bucket(): FilesAdapter & { keys: () => string[] } {
+  const blobs = new Map<string, Uint8Array>();
+  return {
+    put: async (key, value) => void blobs.set(key, value),
+    get: async (key) => {
+      const value = blobs.get(key);
+      return value === undefined ? undefined : { bytes: value };
+    },
+    delete: async (key) => void blobs.delete(key),
+    keys: () => [...blobs.keys()],
+  };
+}
+
+/** Says one line and stops — the turn is the subject here, not the thinking. */
+const quietModel = (): LanguageModel => ({
+  specificationVersion: "v2",
+  provider: "probe",
+  modelId: "probe-v1",
+  supportedUrls: {},
+  async doStream() {
+    return {
+      stream: new ReadableStream({
+        start(controller) {
+          controller.enqueue({ type: "stream-start", warnings: [] });
+          controller.enqueue({ type: "text-start", id: "t1" });
+          controller.enqueue({ type: "text-delta", id: "t1", delta: "ok" });
+          controller.enqueue({ type: "text-end", id: "t1" });
+          controller.enqueue({
+            type: "finish",
+            finishReason: "stop",
+            usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+          });
+          controller.close();
+        },
+      }),
+    };
+  },
+} as unknown as LanguageModel);
+
+async function compose(): Promise<{ vendo: Vendo; files: ReturnType<typeof bucket> }> {
+  const dataDir = await mkdtemp(join(tmpdir(), "vendo-thread-files-"));
+  const store: VendoStore = createStore({ dataDir });
+  const files = bucket();
+  cleanups.push(async () => {
+    await store.close();
+    await rm(dataDir, { recursive: true, force: true });
+  });
+  return {
+    vendo: createVendo({ store, files, auth: jwt({ secret: SECRET }), models: { default: quietModel() } }),
+    files,
+  };
+}
+
+describe("SEAM — a dropped file's whole life", () => {
+  it("stages, homes, is readable by the shell, and is really gone when the thread is", async () => {
+    const { vendo, files } = await compose();
+    const headers = await bearer();
+
+    // 1. It arrives, through the real door, and stages.
+    const big = new Uint8Array(200_000).fill(65); // past the inline cap, so it becomes a BLOB
+    const uploaded = await vendo.handler(new Request(
+      "https://host.test/api/vendo/files?name=scan.pdf",
+      { method: "POST", headers: { "content-type": "application/pdf", [UPLOAD_HEADER]: "1", ...headers }, body: big as BodyInit },
+    ));
+    const { path: staged } = await uploaded.json() as { path: string };
+    expect(staged.startsWith("/user/uploads/")).toBe(true);
+    expect(files.keys()).toHaveLength(1);
+
+    // 2. The turn that receives it homes it.
+    await (await vendo.handler(new Request("https://host.test/api/vendo/threads", {
+      method: "POST",
+      headers: { "content-type": "application/json", ...headers },
+      body: JSON.stringify({
+        threadId: "thr_life",
+        message: {
+          id: "m1",
+          role: "user",
+          parts: [
+            { type: "text", text: "what is this?" },
+            { type: "file", mediaType: "application/pdf", filename: "scan.pdf", url: staged },
+          ],
+        },
+      }),
+    }))).text();
+
+    const homed = "/user/threads/thr_life/files/scan.pdf";
+    const workspace = await vendo.harness.workspace(principal);
+    expect(await workspace.exists(homed)).toBe(true);
+    expect(await workspace.exists(staged)).toBe(false);
+
+    // 3. The SHELL finds it there — the address the agent is told is the address
+    //    that works.
+    const ctx: RunContext = {
+      principal,
+      venue: "chat",
+      presence: "present",
+      sessionId: "s_life",
+      // `trn_` + exactly 32 hex (ids.ts:69) — the guard writes a real audit row
+      // for this call and `auditEventSchema` rejects anything else.
+      turnId: `trn_${"0".repeat(28)}11fe`,
+    };
+    const outcome = await vendo.guardedTools.execute(
+      { id: "call_1", tool: VENDO_BASH_TOOL, args: { command: `wc -c < ${homed}` } },
+      ctx,
+    );
+    expect(outcome.status).toBe("ok");
+    expect((outcome as { output: { stdout: string } }).output.stdout.trim()).toBe("200000");
+
+    // 4. Deleting the conversation really deletes it — rows AND object.
+    const deleted = await vendo.handler(new Request("https://host.test/api/vendo/threads/thr_life", {
+      method: "DELETE",
+      // The wire's CSRF floor requires the json content-type on every mutation
+      // that is not the upload door itself (server.ts:237-248).
+      headers: { "content-type": "application/json", ...headers },
+    }));
+    expect(deleted.status).toBe(200);
+
+    const after = await vendo.harness.workspace(principal);
+    expect(await after.exists(homed)).toBe(false);
+    expect(files.keys()).toHaveLength(0);
+  });
+});

--- a/packages/vendo/tests/upload-cap-seam.test.ts
+++ b/packages/vendo/tests/upload-cap-seam.test.ts
@@ -124,8 +124,11 @@ describe("createVendo({ uploadMaxBytes }) — the drop door's cap, moved", () =>
     const response = await upload(vendo, "export.bin", big, await bearer());
 
     expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({ path: "/user/files/export.bin", bytes: big.byteLength });
-    expect((await readBack(vendo, "/user/files/export.bin")).length).toBe(big.byteLength);
+    // A drop STAGES; the cap is what this test is about, so the assertion is the
+    // byte count and that every one of them landed where the door said.
+    const { path, bytes } = await response.json() as { path: string; bytes: number };
+    expect(bytes).toBe(big.byteLength);
+    expect((await readBack(vendo, path)).length).toBe(big.byteLength);
   });
 
   it("refuses on the DECLARED length too, with the same copy", async () => {

--- a/packages/vendo/tests/upload-cap-seam.test.ts
+++ b/packages/vendo/tests/upload-cap-seam.test.ts
@@ -127,6 +127,7 @@ describe("createVendo({ uploadMaxBytes }) — the drop door's cap, moved", () =>
     // A drop STAGES; the cap is what this test is about, so the assertion is the
     // byte count and that every one of them landed where the door said.
     const { path, bytes } = await response.json() as { path: string; bytes: number };
+    expect(path).toMatch(/^\/user\/uploads\/[0-9a-f]{8}-export\.bin$/);
     expect(bytes).toBe(big.byteLength);
     expect((await readBack(vendo, path)).length).toBe(big.byteLength);
   });

--- a/packages/vendo/tests/upload-cap-seam.test.ts
+++ b/packages/vendo/tests/upload-cap-seam.test.ts
@@ -126,10 +126,12 @@ describe("createVendo({ uploadMaxBytes }) — the drop door's cap, moved", () =>
     expect(response.status).toBe(200);
     // A drop STAGES; the cap is what this test is about, so the assertion is the
     // byte count and that every one of them landed where the door said.
-    const { path, bytes } = await response.json() as { path: string; bytes: number };
-    expect(path).toMatch(/^\/user\/uploads\/[0-9a-f]{8}-export\.bin$/);
-    expect(bytes).toBe(big.byteLength);
-    expect((await readBack(vendo, path)).length).toBe(big.byteLength);
+    const staged = await response.json() as { path: string; bytes: number };
+    expect(staged).toEqual({
+      path: expect.stringMatching(/^\/user\/uploads\/[0-9a-f]{8}-export\.bin$/),
+      bytes: big.byteLength,
+    });
+    expect((await readBack(vendo, staged.path)).length).toBe(big.byteLength);
   });
 
   it("refuses on the DECLARED length too, with the same copy", async () => {

--- a/packages/vendo/tests/upload-staging.seam.test.ts
+++ b/packages/vendo/tests/upload-staging.seam.test.ts
@@ -1,0 +1,146 @@
+/**
+ * SEAM: the drop door STAGES. Written through the REAL `POST /files` door and
+ * read back through the REAL workspace store — no mock on either side, so the
+ * door and the workspace cannot disagree about where a dropped file landed.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { genericJwtPreset } from "@vendoai/actions/presets";
+import { UPLOAD_HEADER, type FilesAdapter, type PermissionGrant, type Principal } from "@vendoai/core";
+import { createStore, type VendoStore } from "@vendoai/store";
+import type { LanguageModel } from "ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { jwt } from "../src/auth-presets/jwt.js";
+import { createVendo, type Vendo } from "../src/server.js";
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+const SECRET = "vendo-upload-staging-seam-secret-with-entropy";
+const SUBJECT = "host_sam";
+const principal: Principal = { kind: "user", subject: SUBJECT };
+
+/** Records every prompt it is asked to think with, then says one line. */
+function recordingModel(seen: string[]): LanguageModel {
+  return {
+    specificationVersion: "v2",
+    provider: "probe",
+    modelId: "probe-v1",
+    supportedUrls: {},
+    async doStream(call: { prompt: unknown }) {
+      seen.push(JSON.stringify(call.prompt));
+      return {
+        stream: new ReadableStream({
+          start(controller) {
+            controller.enqueue({ type: "stream-start", warnings: [] });
+            controller.enqueue({ type: "text-start", id: "t1" });
+            controller.enqueue({ type: "text-delta", id: "t1", delta: "ok" });
+            controller.enqueue({ type: "text-end", id: "t1" });
+            controller.enqueue({
+              type: "finish",
+              finishReason: "stop",
+              usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+            });
+            controller.close();
+          },
+        }),
+      };
+    },
+  } as unknown as LanguageModel;
+}
+
+const grant: PermissionGrant = {
+  id: "grt_upload_staging_seam",
+  subject: SUBJECT,
+  tool: "host_profile",
+  descriptorHash: "sha256:upload-staging-seam",
+  scope: { kind: "tool" },
+  duration: "standing",
+  source: "automation",
+  grantedAt: "2026-08-18T00:00:00.000Z",
+};
+
+/** Mint a REAL host bearer the way the actions half does. */
+async function bearer(): Promise<Record<string, string>> {
+  const mint = genericJwtPreset({ secret: SECRET });
+  return (await mint(principal, grant))!.headers;
+}
+
+async function compose(files?: FilesAdapter): Promise<{ vendo: Vendo; seen: string[] }> {
+  const dataDir = await mkdtemp(join(tmpdir(), "vendo-upload-staging-"));
+  const store: VendoStore = createStore({ dataDir });
+  cleanups.push(async () => {
+    await store.close();
+    await rm(dataDir, { recursive: true, force: true });
+  });
+  const seen: string[] = [];
+  const vendo = createVendo({
+    models: { default: recordingModel(seen) },
+    auth: jwt({ secret: SECRET }),
+    store,
+    ...(files === undefined ? {} : { files }),
+  });
+  return { vendo, seen };
+}
+
+const upload = (
+  vendo: Vendo,
+  name: string,
+  body: Uint8Array,
+  headers: Record<string, string>,
+  contentType = "text/csv",
+): Promise<Response> =>
+  vendo.handler(new Request(`https://host.test/api/vendo/files?name=${encodeURIComponent(name)}`, {
+    method: "POST",
+    headers: { "content-type": contentType, [UPLOAD_HEADER]: "1", ...headers },
+    body: body as BodyInit,
+  }));
+
+/** The REAL read path, through a workspace opened AFTER the write. */
+const readBack = async (vendo: Vendo, path: string): Promise<string> =>
+  await (await vendo.harness.workspace(principal)).readFile(path);
+
+const bytes = (text: string): Uint8Array => new TextEncoder().encode(text);
+
+describe("the drop door stages, it does not shelve", () => {
+  it("lands a dropped file in staging, not in the user's shelf", async () => {
+    const { vendo } = await compose();
+
+    const response = await upload(vendo, "ledger.csv", bytes("month,revenue\njan,31000\n"), await bearer());
+
+    const { path } = await response.json() as { path: string; bytes: number };
+    expect(path).toMatch(/^\/user\/uploads\/[0-9a-f]{8}-ledger\.csv$/);
+    expect(await readBack(vendo, path)).toBe("month,revenue\njan,31000\n");
+    await expect(readBack(vendo, "/user/files/ledger.csv")).rejects.toThrow();
+  });
+
+  it("does not let two drops of one name overwrite each other", async () => {
+    const { vendo } = await compose();
+    const headers = await bearer();
+
+    const first = await (await upload(vendo, "ledger.csv", bytes("jan,31000\n"), headers)).json() as { path: string };
+    const second = await (await upload(vendo, "ledger.csv", bytes("feb,39000\n"), headers)).json() as { path: string };
+
+    expect(first.path).not.toBe(second.path);
+    expect(await readBack(vendo, first.path)).toBe("jan,31000\n");
+    expect(await readBack(vendo, second.path)).toBe("feb,39000\n");
+  });
+
+  it("still refuses a name that is a path", async () => {
+    const { vendo } = await compose();
+
+    const response = await upload(vendo, "../escape.csv", bytes("x"), await bearer());
+
+    expect(response.status).toBe(400);
+  });
+
+  it("leaves vendo.putUserFile on the SHELF — a host push is a deliberate save", async () => {
+    const { vendo } = await compose();
+
+    expect(await vendo.putUserFile({ principal, name: "statement.txt", content: "opening balance 100" }))
+      .toEqual({ path: "/user/files/statement.txt", bytes: 19 });
+  });
+});

--- a/packages/vendo/tests/user-file-paths.test.ts
+++ b/packages/vendo/tests/user-file-paths.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Where a user's bytes can live, and the ONE name rule all three share.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  isUserFilePath,
+  threadFilesDir,
+  threadFilePath,
+  uploadStagingPath,
+  userFilePath,
+  USER_UPLOADS,
+} from "../src/user-files.js";
+
+describe("the three addresses a user's file can have", () => {
+  it("stages a drop under a random prefix, so two drops of one name cannot collide", () => {
+    const first = uploadStagingPath("ledger.csv");
+    const second = uploadStagingPath("ledger.csv");
+
+    expect(first).not.toBe(second);
+    expect(first.startsWith(`${USER_UPLOADS}/`)).toBe(true);
+    expect(first.endsWith("-ledger.csv")).toBe(true);
+  });
+
+  it("homes a file with its conversation", () => {
+    expect(threadFilesDir("thr_abc")).toBe("/user/threads/thr_abc");
+    expect(threadFilePath("thr_abc", "ledger.csv")).toBe("/user/threads/thr_abc/files/ledger.csv");
+  });
+
+  it("keeps the shelf exactly where it was", () => {
+    expect(userFilePath("ledger.csv")).toBe("/user/files/ledger.csv");
+  });
+
+  it("applies the SAME name rule at all three doors", () => {
+    for (const name of ["../escape.csv", "nested/ledger.csv", "..", ""]) {
+      expect(() => uploadStagingPath(name), name).toThrow();
+      expect(() => threadFilePath("thr_abc", name), name).toThrow();
+      expect(() => userFilePath(name), name).toThrow();
+    }
+  });
+
+  it("recognises all three as server-held addresses, and nothing else", () => {
+    expect(isUserFilePath("/user/files/a.csv")).toBe(true);
+    expect(isUserFilePath("/user/uploads/9f2a1c04-a.csv")).toBe(true);
+    expect(isUserFilePath("/user/threads/thr_abc/files/a.csv")).toBe(true);
+    expect(isUserFilePath("data:text/csv;base64,YQ==")).toBe(false);
+    expect(isUserFilePath("https://cdn.test/a.csv")).toBe(false);
+  });
+});

--- a/packages/vendo/tests/user-file-paths.test.ts
+++ b/packages/vendo/tests/user-file-paths.test.ts
@@ -38,6 +38,19 @@ describe("the three addresses a user's file can have", () => {
     }
   });
 
+  it("applies it to the THREAD ID too, which is a segment like any other", () => {
+    // The containment argument in user-files.ts is that every path is BUILT from
+    // parts that provably carry no separator. The id is one of those parts, and
+    // the only shape the wire ever checked is `/^thr_.+$/` (core/src/ids.ts:51),
+    // whose `.+` matches a slash — so a client-supplied id climbed out of
+    // `/user/threads` and homed a drop on the shelf, and the thread's own delete
+    // cascade aimed its recursive rm at whatever the `..`s resolved to.
+    for (const id of ["thr_a/../..", "thr_a/b", "..", ""]) {
+      expect(() => threadFilesDir(id), id).toThrow();
+      expect(() => threadFilePath(id, "ledger.csv"), id).toThrow();
+    }
+  });
+
   it("recognises all three as server-held addresses, and nothing else", () => {
     expect(isUserFilePath("/user/files/a.csv")).toBe(true);
     expect(isUserFilePath("/user/uploads/9f2a1c04-a.csv")).toBe(true);

--- a/packages/vendo/tests/user-files-client.seam.test.ts
+++ b/packages/vendo/tests/user-files-client.seam.test.ts
@@ -63,7 +63,8 @@ describe("the shipped client's upload against the shipped door", () => {
     // percent-encoding and the door's decoding agree on one filename.
     const saved = await client.files.upload(csv("month,revenue\njan,31000\n"));
 
-    expect(saved).toEqual({ path: "/user/files/sales 2026.csv", bytes: 24 });
+    // A drop stages, and the name — space and all — survives the round trip.
+    expect(saved).toEqual({ path: expect.stringMatching(/^\/user\/uploads\/[0-9a-f]{8}-sales 2026\.csv$/), bytes: 24 });
     const workspace = await vendo.harness.workspace(ADA);
     expect(await workspace.readFile(saved.path)).toBe("month,revenue\njan,31000\n");
   });

--- a/packages/vendo/tests/user-files-seam.test.ts
+++ b/packages/vendo/tests/user-files-seam.test.ts
@@ -187,6 +187,7 @@ describe("the user's file drawer — real doors, real workspace", () => {
 
     expect(response.status).toBe(200);
     const { path } = await response.json() as { path: string };
+    expect(path).toMatch(/^\/user\/uploads\/[0-9a-f]{8}-notes\.txt$/);
     expect(await readBack(vendo, path)).toBe("hello");
   });
 

--- a/packages/vendo/tests/user-files-seam.test.ts
+++ b/packages/vendo/tests/user-files-seam.test.ts
@@ -140,8 +140,10 @@ describe("the user's file drawer — real doors, real workspace", () => {
 
     expect(response.status).toBe(200);
     const staged = await response.json() as { path: string; bytes: number };
-    expect(staged.path).toMatch(/^\/user\/uploads\/[0-9a-f]{8}-ledger\.csv$/);
-    expect(staged.bytes).toBe(24);
+    expect(staged).toEqual({
+      path: expect.stringMatching(/^\/user\/uploads\/[0-9a-f]{8}-ledger\.csv$/),
+      bytes: 24,
+    });
     // A workspace opened fresh — its own index read — sees the same bytes.
     expect(await readBack(vendo, staged.path)).toBe("month,revenue\njan,31000\n");
   });

--- a/packages/vendo/tests/user-files-seam.test.ts
+++ b/packages/vendo/tests/user-files-seam.test.ts
@@ -130,13 +130,20 @@ const post = (vendo: Vendo, body: unknown, headers: Record<string, string>): Pro
 const bytes = (text: string): Uint8Array => new TextEncoder().encode(text);
 
 describe("the user's file drawer — real doors, real workspace", () => {
-  it("saves a host push where a LATER workspace open finds it", async () => {
+  it("saves an UPLOAD where a LATER workspace open finds it", async () => {
+    // Through the door, not `putUserFile`: this build moved a drop's landing
+    // address to staging, and retargeting this test at the trusted server call
+    // would have left the default `text/csv` upload path — the one a browser
+    // actually takes — with no happy-path coverage at all.
     const { vendo } = await compose();
-    const put = await vendo.putUserFile({ principal, name: "ledger.csv", content: "month,revenue\njan,31000\n" });
+    const response = await upload(vendo, "ledger.csv", bytes("month,revenue\njan,31000\n"), await bearer());
 
-    expect(put).toEqual({ path: "/user/files/ledger.csv", bytes: 24 });
+    expect(response.status).toBe(200);
+    const staged = await response.json() as { path: string; bytes: number };
+    expect(staged.path).toMatch(/^\/user\/uploads\/[0-9a-f]{8}-ledger\.csv$/);
+    expect(staged.bytes).toBe(24);
     // A workspace opened fresh — its own index read — sees the same bytes.
-    expect(await readBack(vendo, "/user/files/ledger.csv")).toBe("month,revenue\njan,31000\n");
+    expect(await readBack(vendo, staged.path)).toBe("month,revenue\njan,31000\n");
   });
 
   it("puts a host-pushed file through the SAME write, read back the same way", async () => {

--- a/packages/vendo/tests/user-files-seam.test.ts
+++ b/packages/vendo/tests/user-files-seam.test.ts
@@ -130,12 +130,11 @@ const post = (vendo: Vendo, body: unknown, headers: Record<string, string>): Pro
 const bytes = (text: string): Uint8Array => new TextEncoder().encode(text);
 
 describe("the user's file drawer — real doors, real workspace", () => {
-  it("saves an upload where a LATER workspace open finds it", async () => {
+  it("saves a host push where a LATER workspace open finds it", async () => {
     const { vendo } = await compose();
-    const response = await upload(vendo, "ledger.csv", bytes("month,revenue\njan,31000\n"), await bearer());
+    const put = await vendo.putUserFile({ principal, name: "ledger.csv", content: "month,revenue\njan,31000\n" });
 
-    expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({ path: "/user/files/ledger.csv", bytes: 24 });
+    expect(put).toEqual({ path: "/user/files/ledger.csv", bytes: 24 });
     // A workspace opened fresh — its own index read — sees the same bytes.
     expect(await readBack(vendo, "/user/files/ledger.csv")).toBe("month,revenue\njan,31000\n");
   });
@@ -187,7 +186,8 @@ describe("the user's file drawer — real doors, real workspace", () => {
     const response = await upload(vendo, "notes.txt", bytes("hello"), await bearer(), "text/plain");
 
     expect(response.status).toBe(200);
-    expect(await readBack(vendo, "/user/files/notes.txt")).toBe("hello");
+    const { path } = await response.json() as { path: string };
+    expect(await readBack(vendo, path)).toBe("hello");
   });
 
   it("refuses an over-cap upload on its DECLARED length, before reading it", async () => {
@@ -230,12 +230,11 @@ describe("the user's file drawer — real doors, real workspace", () => {
 
   it("REPLACES the file when the same name arrives again", async () => {
     const { vendo } = await compose();
-    const headers = await bearer();
 
-    await upload(vendo, "ledger.csv", bytes("jan,31000\n"), headers);
-    const second = await upload(vendo, "ledger.csv", bytes("jan,33000\nfeb,39000\n"), headers);
+    await vendo.putUserFile({ principal, name: "ledger.csv", content: "jan,31000\n" });
+    const second = await vendo.putUserFile({ principal, name: "ledger.csv", content: "jan,33000\nfeb,39000\n" });
 
-    expect(await second.json()).toEqual({ path: "/user/files/ledger.csv", bytes: 20 });
+    expect(second).toEqual({ path: "/user/files/ledger.csv", bytes: 20 });
     expect(await readBack(vendo, "/user/files/ledger.csv")).toBe("jan,33000\nfeb,39000\n");
   });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1189,9 +1189,18 @@ importers:
       '@vendoai/guard':
         specifier: workspace:*
         version: link:../guard
+      fflate:
+        specifier: ^0.8.3
+        version: 0.8.3
       just-bash:
         specifier: ^3.4.2
         version: 3.4.2
+      unpdf:
+        specifier: ^1.8.1
+        version: 1.8.1
+      xlsx:
+        specifier: https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz
+        version: https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz
       zod:
         specifier: ^3.25.0
         version: 3.25.76
@@ -9361,6 +9370,15 @@ packages:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
 
+  unpdf@1.8.1:
+    resolution: {integrity: sha512-xkURhy2SoGpOIH0a1gLHNkASPIQYonadDJs2AQwPEfUakafeD9EA1WTWWsaR++gfTCXJpV27W7tU1nXuk82UKQ==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      '@napi-rs/canvas': ^0.1.69 || ^1.0.0
+    peerDependenciesMeta:
+      '@napi-rs/canvas':
+        optional: true
+
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
@@ -9618,6 +9636,12 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  xlsx@https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz:
+    resolution: {integrity: sha512-oLDq3jw7AcLqKWH2AhCpVTZl8mf6X2YReP+Neh0SJUzV/BdZYjth94tG5toiMB1PPrYtxOCfaoUCkvtuH+3AJA==, tarball: https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz}
+    version: 0.20.3
+    engines: {node: '>=0.8'}
+    hasBin: true
 
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
@@ -19094,6 +19118,8 @@ snapshots:
 
   universalify@2.0.1: {}
 
+  unpdf@1.8.1: {}
+
   unpipe@1.0.0: {}
 
   unplugin-utils@0.2.5:
@@ -19559,6 +19585,8 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.21.0: {}
+
+  xlsx@https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz: {}
 
   xml-name-validator@5.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1223,9 +1223,6 @@ importers:
       vitest:
         specifier: ^3.2.6
         version: 3.2.7(@types/debug@4.1.13)(@types/node@22.20.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
-      xlsx:
-        specifier: npm:@e965/xlsx@0.20.3
-        version: '@e965/xlsx@0.20.3'
 
   packages/knowledge:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1189,6 +1189,9 @@ importers:
       '@vendoai/guard':
         specifier: workspace:*
         version: link:../guard
+      just-bash:
+        specifier: ^3.4.2
+        version: 3.4.2
       zod:
         specifier: ^3.25.0
         version: 3.25.76
@@ -1205,9 +1208,6 @@ importers:
       ai:
         specifier: 6.0.28
         version: 6.0.28(zod@3.25.76)
-      just-bash:
-        specifier: ^3.1.0
-        version: 3.2.0
       typescript:
         specifier: ^5.6.0
         version: 5.9.3
@@ -7314,6 +7314,11 @@ packages:
     engines: {node: '>=20.18.1'}
     hasBin: true
 
+  just-bash@3.4.2:
+    resolution: {integrity: sha512-T0Vpy7YRgCjxJdqG3tkxn0ZnIDLJvVwb8hH4L+6NVdp+Te27jQxjxnszW9ODjEKbWxWujj83rP5S0GQxCSufgg==}
+    engines: {node: '>=20.18.1'}
+    hasBin: true
+
   katex@0.16.47:
     resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
     hasBin: true
@@ -7748,6 +7753,10 @@ packages:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
 
+  minimatch@10.2.6:
+    resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
+    engines: {node: 18 || 20 || >=22}
+
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
@@ -8039,6 +8048,9 @@ packages:
 
   papaparse@5.5.4:
     resolution: {integrity: sha512-SwzWD9gl/ElwYLCI0nUja1mFJzjq2D8ziShfNBa7zCHzkOozeOGDwHWQ+tvCzEZcewecWZ5U7kUopDnG+DFYEQ==}
+
+  papaparse@5.6.0:
+    resolution: {integrity: sha512-N2vuNQAYGK1/4vs6HJX86+VYU6OkiSTgdJz3JQfTk1y51cFCO/U8gnaeTF4iNE4r57Tt0sV47dUua1/19pxO6Q==}
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -8855,6 +8867,10 @@ packages:
 
   smol-toml@1.7.1:
     resolution: {integrity: sha512-PPlsspAZ4jbMBu5DMFhfUGDQLu/vrL4SyBROVS37x8ynnVmFIs1VPBz1Co8Xks3TvpIaZXmU85y4DrQ+UyVFoQ==}
+    engines: {node: '>= 18'}
+
+  smol-toml@1.8.0:
+    resolution: {integrity: sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==}
     engines: {node: '>= 18'}
 
   sonic-boom@4.2.1:
@@ -16290,6 +16306,30 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  just-bash@3.4.2:
+    dependencies:
+      diff: 8.0.4
+      fast-xml-parser: 5.10.1
+      file-type: 21.3.4
+      ini: 6.0.0
+      minimatch: 10.2.6
+      modern-tar: 0.7.7
+      papaparse: 5.6.0
+      quickjs-emscripten: 0.32.0
+      re2js: 1.3.3
+      seek-bzip: 2.0.0
+      smol-toml: 1.8.0
+      sprintf-js: 1.1.3
+      sql.js: 1.14.1
+      turndown: 7.2.4
+      undici: 7.29.0
+      yaml: 2.9.0
+    optionalDependencies:
+      '@mongodb-js/zstd': 7.0.0
+      node-liblzma: 2.2.0
+    transitivePeerDependencies:
+      - supports-color
+
   katex@0.16.47:
     dependencies:
       commander: 8.3.0
@@ -16974,6 +17014,10 @@ snapshots:
     dependencies:
       brace-expansion: 5.0.9
 
+  minimatch@10.2.6:
+    dependencies:
+      brace-expansion: 5.0.9
+
   minimatch@3.1.5:
     dependencies:
       brace-expansion: 1.1.18
@@ -17328,6 +17372,8 @@ snapshots:
   package-manager-detector@1.8.0: {}
 
   papaparse@5.5.4: {}
+
+  papaparse@5.6.0: {}
 
   parent-module@1.0.1:
     dependencies:
@@ -18487,6 +18533,8 @@ snapshots:
   slash@3.0.0: {}
 
   smol-toml@1.7.1: {}
+
+  smol-toml@1.8.0: {}
 
   sonic-boom@4.2.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1180,6 +1180,9 @@ importers:
       '@anthropic-ai/claude-agent-sdk':
         specifier: '>=0.3.0 <1'
         version: 0.3.214(@anthropic-ai/sdk@0.112.3(zod@3.25.76))(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(zod@3.25.76)
+      '@e965/xlsx':
+        specifier: 0.20.3
+        version: 0.20.3
       '@vendoai/apps':
         specifier: workspace:*
         version: link:../apps
@@ -1198,9 +1201,6 @@ importers:
       unpdf:
         specifier: ^1.8.1
         version: 1.8.1
-      xlsx:
-        specifier: https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz
-        version: https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz
       zod:
         specifier: ^3.25.0
         version: 3.25.76
@@ -1223,6 +1223,9 @@ importers:
       vitest:
         specifier: ^3.2.6
         version: 3.2.7(@types/debug@4.1.13)(@types/node@22.20.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
+      xlsx:
+        specifier: npm:@e965/xlsx@0.20.3
+        version: '@e965/xlsx@0.20.3'
 
   packages/knowledge:
     dependencies:
@@ -2243,6 +2246,11 @@ packages:
 
   '@duckdb/node-bindings@1.5.2-r.2':
     resolution: {integrity: sha512-A17A6pXB7SEBAm93POdmEG+f4vQWMSujUP8/hNUfDWjaqp4C5mUWFnyuBM4XiB4qyXXH3vbjis2TYsnxAN2xEQ==}
+
+  '@e965/xlsx@0.20.3':
+    resolution: {integrity: sha512-703RN/3OdsRD5mtse2HBX7Um7xwaP9tlswEG6svOtjqokXoX7rJdQj7DyabD2I+xk22RgaIIU+R6BHgkpZGB/w==}
+    engines: {node: '>=0.8'}
+    hasBin: true
 
   '@electric-sql/pglite@0.2.17':
     resolution: {integrity: sha512-qEpKRT2oUaWDH6tjRxLHjdzMqRUGYDnGZlKrnL4dJ77JVMcP2Hpo3NYnOSPKdZdeec57B6QPprCUFg0picx5Pw==}
@@ -9637,12 +9645,6 @@ packages:
       utf-8-validate:
         optional: true
 
-  xlsx@https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz:
-    resolution: {integrity: sha512-oLDq3jw7AcLqKWH2AhCpVTZl8mf6X2YReP+Neh0SJUzV/BdZYjth94tG5toiMB1PPrYtxOCfaoUCkvtuH+3AJA==, tarball: https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz}
-    version: 0.20.3
-    engines: {node: '>=0.8'}
-    hasBin: true
-
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
@@ -10645,6 +10647,8 @@ snapshots:
       '@duckdb/node-bindings-linux-x64-musl': 1.5.2-r.2
       '@duckdb/node-bindings-win32-arm64': 1.5.2-r.2
       '@duckdb/node-bindings-win32-x64': 1.5.2-r.2
+
+  '@e965/xlsx@0.20.3': {}
 
   '@electric-sql/pglite@0.2.17': {}
 
@@ -19585,8 +19589,6 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.21.0: {}
-
-  xlsx@https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz: {}
 
   xml-name-validator@5.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,12 +12,14 @@ packages:
 # runtime for the portability gate (scripts/portability-gate.mjs).
 allowBuilds:
   # zstd + lzma are just-bash's OPTIONAL native backends for its compressed-tar
-  # commands. just-bash is a devDependency (the workspace's bash tests) and
-  # nothing in the tree compresses an archive through it, so the native builds
-  # are denied rather than compiled — running two build scripts would widen the
-  # supply-chain surface for a code path with no caller. Kept rather than
-  # dropped because the packages remain in the install graph and strictDepBuilds
-  # fails a cold install that merely ignores them. Flip to true the day a
+  # commands. just-bash is a runtime dependency of @vendoai/harnesses (the shell
+  # tool) and nothing in the tree compresses an archive through it, so the native
+  # builds are denied rather than compiled — running two build scripts would
+  # widen the supply-chain surface for a code path with no caller. Kept rather
+  # than dropped because the packages remain in the install graph and
+  # strictDepBuilds fails a cold install that merely ignores them. Every
+  # consumer of the published packages inherits the same two — that is why
+  # docs-site/index.mdx tells them to deny both. Flip to true the day a
   # bash-native harness needs `tar -z`.
   '@mongodb-js/zstd': false
   cbor-extract: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,9 +7,10 @@ packages:
   - "genbench"
 
 # pnpm 9 ran every dependency build script; pnpm 11 (strictDepBuilds) requires
-# an explicit allowlist. These five are the deps with build scripts in the
-# tree — all allowed, preserving pnpm 9 behavior. workerd is miniflare's
-# runtime for the portability gate (scripts/portability-gate.mjs).
+# an explicit allowlist. These eight are the deps with build scripts in the
+# tree — six allowed, preserving pnpm 9 behavior, two denied (see below).
+# workerd is miniflare's runtime for the portability gate
+# (scripts/portability-gate.mjs).
 allowBuilds:
   # zstd + lzma are just-bash's OPTIONAL native backends for its compressed-tar
   # commands. just-bash is a runtime dependency of @vendoai/harnesses (the shell


### PR DESCRIPTION
**Slice D of 4 — the tip.** Stack, bottom → top:

- A → `main` — #1615
- B → shell-a-engine — #1616
- C → shell-b-js — #1624
- **D → shell-c-parsers** ← you are here

**The whole stack merges once, here.** Review against C, not `main`.

## What this does

Uploads stop landing in a global drawer. They stage at `/user/uploads/<random>-<name>`, the turn that receives them moves them to `/user/threads/<threadId>/files/<name>` and rewrites the parts **before** they are persisted (so the transcript never records a staging path), and every turn sweeps stale strays. `/user/files` is demoted to an explicit keep-shelf. Deleting a conversation deletes it for real — rows, harness state, and the files with their blobs. Deleting an app takes its workspace with it.

A sandboxed harness sees all of it with **zero new code** — `/user/uploads` is deliberately *not* excluded from materialisation, and a test pins that.

## Three storage bugs this fixes that it did not cause

The mandated seam test — real upload door, real turn, real bash, real delete, real Postgres, real blob store, **no mock on any side** — found a live production defect, and pulling the thread found two more:

1. **Every chat drop was stored twice, and the first copy was unreachable forever.** Re-homing used `workspace.mv`, which is `cp` + `rm`; `cp` mints a second blob and `rm` only tombstones, and `eraseStore().byThread` only collects under `/user/threads/<id>%`. The orphan survived deleting the conversation and would have survived an erasure request. Measured: upload → 1 object, after turn → 2, after delete → **1 survives**.
2. **`mv(p, p)` deleted the file.** `cp` staged it at `p`, then `rm` dropped the very path `cp` had just staged. `mv` had **zero test coverage** in the repo; it has six tests now.
3. **An upload the user never sent orphaned its blob** after the six-hour sweep, with no `mv` involved at all.

Fixed with one owner-scoped path-prefix erase (`eraseStore().byWorkspacePath`) reusing `delWorkspace` so rows and objects go together, called from both staging exits.

**Rejected alternative, for the record:** making `mv` a real rename. It was measured and does *not* close the leak — the object is minted at commit inside `place()`, which the façade cannot reach. Closing it that way would have required changing append-only history semantics and editing the commit-time permission gate (`assertCommittable`), which is not a trade worth making for a transient copy.

**Accepted residual:** between the copy and the erase the bucket briefly holds two objects, so an adapter that meters on `put` counts both. A crash inside that window leaves the original orphaned and it is not self-healing, because the stray sweep lists live rows only. Same wart class as the already-accepted bare-`rm` case.

## Test changes, stated out loud

Six existing tests were retargeted — they asserted that a chat **drop** lands on the shelf, which is exactly the behaviour this removes. Each moved only the hard-coded address and kept every other assertion; the new staged address is pinned with an anchored regex rather than read back from the response, so the door cannot be right by construction. No test was weakened, skipped or deleted.

## Proof

The tip's cone gate is green end to end: build 22/22, all 49 test tasks, typecheck 44/44, lint 4/4 with the portability gate all legs green, and `install-seam` passing 5/5 — the first run proving A's `allowBuilds` fix and C's `@e965/xlsx` swap work together. The lifecycle seam is proven able to fail: revert the re-home and the orphaned blob reappears at the exact assertion.

A live browser proof against the demo bank runs before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Files dropped in chat now stage at /user/uploads and the receiving turn rehomes them to /user/threads/<threadId>/files/<name>, rewriting parts before persistence; deleting a thread or app now erases rows, history, and blobs. Previously uploads landed in /user/files and deletes left blob orphans.

- Preserves unique names for same‑name attachments within a message and across later turns; very long names also rehome without refusal by truncating the fallback leaf within the limit.
- Blocks thread id traversal, disallows moving a path into its own subtree, and makes mv(p, p) a no‑op.
- Adds owner‑scoped path erasure for staging; thread and app deletes cascade to blobs; during rehome the bucket briefly holds two blobs and a crash can orphan the original until an explicit erase.
- Shell runs in real hosts without killing dev servers; libraries load from the package regardless of bundler output; violations are audited once per type; boot failures return an exit code.
- `cautious` no longer prompts for `bash`; it remains graded write with audit rows, host rules, and the kill switch.
- UI pills recognize all /user/* paths; xlsx2csv terminates CSV with a newline; docx2txt bounds tag scans to stay linear and avoid blocking the host.
- Seam tests pin the staged path shape and the exact POST /files response.

**Migration**
- Clients must accept POST /files returning a staging path like /user/uploads/<random>-<name> and include that exact path in the message part; stop assuming /user/files/... .
- When building an app from a dropped file, copy it into /user/apps/<app>/ first; do not depend on conversation‑owned files.
- Ensure a FilesAdapter is configured; to get full delete cascades, wire a SQL store or expose StoreOps, otherwise thread delete may only tombstone rows.

<sup>Written for commit e04ddb9863dc986880a69d0b69bbf1540cd5b8f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

