### PR TITLE
feat(ui): per-surface theme overrides on chrome surfaces

### DIFF
--- a/.changeset/per-surface-theme.md
+++ b/.changeset/per-surface-theme.md
@@ -1,0 +1,20 @@
+---
+"@vendoai/ui": minor
+"@vendoai/vendo": minor
+---
+
+Per-surface `theme` overrides on the chrome surfaces.
+
+`VendoOverlay`, `VendoSlot`, `VendoTrigger`, `VendoAppEmbed`,
+`VendoApprovalEmbed`, and `VendoToolResult` each take an optional
+`theme?: Partial<VendoTheme>`, merged group by group over the provider's
+resolved theme (over the default with no provider) — so one surface can be a
+dark panel on a light page without a second provider. What a surface portals to
+`document.body` goes with it: the overlay panel, the approval modal a press
+parks on, and the toast stack all wear the spawning surface's theme instead of
+falling back to the provider's.
+
+Frame only — a generated view mounted inside a themed surface keeps the
+PROVIDER theme, whether it is served in an iframe or rendered natively as a pin.
+
+`VendoTheme` is now nameable from `@vendoai/ui` and `@vendoai/vendo/react`.

--- a/docs-site/customize/theming.mdx
+++ b/docs-site/customize/theming.mdx
@@ -128,6 +128,44 @@ overwritten, and `vendo sync --theme-refresh` takes your app's value back.
   Leave it unset and the server reads `.vendo/theme.json`.
 </Note>
 
+## One surface, a different theme
+
+The provider sets the brand for everything under it. A single surface can
+differ — a dark assistant panel on a light page, a compact slot in a dense
+console — with its own `theme` prop.
+
+```tsx
+import { VendoOverlay, VendoSlot } from "@vendoai/vendo/react";
+
+<VendoSlot id="net-worth-card" />
+<VendoSlot id="ops-console" theme={{ density: "compact" }} />
+<VendoOverlay theme={darkPanel} />
+```
+
+It merges over the provider's resolved theme group by group, the same way the
+provider's merges over Vendo's default — so a surface states only what differs,
+and the groups it leaves out stay the brand. With no provider above it, the
+merge runs over the default.
+
+Six surfaces take it: `VendoOverlay`, `VendoSlot`, `VendoTrigger`,
+`VendoAppEmbed`, `VendoApprovalEmbed`, and `VendoToolResult`. Type it with
+`Partial<VendoTheme>`.
+
+What a surface sends to `document.body` goes with it. The overlay panel, the
+approval modal a press parks on, and the toast stack all wear the theme of the
+surface they came from rather than falling back to the provider's.
+
+<Warning>
+  A surface theme styles Vendo's **frame**, not the view inside it. A generated
+  view keeps the **provider** theme either way it mounts — served in an iframe,
+  or rendered natively as a pin — because the view is its own theme boundary and
+  restates the provider's tokens on itself. Theme a surface to change the chrome
+  around a generated view; change the provider to change the view.
+</Warning>
+
+A slot showing your own markup renders it untouched, with no Vendo wrapper at
+all. There is no chrome on screen there, so `theme` has nothing to style.
+
 ## Where to go next
 
 Theme is how it looks. These three are what it knows.

--- a/packages/ui/src/chrome/approval-modal.tsx
+++ b/packages/ui/src/chrome/approval-modal.tsx
@@ -39,13 +39,13 @@ import {
 } from "react";
 import { createPortal } from "react-dom";
 import { APPROVALS_DECIDED_EVENT, type ApprovalsDecidedDetail } from "../client-impl.js";
-import { useVendoProvider, useVendoTheme, useVendoTools } from "../context.js";
+import { useVendoProvider, useVendoTools } from "../context.js";
 import { themeCssVariables } from "../theme.js";
 import type { ApprovalResolution } from "../wire-types.js";
 import { refusalCopy } from "./approval-card.js";
 import { consentAsk, toolPresentation } from "./build-beat.js";
 import { CARD_EYEBROWS, CardFields, NOTE_SEPARATOR } from "./card-shell.js";
-import { ensureChromeStyles } from "./chrome-root.js";
+import { ensureChromeStyles, useChromeTheme } from "./chrome-root.js";
 import { fieldRows } from "./field-rows.js";
 import { inertBehind } from "./inert-behind.js";
 
