### PR TITLE
fix(vendo): the escalate door names what the room lacks, not "real code"

### DIFF
--- a/.changeset/escalate-names-what-the-room-lacks.md
+++ b/.changeset/escalate-names-what-the-room-lacks.md
@@ -1,0 +1,16 @@
+---
+"@vendoai/vendo": minor
+---
+
+The escalate door now names what the room actually lacks, instead of calling for
+"real code".
+
+A screen IS real code — logic, state, full JS — so "this needs code" was never a
+reason to leave, and a writer who read that bullet literally escalated asks it
+could have assembled. The bullet now gives the three real criteria: a package to
+install, a surface this product's components and the Kit cannot express, and
+computation heavier than a screen's render budget.
+
+It also says what escalating can never buy. A build cannot run its own server,
+work while nobody is watching, or reach the internet — an ask that needs those
+gets an honest no rather than a door out that would end in a failed receipt.

--- a/packages/vendo/src/screen-agent.ts
+++ b/packages/vendo/src/screen-agent.ts
@@ -716,14 +716,18 @@ const surfaceNote = (viewport: ScreenInput["viewport"]): string => {
 const doorOut = (input: ScreenInput): string => {
   if (input.canBuild !== true) return "";
   return `
-- **\`${ESCALATE_TOOL}\`** is the one door out. Writing one screen out of this
-  product's components is all you can do here; an ask that needs real code, its
-  own server, a package to install, or a surface these components cannot express
-  goes through it instead.
+- **\`${ESCALATE_TOOL}\`** is the one door out. A screen is already real code —
+  logic, state, full JS — so "this needs code" is never the reason. Escalate when
+  the ask needs what this room does not have:
+  - a package to install — maps, rich editors, 3D, PDF: anything imported;
+  - a surface this product's components and the Kit cannot express;
+  - heavier computation than a screen's render budget allows.
   - It builds nothing by itself. It ASKS the person whether to have this built
     for real, and their yes — whenever it comes — is what starts it.
-  - A view you could assemble does not keep an ask here: if part of it needs real
-    code, escalate the WHOLE ask.
+  - A build cannot run its own server, work while nobody is watching, or reach
+    the internet. An ask that needs those gets an honest no, not an escalation.
+  - A view you could assemble does not keep an ask here: if part of it needs a
+    package, escalate the WHOLE ask.
   - The builder gets the person's own words, so all you write is one plain
     sentence saying what assembly cannot do.`;
 };


### PR DESCRIPTION
A screen IS real code — logic, state, full JS — so the escalate bullet telling the
writer to leave when an ask "needs real code" described nothing it could act on,
and read as a licence to escalate work assembly could have done.

The bullet now names the three things this room genuinely does not have:

- a package to install — maps, rich editors, 3D, PDF: anything imported;
- a surface this product's components and the Kit cannot express;
- computation heavier than a screen's render budget allows.

It also draws the far edge, which was missing: a build cannot run its own server,
work while nobody is watching, or reach the internet. Those asks get an honest no
rather than a door out that would end in a failed receipt.

Prompt text only — `doorOut` in `packages/vendo/src/screen-agent.ts`. Nothing else
changed.

## Note on tests

No test pins this block, in either wording. The only escalate-prompt assertions in
the suite are the negative ones (`canBuild: false` → no `escalate` hand, no mention
in the environment note), and they are untouched and green. Reverting the source
change leaves the same three suites green, which is the proof there is nothing to
update — and equally that the block is unguarded. Adding a pinning test was outside
this change's scope; flagging it rather than doing it.

## Gate

- `npx vitest run --maxWorkers=2 --minWorkers=1 tests/screen-agent.test.ts tests/screen-escalate-consent.seam.test.ts tests/screen-design-brief.test.ts` — 49 passed
- `turbo run typecheck --filter=@vendoai/vendo` — green
- `eslint --config eslint.blocking.config.mjs packages/vendo/src/screen-agent.ts`, `dependency-guard`, `portability-gate` — green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrites the escalate door prompt: instead of “escalate when it needs real code” (old), it now names concrete gaps and hard limits (new) to prevent unnecessary escalations and to give an explicit no when servers, background work, or internet access are required.

- Copy-only change in doorOut (packages/vendo/src/screen-agent.ts); no logic, API, or runtime behavior changes.
- Tests remain green; none pin this text.
- Releases as a minor update to `@vendoai/vendo`; no migration required.

<sup>Written for commit f8416a4531fee65e2253f4e87c373ff3e6a940a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

