### PR TITLE
fix(core,apps,harnesses,vendo): an offered build stops answering as a success, so its card reaches the thread and outlives the turn

### DIFF
--- a/.changeset/build-consent-pending-approval.md
+++ b/.changeset/build-consent-pending-approval.md
@@ -1,0 +1,30 @@
+---
+"@vendoai/core": minor
+"@vendoai/apps": minor
+"@vendoai/harnesses": minor
+"@vendoai/vendo": minor
+---
+
+An escalated build asks on the standard consent protocol instead of answering
+as a success.
+
+`vendo_make` used to return a `status: "ok"` receipt reading
+`"awaiting-consent"` when the screen agent escalated to the builder, so the
+parked approval was invisible to everything that routes on the outcome: no
+in-thread approval card, and an outside agent over MCP was handed plain success
+for work nobody had authorized. It now returns the ordinary
+`pending-approval` outcome — which is what publishes the `data-vendo-approval`
+part the thread renders the card from, and what the MCP door maps to its
+approval-ref result.
+
+`ToolOutcome`'s `pending-approval` gains two optional fields for the tool that
+parks an ask of its OWN: `approval` (`{ id, question, notes }` — the ask in
+words, for a surface that renders no card) and `say` (the assistant's sentence
+meanwhile). Both are optional and additive; every shipped producer and reader
+is untouched.
+
+Such a card also now SURVIVES the turn. A parked call is swept denied at turn
+end so a live-but-dead card cannot accrete in the queue — which, for a build,
+tombstoned the app the moment the turn that asked for it ended.
+
+`MakeReceipt.status` drops `"awaiting-consent"`; nothing produces it any more.

--- a/.changeset/build-consent-pending-approval.md
+++ b/.changeset/build-consent-pending-approval.md
@@ -2,6 +2,7 @@
 "@vendoai/core": minor
 "@vendoai/apps": minor
 "@vendoai/harnesses": minor
+"@vendoai/ui": minor
 "@vendoai/vendo": minor
 ---
 
@@ -17,11 +18,22 @@ for work nobody had authorized. It now returns the ordinary
 part the thread renders the card from, and what the MCP door maps to its
 approval-ref result.
 
-`ToolOutcome`'s `pending-approval` gains two optional fields for the tool that
-parks an ask of its OWN: `approval` (`{ id, question, notes }` — the ask in
+`ToolOutcome`'s `pending-approval` gains three optional fields for the tool that
+parks an ask of its OWN: `descriptor` (the ask's own — what a CARD derives its
+words from), `approval` (`{ id, question, notes }` — the same ask already in
 words, for a surface that renders no card) and `say` (the assistant's sentence
-meanwhile). Both are optional and additive; every shipped producer and reader
-is untouched.
+meanwhile). All three are optional and additive; every shipped producer and
+reader is untouched.
+
+The descriptor rides the `data-vendo-approval` part, so the in-thread card is
+graded and worded off the BUILD. Graded off the calling tool it read
+`vendo_make`'s "read", and told a person that spending a build machine reads
+their data. And because a standing ask has no parked native call to render
+from — nor may it have one, since the runtime abandons every still-parked ask
+at the next turn — the thread now paints the shipped `ApprovalCard` from that
+part directly, deciding over the wire like the queue and the toast, with no
+`remember` disclosure. Before this the transcript showed only the calling
+tool's beat, "wasn't allowed", for a question nobody had been asked yet.
 
 Such a card also now SURVIVES the turn. A parked call is swept denied at turn
 end so a live-but-dead card cannot accrete in the queue — which, for a build,

--- a/.changeset/build-consent-pending-approval.md
+++ b/.changeset/build-consent-pending-approval.md
@@ -39,4 +39,13 @@ Such a card also now SURVIVES the turn. A parked call is swept denied at turn
 end so a live-but-dead card cannot accrete in the queue — which, for a build,
 tombstoned the app the moment the turn that asked for it ended.
 