@@ -125,7 +125,11 @@ export function ApprovalModal({ approvalId, onClose }: {
   onClose(): void;
 }) {
   const { client } = useVendoProvider();
-  const theme = useVendoTheme();
+  // The ask belongs to the surface the press came from, so it wears THAT
+  // surface's theme — a slot or embed with its own `theme` prop, not just the
+  // provider's. The layer below portals to <body>, so the boundary that themes
+  // the spawning surface can only reach it through React context.
+  const theme = useChromeTheme();
   const tools = useVendoTools();
   const [resolution, setResolution] = useState<ApprovalResolution>();
   const [loadFailed, setLoadFailed] = useState(false);

--- a/packages/ui/src/chrome/chrome-root.tsx
+++ b/packages/ui/src/chrome/chrome-root.tsx
@@ -1,7 +1,8 @@
-import { createContext, useContext, useEffect, type CSSProperties, type ReactNode } from "react";
+import type { VendoTheme } from "@vendoai/apps/contract";
+import { createContext, useContext, useEffect, useMemo, type CSSProperties, type ReactNode } from "react";
 import { useVendoProvider } from "../context.js";
 import { useVendoStatus } from "../hooks/use-vendo-status.js";
-import { themeCssVariables } from "../theme.js";
+import { resolveTheme, themeCssVariables } from "../theme.js";
 import { PolicyNoticeBody } from "./policy-notice-body.js";
 import { ensureThemeFontStyles } from "./theme-fonts.js";
 
@@ -18,10 +19,39 @@ export function ensureChromeStyles(): void {
   document.head.append(style);
 }
 
-const ChromeRootContext = createContext(false);
+/** The theme the enclosing chrome boundary resolved, or null outside one. It
+    carries the VALUE rather than a bare presence flag so that a surface which
+    portals OUT of the boundary's DOM subtree can still read the theme of the
+    surface that spawned it (see {@link useChromeTheme}). */
+const ChromeRootContext = createContext<VendoTheme | null>(null);
 
 export function useChromeRootPresence(): boolean {
-  return useContext(ChromeRootContext);
+  return useContext(ChromeRootContext) !== null;
+}
+
+/**
+ * The theme in force at this point in the REACT tree: the nearest chrome
+ * boundary's resolved theme, else the provider's.
+ *
+ * This is what anything portalling to `document.body` reads. Those surfaces
+ * hand-roll their own `.vendo-root` boundary (the comment above
+ * {@link ensureChromeStyles}), so a DOM-cascade inheritance never reaches
+ * them — but they are still rendered from inside their spawning surface's
+ * React subtree, and that surface may carry its own `theme`.
+ */
+export function useChromeTheme(): VendoTheme {
+  const boundary = useContext(ChromeRootContext);
+  const provider = useVendoProvider().theme;
+  return boundary ?? provider;
+}
+
+/** A surface's own partial theme, merged over the provider's resolved theme —
+    the same merge `VendoProvider` applies over `defaultVendoTheme`. With no
+    provider above, the provider value IS `defaultVendoTheme`, so a bare surface
+    merges over the defaults. */
+export function useSurfaceTheme(theme?: Partial<VendoTheme>): VendoTheme {
+  const provider = useVendoProvider().theme;
+  return useMemo(() => resolveTheme(provider, theme), [provider, theme]);
 }
 
 /**
@@ -45,17 +75,20 @@ function AutomaticPolicyNotice() {
 function ChromeBoundary({
   children,
   className,
+  theme: override,
   automaticPolicyNotice,
 }: {
   children: ReactNode;
   className?: string;
+  theme?: Partial<VendoTheme>;
   automaticPolicyNotice: boolean;
 }) {
-  const { theme, fonts } = useVendoProvider();
+  const { fonts } = useVendoProvider();
+  const theme = useSurfaceTheme(override);
   useEffect(ensureChromeStyles, []);
   useEffect(() => ensureThemeFontStyles(fonts ?? ""), [fonts]);
   return (
-    <ChromeRootContext.Provider value>
+    <ChromeRootContext.Provider value={theme}>
       <div
         className={["vendo-root", className].filter(Boolean).join(" ")}
         // Decision 4 (spec 2026-08-05): the widget excludes itself from the
@@ -76,14 +109,21 @@ function ChromeBoundary({
 export function ChromeRoot({
   children,
   className,
+  /** This surface's own brand tokens, merged over the provider's. */
+  theme,
   /** Opt IN to the developer policy banner (dev/console surfaces only). */
   automaticPolicyNotice = false,
 }: {
   children: ReactNode;
   className?: string;
+  theme?: Partial<VendoTheme>;
   automaticPolicyNotice?: boolean;
 }) {
   const nested = useChromeRootPresence();
-  if (nested) return <>{children}</>;
-  return <ChromeBoundary className={className} automaticPolicyNotice={automaticPolicyNotice}>{children}</ChromeBoundary>;
+  // A nested boundary is redundant — the ancestor already emitted these exact
+  // tokens — UNLESS this surface carries a theme of its own, which the
+  // pass-through would silently drop. Then the inner boundary restates the
+  // merged tokens and the cascade does the rest.
+  if (nested && theme === undefined) return <>{children}</>;
+  return <ChromeBoundary className={className} theme={theme} automaticPolicyNotice={automaticPolicyNotice}>{children}</ChromeBoundary>;
 }

--- a/packages/ui/src/chrome/embeds.tsx
+++ b/packages/ui/src/chrome/embeds.tsx
@@ -184,7 +184,7 @@ function executedCard(summary: string, outcome: ToolOutcome | undefined): ReactN
  * `GET /approvals/:id` and resolves in place to the executed outcome,
  * "declined", or "expired" (the frozen `VendoApprovalEmbedState` vocabulary).
  */
-export function VendoApprovalEmbed({ refValue }: VendoApprovalEmbedProps) {
+export function VendoApprovalEmbed({ refValue, theme }: VendoApprovalEmbedProps) {
   const { client } = useVendoProvider();
   const { approvalId, summary } = refValue;
 
@@ -261,7 +261,7 @@ export function VendoApprovalEmbed({ refValue }: VendoApprovalEmbedProps) {
   }
 
   return (
-    <ChromeRoot>
+    <ChromeRoot theme={theme}>
       <div data-vendo-embed="approval">{body}</div>
     </ChromeRoot>
   );
@@ -272,7 +272,7 @@ export function VendoApprovalEmbed({ refValue }: VendoApprovalEmbedProps) {
  * build streams, then the live app. In-app interactions go over the wire
  * (`apps.call`), never through the host's agent loop.
  */
-export function VendoAppEmbed({ refValue }: VendoAppEmbedProps) {
+export function VendoAppEmbed({ refValue, theme }: VendoAppEmbedProps) {
   const { client, components } = useVendoProvider();
   const { appId, title } = refValue;
   // A press inside the embedded app that parks on the guard asks its question
@@ -403,7 +403,7 @@ export function VendoAppEmbed({ refValue }: VendoAppEmbedProps) {
   const shown: OpenSurface | undefined = surface
     ?? (forming === undefined ? undefined : { kind: "tree", payload: forming });
   return (
-    <ChromeRoot>
+    <ChromeRoot theme={theme}>
       {/* The thread lane's app boundary: the bar narrates forming → live via
           the shared data-state contract ("building" | "ready"). */}
       <div className="fl-uihost fl-appcard" data-vendo-embed="app">
@@ -486,14 +486,18 @@ export function VendoAppEmbed({ refValue }: VendoAppEmbedProps) {
  * embed by `parseVendoToolEnvelope` — or nothing for plain data (the action
  * executed cleanly; the agent already consumed the result).
  */
-export function VendoToolResult({ output }: VendoToolResultProps) {
+export function VendoToolResult({ output, theme }: VendoToolResultProps) {
   const envelope = parseVendoToolEnvelope(output);
   if (envelope === null) return null;
-  if (envelope.kind === VENDO_APP_REF_KIND) return <VendoAppEmbed refValue={envelope} />;
+  if (envelope.kind === VENDO_APP_REF_KIND) return <VendoAppEmbed refValue={envelope} theme={theme} />;
   // The record it just armed, in the card the thread already renders
   // automations with — the envelope's one line IS the rule sentence.
   if (envelope.kind === VENDO_AUTOMATION_REF_KIND) {
-    return <AutomationCard name={envelope.summary} enabled={envelope.armed} />;
+    return (
+      <ChromeRoot theme={theme}>
+        <AutomationCard name={envelope.summary} enabled={envelope.armed} />
+      </ChromeRoot>
+    );
   }
-  return <VendoApprovalEmbed refValue={envelope} />;
+  return <VendoApprovalEmbed refValue={envelope} theme={theme} />;
 }

--- a/packages/ui/src/chrome/thread/parts.tsx
+++ b/packages/ui/src/chrome/thread/parts.tsx
@@ -9,6 +9,7 @@ import { PlacementAction } from "../add-to-picker.js";
 import { ApprovalCard } from "../approval-card.js";
 import { useApprovalModal } from "../approval-modal.js";
 import { ApprovalSheet } from "../approval-sheet.js";
+import { useChromeTheme } from "../chrome-root.js";
 import { ThreadAutomationConsent } from "./automation-consent.js";
 import { BuildBeat, toolPresentation } from "../build-beat.js";
 import { ConnectCard } from "../connect-card.js";
@@ -868,7 +869,12 @@ export function ThreadApprovals({ approvals, risks, guardApprovals, cardRefs, re
   respond: (response: { id: string; approved: boolean }) => void;
   onMorph: (morph: Omit<MorphToastProps, "onDone">) => void;
 }) {
-  const { client, theme, tools } = useVendoProvider();
+  const { client, tools } = useVendoProvider();
+  // The morph toast portals to <body>, so it takes its tokens as a prop rather
+  // than by cascade. They are the ENCLOSING surface's — a themed VendoOverlay's
+  // panel is where the approval was decided, so that is the theme the pill
+  // flies away in.
+  const theme = useChromeTheme();
   // Below the mobile breakpoint the NEWEST parked approval
   // presents as a bottom sheet (thumb-zone consent); older parked ones stay
   // in-list behind it so the thread record is complete when the sheet closes.

--- a/packages/ui/src/chrome/vendo-overlay.tsx
+++ b/packages/ui/src/chrome/vendo-overlay.tsx
@@ -1,7 +1,8 @@
 import type { UIPayload } from "@vendoai/core";
+import type { VendoTheme } from "@vendoai/apps/contract";
 import { useCallback, useEffect, useMemo, useReducer, useRef, useState, useSyncExternalStore, type ComponentProps, type ComponentType, type CSSProperties, type KeyboardEvent, type ReactNode } from "react";
 import { createPortal } from "react-dom";
-import { useVendoProvider, useVendoDiscoverability, useVendoTheme } from "../context.js";
+import { useVendoProvider, useVendoDiscoverability } from "../context.js";
 import { useMobileTakeover } from "../hooks/use-mobile-takeover.js";
 import { useSignedOut } from "../hooks/identity-state.js";
 import { themeCssVariables } from "../theme.js";
@@ -9,7 +10,7 @@ import { PayloadView } from "../tree/renderer.js";
 import { PlacementAction } from "./add-to-picker.js";
 import { useApprovalModal } from "./approval-modal.js";
 import { BeatRail } from "./build-beat.js";
-import { ChromeRoot } from "./chrome-root.js";
+import { ChromeRoot, useSurfaceTheme } from "./chrome-root.js";
 import { hasSeen, markSeen, type VendoDiscoverability, type VendoGreeting } from "./discoverability.js";
 import { HistoryPicker } from "./history-picker.js";
 import { inertBehind } from "./inert-behind.js";
@@ -96,6 +97,20 @@ export interface VendoOverlayProps {
    * provider's `greeting`.
    */
   greeting?: VendoGreeting;
+  /**
+   * This surface's own brand tokens, merged group by group over the provider's
+   * resolved theme — the same merge `VendoProvider` does over
+   * `defaultVendoTheme`, so with no provider above this merges over the
+   * defaults. The panel portals to `<body>` and the approval modal portals
+   * again from inside it; both carry these tokens.
+   *
+   * FRAME ONLY: it styles Vendo's own chrome — launcher, panel, thread,
+   * composer. A generated view mounted in the conversation keeps the PROVIDER
+   * theme, whether it is iframe-served (themed over the app transport) or
+   * rendered natively: the tree surface restates the provider tokens on its
+   * own root, so the local ones do not cascade in.
+   */
+  theme?: Partial<VendoTheme>;
   /**
    * Where the panel sits while open.
    *
@@ -624,6 +639,7 @@ export function VendoOverlay({
   thread: Thread = VendoThread,
   discoverability,
   greeting,
+  theme: themeOverride,
   placement = "center",
   dockWidth = 420,
   signedOutNotice,
@@ -645,7 +661,10 @@ export function VendoOverlay({
   // previous-conversations picker (useRememberedConversation above).
   const { resumeThreadId, setResumeThreadId, historyOpen, setHistoryOpen, forgetForFreshStart } =
     useRememberedConversation(conversationKey);
-  const theme = useVendoTheme();
+  // The panel portals to <body>, so it hand-rolls the same boundary ChromeRoot
+  // below builds — off the SAME resolved theme, or the two halves of one
+  // surface could disagree.
+  const theme = useSurfaceTheme(themeOverride);
   const { client } = useVendoProvider();
   // H2-E / #1372 — the wire refused this visitor for missing identity. The
   // launcher stays (nothing about wire health hides it); the PANEL answers
@@ -1137,7 +1156,7 @@ export function VendoOverlay({
   ) : null;
 
   return (
-    <ChromeRoot>
+    <ChromeRoot theme={themeOverride}>
       {launcherHidden ? null : (
         <button
           ref={launcherRef}

--- a/packages/ui/src/chrome/vendo-slot.tsx
+++ b/packages/ui/src/chrome/vendo-slot.tsx
@@ -1,4 +1,5 @@
 import { log, type AppId, type Json, type ToolOutcome, type UIPayload } from "@vendoai/core";
+import type { VendoTheme } from "@vendoai/apps/contract";
 import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { useVendoProvider } from "../context.js";
 import { announcePin } from "../pin-events.js";
@@ -245,7 +246,7 @@ export interface VendoSlotPin {
  *  the original `children` as the visible recovery path (06-apps §8). Without any
  *  of the three, the children render UNTOUCHED (no wrapper — hosts may inline
  *  slots anywhere). */
-export function VendoSlot({ id, label, description, appId: appIdProp, pin, onAuthor, onParked, discover = true, emptyState, children }: {
+export function VendoSlot({ id, label, description, appId: appIdProp, pin, onAuthor, onParked, discover = true, emptyState, theme, children }: {
   id: string;
   /** What a person choosing this slot in the "Add to…" picker reads. Defaults
    *  to the id read as words ("net-worth-card" → "Net worth card"). */
@@ -281,6 +282,23 @@ export function VendoSlot({ id, label, description, appId: appIdProp, pin, onAut
     /** Primary button label. Default "Design a view". */
     ctaLabel?: string;
   };
+  /**
+   * This slot's own brand tokens, merged group by group over the provider's
+   * resolved theme — the same merge `VendoProvider` does over
+   * `defaultVendoTheme`, so with no provider above this merges over the
+   * defaults. The approval modal a press inside this slot parks on carries
+   * these tokens too, even though it portals to `<body>`.
+   *
+   * FRAME ONLY: it styles Vendo's own chrome — the ghost, the invitation, the
+   * failure cards, the ✦ pin chrome. The mounted view itself keeps the
+   * PROVIDER theme, whether it is an iframe-served app (themed over the app
+   * transport) or a `pin` rendered natively: the tree surface restates the
+   * provider tokens on its own root, so the local ones do not cascade in.
+   *
+   * A slot showing your OWN markup has no Vendo chrome on screen and gets no
+   * wrapper at all, so this does nothing there — by design.
+   */
+  theme?: Partial<VendoTheme>;
   children?: ReactNode;
 }) {
   const { client, components } = useVendoProvider();
@@ -367,7 +385,7 @@ export function VendoSlot({ id, label, description, appId: appIdProp, pin, onAut
   // placement resolves into a mountable app id, and this one never will.
   if (status === "failed" && discovery.appId !== undefined) {
     return (
-      <ChromeRoot>
+      <ChromeRoot theme={theme}>
         <div className="fl-slot" data-vendo-slot={id}>
           <SlotBuildFailed appId={discovery.appId} slotId={id} onChanged={() => void discovery.refresh()} />
         </div>
@@ -385,7 +403,7 @@ export function VendoSlot({ id, label, description, appId: appIdProp, pin, onAut
     // on a first-ever visit.
     if (discovery.isLoading) {
       return (
-        <ChromeRoot>
+        <ChromeRoot theme={theme}>
           <div className="fl-slot" data-vendo-slot={id}>
             <SlotGhost label="Loading app…" slotId={id} />
           </div>
@@ -400,7 +418,7 @@ export function VendoSlot({ id, label, description, appId: appIdProp, pin, onAut
     // The conversation surface carries that beat for the person who asked.
     if (status === "building") {
       return (
-        <ChromeRoot>
+        <ChromeRoot theme={theme}>
           <div className="fl-slot" data-vendo-slot={id}>
             <SlotGhost label="Building your view…" loading />
           </div>
@@ -417,7 +435,7 @@ export function VendoSlot({ id, label, description, appId: appIdProp, pin, onAut
       ctaLabel: emptyState?.ctaLabel ?? "Design a view",
     };
     return (
-      <ChromeRoot>
+      <ChromeRoot theme={theme}>
         <div className="fl-slot" data-vendo-slot={id}>
           <div className="fl-slot-ghost fl-slot-invite">
             <GhostSkeleton />
@@ -463,7 +481,7 @@ export function VendoSlot({ id, label, description, appId: appIdProp, pin, onAut
   );
   const pinTitle = discovery.title !== undefined && discovery.title !== "" ? discovery.title : name;
   return (
-    <ChromeRoot>
+    <ChromeRoot theme={theme}>
       <div className="fl-slot" data-vendo-slot={id}>
         {/* Only a PLACEMENT gets the ✦: a host-asserted `appId` prop is the
             host's own markup decision, and offering to unpin it would clear a

--- a/packages/ui/src/chrome/vendo-toasts.tsx
+++ b/packages/ui/src/chrome/vendo-toasts.tsx
@@ -17,7 +17,7 @@ import { useApprovals } from "../hooks/use-approvals.js";
 import { themeCssVariables } from "../theme.js";
 import { consentAsk, toolPresentation } from "./build-beat.js";
 import { NOTE_SEPARATOR } from "./card-shell.js";
-import { ensureChromeStyles } from "./chrome-root.js";
+import { ensureChromeStyles, useChromeTheme } from "./chrome-root.js";
 import { fieldRows } from "./field-rows.js";
 
 export interface VendoToastAction {
@@ -251,7 +251,11 @@ export interface VendoToastsProps {
 
 /** 08-ui §4 chrome — mount once per page. */
 export function VendoToasts({ placement = "bottom-right", approvals = false, pollMs = 5_000 }: VendoToastsProps = {}): ReactNode {
-  const { theme } = useVendoProvider();
+  // Mounted bare (the usual shape) this is the provider theme. Mounted inside a
+  // chrome surface that carries its own `theme`, the stack wears that one — it
+  // portals out of the DOM subtree, so context is the only way the boundary
+  // reaches it.
+  const theme = useChromeTheme();
   const toasts = useToastQueue();
   // The stack portals out of any ChromeRoot subtree, so it owns its own style
   // injection — a page that mounts ONLY VendoToasts still renders styled.

--- a/packages/ui/src/chrome/vendo-trigger.tsx
+++ b/packages/ui/src/chrome/vendo-trigger.tsx
@@ -1,4 +1,5 @@
 import { log } from "@vendoai/core";
+import type { VendoTheme } from "@vendoai/apps/contract";
 import type { ReactNode } from "react";
 import { ChromeRoot } from "./chrome-root.js";
 import { developmentMode } from "./dev-mode.js";
@@ -13,6 +14,18 @@ export interface VendoTriggerProps {
   context?: string;
   /** Button label. Default "Ask Vendo". */
   children?: ReactNode;
+  /**
+   * This surface's own brand tokens, merged group by group over the provider's
+   * resolved theme — the same merge `VendoProvider` does over
+   * `defaultVendoTheme`, so with no provider above this merges over the
+   * defaults.
+   *
+   * FRAME ONLY: it styles Vendo's own chrome. A mounted generated view keeps
+   * the PROVIDER theme — an iframe-served app is themed over the app
+   * transport, and a natively rendered one restates the provider tokens on its
+   * own surface root.
+   */
+  theme?: Partial<VendoTheme>;
 }
 
 /**
@@ -26,9 +39,9 @@ export interface VendoTriggerProps {
  * programmatic seam this button uses (the repo's idiom; there is deliberately
  * no render-prop API on chrome, ui-usage-dx §4).
  */
-export function VendoTrigger({ prompt, context, children }: VendoTriggerProps) {
+export function VendoTrigger({ prompt, context, children, theme }: VendoTriggerProps) {
   return (
-    <ChromeRoot>
+    <ChromeRoot theme={theme}>
       <button
         type="button"
         className="fl-btn"

--- a/packages/ui/src/embeds.ts
+++ b/packages/ui/src/embeds.ts
@@ -1,3 +1,4 @@
+import type { VendoTheme } from "@vendoai/apps/contract";
 import type { VendoAppRef, VendoApprovalRef } from "@vendoai/core";
 
 /**
@@ -6,12 +7,29 @@ import type { VendoAppRef, VendoApprovalRef } from "@vendoai/core";
  * built on the existing slot / build-beat / approval-card machinery, on the
  * defaults a `VendoProvider` overrides when the host mounts one.
  * Frozen in `docs/superpowers/specs/2026-07-20-existing-agents-contracts.md`.
+ *
+ * `theme` is the one addition since the freeze (approved 2026-08-23): an
+ * OPTIONAL per-surface override, never a required prop and never a second way
+ * to say what the provider already says.
  */
 
 /** Inline generated app: build-beat while the build streams, then the live
  *  app. In-app interactions go over the wire, not through the host loop. */
 export interface VendoAppEmbedProps {
   refValue: VendoAppRef;
+  /**
+   * This embed's own brand tokens, merged group by group over the provider's
+   * resolved theme — the same merge `VendoProvider` does over
+   * `defaultVendoTheme`, so a bare embed merges over the defaults. The approval
+   * modal a press inside the app parks on carries them too.
+   *
+   * FRAME ONLY: it styles Vendo's own chrome — the app card's bar, the beats,
+   * the failure notice. The mounted generated view keeps the PROVIDER theme,
+   * whether it is iframe-served (themed over the app transport) or rendered
+   * natively: the tree surface restates the provider tokens on its own root,
+   * so the local ones do not cascade in.
+   */
+  theme?: Partial<VendoTheme>;
 }
 
 /** Where an approval embed can be, in the order it gets there. The wire owns
@@ -23,10 +41,33 @@ export type VendoApprovalEmbedState = "pending" | "executed" | "declined" | "exp
 /** Approve/deny for a parked guarded call. */
 export interface VendoApprovalEmbedProps {
   refValue: VendoApprovalRef;
+  /**
+   * This embed's own brand tokens, merged group by group over the provider's
+   * resolved theme — the same merge `VendoProvider` does over
+   * `defaultVendoTheme`, so a bare embed merges over the defaults.
+   *
+   * FRAME ONLY: it styles Vendo's own chrome. A mounted generated view keeps
+   * the PROVIDER theme, whether it is iframe-served (themed over the app
+   * transport) or rendered natively: the tree surface restates the provider
+   * tokens on its own root, so the local ones do not cascade in.
+   */
+  theme?: Partial<VendoTheme>;
 }
 
 /** The dispatcher: give it any `vendo_*` tool output and it renders the right
  *  embed by `parseVendoToolEnvelope`, or nothing for plain data. */
 export interface VendoToolResultProps {
   output: unknown;
+  /**
+   * Passed straight through to whichever embed the envelope dispatches to:
+   * this surface's own brand tokens, merged group by group over the provider's
+   * resolved theme — the same merge `VendoProvider` does over
+   * `defaultVendoTheme`, so a bare embed merges over the defaults.
+   *
+   * FRAME ONLY: it styles Vendo's own chrome. A mounted generated view keeps
+   * the PROVIDER theme, whether it is iframe-served (themed over the app
+   * transport) or rendered natively: the tree surface restates the provider
+   * tokens on its own root, so the local ones do not cascade in.
+   */
+  theme?: Partial<VendoTheme>;
 }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -68,7 +68,10 @@ export {
   type WorkbenchTurn,
 } from "./chrome/workbench-store.js";
 export { announcePin, onPinAnnounced } from "./pin-events.js";
-export { defaultVendoTheme, resolveTheme, themeCssVariables } from "./theme.js";
+// `VendoTheme` is nameable from here because hosts now type more than the
+// provider's `theme` prop with it — every chrome surface takes its own
+// `theme?: Partial<VendoTheme>`.
+export { defaultVendoTheme, resolveTheme, themeCssVariables, type VendoTheme } from "./theme.js";
 export type {
   AppListRow,
   ApprovalResolution,

--- a/packages/ui/src/theme.ts
+++ b/packages/ui/src/theme.ts
@@ -9,4 +9,5 @@ export {
   defaultVendoTheme,
   resolveTheme,
   themeCssVariables,
+  type VendoTheme,
 } from "@vendoai/apps/contract";

--- a/packages/ui/test/chrome/surface-theme.test.tsx
+++ b/packages/ui/test/chrome/surface-theme.test.tsx
@@ -1,0 +1,325 @@
+// @vitest-environment jsdom
+/**
+ * Per-surface `theme` overrides on the chrome surfaces.
+ *
+ * One provider theme is the product's brand; a single surface sometimes has to
+ * differ (a dark rail on a light page, a compact embed inside a dense console).
+ * Every case here reads the CSS VARIABLES that actually land on the rendered
+ * boundary — never a prop echo — so the merge, the portal threading, and the
+ * frame-only limit are pinned against the real DOM.
+ */
+import type { ApprovalId, Json, ToolOutcome, UIPayload } from "@vendoai/core";
+import type { VendoTheme } from "@vendoai/apps/contract";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { VendoProvider, createVendoClient, defaultVendoTheme, type VendoClient } from "../../src/index.js";
+import {
+  ChromeRoot,
+  VendoAppEmbed,
+  VendoApprovalEmbed,
+  VendoOverlay,
+  VendoSlot,
+  VendoToasts,
+  VendoToolResult,
+  VendoTrigger,
+  vendoToast,
+} from "../../src/chrome/index.js";
+import { createWireServer } from "../wire-server.js";
+
+let wire: Awaited<ReturnType<typeof createWireServer>>;
+let client: VendoClient;
+
+beforeEach(async () => {
+  window.localStorage.clear();
+  wire = await createWireServer();
+  client = createVendoClient({ baseUrl: wire.url });
+});
+
+afterEach(async () => {
+  // Unmount BEFORE closing the wire: a still-mounted surface keeps polling into
+  // the closing server and server.close() livelocks to the hook timeout.
+  cleanup();
+  await wire.close();
+});
+
+/** The host brand, set once on the provider. */
+const PROVIDER_THEME: Partial<VendoTheme> = {
+  colors: {
+    background: "#FBFBFA",
+    surface: "#FFFFFF",
+    text: "#111111",
+    muted: "#908C85",
+    accent: "#0f5132",
+    accentText: "#FFFFFF",
+    danger: "#B42318",
+    border: "#ecebe8",
+  },
+  radius: { small: "6px", medium: "14px", large: "22px" },
+  density: "comfortable",
+};
+
+/** One surface differing from it: a dark panel, tighter. Radius is deliberately
+ *  ABSENT so the merge has something of the provider's to preserve. */
+const SURFACE_THEME: Partial<VendoTheme> = {
+  colors: {
+    background: "#14151a",
+    surface: "#1d1f27",
+    text: "#f4f4f6",
+    muted: "#9a9aa6",
+    accent: "#8b5cf6",
+    accentText: "#0b0b0f",
+    danger: "#f97066",
+    border: "#2c2e38",
+  },
+  density: "compact",
+};
+
+/** Read a custom property off the element's own inline style — what the
+ *  cascade below it actually resolves against. */
+const cssVar = (el: Element, name: string): string =>
+  (el as HTMLElement).style.getPropertyValue(name);
+
+/** The nearest chrome boundary in the rendered container. */
+function boundary(container: HTMLElement): HTMLElement {
+  const root = container.querySelector<HTMLElement>(".vendo-root");
+  expect(root, "expected a .vendo-root chrome boundary").not.toBeNull();
+  return root!;
+}
+
+/** Every assertion the merge owes: the surface's groups win, the provider's
+ *  untouched groups survive, and nothing silently falls back to the defaults. */
+function expectMerged(el: Element): void {
+  expect(cssVar(el, "--vendo-color-accent")).toBe("#8b5cf6");
+  expect(cssVar(el, "--vendo-color-background")).toBe("#14151a");
+  expect(cssVar(el, "--vendo-density")).toBe("compact");
+  // The group the surface never mentioned is still the PROVIDER's, not the
+  // default — this is a merge over the provider, not a replacement of it.
+  expect(cssVar(el, "--vendo-radius-medium")).toBe("14px");
+  expect(cssVar(el, "--vendo-radius-medium")).not.toBe(defaultVendoTheme.radius.medium);
+}
+
+function expectProvider(el: Element): void {
+  expect(cssVar(el, "--vendo-color-accent")).toBe("#0f5132");
+  expect(cssVar(el, "--vendo-density")).toBe("comfortable");
+  expect(cssVar(el, "--vendo-radius-medium")).toBe("14px");
+}
+
+const withProvider = (children: React.ReactNode) => render(
+  <VendoProvider client={client} theme={PROVIDER_THEME}>{children}</VendoProvider>,
+);
+
+describe("the surface theme merges over the provider's", () => {
+  it("lands the merged tokens on the surface's own chrome boundary", async () => {
+    const { container } = withProvider(<VendoSlot id="hero" theme={SURFACE_THEME} />);
+    await screen.findByText("This space builds itself");
+    expectMerged(boundary(container));
+  });
+
+  it("leaves a surface with no theme of its own on the provider's", async () => {
+    const { container } = withProvider(<VendoSlot id="hero" />);
+    await screen.findByText("This space builds itself");
+    expectProvider(boundary(container));
+  });
+
+  /** The honest limit of the prop on a slot: a slot whose HOST markup is
+   *  showing renders it untouched, with no wrapper at all (hosts inline slots
+   *  anywhere, so it may not introduce a div). There is no Vendo chrome on
+   *  screen, so there is nothing for a theme to style. */
+  it("adds no boundary — and so no tokens — to a slot showing the host's own markup", async () => {
+    const { container } = withProvider(<VendoSlot id="hero" theme={SURFACE_THEME}><span>Host hero</span></VendoSlot>);
+    await screen.findByText("Host hero");
+    expect(container.querySelector(".vendo-root")).toBeNull();
+  });
+
+  it("merges over the DEFAULTS when there is no provider at all", () => {
+    const { container } = render(<VendoTrigger prompt="Pay this" theme={{ density: "compact" }} />);
+    const root = boundary(container);
+    expect(cssVar(root, "--vendo-density")).toBe("compact");
+    // Everything unsaid is the default brand, not blank.
+    expect(cssVar(root, "--vendo-color-accent")).toBe(defaultVendoTheme.colors.accent);
+  });
+
+  it("stamps the merged density and motion attributes the sheet keys off", async () => {
+    const { container } = withProvider(
+      <VendoSlot id="hero" theme={{ ...SURFACE_THEME, motion: "reduced" }} />,
+    );
+    await screen.findByText("This space builds itself");
+    const root = boundary(container);
+    expect(root.dataset.vendoDensity).toBe("compact");
+    expect(root.dataset.vendoMotion).toBe("reduced");
+  });
+});
+
+describe("every chrome surface takes one", () => {
+  it("VendoSlot", async () => {
+    const { container } = withProvider(<VendoSlot id="hero" theme={SURFACE_THEME} />);
+    await screen.findByText("This space builds itself");
+    expectMerged(boundary(container));
+  });
+
+  it("VendoTrigger", () => {
+    const { container } = withProvider(<VendoTrigger prompt="Pay this" theme={SURFACE_THEME} />);
+    expectMerged(boundary(container));
+  });
+
+  it("VendoOverlay — the launcher boundary AND the panel it portals to <body>", async () => {
+    const { container } = withProvider(<VendoOverlay defaultOpen theme={SURFACE_THEME} />);
+    expectMerged(boundary(container));
+    // The panel escapes the host stacking context entirely, so it hand-rolls
+    // its own boundary. The two halves of one surface must not disagree.
+    const panel = await waitFor(() => {
+      const found = document.querySelector(".fl-overlay-portal");
+      expect(found).not.toBeNull();
+      return found!;
+    });
+    expectMerged(panel);
+  });
+
+  it("VendoAppEmbed", async () => {
+    const { container } = withProvider(
+      <VendoAppEmbed refValue={{ kind: "vendo/app-ref@1", appId: "app_x", title: "Dashboard", status: "building" }} theme={SURFACE_THEME} />,
+    );
+    await screen.findByText("Dashboard");
+    expectMerged(boundary(container));
+  });
+
+  it("VendoApprovalEmbed", async () => {
+    const { container } = withProvider(
+      <VendoApprovalEmbed refValue={{ kind: "vendo/approval-ref@1", approvalId: "apr_x", summary: "Send the report" }} theme={SURFACE_THEME} />,
+    );
+    await screen.findByText("Send the report");
+    expectMerged(boundary(container));
+  });
+
+  it("VendoToolResult — through the embed it dispatches to", async () => {
+    const { container } = withProvider(
+      <VendoToolResult output={{ kind: "vendo/app-ref@1", appId: "app_y", title: "Spending", status: "building" }} theme={SURFACE_THEME} />,
+    );
+    await screen.findByText("Spending");
+    expectMerged(boundary(container));
+  });
+
+  it("VendoToolResult — on the automation branch too, not just the embeds", async () => {
+    const { container } = withProvider(
+      <VendoToolResult output={{ kind: "vendo/automation-ref@1", automationId: "aut_1", summary: "Every Monday, email the report", armed: true }} theme={SURFACE_THEME} />,
+    );
+    await screen.findByText("Every Monday, email the report");
+    expectMerged(boundary(container));
+  });
+});
+
+/** A pinned generated view that parks its press on the guard — the real path
+ *  from a press inside a slot to the approval modal on <body>. */
+const PARKING_PIN = {
+  formatVersion: "vendo-genui/v2",
+  root: "root",
+  nodes: [{ id: "root", component: "Button", props: { label: "Pay the bill", onClick: { $action: "host_pay" } } }],
+} as UIPayload;
+
+const parkOnPress = async (): Promise<ToolOutcome> =>
+  ({ status: "pending-approval", approvalId: "apr_1" as ApprovalId }) as ToolOutcome;
+
+describe("surfaces that portal out of the boundary still wear its theme", () => {
+  it("the approval modal a themed slot's press parks carries the SLOT's theme", async () => {
+    withProvider(
+      <VendoSlot
+        id="hero"
+        theme={SURFACE_THEME}
+        pin={{ payload: PARKING_PIN, onAction: parkOnPress as (req: { nodeId: string; action: string; payload?: Json }) => Promise<ToolOutcome> }}
+      />,
+    );
+    fireEvent.click(await screen.findByRole("button", { name: "Pay the bill" }));
+    // The modal portals to <body>, so no DOM cascade reaches it — only the
+    // React context the slot's boundary publishes.
+    const layer = await waitFor(() => {
+      const found = document.querySelector(".fl-apmodal-layer");
+      expect(found).not.toBeNull();
+      return found!;
+    });
+    expectMerged(layer);
+  });
+
+  it("the same modal falls back to the provider theme when the slot set none", async () => {
+    withProvider(
+      <VendoSlot
+        id="hero"
+        pin={{ payload: PARKING_PIN, onAction: parkOnPress as (req: { nodeId: string; action: string; payload?: Json }) => Promise<ToolOutcome> }}
+      />,
+    );
+    fireEvent.click(await screen.findByRole("button", { name: "Pay the bill" }));
+    const layer = await waitFor(() => {
+      const found = document.querySelector(".fl-apmodal-layer");
+      expect(found).not.toBeNull();
+      return found!;
+    });
+    expectProvider(layer);
+  });
+
+  /** `VendoToasts` is normally mounted bare at the app root, so its usual
+   *  answer is the provider theme. Inside a themed chrome boundary it takes
+   *  that boundary's — the same context read the approval modal makes.
+   *  `ChromeRoot` IS that boundary (it is what every surface's `theme` prop
+   *  feeds), so this composes the real seam rather than stubbing one. */
+  it("the toast stack wears the enclosing surface's theme, and the provider's when mounted bare", async () => {
+    withProvider(
+      <ChromeRoot theme={SURFACE_THEME}>
+        <VendoToasts />
+      </ChromeRoot>,
+    );
+    vendoToast({ text: "Report ready" });
+    const inside = await waitFor(() => {
+      const found = document.querySelector("[data-vendo-portal=\"toasts\"]");
+      expect(found).not.toBeNull();
+      return found!;
+    });
+    // A real toast is on screen — not an empty stack that would carry tokens
+    // without ever showing them to anyone.
+    expect(inside.textContent).toContain("Report ready");
+    expectMerged(inside);
+    cleanup();
+
+    withProvider(<VendoToasts />);
+    vendoToast({ text: "Report ready" });
+    const bare = await waitFor(() => {
+      const found = document.querySelector("[data-vendo-portal=\"toasts\"]");
+      expect(found).not.toBeNull();
+      return found!;
+    });
+    expectProvider(bare);
+  });
+});
+
+describe("FRAME ONLY — a generated view keeps the provider theme", () => {
+  /**
+   * The honest answer to "does a natively rendered pin inherit the slot's local
+   * tokens by cascade?" It does NOT. The tree surface is its own theme boundary
+   * (renderer.tsx's TreeView) and restates the PROVIDER tokens on
+   * `[data-vendo-surface]`, which shadows the slot's boundary for everything
+   * inside it. So a pin and an iframe-served app agree: the frame is local, the
+   * view is the provider's — the same theme that ships over `?vendoTheme=`.
+   *
+   * This is the behavior, not an accident of ordering: the assertion below is
+   * what would go red if a future change let the local tokens leak into a
+   * generated view.
+   */
+  it("a pin rendered natively in a themed slot paints in the PROVIDER theme", async () => {
+    const { container } = withProvider(
+      <VendoSlot id="hero" theme={SURFACE_THEME} pin={{ payload: {
+        formatVersion: "vendo-genui/v2",
+        root: "root",
+        nodes: [{ id: "root", component: "Text", props: { text: "Pinned revenue card" } }],
+      } as UIPayload }} />,
+    );
+    await screen.findByText("Pinned revenue card");
+
+    // The frame around it took the local theme…
+    expectMerged(boundary(container));
+
+    // …and the generated view inside it did not.
+    const surface = container.querySelector("[data-vendo-surface]");
+    expect(surface, "expected the tree surface's own theme boundary").not.toBeNull();
+    expect(cssVar(surface!, "--vendo-color-accent")).toBe("#0f5132");
+    expect(cssVar(surface!, "--vendo-color-background")).toBe("#FBFBFA");
+    expect(cssVar(surface!, "--vendo-density")).toBe("comfortable");
+  });
+});

--- a/packages/ui/test/embed-contract.test.ts
+++ b/packages/ui/test/embed-contract.test.ts
@@ -32,13 +32,37 @@ describe("embed prop contracts", () => {
 
   /** The provider went optional by DEFAULTING, not by growing a knob: these
    *  exhaustive (and excess-checked) key maps fail to compile the day a
-   *  client/baseUrl/theme prop appears on any of the three. */
+   *  client/baseUrl prop appears on any of the three.
+   *
+   *  `theme` is the one deliberate addition (approved 2026-08-23, per-surface
+   *  theme overrides). It is not a second way to reach the wire — it is the
+   *  chrome's own tokens, optional, and it never widens what an embed can talk
+   *  to. Everything else on this list stays banned. */
   it("takes no client or config prop of its own, bare or not", () => {
-    const appKeys: Record<keyof VendoAppEmbedProps, true> = { refValue: true };
-    const approvalKeys: Record<keyof VendoApprovalEmbedProps, true> = { refValue: true };
-    const resultKeys: Record<keyof VendoToolResultProps, true> = { output: true };
+    const appKeys: Record<keyof VendoAppEmbedProps, true> = { refValue: true, theme: true };
+    const approvalKeys: Record<keyof VendoApprovalEmbedProps, true> = { refValue: true, theme: true };
+    const resultKeys: Record<keyof VendoToolResultProps, true> = { output: true, theme: true };
     expect([Object.keys(appKeys), Object.keys(approvalKeys), Object.keys(resultKeys)])
-      .toEqual([["refValue"], ["refValue"], ["output"]]);
+      .toEqual([["refValue", "theme"], ["refValue", "theme"], ["output", "theme"]]);
+  });
+
+  /** The prop stays OPTIONAL: an embed still works with nothing but its ref. */
+  it("theme is optional on all three", () => {
+    const app: VendoAppEmbedProps = {
+      refValue: { kind: "vendo/app-ref@1", appId: "app_x", title: "Dashboard", status: "building" },
+    };
+    const approval: VendoApprovalEmbedProps = {
+      refValue: { kind: "vendo/approval-ref@1", approvalId: "apr_x", summary: "Send the report" },
+    };
+    const result: VendoToolResultProps = { output: null };
+    expect([app.theme, approval.theme, result.theme]).toEqual([undefined, undefined, undefined]);
+  });
+
+  /** A PARTIAL is enough — the same `Partial<VendoTheme>` the provider takes,
+   *  so a surface changing only the density says only that. */
+  it("theme takes a partial theme, group by group", () => {
+    const props: VendoToolResultProps = { output: null, theme: { density: "compact" } };
+    expect(props.theme?.density).toBe("compact");
   });
 
   it("VendoToolResult takes any vendo_* tool output and dispatches on the envelope parse", () => {

--- a/packages/vendo/src/react.tsx
+++ b/packages/vendo/src/react.tsx
@@ -95,6 +95,7 @@ export {
   defaultVendoTheme,
   resolveTheme,
   themeCssVariables,
+  type VendoTheme,
   // wire-types.ts
   type OpenSurface,
   type SeedDrift,


### PR DESCRIPTION
## What

Six chrome surfaces each take an optional `theme?: Partial<VendoTheme>`:
`VendoOverlay`, `VendoSlot`, `VendoTrigger`, `VendoAppEmbed`,
`VendoApprovalEmbed`, `VendoToolResult`.

```tsx
<VendoSlot id="net-worth-card" />
<VendoSlot id="ops-console" theme={{ density: "compact" }} />
<VendoOverlay theme={darkPanel} />
```

## Semantics

- The surface's partial theme merges **group by group over the provider's
  resolved theme** — the same `resolveTheme` merge `VendoProvider` applies over
  `defaultVendoTheme`. Groups the surface leaves out stay the host brand.
- With no provider above, the merge runs over `defaultVendoTheme`, so a bare
  surface still works.
- It lands at the surface's chrome boundary (`ChromeRoot`/`ChromeBoundary`),
  which already owned `themeCssVariables`. A **nested** `ChromeRoot` used to
  pass straight through; it now still does, unless it carries a theme of its own
  — otherwise the prop would silently do nothing inside another surface.
- Unset changes nothing: `resolveTheme` returns the base object identity, so the
  boundary publishes the same provider theme it always did.

## Portals

`ChromeRootContext` now carries the boundary's **resolved theme** rather than a
presence boolean. That is the seam that lets a surface which portals out of its
own DOM subtree still wear the theme of the surface that spawned it — no cascade
can reach `document.body`, but React context can.

Threaded through `useChromeTheme()`, which falls back to the provider theme when
no surface set one:

| Portal | Was | Now |
| --- | --- | --- |
| approval modal (`useApprovalModal`) | `useVendoTheme()` | `useChromeTheme()` |
| `MorphToast` (theme arrives as a prop) | `useVendoProvider().theme` in `thread/parts.tsx` | `useChromeTheme()` |
| `VendoToasts` | `useVendoProvider().theme` | `useChromeTheme()` |

## Frame only — the constraint

**A local theme styles Vendo's chrome. A generated view keeps the PROVIDER
theme.** The `?vendoTheme=` app-transport seam is untouched.

### pin vs iframe: they agree, and it is not an accident

The open question was whether a `pin` — which renders natively in the slot's
light DOM — would inherit the local CSS variables by cascade while an
iframe-served app could not. **It does not, and the two stay consistent.**

`TreeView` is its own theme boundary: `renderer.tsx:858` reads
`useVendoThemeOrDefault()` (the provider theme) and re-emits the full variable
set on `[data-vendo-surface]` at `renderer.tsx:1054`, which shadows the slot's
boundary for everything inside it. So a pin and an iframe app are themed the
same way — the provider's. `surface-theme.test.tsx` pins this explicitly: the
frame asserts the merged local tokens, the view inside asserts the provider's.

The JSDoc on all six props states this, and the docs page carries it as a
`<Warning>`.

One further honest limit, also documented: a `VendoSlot` showing the host's own
markup renders it with **no wrapper at all**, so there is no chrome on screen
for a theme to style.

## Tests

New `packages/ui/test/chrome/surface-theme.test.tsx` (16 cases), all reading the
CSS variables that actually land on the rendered DOM — never a prop echo:

- merge over provider (local groups win, untouched provider groups survive, and
  are distinguishable from the defaults)
- no local theme → provider theme; no provider → defaults
- all six surfaces, including the overlay's `<body>` panel and both
  `VendoToolResult` dispatch branches
- portal inheritance: an approval modal parked by a real press inside a themed
  slot carries the slot's theme — and the provider's when the slot set none
- the toast stack inside a themed boundary vs mounted bare
- **pin vs iframe**: the frame takes the local theme, the generated view does not

**Teeth proven:** with the merge disabled in `ChromeBoundary`, 13 of the 16 go
red; restored, 16/16 green.

`test/embed-contract.test.ts` is extended, not weakened — its exhaustive key maps
now include `theme`, with the comment updated to say that `client`/`baseUrl` stay
banned and `theme` is the one approved optional addition.

## Browser proof

A throwaway Playwright script (not committed) against a **fresh production
harness build** — one page, one provider on the light Maple brand, two identical
slots and an open overlay:

| | accent | background | painted |
| --- | --- | --- | --- |
| slot, no local theme | `#1b1c22` | `#f3ede2` | `rgb(243, 237, 226)` |
| slot, local dark theme | `#38bdf8` | `#111827` | `rgb(17, 24, 39)` |
| overlay panel (portaled to `<body>`) | `#38bdf8` | `#111827` | `rgb(17, 24, 39)` |

Computed styles, not declared ones. Every derived token followed — skeleton
bones, chip fills, border, CTA text colour — and the panel proves the portal
threading end to end.

## Also

- `VendoTheme` was not nameable from `@vendoai/ui`; it now is, and
  `packages/vendo/src/react.tsx` keeps export parity.
- Changeset: minor for `@vendoai/ui` + `@vendoai/vendo` (0.41.0 → 0.42.0).
- Docs: `docs-site/customize/theming.mdx` gains "One surface, a different theme".

## Deliberately not touched

`turn-citations.tsx` and `approval-sheet.tsx` also portal out of a boundary and
still read the provider theme. Neither is one of the named surfaces or their
portals, so widening was left out of this PR rather than smuggled in.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-surface theme overrides to chrome surfaces and propagates those themes through portals. Previously chrome always used the provider theme; now each surface can merge a partial theme over the provider, while generated views still keep the provider theme.

- Six surfaces accept theme?: Partial<VendoTheme> and merge it group-by-group over the provider (or defaults): VendoOverlay, VendoSlot, VendoTrigger, VendoAppEmbed, VendoApprovalEmbed, VendoToolResult. Slots rendering host markup have no chrome, so theme has no effect there.
- Portaled UI inherits the spawning surface’s theme via React context: the approval modal, MorphToast, and VendoToasts now read useChromeTheme().
- ChromeRootContext now carries the resolved theme; ChromeRoot passes through when nested unless the inner surface provides a theme. New useSurfaceTheme() merges overrides.
- Frame-only: generated views (iframe or native pin) keep the provider theme; only the chrome frame takes the local override.
- VendoTheme is exported from `@vendoai/ui` and `@vendoai/vendo/react`. Embed prop contracts add optional theme without widening config.

Rollout: No migration required. Minor version bumps in `@vendoai/ui` and `@vendoai/vendo`.

<sup>Written for commit e8697878ba506ff9c754c89727c99e22b700d9fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