+An answered card SETTLES, and the assistant stops talking over it. In-thread
+consent cards resolve into the settled record on decide — including a decide the
+wire says was already answered (or swept), which used to leave the buttons live
+under an error on a closed question. And `say` is now the refusal the harness
+hands the model for a tool that parked its own ask, so the model relays the one
+sentence the door wrote ("I've asked for your go-ahead — the card above has the
+details.") instead of narrating its own paragraphs under a card that is already
+asking.
+
 `MakeReceipt.status` drops `"awaiting-consent"`; nothing produces it any more.

--- a/packages/apps/src/contract/make-receipt.ts
+++ b/packages/apps/src/contract/make-receipt.ts
@@ -29,13 +29,14 @@
  *    agent over MCP — read plain success off a half-built app (2026-08-11). Not
  *    `"failed"`, which means nothing is painted and sends the agent to rebuild:
  *    this view is real, reopenable, and worth keeping.
- * 5. **`"awaiting-consent"` is the honest answer for a BUILD.** A build spends a
- *    machine, and FINAL SPEC v1's law is that no machine is spent without the
- *    person's explicit yes — so the tool raises the standing approval card and
- *    the turn ENDS, having spent nothing. Not `"building"`, which would have the
- *    agent narrate work nobody has authorized yet. Cost governance stays host
- *    config: this is a consent card, not a price quote, and `say` carries no
- *    estimate.
+ * 5. **A BUILD never gets a receipt at all.** A build spends a machine, and FINAL
+ *    SPEC v1's law is that no machine is spent without the person's explicit yes
+ *    — so the tool parks the ask and answers with the standard `pending-approval`
+ *    outcome, which is what every consent surface already routes on. There was an
+ *    `"awaiting-consent"` status here, and it was a receipt saying `status: "ok"`:
+ *    invisible to the card, to the MCP door and to every other reader that
+ *    branches on the outcome. Not `"building"` either, which would have the agent
+ *    narrate work nobody has authorized yet.
  */
 import { z } from "zod";
 import { appIdSchema, type AppId } from "@vendoai/core";
@@ -45,7 +46,7 @@ export interface MakeReceipt {
   id: AppId;
   /** The app's name, in human words — never a slug or an identifier. */
   title: string;
-  status: "ready" | "partial" | "building" | "awaiting-consent" | "failed";
+  status: "ready" | "partial" | "building" | "failed";
   /** Speakable as it stands, consumer voice — the builder's own summary where
    *  there was one to relay. */
   say: string;
@@ -55,6 +56,6 @@ export interface MakeReceipt {
 export const makeReceiptSchema = z.object({
   id: appIdSchema,
   title: z.string().min(1),
-  status: z.enum(["ready", "partial", "building", "awaiting-consent", "failed"]),
+  status: z.enum(["ready", "partial", "building", "failed"]),
   say: z.string().min(1),
 }).passthrough() satisfies z.ZodType<MakeReceipt>;

--- a/packages/apps/src/server/doors/build-door.ts
+++ b/packages/apps/src/server/doors/build-door.ts
@@ -58,7 +58,11 @@ export const BUILD_CONSENT_ASK: Omit<PendingApproval, "id"> = {
   notes: [BUILD_DESCRIPTION],
 };
 
-const buildDescriptor = (): ToolDescriptor => ({
+/** THE authored ask, and the source both surfaces read: the CARD derives its
+ *  words from this descriptor (`consentAsk` off the `data-vendo-approval` part's
+ *  copy of it), and {@link BUILD_CONSENT_ASK} above is the same ask already in
+ *  words for the surfaces that render no card. One author, two renderings. */
+export const buildDescriptor = (): ToolDescriptor => ({
   name: BUILD_TOOL,
   title: BUILD_TITLE,
   description: BUILD_DESCRIPTION,

--- a/packages/apps/src/server/doors/build-door.ts
+++ b/packages/apps/src/server/doors/build-door.ts
@@ -17,6 +17,7 @@ import {
   type AppBundle,
   type AppId,
   type ApprovalId,
+  type PendingApproval,
   type RunContext,
   type ToolCall,
   type ToolDescriptor,
@@ -42,13 +43,25 @@ import type { AppsRuntime } from "../runtime/types.js";
  * on it, so the harness's 90-second approval wait is not in this path at all.
  */
 const BUILD_TOOL = VENDO_APP_BUILD_TOOL;
+// §3 consumer voice — the shared table, like every other Vendo descriptor.
+// Without it the card asked the person to authorize "Vendo app build".
+const BUILD_TITLE = VENDO_TOOL_TITLES[BUILD_TOOL]!;
+const BUILD_DESCRIPTION = "Build this app for real: a sandbox installs the packages it needs, writes and tests the code,"
+  + " and the result is sealed. It spends a build machine, so it needs the person's yes.";
+
+/** This ask in words, for the surfaces that render no card. `consentAsk`'s own
+ *  ladder (ui/chrome/build-beat.tsx) read off the descriptor below — its title as
+ *  the question, its authored sentence as the note — so what an outside caller is
+ *  handed and what the person in the thread is shown come from one source. */
+export const BUILD_CONSENT_ASK: Omit<PendingApproval, "id"> = {
+  question: `${BUILD_TITLE}?`,
+  notes: [BUILD_DESCRIPTION],
+};
+
 const buildDescriptor = (): ToolDescriptor => ({
   name: BUILD_TOOL,
-  // §3 consumer voice — the shared table, like every other Vendo descriptor.
-  // Without it the card asked the person to authorize "Vendo app build".
-  title: VENDO_TOOL_TITLES[BUILD_TOOL],
-  description: "Build this app for real: a sandbox installs the packages it needs, writes and tests the code,"
-    + " and the result is sealed. It spends a build machine, so it needs the person's yes.",
+  title: BUILD_TITLE,
+  description: BUILD_DESCRIPTION,
   inputSchema: {
     type: "object",
     properties: { appId: { type: "string" }, prompt: { type: "string" } },

--- a/packages/apps/src/server/doors/build-messages.ts
+++ b/packages/apps/src/server/doors/build-messages.ts
@@ -35,9 +35,14 @@ export const NO_MACHINE = "This needs a real build — code running on a server 
  *  screen. FIRST person, unlike the three above: this one is the assistant's
  *  own sentence on the receipt, and it is the only thing the calling agent is
  *  given to say. No estimate and no cost — the card is a consent question, not
- *  a price quote (make-receipt.ts law 5). */
-export const AWAITING_CONSENT = "This one needs a real build, not just a screen — I've asked for your"
-  + " go-ahead, and it starts as soon as you approve.";
+ *  a price quote (make-receipt.ts law 5).
+ *
+ *  ONE SHORT SENTENCE, and it points AT the card. The say is what the agent
+ *  utters verbatim (make-receipt.ts law 2), and a say that explained the
+ *  situation was read as an invitation to explain it further: the model wrote
+ *  paragraphs under a card that was already asking the question. The shape is
+ *  the instruction — there is nothing here left to expand on. */
+export const AWAITING_CONSENT = "I've asked for your go-ahead — the card above has the details.";
 /** The other terminal landing an OFFERED build has: the person answered the
  *  standing card with no. Same third-person voice as NO_MACHINE — a system
  *  notice — and it never mentions a box, because none was opened. */

--- a/packages/apps/src/server/doors/make-tool.ts
+++ b/packages/apps/src/server/doors/make-tool.ts
@@ -30,7 +30,7 @@ import {
 } from "../../contract/index.js";
 import type { AgentToolsDataDependencies } from "./agent-tools.js";
 import { automationCard } from "./automate-tool.js";
-import { BUILD_CONSENT_ASK } from "./build-door.js";
+import { BUILD_CONSENT_ASK, buildDescriptor } from "./build-door.js";
 import { AWAITING_CONSENT, NO_ASSEMBLER, NOTHING_RENDERABLE, NO_MACHINE } from "./build-messages.js";
 import { input, optionalString, resolveAppRef } from "./tool-args.js";
 import type { AppsRuntime, EditResult } from "../runtime/types.js";
@@ -234,12 +234,16 @@ const makeNewApp = async (
   // `status: "ok"` was invisible to everything downstream that routes on the
   // status — the in-thread approval card is published off this outcome
   // (harnesses' `guardedCall`), and an outside caller reads the ask off it. The
-  // words ride along because nothing else here can say them: `approval` is what
-  // a surface with no card renders, and `say` is the assistant's own sentence.
+  // words ride along because nothing else here can say them: `descriptor` is
+  // what a CARD derives its words from, `approval` is the same ask already in
+  // words for a surface that renders none, and `say` is the assistant's own
+  // sentence. Without the descriptor the card graded this ask off `vendo_make`
+  // — a read — and told the person a build "reads your data".
   return {
     status: "pending-approval",
     approvalId: proposed.approvalId,
     approval: { id: proposed.approvalId, ...BUILD_CONSENT_ASK },
+    descriptor: buildDescriptor(),
     say: AWAITING_CONSENT,
   };
 };

--- a/packages/apps/src/server/doors/make-tool.ts
+++ b/packages/apps/src/server/doors/make-tool.ts
@@ -30,6 +30,7 @@ import {
 } from "../../contract/index.js";
 import type { AgentToolsDataDependencies } from "./agent-tools.js";
 import { automationCard } from "./automate-tool.js";
+import { BUILD_CONSENT_ASK } from "./build-door.js";
 import { AWAITING_CONSENT, NO_ASSEMBLER, NOTHING_RENDERABLE, NO_MACHINE } from "./build-messages.js";
 import { input, optionalString, resolveAppRef } from "./tool-args.js";
 import type { AppsRuntime, EditResult } from "../runtime/types.js";
@@ -229,7 +230,18 @@ const makeNewApp = async (
     return await failUnbuilt(title, unbuiltSay(proposed.declined));
   }
   await remember(appId);
-  return receipt({ id: appId, title, status: "awaiting-consent", say: AWAITING_CONSENT });
+  // THE STANDARD PROTOCOL, and not a receipt: a parked ask that answered
+  // `status: "ok"` was invisible to everything downstream that routes on the
+  // status — the in-thread approval card is published off this outcome
+  // (harnesses' `guardedCall`), and an outside caller reads the ask off it. The
+  // words ride along because nothing else here can say them: `approval` is what
+  // a surface with no card renders, and `say` is the assistant's own sentence.
+  return {
+    status: "pending-approval",
+    approvalId: proposed.approvalId,
+    approval: { id: proposed.approvalId, ...BUILD_CONSENT_ASK },
+    say: AWAITING_CONSENT,
+  };
 };
 
 const changeExistingApp = async (

--- a/packages/apps/tests/agent-tools.test.ts
+++ b/packages/apps/tests/agent-tools.test.ts
@@ -735,13 +735,12 @@ describe("vendo_make — the slot a new app lands in", () => {
       args: { request: "match my invoices to payments", slot: "dashboard.hero" },
     }, ctx);
 
-    expect(outcome.status).toBe("ok");
-    const receipt = (outcome as { output: { id: string; status: string } }).output;
-    // S3 — the escalated ask is now OFFERED, not built. The row and the slot
-    // still land at the mint, which is what this test is about.
-    expect(receipt.status).toBe("awaiting-consent");
+    // S3 — the escalated ask is now OFFERED, not built, and it answers on the
+    // standard park. The row and the slot still land at the mint, which is what
+    // this test is about.
+    expect(outcome.status).toBe("pending-approval");
     expect(await runtime.placements({}, ctx)).toEqual([
-      expect.objectContaining({ slot: "dashboard.hero", app: receipt.id }),
+      expect.objectContaining({ slot: "dashboard.hero", app: expect.stringMatching(/^app_/) }),
     ]);
   });
 

--- a/packages/apps/tests/build-consent.test.ts
+++ b/packages/apps/tests/build-consent.test.ts
@@ -14,6 +14,7 @@ import {
   VendoError,
   engineOverAdapter,
   type AppId,
+  type ApprovalId,
   type FilesAdapter,
   type RunContext,
   type ToolRegistry,
@@ -29,7 +30,7 @@ import { APPS_COLLECTION } from "../src/server/persistence/persistence.js";
 import { runMakeTool } from "../src/server/doors/make-tool.js";
 import { readBundleBlob } from "../src/server/persistence/app-source.js";
 import { createApps, type AppsConfig } from "../src/server/index.js";
-import { guardFixture } from "../src/server/testing/guard-fixture.js";
+import { guardFixture, type GuardFixture } from "../src/server/testing/guard-fixture.js";
 import { memoryStore } from "../src/server/testing/memory-store.js";
 import type { AgentToolsDataDependencies } from "../src/server/doors/agent-tools.js";
 import { PARKED_BUILD_COLLECTION } from "@vendoai/core";
@@ -122,25 +123,48 @@ const receiptOf = (outcome: Awaited<ReturnType<typeof runMakeTool>>): { id: stri
   return outcome.output as unknown as { id: string; status: string; say: string };
 };
 
+/** An offered build is a PARK, not a receipt — and the app it is about is named
+ *  on the standing card itself, which is the only place a caller could read it. */
+const parkedOf = (
+  outcome: Awaited<ReturnType<typeof runMakeTool>>,
+  guard: GuardFixture,
+): { approvalId: ApprovalId; appId: AppId } => {
+  if (outcome.status !== "pending-approval") throw new Error(`expected a park, got ${outcome.status}`);
+  const ask = guard.approvals.find((approval) => approval.id === outcome.approvalId);
+  return { approvalId: outcome.approvalId, appId: (ask?.call.args as { appId: AppId }).appId };
+};
+
 describe("propose spends no box", () => {
   it("raises the standing card, parks the build, and claims nothing", async () => {
     const { builder, built } = recordingBuilder();
     const { guard, engine, make, rowOf } = setup({ build: builder });
 
-    const receipt = receiptOf(await make());
+    const outcome = await make();
+    const { approvalId, appId } = parkedOf(outcome, guard);
 
-    expect(receipt.status).toBe("awaiting-consent");
+    // THE PROTOCOL: the same `pending-approval` answer every other parked call
+    // gives, carrying the ask in words for a surface that renders no card.
+    expect(outcome).toMatchObject({
+      status: "pending-approval",
+      approvalId,
+      approval: {
+        id: approvalId,
+        question: "Build this app for real?",
+        notes: [expect.stringContaining("spends a build machine")],
+      },
+      say: expect.stringContaining("go-ahead"),
+    });
     // The whole point: the turn ended with the box untouched.
     expect(built).toEqual([]);
     // One undecided card, and the ask verbatim on it.
     expect(guard.approvals).toHaveLength(1);
-    expect(guard.approvals[0]?.call.args).toMatchObject({ appId: receipt.id, prompt: ASK });
+    expect(guard.approvals[0]?.call.args).toMatchObject({ appId, prompt: ASK });
     // Parked against that card, in the real collection.
-    const parked = await engine.get(PARKED_BUILD_COLLECTION, guard.approvals[0]?.id ?? "");
-    expect(parked?.data).toMatchObject({ appId: receipt.id, prompt: ASK, owner: "user_ada" });
+    const parked = await engine.get(PARKED_BUILD_COLLECTION, approvalId);
+    expect(parked?.data).toMatchObject({ appId, prompt: ASK, owner: "user_ada" });
     // The row says "offered, unanswered" — and never "building".
-    const row = await rowOf(receipt.id);
-    expect(row?.proposal).toMatchObject({ approvalId: guard.approvals[0]?.id, prompt: ASK });
+    const row = await rowOf(appId);
+    expect(row?.proposal).toMatchObject({ approvalId, prompt: ASK });
     expect(row?.building).toBeUndefined();
   });
 });
@@ -151,21 +175,20 @@ describe("the decision alone starts the build", () => {
     const bytes = new TextEncoder().encode("console.log('built')");
     const { builder, built } = recordingBuilder({ kind: "built", files: [{ path: entry, bytes }], entry });
     const { guard, engine, files, make, rowOf } = setup({ build: builder });
-    const receipt = receiptOf(await make());
-    const approvalId = guard.approvals[0]?.id ?? "";
+    const { approvalId, appId } = parkedOf(await make(), guard);
     expect(built).toEqual([]);
 
     // Nothing but the decision. No second tool call, no re-dispatch.
     guard.decide(approvalId, true);
     await new Promise((resolve) => setImmediate(resolve));
 
-    expect(built).toEqual([{ appId: receipt.id, prompt: ASK, why: "this needs a real image library" }]);
-    const row = await rowOf(receipt.id);
+    expect(built).toEqual([{ appId, prompt: ASK, why: "this needs a real image library" }]);
+    const row = await rowOf(appId);
     expect(row?.ui).toBe("bundle");
     expect(row?.bundle).toMatchObject({ bytes: bytes.byteLength });
     // Sealed for real: the entry hash reads back as the bytes the builder made.
     const entryHash = (row?.bundle as { entry: string }).entry;
-    expect(await readBundleBlob(receipt.id as AppId, entryHash, files)).toEqual(bytes);
+    expect(await readBundleBlob(appId, entryHash, files)).toEqual(bytes);
     // Both build-state fields are gone: the app IS built now.
     expect(row?.proposal).toBeUndefined();
     expect(row?.building).toBeUndefined();
@@ -176,14 +199,13 @@ describe("the decision alone starts the build", () => {
   it("denying it spends no box and leaves the honest failure card", async () => {
     const { builder, built } = recordingBuilder();
     const { guard, engine, make, rowOf } = setup({ build: builder });
-    const receipt = receiptOf(await make());
-    const approvalId = guard.approvals[0]?.id ?? "";
+    const { approvalId, appId } = parkedOf(await make(), guard);
 
     guard.decide(approvalId, false);
     await new Promise((resolve) => setImmediate(resolve));
 
     expect(built).toEqual([]);
-    const row = await rowOf(receipt.id);
+    const row = await rowOf(appId);
     expect(row?.proposal).toBeUndefined();
     expect(row?.buildFailed).toMatchObject({ reason: expect.stringContaining("not approved") });
     expect(await engine.get(PARKED_BUILD_COLLECTION, approvalId)).toBeNull();
@@ -238,10 +260,10 @@ describe("a refusal reads the row it is refusing", () => {
   const ran = async (lane: ReturnType<typeof laneThat>) => {
     const composed = setup({ build: lane.builder });
     lane.bind(composed.engine);
-    const receipt = receiptOf(await composed.make());
-    composed.guard.decide(composed.guard.approvals[0]?.id ?? "", true);
+    const { approvalId, appId } = parkedOf(await composed.make(), composed.guard);
+    composed.guard.decide(approvalId, true);
     await new Promise((resolve) => setImmediate(resolve));
-    return await composed.rowOf(receipt.id);
+    return await composed.rowOf(appId);
   };
 
   it("leaves a SEALED app alone when the refusal lands after the seal", async () => {

--- a/packages/apps/tests/make-tool.test.ts
+++ b/packages/apps/tests/make-tool.test.ts
@@ -153,12 +153,25 @@ describe("vendo_make publishes the automation card (#881)", () => {
 });
 
 describe("an escalated ask is OFFERED, never built (S3)", () => {
-  it("ends the turn on awaiting-consent, with nothing spent", async () => {
-    const { call } = makeCall();
-    const { runtime } = runtimeWith(undefined);
-    const receipt = receiptOf(await runMakeTool(runtime, deps, call, ctx));
-    expect(receipt.status).toBe("awaiting-consent");
-    expect(receipt.say).toContain("go-ahead");
+  it("parks the ask on the standard protocol, with nothing spent and nothing armed", async () => {
+    // COMPOUND on purpose: an offered build has no app yet, so the schedule half
+    // has nothing to arm and the automation door must not be asked for one.
+    const { call } = makeCall("build me the invoice board and refresh it every monday");
+    const { runtime, asked } = runtimeWith(undefined);
+
+    // The same answer every other parked call gives, plus the ask in words for a
+    // surface that renders no card.
+    expect(await runMakeTool(runtime, deps, call, ctx)).toMatchObject({
+      status: "pending-approval",
+      approvalId: "apr_build_1",
+      approval: {
+        id: "apr_build_1",
+        question: "Build this app for real?",
+        notes: [expect.stringContaining("spends a build machine")],
+      },
+      say: expect.stringContaining("go-ahead"),
+    });
+    expect(asked).toEqual([]);
   });
 });
 
@@ -166,7 +179,7 @@ describe("the schedule half of a compound ask", () => {
   const COMPOUND = "build me the invoice board and refresh it every monday";
 
   it("reaches the automation door, and says so on the receipt", async () => {
-    const { call, updates } = makeCall(COMPOUND);
+    const { call, updates } = makeCall(COMPOUND, "app_made");
     const { runtime, asked } = runtimeWith(undefined, {
       ok: true,
       document: { format: VENDO_APP_FORMAT, id: "app_made", name: "Invoice nudges" },
@@ -189,12 +202,12 @@ describe("the schedule half of a compound ask", () => {
   });
 
   it("never fails the make when the schedule could not be armed — the app is on screen", async () => {
-    const { call, updates } = makeCall(COMPOUND);
+    const { call, updates } = makeCall(COMPOUND, "app_made");
     const { runtime } = runtimeWith(undefined, { ok: false, issues: ["no valid plan validated"] });
     const outcome = await runMakeTool(runtime, deps, call, ctx);
 
     const receipt = receiptOf(outcome);
-    expect(receipt.status).toBe("awaiting-consent");
+    expect(receipt.status).toBe("ready");
     expect(receipt.say).toContain("I couldn't set up the schedule: no valid plan validated");
     expect(updates.some((update) => update.part.type === "data-vendo-automation")).toBe(false);
   });

--- a/packages/apps/tests/screen-route.test.ts
+++ b/packages/apps/tests/screen-route.test.ts
@@ -187,22 +187,23 @@ describe("an escalation and the build that finishes it share ONE app id", () => 
 
     const outcome = await make(agentTools);
 
-    expect(outcome.status).toBe("ok");
-    const receipt = (outcome as { output: { id: string; status: string } }).output;
+    // S3 — an escalation with somewhere to build is an ASK, not a build, and it
+    // answers on the standard park so every consent surface downstream sees it.
+    if (outcome.status !== "pending-approval") throw new Error(`expected a park, got ${outcome.status}`);
     // The assembler was consulted ONCE, before anything was built — the seam
     // routes, the caller does not, and an escalation carries its `why` into the
     // proposal so the build never runs a second agent over the same ask.
     expect(seen).toHaveLength(1);
-    // …and that consultation, plus the build the person is being asked about,
-    // is at ONE id. This is the assertion that stops a stranded second stream.
-    expect(seen[0]?.appId).toBe(receipt.id);
-    // S3 — an escalation with somewhere to build is an ASK, not a build.
-    expect(receipt.status).toBe("awaiting-consent");
     // THE ASK IS THE BRIEF, and it is held as written — the person's own words
     // rather than a second, unrelated answer to the same ask. It waits on the
-    // proposal because the yes may land long after this turn.
-    const row = await store.records("vendo_apps").get(receipt.id);
-    const proposal = (row?.data as { doc: { proposal?: { prompt: string; why: string } } }).doc.proposal;
+    // proposal because the yes may land long after this turn — and that proposal
+    // is at the id the screen agent was handed, carrying the very approval the
+    // caller was answered with. This is what stops a stranded second stream.
+    const row = await store.records("vendo_apps").get(seen[0]!.appId);
+    const proposal = (row?.data as {
+      doc: { proposal?: { approvalId: string; prompt: string; why: string } };
+    }).doc.proposal;
+    expect(proposal?.approvalId).toBe(outcome.approvalId);
     expect(proposal?.prompt).toContain("Show my spending by category");
     // The escalation's one-line `why` travels beside it: the box will hear why
     // this cannot happen in the browser, and nothing else was decided for it.

--- a/packages/core/src/stream-parts.ts
+++ b/packages/core/src/stream-parts.ts
@@ -13,7 +13,7 @@ import {
   type TurnId,
 } from "./ids.js";
 import { knowledgeKindSchema, knowledgeVisibilitySchema, type KnowledgeKind, type KnowledgeVisibility } from "./knowledge.js";
-import { riskLabelSchema, type RiskLabel } from "./tools.js";
+import { riskLabelSchema, toolDescriptorSchema, type RiskLabel, type ToolDescriptor } from "./tools.js";
 import type { ToolCall } from "./tools.js";
 import { uiPayloadSchema, type UIPayload } from "./genui/tree-node.js";
 import { triggerSourceSchema, type TriggerSource } from "./triggers.js";
@@ -160,6 +160,12 @@ export interface VendoApprovalPart {
     id: GrantId;
     grantedAt: IsoDateTime;
   };
+  /** The ask's OWN descriptor, present when the tool parked an ask about
+   *  something other than the call the model made (the built-app door asks about
+   *  a BUILD, from inside `vendo_make`). The client's shared §16 builder reads
+   *  its title and schema (`buildApprovalRequest`), so the card derives the same
+   *  words the server authored instead of humanizing the calling tool's slug. */
+  descriptor?: ToolDescriptor;
 }
 
 /** 01-core §16 */
@@ -172,6 +178,7 @@ export const vendoApprovalPartSchema = z.object({
     id: grantIdSchema,
     grantedAt: isoDateTimeSchema,
   }).passthrough().optional(),
+  descriptor: toolDescriptorSchema.optional(),
 }).passthrough() satisfies z.ZodType<VendoApprovalPart>;
 
 /** Streamed when the agent loop stops because it exhausted its step cap, so

--- a/packages/core/src/tools.ts
+++ b/packages/core/src/tools.ts
@@ -447,14 +447,25 @@ const pendingApprovalSchema = z.object({
 export type ToolOutcome =
   | { status: "ok"; output: Json }
   | { status: "error"; error: { code: string; message: string } }
-  // `approval`/`say` are FIELDS on the existing status, never a status of their
-  // own — the same trade `blocked.cause` makes above. A tool that parks an ask
-  // of its OWN (the built-app door: the ask is about a build, not about calling
-  // that tool) is the one that knows what the card says and what to tell the
-  // person meanwhile; a park the guard raised on the tool's own descriptor is
-  // already described by it, so both stay optional and every shipped producer
-  // and reader is untouched.
-  | { status: "pending-approval"; approvalId: ApprovalId; approval?: PendingApproval; say?: string }
+  // `approval`/`say`/`descriptor` are FIELDS on the existing status, never a
+  // status of their own — the same trade `blocked.cause` makes above. A tool
+  // that parks an ask of its OWN (the built-app door: the ask is about a build,
+  // not about calling that tool) is the one that knows what the card says and
+  // what to tell the person meanwhile; a park the guard raised on the tool's own
+  // descriptor is already described by it, so all three stay optional and every
+  // shipped producer and reader is untouched.
+  //
+  // `descriptor` is the ask's own — what the CARD reads. `approval` is the same
+  // ask already in words, for the surfaces that render no card, and both are
+  // authored off the one descriptor (build-door.ts), so a card and an outside
+  // agent can never be told different things about one ask.
+  | {
+      status: "pending-approval";
+      approvalId: ApprovalId;
+      approval?: PendingApproval;
+      say?: string;
+      descriptor?: ToolDescriptor;
+    }
   | { status: "blocked"; reason: string; cause?: "expired" }
   | { status: "connect-required"; connect: ConnectRequired };
 
@@ -470,6 +481,7 @@ export const toolOutcomeSchema = z.discriminatedUnion("status", [
     approvalId: approvalIdSchema,
     approval: pendingApprovalSchema.optional(),
     say: z.string().min(1).optional(),
+    descriptor: toolDescriptorSchema.optional(),
   }).passthrough(),
   z.object({
     status: z.literal("blocked"),

--- a/packages/core/src/tools.ts
+++ b/packages/core/src/tools.ts
@@ -416,6 +416,24 @@ const connectRequiredSchema = z.object({
   message: z.string(),
 }).passthrough() satisfies z.ZodType<ConnectRequired>;
 
+/** 01-core §4 — the parked ask in words, for the surfaces that render no card:
+ *  an outside agent over MCP, a text message, a transcript. `question` is what
+ *  the person is being asked; `notes` are the quiet lines under it — the same
+ *  pair the in-thread card composes (`consentAsk`, ui/chrome/build-beat.tsx),
+ *  never a second vocabulary for one ask. */
+export interface PendingApproval {
+  id: ApprovalId;
+  question: string;
+  notes: string[];
+}
+
+/** 01-core §4 */
+const pendingApprovalSchema = z.object({
+  id: approvalIdSchema,
+  question: z.string().min(1),
+  notes: z.array(z.string()),
+}).passthrough() satisfies z.ZodType<PendingApproval>;
+
 /** 01-core §4
  *
  *  `blocked.cause` narrows WHY nothing ran when the reason is nobody's doing:
@@ -429,7 +447,14 @@ const connectRequiredSchema = z.object({
 export type ToolOutcome =
   | { status: "ok"; output: Json }
   | { status: "error"; error: { code: string; message: string } }
-  | { status: "pending-approval"; approvalId: ApprovalId }
+  // `approval`/`say` are FIELDS on the existing status, never a status of their
+  // own — the same trade `blocked.cause` makes above. A tool that parks an ask
+  // of its OWN (the built-app door: the ask is about a build, not about calling
+  // that tool) is the one that knows what the card says and what to tell the
+  // person meanwhile; a park the guard raised on the tool's own descriptor is
+  // already described by it, so both stay optional and every shipped producer
+  // and reader is untouched.
+  | { status: "pending-approval"; approvalId: ApprovalId; approval?: PendingApproval; say?: string }
   | { status: "blocked"; reason: string; cause?: "expired" }
   | { status: "connect-required"; connect: ConnectRequired };
 
@@ -440,7 +465,12 @@ export const toolOutcomeSchema = z.discriminatedUnion("status", [
     status: z.literal("error"),
     error: z.object({ code: z.string(), message: z.string() }).passthrough(),
   }).passthrough(),
-  z.object({ status: z.literal("pending-approval"), approvalId: approvalIdSchema }).passthrough(),
+  z.object({
+    status: z.literal("pending-approval"),
+    approvalId: approvalIdSchema,
+    approval: pendingApprovalSchema.optional(),
+    say: z.string().min(1).optional(),
+  }).passthrough(),
   z.object({
     status: z.literal("blocked"),
     reason: z.string(),

--- a/packages/harnesses/src/tool-bridge.ts
+++ b/packages/harnesses/src/tool-bridge.ts
@@ -145,13 +145,19 @@ export function approvalPart(
   risk: RiskLabel,
   approvalId: ApprovalId,
   invalidatedGrant?: VendoApprovalPart["invalidatedGrant"],
+  /** The ask's OWN descriptor, when the tool parked an ask about something
+   *  other than the call the model made. It both GRADES the card and gives it
+   *  its authored words — `risk` above belongs to the calling tool, which for a
+   *  build is `vendo_make`'s "read". */
+  asked?: ToolDescriptor,
 ): VendoApprovalPart {
   return {
     type: "data-vendo-approval",
     toolCallId,
-    risk,
+    risk: asked?.risk ?? risk,
     approvalId,
     ...(invalidatedGrant === undefined ? {} : { invalidatedGrant }),
+    ...(asked === undefined ? {} : { descriptor: asked }),
   };
 }
 
@@ -308,7 +314,8 @@ export async function guardedCall(
     // so the card is published by the apps runtime through the stream seam above,
     // by the side that knows it armed something. One less thing read by shape.
   } else if (outcome.status === "pending-approval") {
-    writePart(options.writer, approvalPart(toolCallId, descriptor.risk, outcome.approvalId));
+    writePart(options.writer, approvalPart(
+      toolCallId, descriptor.risk, outcome.approvalId, undefined, outcome.descriptor));
   } else if (outcome.status === "connect-required") {
     // The inline connect card (04-actions §3): emitted beside the native
     // tool part exactly like the approval part, keyed by toolCallId.

--- a/packages/harnesses/src/turn-tools.ts
+++ b/packages/harnesses/src/turn-tools.ts
@@ -412,7 +412,16 @@ export function createTurnTools(options: TurnToolsOptions): RuntimeTurnTools {
         if (outcome.status === "pending-approval") {
           // The preview said run and the REAL check asked — a breaker or presence
           // boundary. Nobody is waiting on this one, so it must still be swept.
-          waiter.raise(outcome.approvalId, { standing: !options.interactive });
+          //
+          // UNLESS the tool parked an ask of its OWN and said what it asks
+          // (`approval`): the built-app door's card is answered on the person's
+          // clock, long after this turn, and sweeping it denied at turn end
+          // tombstoned the build the moment the turn ended. Only a tool that
+          // raised the ask itself can know that, which is why it is the tool
+          // that says so.
+          waiter.raise(outcome.approvalId, {
+            standing: !options.interactive || outcome.approval !== undefined,
+          });
           // The guard asked twice for one tap; refusing to loop is the honest
           // answer (a second card for the same call would be a trap).
           return refused("This still needs approval.", {

--- a/packages/harnesses/src/turn-tools.ts
+++ b/packages/harnesses/src/turn-tools.ts
@@ -424,7 +424,13 @@ export function createTurnTools(options: TurnToolsOptions): RuntimeTurnTools {
           });
           // The guard asked twice for one tap; refusing to loop is the honest
           // answer (a second card for the same call would be a trap).
-          return refused("This still needs approval.", {
+          //
+          // A tool that raised the ask ITSELF also wrote the one line the agent
+          // is to relay (`say` — make-receipt.ts law 2), and this refusal is the
+          // only thing the model reads about the call. Without it the model was
+          // told nothing but "needs approval" beside a card already asking the
+          // question, and narrated its own paragraphs under it.
+          return refused(outcome.say ?? "This still needs approval.", {
             kind: "approval",
             approvalId: outcome.approvalId,
           });

--- a/packages/ui/src/chrome/embeds.tsx
+++ b/packages/ui/src/chrome/embeds.tsx
@@ -117,7 +117,7 @@ function BeatLine({ state, children }: { state: "working" | "done" | "error"; ch
  *  the line, and the line in danger colour. Muting the failure to the same grey
  *  as "Approved — ran" left the WORDS as the only difference between a call
  *  that landed and one that didn't, on a receipt people scan rather than read. */
-function ResolvedApprovalCard({ summary, ok, line, detail }: {
+export function ResolvedApprovalCard({ summary, ok, line, detail }: {
   summary: string;
   ok: boolean;
   line: string;

--- a/packages/ui/src/chrome/humanize.ts
+++ b/packages/ui/src/chrome/humanize.ts
@@ -198,7 +198,12 @@ export function previewArgs(args: unknown): string {
   if (fields.length > 0) return fields.map(field => `${field.label}: ${field.value}`).join("\n");
   if (typeof args === "string") return args;
   try {
-    return JSON.stringify(args, null, 2);
+    // `JSON.stringify(undefined)` ANSWERS undefined, and a call with no
+    // arguments is a real wire shape (`ApprovalWirePart.args` is optional, and a
+    // parked native part need not carry `input`) — the caller reads `.length`
+    // off this, so the card crashed the whole thread instead of showing an ask
+    // with nothing to display. Empty, never the word "undefined".
+    return JSON.stringify(args, null, 2) ?? "";
   } catch {
     return String(args);
   }

--- a/packages/ui/src/chrome/thread/parts.tsx
+++ b/packages/ui/src/chrome/thread/parts.tsx
@@ -1,4 +1,4 @@
-import { riskLabelSchema, VENDO_MAKE_TOOL, type RiskLabel, type UIPayload, type VendoApprovalPart, type VendoAutomationPart, type VendoBuildFailedPart, type VendoConnectPart, type VendoGrantSetPart, type VendoLimitPart, type VendoStepLimitPart, type VendoTurnErrorPart, type VendoViewPart } from "@vendoai/core";
+import { isVendoError, riskLabelSchema, VENDO_MAKE_TOOL, type RiskLabel, type UIPayload, type VendoApprovalPart, type VendoAutomationPart, type VendoBuildFailedPart, type VendoConnectPart, type VendoGrantSetPart, type VendoLimitPart, type VendoStepLimitPart, type VendoTurnErrorPart, type VendoViewPart } from "@vendoai/core";
 import { isToolUIPart, type DynamicToolUIPart, type ToolUIPart, type UIMessage } from "ai";
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import { useVendoProvider } from "../../context.js";
@@ -6,7 +6,7 @@ import { useSplitView } from "../split-view.js";
 import { useApprovalSheetPresentation } from "../../hooks/use-mobile-takeover.js";
 import { PayloadView } from "../../tree/renderer.js";
 import { PlacementAction } from "../add-to-picker.js";
-import { ApprovalCard } from "../approval-card.js";
+import { ApprovalCard, refusalCopy } from "../approval-card.js";
 import { useApprovalModal } from "../approval-modal.js";
 import { ApprovalSheet } from "../approval-sheet.js";
 import { ChromeRoot, useChromeTheme } from "../chrome-root.js";
@@ -573,6 +573,38 @@ function GrantSetConsent({ toolCallId, grantSetId, name, permissions, siblingPar
 }
 
 /**
+ * One decided card, SETTLED in place — the same settled register the wire-driven
+ * embed resolves into (`ResolvedApprovalCard` in embeds.tsx).
+ *
+ * A standing ask outlives the turn that raised it, so no stream will ever move
+ * its part out of `approval-requested`: without this the buttons stay live on a
+ * question the person already answered, and pressing them again asks the wire
+ * about a decision it has already made.
+ *
+ * An ask the wire says is ALREADY answered (or has been swept) settles too — the
+ * question is closed either way, and the consumer sentence for it is the card's
+ * own (`refusalCopy`). Only then: `landed` is the answer's onward journey (the
+ * native resume), which an ask that was decided elsewhere has no business
+ * restarting. Any other failure rethrows, so the card keeps its buttons and the
+ * person can try again.
+ */
+async function settleDecision(
+  decided: Promise<unknown>,
+  approve: boolean,
+  landed?: () => void,
+): Promise<{ ok: boolean; line: string }> {
+  try {
+    await decided;
+  } catch (reason) {
+    const code = isVendoError(reason) ? reason.code : undefined;
+    if (code !== "conflict" && code !== "not-found") throw reason;
+    return { ok: false, line: refusalCopy(reason) };
+  }
+  landed?.();
+  return { ok: approve, line: approve ? "Approved — under way" : "Declined — nothing ran" };
+}
+
+/**
  * A STANDING consent ask at its transcript position, on the ONE approval card.
  *
  * `ThreadApprovals` below renders every ask a NATIVE parked call carries, and
@@ -632,8 +664,7 @@ function ThreadStandingApproval({ part, siblingParts }: {
       allowRemember={false}
       showContext={false}
       onDecide={async ({ approve }) => {
-        await client.approvals.decide(approvalId, { approve });
-        setSettled({ ok: approve, line: approve ? "Approved — under way" : "Declined — nothing ran" });
+        setSettled(await settleDecision(client.approvals.decide(approvalId, { approve }), approve));
       }}
     />
   );
@@ -957,6 +988,11 @@ export function ThreadApprovals({ approvals, risks, guardApprovals, cardRefs, re
   // regression): on short viewports the consent stays an in-list card so the
   // voice stage's controls remain reachable.
   const mobile = useApprovalSheetPresentation();
+  // The answered cards, by ask id. A parked NATIVE ask normally leaves this list
+  // on its own — the stream moves its part past `approval-requested` — but a
+  // standing one (a restored transcript, an ask that outlived its turn) has no
+  // stream left to do it, so the card it left behind settles here instead.
+  const [settled, setSettled] = useState(new Map<string, { ok: boolean; line: string }>());
   return (
     <>
       {approvals.map((part, index) => {
@@ -983,6 +1019,14 @@ export function ThreadApprovals({ approvals, risks, guardApprovals, cardRefs, re
             ? {} : { descriptor: guardApproval.descriptor }),
         }, tools);
         const guardApprovalId = guardApproval?.approvalId;
+        const answered = settled.get(part.approval.id);
+        if (answered !== undefined) {
+          return (
+            <ChromeRoot key={part.approval.id}>
+              <ResolvedApprovalCard summary={approval.descriptor.title ?? name} ok={answered.ok} line={answered.line} />
+            </ChromeRoot>
+          );
+        }
         const asSheet = mobile && index === approvals.length - 1;
         const card = (
           <div key={part.approval.id} ref={element => { cardRefs.current.set(part.approval.id, element); }}>
@@ -1031,11 +1075,17 @@ export function ThreadApprovals({ approvals, risks, guardApprovals, cardRefs, re
                 }
                 // Decide the guard's approval record over the wire FIRST so the
                 // resumed execution replays as approved (05 §1) — the native
-                // response alone only tells the model loop to continue.
-                if (guardApprovalId !== undefined) {
-                  await client.approvals.decide([guardApprovalId], decision);
-                }
-                respond({ id: part.approval.id, approved: decision.approve });
+                // response alone only tells the model loop to continue. Then the
+                // card settles, because this one may be all there is: an ask that
+                // outlived its turn has no stream left to retire it.
+                const record = await settleDecision(
+                  guardApprovalId === undefined
+                    ? Promise.resolve()
+                    : client.approvals.decide([guardApprovalId], decision),
+                  decision.approve,
+                  () => respond({ id: part.approval.id, approved: decision.approve }),
+                );
+                setSettled(previous => new Map(previous).set(part.approval.id, record));
               }}
             />
           </div>

--- a/packages/ui/src/chrome/thread/parts.tsx
+++ b/packages/ui/src/chrome/thread/parts.tsx
@@ -1,4 +1,4 @@
-import { riskLabelSchema, VENDO_MAKE_TOOL, type RiskLabel, type UIPayload, type VendoAutomationPart, type VendoBuildFailedPart, type VendoConnectPart, type VendoGrantSetPart, type VendoLimitPart, type VendoStepLimitPart, type VendoTurnErrorPart, type VendoViewPart } from "@vendoai/core";
+import { riskLabelSchema, VENDO_MAKE_TOOL, type RiskLabel, type UIPayload, type VendoApprovalPart, type VendoAutomationPart, type VendoBuildFailedPart, type VendoConnectPart, type VendoGrantSetPart, type VendoLimitPart, type VendoStepLimitPart, type VendoTurnErrorPart, type VendoViewPart } from "@vendoai/core";
 import { isToolUIPart, type DynamicToolUIPart, type ToolUIPart, type UIMessage } from "ai";
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import { useVendoProvider } from "../../context.js";
@@ -9,7 +9,8 @@ import { PlacementAction } from "../add-to-picker.js";
 import { ApprovalCard } from "../approval-card.js";
 import { useApprovalModal } from "../approval-modal.js";
 import { ApprovalSheet } from "../approval-sheet.js";
-import { useChromeTheme } from "../chrome-root.js";
+import { ChromeRoot, useChromeTheme } from "../chrome-root.js";
+import { ResolvedApprovalCard } from "../embeds.js";
 import { ThreadAutomationConsent } from "./automation-consent.js";
 import { BuildBeat, toolPresentation } from "../build-beat.js";
 import { ConnectCard } from "../connect-card.js";
@@ -361,6 +362,15 @@ export function ThreadPart({ part, partKey, role, restored, count = 1, risks, co
     if (rendered) return null;
     return <ThreadConnect ask={ask} live={connectLive} sendMessage={sendMessage} />;
   }
+  if (part.type === "data-vendo-approval") {
+    // A STANDING ask — one raised by a TOOL about another call — renders its own
+    // card here; anything else is a parked native call's ask and renders from
+    // that call's approval state (ThreadApprovals). Which is which is the
+    // component's own question; before it, the transcript showed a person
+    // nothing but the calling tool's beat ("wasn't allowed") for a question they
+    // had not been asked yet.
+    return <ThreadStandingApproval part={part} siblingParts={siblingParts ?? []} />;
+  }
   if (part.type === "data-vendo-build-failed") {
     // 0.4.4 cert defect B — a terminally failed app build is content, not
     // progress: the turn ends right after this part, so without it the thread
@@ -462,13 +472,6 @@ export function ThreadPart({ part, partKey, role, restored, count = 1, risks, co
       />
     );
   }
-  if (part.type === "data-vendo-citations") {
-    // Knowledge K1 — rendered at TURN level (message.tsx → TurnCitations),
-    // under the answer text the citations ground, matching the signed
-    // mockups; at this part's transcript position the answer hasn't
-    // streamed yet, so rendering here would put sources above the text.
-    return null;
-  }
   if (part.type === "data-vendo-view") {
     const data = partData(part) as Partial<VendoViewPart>;
     if (typeof data.appId !== "string" || !data.payload) return null;
@@ -492,6 +495,11 @@ export function ThreadPart({ part, partKey, role, restored, count = 1, risks, co
     } = data.payload as typeof data.payload & { inClient?: unknown; pinDrift?: unknown };
     return <ThreadAppCard key={`${partKey}-${data.appId}`} buildKey={`${partKey}-${data.appId}`} appId={data.appId} payload={payload} restored={restored} />;
   }
+  // Everything else renders nothing HERE, and `data-vendo-citations` is the one
+  // that renders nothing on purpose: Knowledge K1 puts it at TURN level
+  // (message.tsx → TurnCitations), under the answer text the citations ground,
+  // matching the signed mockups — at this part's transcript position the answer
+  // hasn't streamed yet, so sources would sit above the text.
   return null;
 }
 
@@ -560,6 +568,73 @@ function GrantSetConsent({ toolCallId, grantSetId, name, permissions, siblingPar
           if (nativeApprovalId !== undefined) respond?.({ id: nativeApprovalId, approved: approve });
         },
       })}
+    />
+  );
+}
+
+/**
+ * A STANDING consent ask at its transcript position, on the ONE approval card.
+ *
+ * `ThreadApprovals` below renders every ask a NATIVE parked call carries, and
+ * this one has none: the tool parked an ask of its OWN (the built-app door asks
+ * about a build from inside `vendo_make`), the call itself returned, and no part
+ * will ever reach `approval-requested` — nor may it, since the runtime abandons
+ * every still-parked native ask at the next turn and this ask has to outlive the
+ * turn that raised it. Same shape as the connect card above: the `data-vendo-*`
+ * part is the whole ask, because the native part cannot carry it.
+ *
+ * WHICH asks are those: the ones whose descriptor names a DIFFERENT call than
+ * the one the part rides beside. A guard-raised ask describes the very call
+ * parked next to it and keeps its card there, where the resume lives — one
+ * consent surface per ask.
+ *
+ * That descriptor is also what the shared §16 builder derives the words from, so
+ * this card, the queue row and the toast read one ladder off one descriptor.
+ *
+ * Decided over the WIRE, like the queue and the toast: there is no parked turn
+ * to resume, and the yes may land long after this one is gone. No `remember`,
+ * because a grant is a standing yes to a CALL the person chose — this ask is
+ * about spending a machine once.
+ */
+function ThreadStandingApproval({ part, siblingParts }: {
+  part: UIMessage["parts"][number];
+  siblingParts: UIMessage["parts"];
+}) {
+  const { client, tools } = useVendoProvider();
+  const [settled, setSettled] = useState<{ ok: boolean; line: string }>();
+  const data = partData(part) as Partial<VendoApprovalPart>;
+  const asked = data.descriptor;
+  const rides = siblingParts.filter(isToolUIPart)
+    .find(candidate => candidate.toolCallId === data.toolCallId);
+  if (typeof data.approvalId !== "string" || asked?.name === undefined
+    || !riskLabelSchema.safeParse(data.risk).success
+    || (rides !== undefined && toolName(rides) === asked.name)) return null;
+  const approvalId = data.approvalId;
+  const approval = buildApprovalRequest({
+    approvalId,
+    toolCallId: data.toolCallId ?? approvalId,
+    // The ask is about THIS call, not the one the model made: `vendo_make` is a
+    // read, and grading the card off it told the person a build reads their data.
+    tool: asked.name,
+    risk: data.risk as RiskLabel,
+    descriptor: asked,
+  }, tools);
+  if (settled !== undefined) {
+    return (
+      <ChromeRoot>
+        <ResolvedApprovalCard summary={approval.descriptor.title ?? asked.name} ok={settled.ok} line={settled.line} />
+      </ChromeRoot>
+    );
+  }
+  return (
+    <ApprovalCard
+      approval={approval}
+      allowRemember={false}
+      showContext={false}
+      onDecide={async ({ approve }) => {
+        await client.approvals.decide(approvalId, { approve });
+        setSettled({ ok: approve, line: approve ? "Approved — under way" : "Declined — nothing ran" });
+      }}
     />
   );
 }

--- a/packages/ui/test/chrome/thread-and-overlay.test.tsx
+++ b/packages/ui/test/chrome/thread-and-overlay.test.tsx
@@ -79,6 +79,26 @@ describe("VendoThread and VendoOverlay exports", () => {
     });
   });
 
+  it("settles a card the wire has already answered, rather than leaving live buttons on it", { timeout: 20_000 }, async () => {
+    // No guard record for this turn's ask, so the wire answers the decision "not
+    // found" — the shape of an ask already answered (or swept) elsewhere, which
+    // is the ordinary end of one that outlived its turn. The question is closed
+    // either way, so the card records it instead of standing there with two live
+    // buttons and an error underneath.
+    render(<VendoProvider client={client}><VendoThread threadId="thr_1" /></VendoProvider>);
+    expect(await screen.findByText("Existing thread")).toBeTruthy();
+    const composer = screen.getByRole("textbox", { name: "Message" });
+    fireEvent.change(composer, { target: { value: "Send the email" } });
+    fireEvent.keyDown(composer, { key: "Enter" });
+
+    await screen.findByLabelText("Approval for Send the report");
+    fireEvent.click(screen.getByRole("button", { name: "Approve" }));
+
+    const receipt = await screen.findByLabelText(/^Approval — This request isn’t waiting on you any more/);
+    expect(receipt.textContent).toContain("Send the report");
+    expect(screen.queryByRole("button", { name: "Approve" })).toBeNull();
+  });
+
   it("brings a new approval into view even while the transcript keeps re-rendering", { timeout: 20_000 }, async () => {
     // A build's approval lands below a tall generated view, off-screen, so the
     // thread scrolls it into view 80ms after it appears. That effect marked the

--- a/packages/vendo/src/pack.ts
+++ b/packages/vendo/src/pack.ts
@@ -88,10 +88,8 @@ function appRefTitleFromPrompt(prompt: unknown): string {
  * laundering a partial receipt through it leaves a caller waiting on a completion
  * that already came, and drops the one sentence that says what is missing.
  *
- * `"awaiting-consent"` is refused for the third form of the same reason: the ask
- * has been PUT to the person and nothing is under way, so a ref reading
- * "accepted, still streaming" would show a build skeleton for a build nobody has
- * authorized — and drop the one sentence that says a card is waiting.
+ * An offered BUILD needs no clause here: it is a `pending-approval` outcome now,
+ * so it never reaches a receipt at all.
  *
  * Local to the PACK on purpose. `vendo/app-ref@1` means "accepted, still
  * streaming, NOT built yet"; only this fast-return path can honestly say that.
@@ -101,8 +99,7 @@ function appRefTitleFromPrompt(prompt: unknown): string {
  */
 function appRefFromReceipt(output: unknown, fallbackTitle: string): VendoAppRef | null {
   const receipt = makeReceiptSchema.safeParse(output);
-  if (!receipt.success || receipt.data.status === "failed" || receipt.data.status === "partial"
-    || receipt.data.status === "awaiting-consent") {
+  if (!receipt.success || receipt.data.status === "failed" || receipt.data.status === "partial") {
     return null;
   }
   return {

--- a/packages/vendo/tests/screen-escalate-consent.seam.test.ts
+++ b/packages/vendo/tests/screen-escalate-consent.seam.test.ts
@@ -271,8 +271,15 @@ describe("a chat ask bigger than a screen reaches the build lane", () => {
     expect(pending[0]?.call.args).toMatchObject({ prompt: ASK });
     const appId = (pending[0]?.call.args as { appId: AppId }).appId;
 
-    // THE ANSWER the calling agent got is the standard park, aimed at that card.
-    expect(walked.result).toMatchObject({ needs: { kind: "approval", approvalId: pending[0]?.id } });
+    // THE ANSWER the calling agent got is the standard park, aimed at that card —
+    // and its reason is the DOOR's own one line (`say`), not the harness's
+    // generic "This still needs approval.": the refusal is the only thing the
+    // model reads about this call, so a say that never reached it left the model
+    // narrating its own paragraphs under a card already asking the question.
+    expect(walked.result).toMatchObject({
+      reason: expect.stringContaining("the card above"),
+      needs: { kind: "approval", approvalId: pending[0]?.id },
+    });
 
     // THE CARD IN THE THREAD: the wire part the shipped bridge publishes off a
     // `pending-approval` outcome, which is what the receipt could never raise —
@@ -356,7 +363,7 @@ describe("the ask reaches the person on the ONE approval card", () => {
     // THE WORDS, off the shared ladder (`consentAsk`) reading the descriptor the
     // door authored — never a second sentence written for this surface.
     expect(card.textContent).toContain("Build this app for real?");
-    expect(card.textContent).toContain("This changes something in your account, as you.");
+    expect(card.textContent).toContain("This changes something in your account, and it runs as you.");
     // What it said before the descriptor travelled: ungraded, so the note could
     // only say nobody had checked what spending a build machine does.
     expect(card.textContent).not.toContain("This hasn’t been checked");
@@ -367,6 +374,20 @@ describe("the ask reaches the person on the ONE approval card", () => {
     const label = (element: Element) => (element.textContent ?? "").trim();
     expect([...card.querySelectorAll("button")].map(label)).toContain("Approve");
     expect(card.textContent).not.toContain("Remember this decision");
+
+    // AND IT SETTLES once they answer. This ask outlives its turn by design, so
+    // there is no stream left to retire the part it was painted from: without
+    // settling here the buttons stand for good on a question already decided, and
+    // pressing them asks the guard again about a record it has already written.
+    const deny = [...card.querySelectorAll("button")].find((button) => label(button) === "Deny")!;
+    await act(async () => { deny.click(); });
+    const settled = await until("the settled card", () =>
+      document.querySelector<HTMLElement>(".fl-cardshell--settled"));
+    expect(settled.textContent).toContain("Build this app for real");
+    expect(settled.textContent).toContain("Declined — nothing ran");
+    expect([...settled.querySelectorAll("button")].map(label)).not.toContain("Deny");
+    // The person's no reached the real guard, not just the card.
+    expect(await walked.vendo.guard.approvals.pending(principal)).toEqual([]);
   }, 60_000);
 });
 

--- a/packages/vendo/tests/screen-escalate-consent.seam.test.ts
+++ b/packages/vendo/tests/screen-escalate-consent.seam.test.ts
@@ -23,9 +23,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   VENDO_MAKE_TOOL,
+  vendoApprovalPartSchema,
+  type AppId,
   type Principal,
   type RunContext,
   type ToolResult,
+  type VendoApprovalPart,
 } from "@vendoai/core";
 import { makeReceiptSchema } from "@vendoai/apps/contract";
 import type { SandboxAdapter } from "@vendoai/apps";
@@ -134,10 +137,23 @@ async function tempStore(): Promise<VendoStore> {
 interface Walked {
   receipt: ReturnType<typeof makeReceiptSchema.parse> | undefined;
   result: ToolResult | undefined;
+  /** The turn's whole wire, as the browser receives it. */
+  stream: string;
   vendo: ReturnType<typeof createVendo>;
   model: LanguageModel & { toolNamesPerCall: string[][] };
   sandbox: ReturnType<typeof noBoxes>;
 }
+
+/** The `data-vendo-approval` part off that wire, parsed with core's own schema —
+ *  the one shape every native surface builds the in-thread ApprovalCard from. */
+const approvalPartIn = (stream: string): VendoApprovalPart => {
+  const chunk = stream.split("\n")
+    .filter((line) => line.startsWith("data: {"))
+    .map((line) => JSON.parse(line.slice(6)) as { type: string; data: Record<string, unknown> })
+    .find((part) => part.type === "data-vendo-approval");
+  if (chunk === undefined) throw new Error("no data-vendo-approval part was published");
+  return vendoApprovalPartSchema.parse({ type: chunk.type, ...chunk.data });
+};
 
 /** One real turn whose harness does what a calling agent does: ask `vendo_make`
  *  in words, and hand back the receipt. */
@@ -169,10 +185,11 @@ async function walk(options: { turns: Chunk[][]; sandbox?: boolean }): Promise<W
     }),
   }));
   expect(response.status).toBe(200);
-  await response.text();
+  const stream = await response.text();
   return {
     receipt: result?.status === "ok" ? makeReceiptSchema.parse(result.output) : undefined,
     result,
+    stream,
     vendo,
     model,
     sandbox,
@@ -180,7 +197,7 @@ async function walk(options: { turns: Chunk[][]; sandbox?: boolean }): Promise<W
 }
 
 describe("a chat ask bigger than a screen reaches the build lane", () => {
-  it("lands as a standing card and an awaiting-consent receipt, with no box claimed", async () => {
+  it("lands as a standing card, a card part in the thread, and a park, with no box claimed", async () => {
     const walked = await walk({
       turns: [call(ESCALATE_TOOL, { why: WHY }, "c1"), speak("Asked about building it.")],
     });
@@ -188,18 +205,26 @@ describe("a chat ask bigger than a screen reaches the build lane", () => {
     // THE DOOR IS ON THE LOADOUT — the fact that was missing.
     expect(walked.model.toolNamesPerCall[0]).toContain(ESCALATE_TOOL);
 
-    // THE RECEIPT: the ask is alive and waiting on the person, not failed.
-    expect(walked.receipt?.status).toBe("awaiting-consent");
-
     // THE STANDING CARD, on the real guard: one undecided ask for the build,
-    // carrying this app and the person's own words.
+    // carrying this app and the person's own words. STANDING is the whole word:
+    // the turn is over and the ask is still there to be answered — an ordinary
+    // parked call is swept denied at turn end, and sweeping this one tombstoned
+    // the build the moment the turn that asked for it finished.
     const pending = await walked.vendo.guard.approvals.pending(principal);
     expect(pending.map((ask) => ask.call.tool)).toEqual(["vendo_app_build"]);
-    expect(pending[0]?.call.args).toMatchObject({ appId: walked.receipt?.id, prompt: ASK });
+    expect(pending[0]?.call.args).toMatchObject({ prompt: ASK });
+    const appId = (pending[0]?.call.args as { appId: AppId }).appId;
+
+    // THE ANSWER the calling agent got is the standard park, aimed at that card.
+    expect(walked.result).toMatchObject({ needs: { kind: "approval", approvalId: pending[0]?.id } });
+
+    // THE CARD IN THE THREAD: the wire part the shipped bridge publishes off a
+    // `pending-approval` outcome, which is what the receipt could never raise.
+    expect(approvalPartIn(walked.stream).approvalId).toBe(pending[0]?.id);
 
     // THE ROW says "offered, unanswered" — and carries the model's own one line,
     // which is what the person reads on the card.
-    const row = await walked.vendo.apps.get(walked.receipt!.id, ctx);
+    const row = await walked.vendo.apps.get(appId, ctx);
     expect(row?.proposal).toMatchObject({ approvalId: pending[0]?.id, why: WHY });
     expect(row?.building).toBeUndefined();
 
@@ -223,9 +248,9 @@ describe("a chat ask bigger than a screen reaches the build lane", () => {
     // ONE model call: the escalation was the last thing this drive did. The two
     // scripted turns behind it were never reached.
     expect(walked.model.toolNamesPerCall).toHaveLength(1);
-    expect(walked.receipt?.status).toBe("awaiting-consent");
+    const pending = await walked.vendo.guard.approvals.pending(principal);
     // …and the row is still only an OFFER: no screen was written past the ask.
-    const row = await walked.vendo.apps.get(walked.receipt!.id, ctx);
+    const row = await walked.vendo.apps.get((pending[0]?.call.args as { appId: AppId }).appId, ctx);
     expect(row?.proposal).toBeDefined();
     expect(row?.source).toBeUndefined();
     expect(walked.sandbox.claims).toBe(0);

--- a/packages/vendo/tests/screen-escalate-consent.seam.test.ts
+++ b/packages/vendo/tests/screen-escalate-consent.seam.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 /**
  * THE DEAD SEAM — the screen agent's way of asking for a build, and where it
  * lands.
@@ -17,11 +18,18 @@
  * mood) and the sandbox PROVIDER — a stub that refuses to hand out a machine,
  * because the one thing this whole flow must not do before the person's yes is
  * claim a box.
+ *
+ * The last test closes the seam on the READ side too: the shipped `VendoThread`
+ * reads that same turn back over the real client and paints the real
+ * `ApprovalCard`. The producer and the consumer disagreeing about one wire part
+ * is exactly how this ask reached a person mis-graded, so neither side gets to
+ * hold its own copy of it.
  */
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  VENDO_APP_BUILD_TOOL,
   VENDO_MAKE_TOOL,
   vendoApprovalPartSchema,
   type AppId,
@@ -34,15 +42,20 @@ import { makeReceiptSchema } from "@vendoai/apps/contract";
 import type { SandboxAdapter } from "@vendoai/apps";
 import { defineHarness } from "@vendoai/harnesses";
 import { createStore, type VendoStore } from "@vendoai/store";
+import { VendoProvider, createVendoClient } from "@vendoai/ui";
+import { VendoThread } from "@vendoai/ui/chrome";
 import type { LanguageModel } from "ai";
 import { MockLanguageModelV3, simulateReadableStream } from "ai/test";
+import { act, createElement, type ReactElement } from "react";
+import { createRoot } from "react-dom/client";
 import { afterEach, describe, expect, it } from "vitest";
 import { ESCALATE_TOOL, SAVE_APP_TOOL } from "../src/screen-agent.js";
 import { createVendo } from "../src/server.js";
 
-const cleanups: Array<() => Promise<void>> = [];
+const cleanups: Array<() => Promise<void> | void> = [];
 afterEach(async () => {
   for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+  document.body.innerHTML = "";
 });
 
 const principal: Principal = { kind: "user", subject: "user_escalate" };
@@ -196,6 +209,49 @@ async function walk(options: { turns: Chunk[][]; sandbox?: boolean }): Promise<W
   };
 }
 
+// --- the READ side: the shipped thread, painting that same turn --------------
+
+const BASE = "https://host.test/api/vendo";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+/** The client's fetch IS the door — every read the thread makes is answered by
+ *  the composition that just wrote the turn, so nothing painted is arranged. */
+function serve(vendo: Walked["vendo"]): void {
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    // jsdom's AbortSignal is not undici's, and undici's Request rejects it
+    // outright; nothing here aborts, so it is dropped at the boundary.
+    const { signal: _signal, ...rest } = init ?? {};
+    const url = typeof input === "string" || input instanceof URL ? String(input) : (input as { url: string }).url;
+    return await vendo.handler(new Request(url, rest as RequestInit));
+  }) as typeof fetch;
+  cleanups.push(() => { globalThis.fetch = realFetch; });
+}
+
+async function mount(element: ReactElement): Promise<void> {
+  const container = document.createElement("div");
+  document.body.append(container);
+  const root = createRoot(container);
+  cleanups.push(() => act(() => root.unmount()));
+  await act(async () => { root.render(element); });
+}
+
+/** Poll the painted DOM. The budget is the TEST's own — a tighter inner clock
+ *  would report a product bug whenever the machine is merely busy. */
+async function until<T>(what: string, probe: () => T | null | undefined | false): Promise<T> {
+  const deadline = Date.now() + 25_000;
+  for (;;) {
+    let found: T | null | undefined | false;
+    await act(async () => {
+      found = probe();
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    });
+    if (found) return found;
+    if (Date.now() > deadline) throw new Error(`timed out waiting for ${what}`);
+  }
+}
+
 describe("a chat ask bigger than a screen reaches the build lane", () => {
   it("lands as a standing card, a card part in the thread, and a park, with no box claimed", async () => {
     const walked = await walk({
@@ -219,8 +275,18 @@ describe("a chat ask bigger than a screen reaches the build lane", () => {
     expect(walked.result).toMatchObject({ needs: { kind: "approval", approvalId: pending[0]?.id } });
 
     // THE CARD IN THE THREAD: the wire part the shipped bridge publishes off a
-    // `pending-approval` outcome, which is what the receipt could never raise.
-    expect(approvalPartIn(walked.stream).approvalId).toBe(pending[0]?.id);
+    // `pending-approval` outcome, which is what the receipt could never raise —
+    // carrying the ask's OWN descriptor, because the card must speak about the
+    // BUILD. Graded off the calling tool it spoke about `vendo_make`, a read,
+    // and told the person that spending a build machine reads their data.
+    const part = approvalPartIn(walked.stream);
+    expect(part.approvalId).toBe(pending[0]?.id);
+    expect(part.risk).toBe("write");
+    expect(part.descriptor).toMatchObject({
+      name: VENDO_APP_BUILD_TOOL,
+      title: "Build this app for real",
+      risk: "write",
+    });
 
     // THE ROW says "offered, unanswered" — and carries the model's own one line,
     // which is what the person reads on the card.
@@ -266,6 +332,41 @@ describe("a chat ask bigger than a screen reaches the build lane", () => {
 
     expect(walked.model.toolNamesPerCall[0]).not.toContain(ESCALATE_TOOL);
     expect(walked.receipt?.status).toBe("failed");
+  }, 60_000);
+});
+
+describe("the ask reaches the person on the ONE approval card", () => {
+  it("paints the shipped ApprovalCard in the thread, in the build's own words", async () => {
+    const walked = await walk({
+      turns: [call(ESCALATE_TOOL, { why: WHY }, "c1"), speak("Asked about building it.")],
+    });
+    serve(walked.vendo);
+    await mount(createElement(VendoProvider, {
+      client: createVendoClient({ baseUrl: BASE }),
+      children: createElement(VendoThread, { threadId: "thr_escalate" }),
+    }));
+
+    // THE LITERAL CARD — `.fl-approval` is `ApprovalCard`'s own shell, and its
+    // machine attributes say which ask it is grading.
+    const card = await until("the approval card", () =>
+      document.querySelector<HTMLElement>(".fl-approval"));
+    expect(card.getAttribute("data-vendo-tool")).toBe(VENDO_APP_BUILD_TOOL);
+    expect(card.getAttribute("data-risk")).toBe("write");
+
+    // THE WORDS, off the shared ladder (`consentAsk`) reading the descriptor the
+    // door authored — never a second sentence written for this surface.
+    expect(card.textContent).toContain("Build this app for real?");
+    expect(card.textContent).toContain("This changes something in your account, as you.");
+    // What it said before the descriptor travelled: ungraded, so the note could
+    // only say nobody had checked what spending a build machine does.
+    expect(card.textContent).not.toContain("This hasn’t been checked");
+    expect(card.textContent).not.toContain("Nobody has checked what this changes");
+
+    // Answerable, and NOT rememberable: a grant is a standing yes to a call the
+    // person chose to make; this ask is about spending one machine, once.
+    const label = (element: Element) => (element.textContent ?? "").trim();
+    expect([...card.querySelectorAll("button")].map(label)).toContain("Approve");
+    expect(card.textContent).not.toContain("Remember this decision");
   }, 60_000);
 });
 

--- a/packages/vendo/tests/your-agent-docs.docs.test.ts
+++ b/packages/vendo/tests/your-agent-docs.docs.test.ts
@@ -309,11 +309,11 @@ describe("the documented arguments match the real schemas", () => {
 });
 
 describe("the receipt law the docs teach is the real receipt", () => {
-  it("has exactly id, title, status, say — and status's five values", async () => {
+  it("has exactly id, title, status, say — and status's four values", async () => {
     const source = await read("packages/apps/src/contract/make-receipt.ts");
     expect(source).toContain("id: appIdSchema");
     expect(source).toContain("title: z.string().min(1)");
-    expect(source).toContain('status: z.enum(["ready", "partial", "building", "awaiting-consent", "failed"])');
+    expect(source).toContain('status: z.enum(["ready", "partial", "building", "failed"])');
     expect(source).toContain("say: z.string().min(1)");
   });
 


### PR DESCRIPTION
## The dead answer

The screen agent's `escalate` reaches `vendo_make`, which parks a real guard
approval for the build and then answers with `receipt({ status: "awaiting-consent" })`
— a `status: "ok"` ToolOutcome. Every consent surface downstream routes on the
outcome's status, so a parked build was invisible to all of them: no
`data-vendo-approval` part, therefore no in-thread ApprovalCard, and an outside
agent over MCP read plain success for a build nobody had authorized.

## The change

`vendo_make` now answers the standard `pending-approval` outcome:

```ts
{ status: "pending-approval",
  approvalId,
  approval: { id: approvalId, question, notes },
  say }
```

- `ToolOutcome`'s `pending-approval` member gains two OPTIONAL fields —
  `approval` (the ask in words, for a surface that renders no card) and `say`
  (the assistant's sentence meanwhile). Fields on the existing status, never a
  new status: the same trade `blocked.cause` already makes. Every shipped
  producer and reader is untouched.
- `question`/`notes` are composed from the build door's OWN descriptor —
  `consentAsk`'s ladder (`ui/chrome/build-beat.tsx`) run on the title and the
  authored sentence the guard approval row already holds — so the payload and
  the in-thread card cannot say different things about one ask. No new prose.
- The `data-vendo-approval` part needed no new code: the shipped bridge already
  publishes it for a `pending-approval` outcome (`guardedCall`,
  tool-bridge.ts:310). The producer changing status is the whole fix.
- `MakeReceipt.status` loses `"awaiting-consent"` — nothing produces it any
  more, and the pack's app-ref refusal clause goes with it.

## The one thing that was not a drop-in

An interactive turn SWEEPS its unanswered approvals denied at turn end
(`abandonUnanswered`), so a card nobody waited on cannot accrete in the pending
queue. For a build that is fatal: the yes arrives on the person's clock, minutes
or hours later, and the sweep denied the card the instant the turn ended —
which fires the decision seam, which tombstones the app. Measured, not
theorized: with the producer change alone, `guard.approvals.pending()` came back
`[]` after the response.

So a `pending-approval` outcome that CARRIES an `approval` (i.e. the tool parked
an ask of its own and described it) is raised as STANDING. A bare re-ask stays
swept — that is the guard asking twice for one tap, and a second card for the
same call would be a trap.

## Proof

The full real chain, no stub on either side (`screen-escalate-consent.seam.test.ts`):
real deployment, real front door, real screen loop, real build door, real guard —
the outcome parks, the `data-vendo-approval` part comes back off the wire parsed
with core's own schema, the card is still pending after the turn, and the sandbox
is untouched. `build-consent.test.ts` pins the frozen payload against the real
propose path and still proves the guard's decision ALONE runs the builder and
seals what it built.

Both new facts proven able to fail:
- producer reverted → 9 tests red across `make-tool` / `build-consent` /
  `screen-route` / `agent-tools` ("expected a park, got ok").
- standing flag reverted → `expected [] to deeply equal [ 'vendo_app_build' ]`.

## Knock-on worth naming

A COMPOUND escalated ask ("build me the board and refresh it every Monday") no
longer reaches the automation door, because the park short-circuits
`withCompoundSchedule`. That is the honest outcome: the app does not exist and
may never be approved, so arming a schedule on it — and asking its author for
the scopes — was work for a screen that is not there. Pinned in
`make-tool.test.ts`.

## Gate

`pnpm build` · `pnpm typecheck` (43/43) · `pnpm lint` (0 errors) · apps 1327,
core 817, harnesses 608, mcp 151, plus the vendo approval/pack/make/MCP-door
files — all green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Offered builds now answer with a standard pending-approval (not an ok receipt), carrying the build’s descriptor so the approval card renders in-thread, survives the turn, and settles when decided. The harness also relays the door’s one-line say to the model, so the agent stops narrating under a live card.

- `vendo_make` returns `{ status: "pending-approval", approvalId, approval?, say?, descriptor? }` sourced from the build door.
- `@vendoai/core` adds optional `approval`, `say`, and `descriptor` to `ToolOutcome.status: "pending-approval"` and allows `descriptor` on `data-vendo-approval`.
- `@vendoai/harnesses` publishes `data-vendo-approval` with the descriptor, marks such asks as standing, and uses `say` as the refusal text given to the model.
- `@vendoai/ui` renders the standing approval card directly from `data-vendo-approval` (no “remember”), and settles the card on decide or when the wire reports it already resolved; fixes `previewArgs` returning undefined.
- `@vendoai/apps` removes `"awaiting-consent"` from `MakeReceipt.status`, composes the approval ask/descriptor once, and stops arming automation for compound asks until approval; `say` is now a single line that points at the card.
- `@vendoai/vendo` stops mapping offered builds into receipts/app-refs.

**Migration**
- Handle `pending-approval` outcomes with optional `approval`, `say`, and `descriptor`; stop expecting `"awaiting-consent"` in `MakeReceipt.status`.
- When rendering approvals, prefer the `descriptor` (from the outcome or `data-vendo-approval`) to grade and label the card; use `approval.question/notes` and `say` when present.
- Remove `"awaiting-consent"` from any receipt enums or switches.

<sup>Written for commit a5f0139be0fad99e26dbc49da3034dd4dbc8ba20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

