### PR TITLE
feat(mcp,vendo): the door speaks built apps — a sealed bundle links out, and the two build waits stop reading as failures

### DIFF
--- a/.changeset/build-consent-pending-approval.md
+++ b/.changeset/build-consent-pending-approval.md
@@ -1,0 +1,30 @@
+---
+"@vendoai/core": minor
+"@vendoai/apps": minor
+"@vendoai/harnesses": minor
+"@vendoai/vendo": minor
+---
+
+An escalated build asks on the standard consent protocol instead of answering
+as a success.
+
+`vendo_make` used to return a `status: "ok"` receipt reading
+`"awaiting-consent"` when the screen agent escalated to the builder, so the
+parked approval was invisible to everything that routes on the outcome: no
+in-thread approval card, and an outside agent over MCP was handed plain success
+for work nobody had authorized. It now returns the ordinary
+`pending-approval` outcome — which is what publishes the `data-vendo-approval`
+part the thread renders the card from, and what the MCP door maps to its
+approval-ref result.
+
+`ToolOutcome`'s `pending-approval` gains two optional fields for the tool that
+parks an ask of its OWN: `approval` (`{ id, question, notes }` — the ask in
+words, for a surface that renders no card) and `say` (the assistant's sentence
+meanwhile). Both are optional and additive; every shipped producer and reader
+is untouched.
+
+Such a card also now SURVIVES the turn. A parked call is swept denied at turn
+end so a live-but-dead card cannot accrete in the queue — which, for a build,
+tombstoned the app the moment the turn that asked for it ended.
+
+`MakeReceipt.status` drops `"awaiting-consent"`; nothing produces it any more.

--- a/.changeset/build-consent-pending-approval.md
+++ b/.changeset/build-consent-pending-approval.md
@@ -2,6 +2,7 @@
 "@vendoai/core": minor
 "@vendoai/apps": minor
 "@vendoai/harnesses": minor
+"@vendoai/ui": minor
 "@vendoai/vendo": minor
 ---
 
@@ -17,11 +18,22 @@ for work nobody had authorized. It now returns the ordinary
 part the thread renders the card from, and what the MCP door maps to its
 approval-ref result.
 
-`ToolOutcome`'s `pending-approval` gains two optional fields for the tool that
-parks an ask of its OWN: `approval` (`{ id, question, notes }` — the ask in
+`ToolOutcome`'s `pending-approval` gains three optional fields for the tool that
+parks an ask of its OWN: `descriptor` (the ask's own — what a CARD derives its
+words from), `approval` (`{ id, question, notes }` — the same ask already in
 words, for a surface that renders no card) and `say` (the assistant's sentence
-meanwhile). Both are optional and additive; every shipped producer and reader
-is untouched.
+meanwhile). All three are optional and additive; every shipped producer and
+reader is untouched.
+
+The descriptor rides the `data-vendo-approval` part, so the in-thread card is
+graded and worded off the BUILD. Graded off the calling tool it read
+`vendo_make`'s "read", and told a person that spending a build machine reads
+their data. And because a standing ask has no parked native call to render
+from — nor may it have one, since the runtime abandons every still-parked ask
+at the next turn — the thread now paints the shipped `ApprovalCard` from that
+part directly, deciding over the wire like the queue and the toast, with no
+`remember` disclosure. Before this the transcript showed only the calling
+tool's beat, "wasn't allowed", for a question nobody had been asked yet.
 
 Such a card also now SURVIVES the turn. A parked call is swept denied at turn
 end so a live-but-dead card cannot accrete in the queue — which, for a build,

--- a/.changeset/build-consent-pending-approval.md
+++ b/.changeset/build-consent-pending-approval.md
@@ -39,4 +39,13 @@ Such a card also now SURVIVES the turn. A parked call is swept denied at turn
 end so a live-but-dead card cannot accrete in the queue — which, for a build,
 tombstoned the app the moment the turn that asked for it ended.
 
+An answered card SETTLES, and the assistant stops talking over it. In-thread
+consent cards resolve into the settled record on decide — including a decide the
+wire says was already answered (or swept), which used to leave the buttons live
+under an error on a closed question. And `say` is now the refusal the harness
+hands the model for a tool that parked its own ask, so the model relays the one
+sentence the door wrote ("I've asked for your go-ahead — the card above has the
+details.") instead of narrating its own paragraphs under a card that is already
+asking.
+
 `MakeReceipt.status` drops `"awaiting-consent"`; nothing produces it any more.

--- a/.changeset/mcp-door-built-apps.md
+++ b/.changeset/mcp-door-built-apps.md
@@ -1,0 +1,28 @@
+---
+"@vendoai/mcp": minor
+"@vendoai/vendo": minor
+---
+
+The MCP door speaks the built-app world an outside agent now meets.
+
+A SEALED bundle is the app, and it is not a page: it boots inside the host's own
+UI, in a sandboxed frame whose only way out is the host's postMessage bridge. So
+`vendo_apps_open` answers a bundle with the open-in-product card an app with a
+url of its own already took — the product's name and the deployment's public url,
+"Open Spending in Maple: https://…" — and a deployment that named no public url
+still says the app is built and ready rather than handing back a content hash,
+which was the whole of the previous answer.
+
+The two build-window waits stop arriving as failures. An app whose build the
+person has not approved, and one still being built, both refuse an open with a
+not-found; the door names them ("waiting on the user's build approval", "still
+being built") on every leg it serves — its own apps path and the one the bound
+registry owns — so an agent narrates the wait instead of telling someone their
+app is gone. A build that failed for good comes back as its reason, plus whether
+asking again may work, instead of a JSON record to paraphrase. Each answer still
+rides as `structuredContent` under its own `kind`, so a loop reads the state
+rather than the English.
+
+The umbrella's door port stops narrowing what an open may answer: it forwarded
+trees and http surfaces and threw "this is a server app resuming in-product" at
+everything else — a rung that no longer exists.

--- a/fixtures/mcp-e2e/src/harness.ts
+++ b/fixtures/mcp-e2e/src/harness.ts
@@ -13,14 +13,15 @@ import type {
   VendoTheme,
 } from "@vendoai/apps/contract";
 import { createActions } from "@vendoai/actions";
-import { createApps, SCREEN_FILE, type AppsRuntime } from "@vendoai/apps";
+import { createApps, sealBundleBlobs, SCREEN_FILE, type AppsRuntime } from "@vendoai/apps";
 import { createGuard, type PolicyConfig, type VendoGuard } from "@vendoai/guard";
 import { createMcpDoor, type McpDoorConfig, type HostOAuthAdapter } from "@vendoai/mcp";
-import { createStore, type VendoStore } from "@vendoai/store";
+import { createStore, storeFiles, type VendoStore } from "@vendoai/store";
 
 export const SUBJECT = "user_1";
 export const FIXTURE_APP_ID = "app_mcp_fixture";
 export const HTTP_FIXTURE_APP_ID = "app_mcp_http_fixture";
+export const BUNDLE_FIXTURE_APP_ID = "app_mcp_bundle_fixture";
 export const MCP_MOUNT = "/api/vendo/mcp";
 export const FIXTURE_THEME: VendoTheme = {
   colors: {
@@ -214,6 +215,30 @@ export async function createStack(options: StackOptions = {}): Promise<Stack> {
     data: { subject: SUBJECT, enabled: false, doc: httpFixtureApp },
     refs: { subject: SUBJECT },
   });
+  // A SEALED bundle (FINAL SPEC v1) written through the REAL seal, so what the
+  // door projects is a built app's own surface rather than a shape this file
+  // invented.
+  const bundle = await sealBundleBlobs(
+    BUNDLE_FIXTURE_APP_ID,
+    [{ path: "dist/app.js", bytes: new TextEncoder().encode('document.title = "sealed";\n') }],
+    "dist/app.js",
+    storeFiles(store),
+  );
+  await store.records("vendo_apps").put({
+    id: BUNDLE_FIXTURE_APP_ID,
+    data: {
+      subject: SUBJECT,
+      enabled: false,
+      doc: {
+        format: "vendo/app@1",
+        id: BUNDLE_FIXTURE_APP_ID,
+        name: "MCP sealed app",
+        ui: "bundle",
+        bundle,
+      } satisfies AppDocument,
+    },
+    refs: { subject: SUBJECT },
+  });
   const resolvePrincipal: HostOAuthAdapter["principal"] = async (subject) => {
     return revoked.has(subject)
       ? null
@@ -246,9 +271,11 @@ export async function createStack(options: StackOptions = {}): Promise<Stack> {
         return { kind: "http", url: `${origin}/fixture/apps/${HTTP_FIXTURE_APP_ID}` };
       }
       const opened = await apps.open(appId, ctx);
-      if (opened.kind === "tree") return { kind: "tree", payload: opened.payload };
-      if (opened.kind === "http") return { kind: "http", url: opened.url };
-      throw new Error(`rung-1 fixture cannot serve app surface "${opened.kind}"`);
+      // Only the tree is narrowed (its resolved payload is what the shim
+      // renders); every other surface travels as itself, exactly as the
+      // umbrella's own port does — the DOOR is what turns an open into
+      // something an agent can say.
+      return opened.kind === "tree" ? { kind: "tree", payload: opened.payload } : opened;
     },
     call: (appId, ref, args, ctx) => apps.call(appId, ref, args, ctx),
   };

--- a/fixtures/mcp-e2e/tests/apps-ride-along.e2e.test.ts
+++ b/fixtures/mcp-e2e/tests/apps-ride-along.e2e.test.ts
@@ -1,5 +1,11 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { createStack, FIXTURE_APP_ID, HTTP_FIXTURE_APP_ID, resetFixture } from "../src/harness.js";
+import {
+  BUNDLE_FIXTURE_APP_ID,
+  createStack,
+  FIXTURE_APP_ID,
+  HTTP_FIXTURE_APP_ID,
+  resetFixture,
+} from "../src/harness.js";
 import { connectWithSdk, textOf } from "../src/support.js";
 
 const SHIM_URI = "ui://vendo/tree-shim.html";
@@ -88,6 +94,29 @@ describe("saved apps ride along as MCP Apps", () => {
         expect(textOf(opened)).toMatch(
           new RegExp(`Open MCP hosted dashboard in .+: ${stack.origin}/fixture/apps/${HTTP_FIXTURE_APP_ID}`),
         );
+      } finally {
+        await connected.close();
+      }
+    } finally {
+      await stack.close();
+    }
+  });
+
+  it("opens a SEALED bundle as the built app it is, never as its content hash", async () => {
+    const stack = await createStack();
+    try {
+      const connected = await connectWithSdk(stack);
+      try {
+        const opened = await connected.client.callTool({
+          name: "vendo_apps_open",
+          arguments: { appId: BUNDLE_FIXTURE_APP_ID },
+        });
+        expect(opened.isError).not.toBe(true);
+        // This door was composed with no public base url, so there is no link to
+        // hand out — and the answer is still a sentence about a ready app rather
+        // than the entry hash, which is the one thing an agent cannot use.
+        expect(textOf(opened)).toMatch(/^This app is built and ready to open in .+\.$/);
+        expect(textOf(opened)).not.toMatch(/[0-9a-f]{64}/);
       } finally {
         await connected.close();
       }

--- a/packages/apps/src/contract/make-receipt.ts
+++ b/packages/apps/src/contract/make-receipt.ts
@@ -29,13 +29,14 @@
  *    agent over MCP — read plain success off a half-built app (2026-08-11). Not
  *    `"failed"`, which means nothing is painted and sends the agent to rebuild:
  *    this view is real, reopenable, and worth keeping.
- * 5. **`"awaiting-consent"` is the honest answer for a BUILD.** A build spends a
- *    machine, and FINAL SPEC v1's law is that no machine is spent without the
- *    person's explicit yes — so the tool raises the standing approval card and
- *    the turn ENDS, having spent nothing. Not `"building"`, which would have the
- *    agent narrate work nobody has authorized yet. Cost governance stays host
- *    config: this is a consent card, not a price quote, and `say` carries no
- *    estimate.
+ * 5. **A BUILD never gets a receipt at all.** A build spends a machine, and FINAL
+ *    SPEC v1's law is that no machine is spent without the person's explicit yes
+ *    — so the tool parks the ask and answers with the standard `pending-approval`
+ *    outcome, which is what every consent surface already routes on. There was an
+ *    `"awaiting-consent"` status here, and it was a receipt saying `status: "ok"`:
+ *    invisible to the card, to the MCP door and to every other reader that
+ *    branches on the outcome. Not `"building"` either, which would have the agent
+ *    narrate work nobody has authorized yet.
  */
 import { z } from "zod";
 import { appIdSchema, type AppId } from "@vendoai/core";
@@ -45,7 +46,7 @@ export interface MakeReceipt {
   id: AppId;
   /** The app's name, in human words — never a slug or an identifier. */
   title: string;
-  status: "ready" | "partial" | "building" | "awaiting-consent" | "failed";
+  status: "ready" | "partial" | "building" | "failed";
   /** Speakable as it stands, consumer voice — the builder's own summary where
    *  there was one to relay. */
   say: string;
@@ -55,6 +56,6 @@ export interface MakeReceipt {
 export const makeReceiptSchema = z.object({
   id: appIdSchema,
   title: z.string().min(1),
-  status: z.enum(["ready", "partial", "building", "awaiting-consent", "failed"]),
+  status: z.enum(["ready", "partial", "building", "failed"]),
   say: z.string().min(1),
 }).passthrough() satisfies z.ZodType<MakeReceipt>;

--- a/packages/apps/src/server/doors/build-door.ts
+++ b/packages/apps/src/server/doors/build-door.ts
@@ -58,7 +58,11 @@ export const BUILD_CONSENT_ASK: Omit<PendingApproval, "id"> = {
   notes: [BUILD_DESCRIPTION],
 };
 
-const buildDescriptor = (): ToolDescriptor => ({
+/** THE authored ask, and the source both surfaces read: the CARD derives its
+ *  words from this descriptor (`consentAsk` off the `data-vendo-approval` part's
+ *  copy of it), and {@link BUILD_CONSENT_ASK} above is the same ask already in
+ *  words for the surfaces that render no card. One author, two renderings. */
+export const buildDescriptor = (): ToolDescriptor => ({
   name: BUILD_TOOL,
   title: BUILD_TITLE,
   description: BUILD_DESCRIPTION,

--- a/packages/apps/src/server/doors/build-door.ts
+++ b/packages/apps/src/server/doors/build-door.ts
@@ -17,6 +17,7 @@ import {
   type AppBundle,
   type AppId,
   type ApprovalId,
+  type PendingApproval,
   type RunContext,
   type ToolCall,
   type ToolDescriptor,
@@ -42,13 +43,25 @@ import type { AppsRuntime } from "../runtime/types.js";
  * on it, so the harness's 90-second approval wait is not in this path at all.
  */
 const BUILD_TOOL = VENDO_APP_BUILD_TOOL;
+// §3 consumer voice — the shared table, like every other Vendo descriptor.
+// Without it the card asked the person to authorize "Vendo app build".
+const BUILD_TITLE = VENDO_TOOL_TITLES[BUILD_TOOL]!;
+const BUILD_DESCRIPTION = "Build this app for real: a sandbox installs the packages it needs, writes and tests the code,"
+  + " and the result is sealed. It spends a build machine, so it needs the person's yes.";
+
+/** This ask in words, for the surfaces that render no card. `consentAsk`'s own
+ *  ladder (ui/chrome/build-beat.tsx) read off the descriptor below — its title as
+ *  the question, its authored sentence as the note — so what an outside caller is
+ *  handed and what the person in the thread is shown come from one source. */
+export const BUILD_CONSENT_ASK: Omit<PendingApproval, "id"> = {
+  question: `${BUILD_TITLE}?`,
+  notes: [BUILD_DESCRIPTION],
+};
+
 const buildDescriptor = (): ToolDescriptor => ({
   name: BUILD_TOOL,
-  // §3 consumer voice — the shared table, like every other Vendo descriptor.
-  // Without it the card asked the person to authorize "Vendo app build".
-  title: VENDO_TOOL_TITLES[BUILD_TOOL],
-  description: "Build this app for real: a sandbox installs the packages it needs, writes and tests the code,"
-    + " and the result is sealed. It spends a build machine, so it needs the person's yes.",
+  title: BUILD_TITLE,
+  description: BUILD_DESCRIPTION,
   inputSchema: {
     type: "object",
     properties: { appId: { type: "string" }, prompt: { type: "string" } },

--- a/packages/apps/src/server/doors/build-messages.ts
+++ b/packages/apps/src/server/doors/build-messages.ts
@@ -35,9 +35,14 @@ export const NO_MACHINE = "This needs a real build — code running on a server 
  *  screen. FIRST person, unlike the three above: this one is the assistant's
  *  own sentence on the receipt, and it is the only thing the calling agent is
  *  given to say. No estimate and no cost — the card is a consent question, not
- *  a price quote (make-receipt.ts law 5). */
-export const AWAITING_CONSENT = "This one needs a real build, not just a screen — I've asked for your"
-  + " go-ahead, and it starts as soon as you approve.";
+ *  a price quote (make-receipt.ts law 5).
+ *
+ *  ONE SHORT SENTENCE, and it points AT the card. The say is what the agent
+ *  utters verbatim (make-receipt.ts law 2), and a say that explained the
+ *  situation was read as an invitation to explain it further: the model wrote
+ *  paragraphs under a card that was already asking the question. The shape is
+ *  the instruction — there is nothing here left to expand on. */
+export const AWAITING_CONSENT = "I've asked for your go-ahead — the card above has the details.";
 /** The other terminal landing an OFFERED build has: the person answered the
  *  standing card with no. Same third-person voice as NO_MACHINE — a system
  *  notice — and it never mentions a box, because none was opened. */

--- a/packages/apps/src/server/doors/make-tool.ts
+++ b/packages/apps/src/server/doors/make-tool.ts
@@ -30,7 +30,7 @@ import {
 } from "../../contract/index.js";
 import type { AgentToolsDataDependencies } from "./agent-tools.js";
 import { automationCard } from "./automate-tool.js";
-import { BUILD_CONSENT_ASK } from "./build-door.js";
+import { BUILD_CONSENT_ASK, buildDescriptor } from "./build-door.js";
 import { AWAITING_CONSENT, NO_ASSEMBLER, NOTHING_RENDERABLE, NO_MACHINE } from "./build-messages.js";
 import { input, optionalString, resolveAppRef } from "./tool-args.js";
 import type { AppsRuntime, EditResult } from "../runtime/types.js";
@@ -234,12 +234,16 @@ const makeNewApp = async (
   // `status: "ok"` was invisible to everything downstream that routes on the
   // status — the in-thread approval card is published off this outcome
   // (harnesses' `guardedCall`), and an outside caller reads the ask off it. The
-  // words ride along because nothing else here can say them: `approval` is what
-  // a surface with no card renders, and `say` is the assistant's own sentence.
+  // words ride along because nothing else here can say them: `descriptor` is
+  // what a CARD derives its words from, `approval` is the same ask already in
+  // words for a surface that renders none, and `say` is the assistant's own
+  // sentence. Without the descriptor the card graded this ask off `vendo_make`
+  // — a read — and told the person a build "reads your data".
   return {
     status: "pending-approval",
     approvalId: proposed.approvalId,
     approval: { id: proposed.approvalId, ...BUILD_CONSENT_ASK },
+    descriptor: buildDescriptor(),
     say: AWAITING_CONSENT,
   };
 };

--- a/packages/apps/src/server/doors/make-tool.ts
+++ b/packages/apps/src/server/doors/make-tool.ts
@@ -30,6 +30,7 @@ import {
 } from "../../contract/index.js";
 import type { AgentToolsDataDependencies } from "./agent-tools.js";
 import { automationCard } from "./automate-tool.js";
+import { BUILD_CONSENT_ASK } from "./build-door.js";
 import { AWAITING_CONSENT, NO_ASSEMBLER, NOTHING_RENDERABLE, NO_MACHINE } from "./build-messages.js";
 import { input, optionalString, resolveAppRef } from "./tool-args.js";
 import type { AppsRuntime, EditResult } from "../runtime/types.js";
@@ -229,7 +230,18 @@ const makeNewApp = async (
     return await failUnbuilt(title, unbuiltSay(proposed.declined));
   }
   await remember(appId);
-  return receipt({ id: appId, title, status: "awaiting-consent", say: AWAITING_CONSENT });
+  // THE STANDARD PROTOCOL, and not a receipt: a parked ask that answered
+  // `status: "ok"` was invisible to everything downstream that routes on the
+  // status — the in-thread approval card is published off this outcome
+  // (harnesses' `guardedCall`), and an outside caller reads the ask off it. The
+  // words ride along because nothing else here can say them: `approval` is what
+  // a surface with no card renders, and `say` is the assistant's own sentence.
+  return {
+    status: "pending-approval",
+    approvalId: proposed.approvalId,
+    approval: { id: proposed.approvalId, ...BUILD_CONSENT_ASK },
+    say: AWAITING_CONSENT,
+  };
 };
 
 const changeExistingApp = async (

--- a/packages/apps/tests/agent-tools.test.ts
+++ b/packages/apps/tests/agent-tools.test.ts
@@ -735,13 +735,12 @@ describe("vendo_make — the slot a new app lands in", () => {
       args: { request: "match my invoices to payments", slot: "dashboard.hero" },
     }, ctx);
 
-    expect(outcome.status).toBe("ok");
-    const receipt = (outcome as { output: { id: string; status: string } }).output;
-    // S3 — the escalated ask is now OFFERED, not built. The row and the slot
-    // still land at the mint, which is what this test is about.
-    expect(receipt.status).toBe("awaiting-consent");
+    // S3 — the escalated ask is now OFFERED, not built, and it answers on the
+    // standard park. The row and the slot still land at the mint, which is what
+    // this test is about.
+    expect(outcome.status).toBe("pending-approval");
     expect(await runtime.placements({}, ctx)).toEqual([
-      expect.objectContaining({ slot: "dashboard.hero", app: receipt.id }),
+      expect.objectContaining({ slot: "dashboard.hero", app: expect.stringMatching(/^app_/) }),
     ]);
   });
 

--- a/packages/apps/tests/build-consent.test.ts
+++ b/packages/apps/tests/build-consent.test.ts
@@ -14,6 +14,7 @@ import {
   VendoError,
   engineOverAdapter,
   type AppId,
+  type ApprovalId,
   type FilesAdapter,
   type RunContext,
   type ToolRegistry,
@@ -29,7 +30,7 @@ import { APPS_COLLECTION } from "../src/server/persistence/persistence.js";
 import { runMakeTool } from "../src/server/doors/make-tool.js";
 import { readBundleBlob } from "../src/server/persistence/app-source.js";
 import { createApps, type AppsConfig } from "../src/server/index.js";
-import { guardFixture } from "../src/server/testing/guard-fixture.js";
+import { guardFixture, type GuardFixture } from "../src/server/testing/guard-fixture.js";
 import { memoryStore } from "../src/server/testing/memory-store.js";
 import type { AgentToolsDataDependencies } from "../src/server/doors/agent-tools.js";
 import { PARKED_BUILD_COLLECTION } from "@vendoai/core";
@@ -122,25 +123,48 @@ const receiptOf = (outcome: Awaited<ReturnType<typeof runMakeTool>>): { id: stri
   return outcome.output as unknown as { id: string; status: string; say: string };
 };
 
+/** An offered build is a PARK, not a receipt — and the app it is about is named
+ *  on the standing card itself, which is the only place a caller could read it. */
+const parkedOf = (
+  outcome: Awaited<ReturnType<typeof runMakeTool>>,
+  guard: GuardFixture,
+): { approvalId: ApprovalId; appId: AppId } => {
+  if (outcome.status !== "pending-approval") throw new Error(`expected a park, got ${outcome.status}`);
+  const ask = guard.approvals.find((approval) => approval.id === outcome.approvalId);
+  return { approvalId: outcome.approvalId, appId: (ask?.call.args as { appId: AppId }).appId };
+};
+
 describe("propose spends no box", () => {
   it("raises the standing card, parks the build, and claims nothing", async () => {
     const { builder, built } = recordingBuilder();
     const { guard, engine, make, rowOf } = setup({ build: builder });
 
-    const receipt = receiptOf(await make());
+    const outcome = await make();
+    const { approvalId, appId } = parkedOf(outcome, guard);
 
-    expect(receipt.status).toBe("awaiting-consent");
+    // THE PROTOCOL: the same `pending-approval` answer every other parked call
+    // gives, carrying the ask in words for a surface that renders no card.
+    expect(outcome).toMatchObject({
+      status: "pending-approval",
+      approvalId,
+      approval: {
+        id: approvalId,
+        question: "Build this app for real?",
+        notes: [expect.stringContaining("spends a build machine")],
+      },
+      say: expect.stringContaining("go-ahead"),
+    });
     // The whole point: the turn ended with the box untouched.
     expect(built).toEqual([]);
     // One undecided card, and the ask verbatim on it.
     expect(guard.approvals).toHaveLength(1);
-    expect(guard.approvals[0]?.call.args).toMatchObject({ appId: receipt.id, prompt: ASK });
+    expect(guard.approvals[0]?.call.args).toMatchObject({ appId, prompt: ASK });
     // Parked against that card, in the real collection.
-    const parked = await engine.get(PARKED_BUILD_COLLECTION, guard.approvals[0]?.id ?? "");
-    expect(parked?.data).toMatchObject({ appId: receipt.id, prompt: ASK, owner: "user_ada" });
+    const parked = await engine.get(PARKED_BUILD_COLLECTION, approvalId);
+    expect(parked?.data).toMatchObject({ appId, prompt: ASK, owner: "user_ada" });
     // The row says "offered, unanswered" — and never "building".
-    const row = await rowOf(receipt.id);
-    expect(row?.proposal).toMatchObject({ approvalId: guard.approvals[0]?.id, prompt: ASK });
+    const row = await rowOf(appId);
+    expect(row?.proposal).toMatchObject({ approvalId, prompt: ASK });
     expect(row?.building).toBeUndefined();
   });
 });
@@ -151,21 +175,20 @@ describe("the decision alone starts the build", () => {
     const bytes = new TextEncoder().encode("console.log('built')");
     const { builder, built } = recordingBuilder({ kind: "built", files: [{ path: entry, bytes }], entry });
     const { guard, engine, files, make, rowOf } = setup({ build: builder });
-    const receipt = receiptOf(await make());
-    const approvalId = guard.approvals[0]?.id ?? "";
+    const { approvalId, appId } = parkedOf(await make(), guard);
     expect(built).toEqual([]);
 
     // Nothing but the decision. No second tool call, no re-dispatch.
     guard.decide(approvalId, true);
     await new Promise((resolve) => setImmediate(resolve));
 
-    expect(built).toEqual([{ appId: receipt.id, prompt: ASK, why: "this needs a real image library" }]);
-    const row = await rowOf(receipt.id);
+    expect(built).toEqual([{ appId, prompt: ASK, why: "this needs a real image library" }]);
+    const row = await rowOf(appId);
     expect(row?.ui).toBe("bundle");
     expect(row?.bundle).toMatchObject({ bytes: bytes.byteLength });
     // Sealed for real: the entry hash reads back as the bytes the builder made.
     const entryHash = (row?.bundle as { entry: string }).entry;
-    expect(await readBundleBlob(receipt.id as AppId, entryHash, files)).toEqual(bytes);
+    expect(await readBundleBlob(appId, entryHash, files)).toEqual(bytes);
     // Both build-state fields are gone: the app IS built now.
     expect(row?.proposal).toBeUndefined();
     expect(row?.building).toBeUndefined();
@@ -176,14 +199,13 @@ describe("the decision alone starts the build", () => {
   it("denying it spends no box and leaves the honest failure card", async () => {
     const { builder, built } = recordingBuilder();
     const { guard, engine, make, rowOf } = setup({ build: builder });
-    const receipt = receiptOf(await make());
-    const approvalId = guard.approvals[0]?.id ?? "";
+    const { approvalId, appId } = parkedOf(await make(), guard);
 
     guard.decide(approvalId, false);
     await new Promise((resolve) => setImmediate(resolve));
 
     expect(built).toEqual([]);
-    const row = await rowOf(receipt.id);
+    const row = await rowOf(appId);
     expect(row?.proposal).toBeUndefined();
     expect(row?.buildFailed).toMatchObject({ reason: expect.stringContaining("not approved") });
     expect(await engine.get(PARKED_BUILD_COLLECTION, approvalId)).toBeNull();
@@ -238,10 +260,10 @@ describe("a refusal reads the row it is refusing", () => {
   const ran = async (lane: ReturnType<typeof laneThat>) => {
     const composed = setup({ build: lane.builder });
     lane.bind(composed.engine);
-    const receipt = receiptOf(await composed.make());
-    composed.guard.decide(composed.guard.approvals[0]?.id ?? "", true);
+    const { approvalId, appId } = parkedOf(await composed.make(), composed.guard);
+    composed.guard.decide(approvalId, true);
     await new Promise((resolve) => setImmediate(resolve));
-    return await composed.rowOf(receipt.id);
+    return await composed.rowOf(appId);
   };
 
   it("leaves a SEALED app alone when the refusal lands after the seal", async () => {

--- a/packages/apps/tests/make-tool.test.ts
+++ b/packages/apps/tests/make-tool.test.ts
@@ -153,12 +153,25 @@ describe("vendo_make publishes the automation card (#881)", () => {
 });
 
 describe("an escalated ask is OFFERED, never built (S3)", () => {
-  it("ends the turn on awaiting-consent, with nothing spent", async () => {
-    const { call } = makeCall();
-    const { runtime } = runtimeWith(undefined);
-    const receipt = receiptOf(await runMakeTool(runtime, deps, call, ctx));
-    expect(receipt.status).toBe("awaiting-consent");
-    expect(receipt.say).toContain("go-ahead");
+  it("parks the ask on the standard protocol, with nothing spent and nothing armed", async () => {
+    // COMPOUND on purpose: an offered build has no app yet, so the schedule half
+    // has nothing to arm and the automation door must not be asked for one.
+    const { call } = makeCall("build me the invoice board and refresh it every monday");
+    const { runtime, asked } = runtimeWith(undefined);
+
+    // The same answer every other parked call gives, plus the ask in words for a
+    // surface that renders no card.
+    expect(await runMakeTool(runtime, deps, call, ctx)).toMatchObject({
+      status: "pending-approval",
+      approvalId: "apr_build_1",
+      approval: {
+        id: "apr_build_1",
+        question: "Build this app for real?",
+        notes: [expect.stringContaining("spends a build machine")],
+      },
+      say: expect.stringContaining("go-ahead"),
+    });
+    expect(asked).toEqual([]);
   });
 });
 
@@ -166,7 +179,7 @@ describe("the schedule half of a compound ask", () => {
   const COMPOUND = "build me the invoice board and refresh it every monday";
 
   it("reaches the automation door, and says so on the receipt", async () => {
-    const { call, updates } = makeCall(COMPOUND);
+    const { call, updates } = makeCall(COMPOUND, "app_made");
     const { runtime, asked } = runtimeWith(undefined, {
       ok: true,
       document: { format: VENDO_APP_FORMAT, id: "app_made", name: "Invoice nudges" },
@@ -189,12 +202,12 @@ describe("the schedule half of a compound ask", () => {
   });
 
   it("never fails the make when the schedule could not be armed — the app is on screen", async () => {
-    const { call, updates } = makeCall(COMPOUND);
+    const { call, updates } = makeCall(COMPOUND, "app_made");
     const { runtime } = runtimeWith(undefined, { ok: false, issues: ["no valid plan validated"] });
     const outcome = await runMakeTool(runtime, deps, call, ctx);
 
     const receipt = receiptOf(outcome);
-    expect(receipt.status).toBe("awaiting-consent");
+    expect(receipt.status).toBe("ready");
     expect(receipt.say).toContain("I couldn't set up the schedule: no valid plan validated");
     expect(updates.some((update) => update.part.type === "data-vendo-automation")).toBe(false);
   });

--- a/packages/apps/tests/screen-route.test.ts
+++ b/packages/apps/tests/screen-route.test.ts
@@ -187,22 +187,23 @@ describe("an escalation and the build that finishes it share ONE app id", () => 
 
     const outcome = await make(agentTools);
 
-    expect(outcome.status).toBe("ok");
-    const receipt = (outcome as { output: { id: string; status: string } }).output;
+    // S3 — an escalation with somewhere to build is an ASK, not a build, and it
+    // answers on the standard park so every consent surface downstream sees it.
+    if (outcome.status !== "pending-approval") throw new Error(`expected a park, got ${outcome.status}`);
     // The assembler was consulted ONCE, before anything was built — the seam
     // routes, the caller does not, and an escalation carries its `why` into the
     // proposal so the build never runs a second agent over the same ask.
     expect(seen).toHaveLength(1);
-    // …and that consultation, plus the build the person is being asked about,
-    // is at ONE id. This is the assertion that stops a stranded second stream.
-    expect(seen[0]?.appId).toBe(receipt.id);
-    // S3 — an escalation with somewhere to build is an ASK, not a build.
-    expect(receipt.status).toBe("awaiting-consent");
     // THE ASK IS THE BRIEF, and it is held as written — the person's own words
     // rather than a second, unrelated answer to the same ask. It waits on the
-    // proposal because the yes may land long after this turn.
-    const row = await store.records("vendo_apps").get(receipt.id);
-    const proposal = (row?.data as { doc: { proposal?: { prompt: string; why: string } } }).doc.proposal;
+    // proposal because the yes may land long after this turn — and that proposal
+    // is at the id the screen agent was handed, carrying the very approval the
+    // caller was answered with. This is what stops a stranded second stream.
+    const row = await store.records("vendo_apps").get(seen[0]!.appId);
+    const proposal = (row?.data as {
+      doc: { proposal?: { approvalId: string; prompt: string; why: string } };
+    }).doc.proposal;
+    expect(proposal?.approvalId).toBe(outcome.approvalId);
     expect(proposal?.prompt).toContain("Show my spending by category");
     // The escalation's one-line `why` travels beside it: the box will hear why
     // this cannot happen in the browser, and nothing else was decided for it.

--- a/packages/core/src/stream-parts.ts
+++ b/packages/core/src/stream-parts.ts
@@ -13,7 +13,7 @@ import {
   type TurnId,
 } from "./ids.js";
 import { knowledgeKindSchema, knowledgeVisibilitySchema, type KnowledgeKind, type KnowledgeVisibility } from "./knowledge.js";
-import { riskLabelSchema, type RiskLabel } from "./tools.js";
+import { riskLabelSchema, toolDescriptorSchema, type RiskLabel, type ToolDescriptor } from "./tools.js";
 import type { ToolCall } from "./tools.js";
 import { uiPayloadSchema, type UIPayload } from "./genui/tree-node.js";
 import { triggerSourceSchema, type TriggerSource } from "./triggers.js";
@@ -160,6 +160,12 @@ export interface VendoApprovalPart {
     id: GrantId;
     grantedAt: IsoDateTime;
   };
+  /** The ask's OWN descriptor, present when the tool parked an ask about
+   *  something other than the call the model made (the built-app door asks about
+   *  a BUILD, from inside `vendo_make`). The client's shared §16 builder reads
+   *  its title and schema (`buildApprovalRequest`), so the card derives the same
+   *  words the server authored instead of humanizing the calling tool's slug. */
+  descriptor?: ToolDescriptor;
 }
 
 /** 01-core §16 */
@@ -172,6 +178,7 @@ export const vendoApprovalPartSchema = z.object({
     id: grantIdSchema,
     grantedAt: isoDateTimeSchema,
   }).passthrough().optional(),
+  descriptor: toolDescriptorSchema.optional(),
 }).passthrough() satisfies z.ZodType<VendoApprovalPart>;
 
 /** Streamed when the agent loop stops because it exhausted its step cap, so

--- a/packages/core/src/tools.ts
+++ b/packages/core/src/tools.ts
@@ -447,14 +447,25 @@ const pendingApprovalSchema = z.object({
 export type ToolOutcome =
   | { status: "ok"; output: Json }
   | { status: "error"; error: { code: string; message: string } }
-  // `approval`/`say` are FIELDS on the existing status, never a status of their
-  // own — the same trade `blocked.cause` makes above. A tool that parks an ask
-  // of its OWN (the built-app door: the ask is about a build, not about calling
-  // that tool) is the one that knows what the card says and what to tell the
-  // person meanwhile; a park the guard raised on the tool's own descriptor is
-  // already described by it, so both stay optional and every shipped producer
-  // and reader is untouched.
-  | { status: "pending-approval"; approvalId: ApprovalId; approval?: PendingApproval; say?: string }
+  // `approval`/`say`/`descriptor` are FIELDS on the existing status, never a
+  // status of their own — the same trade `blocked.cause` makes above. A tool
+  // that parks an ask of its OWN (the built-app door: the ask is about a build,
+  // not about calling that tool) is the one that knows what the card says and
+  // what to tell the person meanwhile; a park the guard raised on the tool's own
+  // descriptor is already described by it, so all three stay optional and every
+  // shipped producer and reader is untouched.
+  //
+  // `descriptor` is the ask's own — what the CARD reads. `approval` is the same
+  // ask already in words, for the surfaces that render no card, and both are
+  // authored off the one descriptor (build-door.ts), so a card and an outside
+  // agent can never be told different things about one ask.
+  | {
+      status: "pending-approval";
+      approvalId: ApprovalId;
+      approval?: PendingApproval;
+      say?: string;
+      descriptor?: ToolDescriptor;
+    }
   | { status: "blocked"; reason: string; cause?: "expired" }
   | { status: "connect-required"; connect: ConnectRequired };
 
@@ -470,6 +481,7 @@ export const toolOutcomeSchema = z.discriminatedUnion("status", [
     approvalId: approvalIdSchema,
     approval: pendingApprovalSchema.optional(),
     say: z.string().min(1).optional(),
+    descriptor: toolDescriptorSchema.optional(),
   }).passthrough(),
   z.object({
     status: z.literal("blocked"),

--- a/packages/core/src/tools.ts
+++ b/packages/core/src/tools.ts
@@ -416,6 +416,24 @@ const connectRequiredSchema = z.object({
   message: z.string(),
 }).passthrough() satisfies z.ZodType<ConnectRequired>;
 
+/** 01-core §4 — the parked ask in words, for the surfaces that render no card:
+ *  an outside agent over MCP, a text message, a transcript. `question` is what
+ *  the person is being asked; `notes` are the quiet lines under it — the same
+ *  pair the in-thread card composes (`consentAsk`, ui/chrome/build-beat.tsx),
+ *  never a second vocabulary for one ask. */
+export interface PendingApproval {
+  id: ApprovalId;
+  question: string;
+  notes: string[];
+}
+
+/** 01-core §4 */
+const pendingApprovalSchema = z.object({
+  id: approvalIdSchema,
+  question: z.string().min(1),
+  notes: z.array(z.string()),
+}).passthrough() satisfies z.ZodType<PendingApproval>;
+
 /** 01-core §4
  *
  *  `blocked.cause` narrows WHY nothing ran when the reason is nobody's doing:
@@ -429,7 +447,14 @@ const connectRequiredSchema = z.object({
 export type ToolOutcome =
   | { status: "ok"; output: Json }
   | { status: "error"; error: { code: string; message: string } }
-  | { status: "pending-approval"; approvalId: ApprovalId }
+  // `approval`/`say` are FIELDS on the existing status, never a status of their
+  // own — the same trade `blocked.cause` makes above. A tool that parks an ask
+  // of its OWN (the built-app door: the ask is about a build, not about calling
+  // that tool) is the one that knows what the card says and what to tell the
+  // person meanwhile; a park the guard raised on the tool's own descriptor is
+  // already described by it, so both stay optional and every shipped producer
+  // and reader is untouched.
+  | { status: "pending-approval"; approvalId: ApprovalId; approval?: PendingApproval; say?: string }
   | { status: "blocked"; reason: string; cause?: "expired" }
   | { status: "connect-required"; connect: ConnectRequired };
 
@@ -440,7 +465,12 @@ export const toolOutcomeSchema = z.discriminatedUnion("status", [
     status: z.literal("error"),
     error: z.object({ code: z.string(), message: z.string() }).passthrough(),
   }).passthrough(),
-  z.object({ status: z.literal("pending-approval"), approvalId: approvalIdSchema }).passthrough(),
+  z.object({
+    status: z.literal("pending-approval"),
+    approvalId: approvalIdSchema,
+    approval: pendingApprovalSchema.optional(),
+    say: z.string().min(1).optional(),
+  }).passthrough(),
   z.object({
     status: z.literal("blocked"),
     reason: z.string(),

--- a/packages/harnesses/src/tool-bridge.ts
+++ b/packages/harnesses/src/tool-bridge.ts
@@ -145,13 +145,19 @@ export function approvalPart(
   risk: RiskLabel,
   approvalId: ApprovalId,
   invalidatedGrant?: VendoApprovalPart["invalidatedGrant"],
+  /** The ask's OWN descriptor, when the tool parked an ask about something
+   *  other than the call the model made. It both GRADES the card and gives it
+   *  its authored words — `risk` above belongs to the calling tool, which for a
+   *  build is `vendo_make`'s "read". */
+  asked?: ToolDescriptor,
 ): VendoApprovalPart {
   return {
     type: "data-vendo-approval",
     toolCallId,
-    risk,
+    risk: asked?.risk ?? risk,
     approvalId,
     ...(invalidatedGrant === undefined ? {} : { invalidatedGrant }),
+    ...(asked === undefined ? {} : { descriptor: asked }),
   };
 }
 
@@ -308,7 +314,8 @@ export async function guardedCall(
     // so the card is published by the apps runtime through the stream seam above,
     // by the side that knows it armed something. One less thing read by shape.
   } else if (outcome.status === "pending-approval") {
-    writePart(options.writer, approvalPart(toolCallId, descriptor.risk, outcome.approvalId));
+    writePart(options.writer, approvalPart(
+      toolCallId, descriptor.risk, outcome.approvalId, undefined, outcome.descriptor));
   } else if (outcome.status === "connect-required") {
     // The inline connect card (04-actions §3): emitted beside the native
     // tool part exactly like the approval part, keyed by toolCallId.

--- a/packages/harnesses/src/turn-tools.ts
+++ b/packages/harnesses/src/turn-tools.ts
@@ -412,7 +412,16 @@ export function createTurnTools(options: TurnToolsOptions): RuntimeTurnTools {
         if (outcome.status === "pending-approval") {
           // The preview said run and the REAL check asked — a breaker or presence
           // boundary. Nobody is waiting on this one, so it must still be swept.
-          waiter.raise(outcome.approvalId, { standing: !options.interactive });
+          //
+          // UNLESS the tool parked an ask of its OWN and said what it asks
+          // (`approval`): the built-app door's card is answered on the person's
+          // clock, long after this turn, and sweeping it denied at turn end
+          // tombstoned the build the moment the turn ended. Only a tool that
+          // raised the ask itself can know that, which is why it is the tool
+          // that says so.
+          waiter.raise(outcome.approvalId, {
+            standing: !options.interactive || outcome.approval !== undefined,
+          });
           // The guard asked twice for one tap; refusing to loop is the honest
           // answer (a second card for the same call would be a trap).
           return refused("This still needs approval.", {

--- a/packages/harnesses/src/turn-tools.ts
+++ b/packages/harnesses/src/turn-tools.ts
@@ -424,7 +424,13 @@ export function createTurnTools(options: TurnToolsOptions): RuntimeTurnTools {
           });
           // The guard asked twice for one tap; refusing to loop is the honest
           // answer (a second card for the same call would be a trap).
-          return refused("This still needs approval.", {
+          //
+          // A tool that raised the ask ITSELF also wrote the one line the agent
+          // is to relay (`say` — make-receipt.ts law 2), and this refusal is the
+          // only thing the model reads about the call. Without it the model was
+          // told nothing but "needs approval" beside a card already asking the
+          // question, and narrated its own paragraphs under it.
+          return refused(outcome.say ?? "This still needs approval.", {
             kind: "approval",
             approvalId: outcome.approvalId,
           });

--- a/packages/mcp/src/door.ts
+++ b/packages/mcp/src/door.ts
@@ -895,8 +895,12 @@ class Door {
       // OpenSurface envelope — the same unwrap the OAuth leg does below. Both
       // legs share one mount and one `apps` config, so they cannot disagree
       // about whether a saved app renders.
-      if (name === "vendo_apps_open" && this.#config.apps !== undefined && result.status === "ok") {
-        return textResult(await this.#mcpAppsOpenOutput(result.output, args, turn.ctx, identity));
+      if (name === "vendo_apps_open" && this.#config.apps !== undefined) {
+        if (result.status === "ok") {
+          return textResult(await this.#mcpAppsOpenOutput(result.output, args, turn.ctx, identity));
+        }
+        const waiting = result.status === "error" ? buildWaitSay(result.error) : undefined;
+        if (waiting !== undefined) return textResult({ kind: "pending", say: waiting });
       }
       return turnResult(result);
     }
@@ -921,9 +925,18 @@ class Door {
     // apps.agentTools()) returns an OpenSurface envelope ({kind,payload}); the
     // MCP Apps shim renders a bare format-tagged UIPayload (core §8), so unwrap
     // it exactly as the door's own apps path does before mapping the result.
-    if (name === "vendo_apps_open" && this.#config.apps !== undefined && outcome.status === "ok") {
-      const output = await this.#mcpAppsOpenOutput(outcome.output, args, state.context, identity);
-      return mapOutcome({ status: "ok", output: output as Json }, identity.name);
+    if (name === "vendo_apps_open" && this.#config.apps !== undefined) {
+      if (outcome.status === "ok") {
+        const output = await this.#mcpAppsOpenOutput(outcome.output, args, state.context, identity);
+        return mapOutcome({ status: "ok", output: output as Json }, identity.name);
+      }
+      // A build the person has not approved, and one still running, both refuse
+      // the open with a not-found (06-apps, `persistence/open.ts`). Neither is a
+      // broken tool — an agent has to be able to narrate the wait — so the door
+      // names them here, on the leg the registry owns the tool on, exactly as it
+      // does on its own apps path (`#executeAppsTool`).
+      const waiting = outcome.status === "error" ? buildWaitSay(outcome.error) : undefined;
+      if (waiting !== undefined) return textResult({ kind: "pending", say: waiting });
     }
     return mapOutcome(outcome, identity.name, { descriptor, args });
   }
@@ -1018,9 +1031,16 @@ class Door {
       }
       return { status: "ok", output: await apps.call(appId, args.ref as string, args.args as Json, ctx) };
     } catch (error) {
+      // An app whose build is not through yet refuses the open with a not-found
+      // (06-apps, `persistence/open.ts`). That is a WAIT, not a broken tool, and
+      // an outside agent has to be able to narrate it — so the door names the
+      // two of them instead of handing back a failure.
+      const failure = { code: errorCode(error), message: errorMessage(error) };
+      const waiting = buildWaitSay(failure);
+      if (waiting !== undefined) return { status: "ok", output: { kind: "pending", say: waiting } };
       // Preserve the VendoError taxonomy (e.g. "cloud-required",
       // "sandbox-unavailable") — 00-overview's "one error taxonomy" convention.
-      return { status: "error", error: { code: errorCode(error), message: errorMessage(error) } };
+      return { status: "error", error: failure };
     }
   }
 
@@ -1069,7 +1089,7 @@ class Door {
     identity: HostIdentity,
   ): Promise<unknown> {
     let appName: string | undefined;
-    if (isHttpOpenSurface(output) && typeof args.appId === "string") {
+    if ((isHttpOpenSurface(output) || isBundleOpenSurface(output)) && typeof args.appId === "string") {
       try {
         appName = (await this.#config.apps!.list(ctx)).find((app) => app.id === args.appId)?.name;
       } catch {
@@ -1077,7 +1097,13 @@ class Door {
         // a secondary list failure must not hide the safe link-out path.
       }
     }
-    return projectAppsOpenOutput(output, { productName: identity.name, appName });
+    return projectAppsOpenOutput(output, {
+      productName: identity.name,
+      // The deployment's canonical public base (10-mcp §5), which is the only
+      // address the door knows a person can open this product at.
+      ...(this.#publicOrigin === undefined ? {} : { productUrl: this.#publicOrigin + this.#publicBasePath }),
+      appName,
+    });
   }
 
   async #sweepIdleSessions(): Promise<void> {
@@ -1619,6 +1645,10 @@ function isHttpOpenSurface(output: unknown): output is { kind: "http"; url: stri
   return isRecord(output) && output.kind === "http" && typeof output.url === "string";
 }
 
+function isBundleOpenSurface(output: unknown): output is { kind: "bundle"; entry: string } {
+  return isRecord(output) && output.kind === "bundle" && typeof output.entry === "string";
+}
+
 interface OpenInProductPayload {
   kind: typeof OPEN_IN_PRODUCT_KIND;
   url: string;
@@ -1634,16 +1664,36 @@ interface OpenInProductPayload {
  * for non-door hosts that send unresolved trees directly. */
 function projectAppsOpenOutput(
   output: unknown,
-  details: { productName: string; appName?: string },
+  details: { productName: string; productUrl?: string; appName?: string },
 ): unknown {
-  if (isHttpOpenSurface(output)) {
+  // A build that terminally failed never becomes servable (06-apps §1). The
+  // reason is written for a person, so the door speaks it instead of leaving an
+  // agent to paraphrase a JSON record.
+  if (isRecord(output) && output.kind === "failed" && typeof output.reason === "string") {
+    const retry = output.retryable === true ? " Asking for it again may work." : "";
+    return { ...output, say: `${output.reason}${retry}` };
+  }
+  // FINAL SPEC v1 — a SEALED bundle IS the app, and it is not a page: it boots
+  // inside the host's own UI, in a sandboxed frame whose only way out is the
+  // host's postMessage bridge (`ui/src/tree/frame-bridge.ts`). So the link-out
+  // names the PRODUCT, which is where the person opens it — the same card an
+  // app with a url of its own takes, because the sentence is the same sentence.
+  const url = isHttpOpenSurface(output)
+    ? output.url
+    : isBundleOpenSurface(output) ? details.productUrl : undefined;
+  if (url !== undefined) {
     const projected: OpenInProductPayload = {
       kind: OPEN_IN_PRODUCT_KIND,
-      url: output.url,
+      url,
       productName: details.productName,
       ...(details.appName === undefined ? {} : { appName: details.appName }),
     };
     return projected;
+  }
+  // A deployment that named no public URL has no link to give, so the sealed
+  // bundle says the one thing left that is true and useful — never its hash.
+  if (isBundleOpenSurface(output)) {
+    return { ...output, say: `This app is built and ready to open in ${details.productName}.` };
   }
   // FIX E — the registry's vendo_apps_open returns an OpenSurface envelope
   // (`{ kind: "tree", payload } | { kind: "http", url } | { kind: "resuming" }`);
@@ -1660,6 +1710,21 @@ function projectAppsOpenOutput(
   delete projected.queries;
   return projected;
 }
+
+/** The two answers the build window refuses an open with (`persistence/open.ts`):
+ *  a build nobody has approved yet, and one still running. Both are waits, and
+ *  this is what the door says instead of reporting them as failures. */
+function buildWaitSay(error: { code: string; message: string }): string | undefined {
+  const { code, message } = error;
+  if (code !== "not-found") return undefined;
+  if (message.endsWith("is waiting on its build to be approved")) {
+    return "This app is waiting on the user's build approval. Once they approve it, open it again.";
+  }
+  return message.endsWith("is still being built")
+    ? "This app is still being built. Open it again in a moment."
+    : undefined;
+}
+
 function replayKey(tool: string, args: Record<string, unknown>): string {
   return `${tool}\0${canonicalJson(args)}`;
 }
@@ -1775,7 +1840,7 @@ function mapOutcome(
 function textResult(output: unknown): CallToolResult {
   const text = isOpenInProductPayload(output)
     ? `Open ${output.appName ?? "this app"} in ${output.productName}: ${output.url}`
-    : stringify(output);
+    : appAnswerSay(output) ?? stringify(output);
   return {
     content: [{ type: "text", text }],
     structuredContent: isRecord(output) ? output : { [VENDO_RESULT_VALUE]: output },
@@ -1788,6 +1853,19 @@ function inBandError(text: string): CallToolResult {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** The answers an open gives that are not a surface to render: the build
+ *  window's waits, a build that failed for good, and a sealed bundle with no
+ *  product url to link to. The door mints `say` where it projects the answer
+ *  (`projectAppsOpenOutput`), so it speaks one line the agent can narrate while
+ *  the record still rides intact as `structuredContent` for a loop reading
+ *  `kind`. */
+const SAID_OPEN_KINDS: ReadonlySet<unknown> = new Set(["pending", "failed", "bundle"]);
+
+function appAnswerSay(value: unknown): string | undefined {
+  if (!isRecord(value) || !SAID_OPEN_KINDS.has(value.kind)) return undefined;
+  return typeof value.say === "string" ? value.say : undefined;
 }
 
 function isOpenInProductPayload(value: unknown): value is OpenInProductPayload {

--- a/packages/ui/src/chrome/embeds.tsx
+++ b/packages/ui/src/chrome/embeds.tsx
@@ -117,7 +117,7 @@ function BeatLine({ state, children }: { state: "working" | "done" | "error"; ch
  *  the line, and the line in danger colour. Muting the failure to the same grey
  *  as "Approved — ran" left the WORDS as the only difference between a call
  *  that landed and one that didn't, on a receipt people scan rather than read. */
-function ResolvedApprovalCard({ summary, ok, line, detail }: {
+export function ResolvedApprovalCard({ summary, ok, line, detail }: {
   summary: string;
   ok: boolean;
   line: string;

--- a/packages/ui/src/chrome/humanize.ts
+++ b/packages/ui/src/chrome/humanize.ts
@@ -198,7 +198,12 @@ export function previewArgs(args: unknown): string {
   if (fields.length > 0) return fields.map(field => `${field.label}: ${field.value}`).join("\n");
   if (typeof args === "string") return args;
   try {
-    return JSON.stringify(args, null, 2);
+    // `JSON.stringify(undefined)` ANSWERS undefined, and a call with no
+    // arguments is a real wire shape (`ApprovalWirePart.args` is optional, and a
+    // parked native part need not carry `input`) — the caller reads `.length`
+    // off this, so the card crashed the whole thread instead of showing an ask
+    // with nothing to display. Empty, never the word "undefined".
+    return JSON.stringify(args, null, 2) ?? "";
   } catch {
     return String(args);
   }

--- a/packages/ui/src/chrome/thread/parts.tsx
+++ b/packages/ui/src/chrome/thread/parts.tsx
@@ -1,4 +1,4 @@
-import { riskLabelSchema, VENDO_MAKE_TOOL, type RiskLabel, type UIPayload, type VendoApprovalPart, type VendoAutomationPart, type VendoBuildFailedPart, type VendoConnectPart, type VendoGrantSetPart, type VendoLimitPart, type VendoStepLimitPart, type VendoTurnErrorPart, type VendoViewPart } from "@vendoai/core";
+import { isVendoError, riskLabelSchema, VENDO_MAKE_TOOL, type RiskLabel, type UIPayload, type VendoApprovalPart, type VendoAutomationPart, type VendoBuildFailedPart, type VendoConnectPart, type VendoGrantSetPart, type VendoLimitPart, type VendoStepLimitPart, type VendoTurnErrorPart, type VendoViewPart } from "@vendoai/core";
 import { isToolUIPart, type DynamicToolUIPart, type ToolUIPart, type UIMessage } from "ai";
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import { useVendoProvider } from "../../context.js";
@@ -6,7 +6,7 @@ import { useSplitView } from "../split-view.js";
 import { useApprovalSheetPresentation } from "../../hooks/use-mobile-takeover.js";
 import { PayloadView } from "../../tree/renderer.js";
 import { PlacementAction } from "../add-to-picker.js";
-import { ApprovalCard } from "../approval-card.js";
+import { ApprovalCard, refusalCopy } from "../approval-card.js";
 import { useApprovalModal } from "../approval-modal.js";
 import { ApprovalSheet } from "../approval-sheet.js";
 import { ChromeRoot, useChromeTheme } from "../chrome-root.js";
@@ -573,6 +573,38 @@ function GrantSetConsent({ toolCallId, grantSetId, name, permissions, siblingPar
 }
 
 /**
+ * One decided card, SETTLED in place — the same settled register the wire-driven
+ * embed resolves into (`ResolvedApprovalCard` in embeds.tsx).
+ *
+ * A standing ask outlives the turn that raised it, so no stream will ever move
+ * its part out of `approval-requested`: without this the buttons stay live on a
+ * question the person already answered, and pressing them again asks the wire
+ * about a decision it has already made.
+ *
+ * An ask the wire says is ALREADY answered (or has been swept) settles too — the
+ * question is closed either way, and the consumer sentence for it is the card's
+ * own (`refusalCopy`). Only then: `landed` is the answer's onward journey (the
+ * native resume), which an ask that was decided elsewhere has no business
+ * restarting. Any other failure rethrows, so the card keeps its buttons and the
+ * person can try again.
+ */
+async function settleDecision(
+  decided: Promise<unknown>,
+  approve: boolean,
+  landed?: () => void,
+): Promise<{ ok: boolean; line: string }> {
+  try {
+    await decided;
+  } catch (reason) {
+    const code = isVendoError(reason) ? reason.code : undefined;
+    if (code !== "conflict" && code !== "not-found") throw reason;
+    return { ok: false, line: refusalCopy(reason) };
+  }
+  landed?.();
+  return { ok: approve, line: approve ? "Approved — under way" : "Declined — nothing ran" };
+}
+
+/**
  * A STANDING consent ask at its transcript position, on the ONE approval card.
  *
  * `ThreadApprovals` below renders every ask a NATIVE parked call carries, and
@@ -632,8 +664,7 @@ function ThreadStandingApproval({ part, siblingParts }: {
       allowRemember={false}
       showContext={false}
       onDecide={async ({ approve }) => {
-        await client.approvals.decide(approvalId, { approve });
-        setSettled({ ok: approve, line: approve ? "Approved — under way" : "Declined — nothing ran" });
+        setSettled(await settleDecision(client.approvals.decide(approvalId, { approve }), approve));
       }}
     />
   );
@@ -957,6 +988,11 @@ export function ThreadApprovals({ approvals, risks, guardApprovals, cardRefs, re
   // regression): on short viewports the consent stays an in-list card so the
   // voice stage's controls remain reachable.
   const mobile = useApprovalSheetPresentation();
+  // The answered cards, by ask id. A parked NATIVE ask normally leaves this list
+  // on its own — the stream moves its part past `approval-requested` — but a
+  // standing one (a restored transcript, an ask that outlived its turn) has no
+  // stream left to do it, so the card it left behind settles here instead.
+  const [settled, setSettled] = useState(new Map<string, { ok: boolean; line: string }>());
   return (
     <>
       {approvals.map((part, index) => {
@@ -983,6 +1019,14 @@ export function ThreadApprovals({ approvals, risks, guardApprovals, cardRefs, re
             ? {} : { descriptor: guardApproval.descriptor }),
         }, tools);
         const guardApprovalId = guardApproval?.approvalId;
+        const answered = settled.get(part.approval.id);
+        if (answered !== undefined) {
+          return (
+            <ChromeRoot key={part.approval.id}>
+              <ResolvedApprovalCard summary={approval.descriptor.title ?? name} ok={answered.ok} line={answered.line} />
+            </ChromeRoot>
+          );
+        }
         const asSheet = mobile && index === approvals.length - 1;
         const card = (
           <div key={part.approval.id} ref={element => { cardRefs.current.set(part.approval.id, element); }}>
@@ -1031,11 +1075,17 @@ export function ThreadApprovals({ approvals, risks, guardApprovals, cardRefs, re
                 }
                 // Decide the guard's approval record over the wire FIRST so the
                 // resumed execution replays as approved (05 §1) — the native
-                // response alone only tells the model loop to continue.
-                if (guardApprovalId !== undefined) {
-                  await client.approvals.decide([guardApprovalId], decision);
-                }
-                respond({ id: part.approval.id, approved: decision.approve });
+                // response alone only tells the model loop to continue. Then the
+                // card settles, because this one may be all there is: an ask that
+                // outlived its turn has no stream left to retire it.
+                const record = await settleDecision(
+                  guardApprovalId === undefined
+                    ? Promise.resolve()
+                    : client.approvals.decide([guardApprovalId], decision),
+                  decision.approve,
+                  () => respond({ id: part.approval.id, approved: decision.approve }),
+                );
+                setSettled(previous => new Map(previous).set(part.approval.id, record));
               }}
             />
           </div>

--- a/packages/ui/src/chrome/thread/parts.tsx
+++ b/packages/ui/src/chrome/thread/parts.tsx
@@ -1,4 +1,4 @@
-import { riskLabelSchema, VENDO_MAKE_TOOL, type RiskLabel, type UIPayload, type VendoAutomationPart, type VendoBuildFailedPart, type VendoConnectPart, type VendoGrantSetPart, type VendoLimitPart, type VendoStepLimitPart, type VendoTurnErrorPart, type VendoViewPart } from "@vendoai/core";
+import { riskLabelSchema, VENDO_MAKE_TOOL, type RiskLabel, type UIPayload, type VendoApprovalPart, type VendoAutomationPart, type VendoBuildFailedPart, type VendoConnectPart, type VendoGrantSetPart, type VendoLimitPart, type VendoStepLimitPart, type VendoTurnErrorPart, type VendoViewPart } from "@vendoai/core";
 import { isToolUIPart, type DynamicToolUIPart, type ToolUIPart, type UIMessage } from "ai";
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import { useVendoProvider } from "../../context.js";
@@ -9,7 +9,8 @@ import { PlacementAction } from "../add-to-picker.js";
 import { ApprovalCard } from "../approval-card.js";
 import { useApprovalModal } from "../approval-modal.js";
 import { ApprovalSheet } from "../approval-sheet.js";
-import { useChromeTheme } from "../chrome-root.js";
+import { ChromeRoot, useChromeTheme } from "../chrome-root.js";
+import { ResolvedApprovalCard } from "../embeds.js";
 import { ThreadAutomationConsent } from "./automation-consent.js";
 import { BuildBeat, toolPresentation } from "../build-beat.js";
 import { ConnectCard } from "../connect-card.js";
@@ -361,6 +362,15 @@ export function ThreadPart({ part, partKey, role, restored, count = 1, risks, co
     if (rendered) return null;
     return <ThreadConnect ask={ask} live={connectLive} sendMessage={sendMessage} />;
   }
+  if (part.type === "data-vendo-approval") {
+    // A STANDING ask — one raised by a TOOL about another call — renders its own
+    // card here; anything else is a parked native call's ask and renders from
+    // that call's approval state (ThreadApprovals). Which is which is the
+    // component's own question; before it, the transcript showed a person
+    // nothing but the calling tool's beat ("wasn't allowed") for a question they
+    // had not been asked yet.
+    return <ThreadStandingApproval part={part} siblingParts={siblingParts ?? []} />;
+  }
   if (part.type === "data-vendo-build-failed") {
     // 0.4.4 cert defect B — a terminally failed app build is content, not
     // progress: the turn ends right after this part, so without it the thread
@@ -462,13 +472,6 @@ export function ThreadPart({ part, partKey, role, restored, count = 1, risks, co
       />
     );
   }
-  if (part.type === "data-vendo-citations") {
-    // Knowledge K1 — rendered at TURN level (message.tsx → TurnCitations),
-    // under the answer text the citations ground, matching the signed
-    // mockups; at this part's transcript position the answer hasn't
-    // streamed yet, so rendering here would put sources above the text.
-    return null;
-  }
   if (part.type === "data-vendo-view") {
     const data = partData(part) as Partial<VendoViewPart>;
     if (typeof data.appId !== "string" || !data.payload) return null;
@@ -492,6 +495,11 @@ export function ThreadPart({ part, partKey, role, restored, count = 1, risks, co
     } = data.payload as typeof data.payload & { inClient?: unknown; pinDrift?: unknown };
     return <ThreadAppCard key={`${partKey}-${data.appId}`} buildKey={`${partKey}-${data.appId}`} appId={data.appId} payload={payload} restored={restored} />;
   }
+  // Everything else renders nothing HERE, and `data-vendo-citations` is the one
+  // that renders nothing on purpose: Knowledge K1 puts it at TURN level
+  // (message.tsx → TurnCitations), under the answer text the citations ground,
+  // matching the signed mockups — at this part's transcript position the answer
+  // hasn't streamed yet, so sources would sit above the text.
   return null;
 }
 
@@ -560,6 +568,73 @@ function GrantSetConsent({ toolCallId, grantSetId, name, permissions, siblingPar
           if (nativeApprovalId !== undefined) respond?.({ id: nativeApprovalId, approved: approve });
         },
       })}
+    />
+  );
+}
+
+/**
+ * A STANDING consent ask at its transcript position, on the ONE approval card.
+ *
+ * `ThreadApprovals` below renders every ask a NATIVE parked call carries, and
+ * this one has none: the tool parked an ask of its OWN (the built-app door asks
+ * about a build from inside `vendo_make`), the call itself returned, and no part
+ * will ever reach `approval-requested` — nor may it, since the runtime abandons
+ * every still-parked native ask at the next turn and this ask has to outlive the
+ * turn that raised it. Same shape as the connect card above: the `data-vendo-*`
+ * part is the whole ask, because the native part cannot carry it.
+ *
+ * WHICH asks are those: the ones whose descriptor names a DIFFERENT call than
+ * the one the part rides beside. A guard-raised ask describes the very call
+ * parked next to it and keeps its card there, where the resume lives — one
+ * consent surface per ask.
+ *
+ * That descriptor is also what the shared §16 builder derives the words from, so
+ * this card, the queue row and the toast read one ladder off one descriptor.
+ *
+ * Decided over the WIRE, like the queue and the toast: there is no parked turn
+ * to resume, and the yes may land long after this one is gone. No `remember`,
+ * because a grant is a standing yes to a CALL the person chose — this ask is
+ * about spending a machine once.
+ */
+function ThreadStandingApproval({ part, siblingParts }: {
+  part: UIMessage["parts"][number];
+  siblingParts: UIMessage["parts"];
+}) {
+  const { client, tools } = useVendoProvider();
+  const [settled, setSettled] = useState<{ ok: boolean; line: string }>();
+  const data = partData(part) as Partial<VendoApprovalPart>;
+  const asked = data.descriptor;
+  const rides = siblingParts.filter(isToolUIPart)
+    .find(candidate => candidate.toolCallId === data.toolCallId);
+  if (typeof data.approvalId !== "string" || asked?.name === undefined
+    || !riskLabelSchema.safeParse(data.risk).success
+    || (rides !== undefined && toolName(rides) === asked.name)) return null;
+  const approvalId = data.approvalId;
+  const approval = buildApprovalRequest({
+    approvalId,
+    toolCallId: data.toolCallId ?? approvalId,
+    // The ask is about THIS call, not the one the model made: `vendo_make` is a
+    // read, and grading the card off it told the person a build reads their data.
+    tool: asked.name,
+    risk: data.risk as RiskLabel,
+    descriptor: asked,
+  }, tools);
+  if (settled !== undefined) {
+    return (
+      <ChromeRoot>
+        <ResolvedApprovalCard summary={approval.descriptor.title ?? asked.name} ok={settled.ok} line={settled.line} />
+      </ChromeRoot>
+    );
+  }
+  return (
+    <ApprovalCard
+      approval={approval}
+      allowRemember={false}
+      showContext={false}
+      onDecide={async ({ approve }) => {
+        await client.approvals.decide(approvalId, { approve });
+        setSettled({ ok: approve, line: approve ? "Approved — under way" : "Declined — nothing ran" });
+      }}
     />
   );
 }

--- a/packages/ui/test/chrome/thread-and-overlay.test.tsx
+++ b/packages/ui/test/chrome/thread-and-overlay.test.tsx
@@ -79,6 +79,26 @@ describe("VendoThread and VendoOverlay exports", () => {
     });
   });
 
+  it("settles a card the wire has already answered, rather than leaving live buttons on it", { timeout: 20_000 }, async () => {
+    // No guard record for this turn's ask, so the wire answers the decision "not
+    // found" — the shape of an ask already answered (or swept) elsewhere, which
+    // is the ordinary end of one that outlived its turn. The question is closed
+    // either way, so the card records it instead of standing there with two live
+    // buttons and an error underneath.
+    render(<VendoProvider client={client}><VendoThread threadId="thr_1" /></VendoProvider>);
+    expect(await screen.findByText("Existing thread")).toBeTruthy();
+    const composer = screen.getByRole("textbox", { name: "Message" });
+    fireEvent.change(composer, { target: { value: "Send the email" } });
+    fireEvent.keyDown(composer, { key: "Enter" });
+
+    await screen.findByLabelText("Approval for Send the report");
+    fireEvent.click(screen.getByRole("button", { name: "Approve" }));
+
+    const receipt = await screen.findByLabelText(/^Approval — This request isn’t waiting on you any more/);
+    expect(receipt.textContent).toContain("Send the report");
+    expect(screen.queryByRole("button", { name: "Approve" })).toBeNull();
+  });
+
   it("brings a new approval into view even while the transcript keeps re-rendering", { timeout: 20_000 }, async () => {
     // A build's approval lands below a tall generated view, off-screen, so the
     // thread scrolls it into view 80ms after it appears. That effect marked the

--- a/packages/vendo/src/compose-mcp.ts
+++ b/packages/vendo/src/compose-mcp.ts
@@ -25,12 +25,13 @@ const appsPortFor = (composition: VendoComposition): McpDoorConfig["apps"] => {
       list: (ctx) => apps.list(ctx),
       async open(appId, ctx) {
         const opened = await apps.open(appId, ctx);
-        if (opened.kind === "tree") return { kind: "tree", payload: opened.payload };
-        if (opened.kind === "http") return { kind: "http", url: opened.url };
-        throw new VendoError(
-          "not-implemented",
-          "This is a server app resuming in-product; open it in the host to use it over MCP.",
-        );
+        // Only the tree needs narrowing (its resolved payload is what the shim
+        // renders). Every other surface — a sealed bundle, a build that failed —
+        // travels as itself, because the DOOR is what turns an open into
+        // something an agent can say (`projectAppsOpenOutput`), and a port that
+        // refused here answered every BUILT app with "this is a server app
+        // resuming in-product" — a rung that no longer exists.
+        return opened.kind === "tree" ? { kind: "tree", payload: opened.payload } : opened;
       },
       call: (appId, ref, args, ctx) => apps.call(appId, ref, args, ctx),
   };

--- a/packages/vendo/src/pack.ts
+++ b/packages/vendo/src/pack.ts
@@ -88,10 +88,8 @@ function appRefTitleFromPrompt(prompt: unknown): string {
  * laundering a partial receipt through it leaves a caller waiting on a completion
  * that already came, and drops the one sentence that says what is missing.
  *
- * `"awaiting-consent"` is refused for the third form of the same reason: the ask
- * has been PUT to the person and nothing is under way, so a ref reading
- * "accepted, still streaming" would show a build skeleton for a build nobody has
- * authorized — and drop the one sentence that says a card is waiting.
+ * An offered BUILD needs no clause here: it is a `pending-approval` outcome now,
+ * so it never reaches a receipt at all.
  *
  * Local to the PACK on purpose. `vendo/app-ref@1` means "accepted, still
  * streaming, NOT built yet"; only this fast-return path can honestly say that.
@@ -101,8 +99,7 @@ function appRefTitleFromPrompt(prompt: unknown): string {
  */
 function appRefFromReceipt(output: unknown, fallbackTitle: string): VendoAppRef | null {
   const receipt = makeReceiptSchema.safeParse(output);
-  if (!receipt.success || receipt.data.status === "failed" || receipt.data.status === "partial"
-    || receipt.data.status === "awaiting-consent") {
+  if (!receipt.success || receipt.data.status === "failed" || receipt.data.status === "partial") {
     return null;
   }
   return {

--- a/packages/vendo/tests/mcp-door-outside-agent.e2e.test.ts
+++ b/packages/vendo/tests/mcp-door-outside-agent.e2e.test.ts
@@ -18,8 +18,10 @@
  * the same composed host and the same minimal MCP client from
  * `mcp-door.test-util.ts`.
  */
-import { vendoApprovalRefSchema } from "@vendoai/core";
-import { afterEach, describe, expect, it } from "vitest";
+import { sealBundleBlobs } from "@vendoai/apps";
+import { VENDO_APP_FORMAT, vendoApprovalRefSchema, type AppDocument, type AppId } from "@vendoai/core";
+import { storeFiles, type VendoStore } from "@vendoai/store";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   MOUNT,
   READ_TOOL,
@@ -33,7 +35,10 @@ import {
   shapeOf,
 } from "../src/mcp-door.test-util.js";
 
-afterEach(runCleanups);
+afterEach(async () => {
+  vi.unstubAllEnvs();
+  await runCleanups();
+});
 
 const rpcBody = (method: string, params?: unknown): string =>
   JSON.stringify({ jsonrpc: "2.0", id: 1, method, ...(params === undefined ? {} : { params }) });
@@ -43,6 +48,16 @@ const INITIALIZE = rpcBody("initialize", {
   capabilities: {},
   clientInfo: { name: "outside", version: "1.0.0" },
 });
+
+/** One app row for the granted subject, written where every real one is written
+ *  — so `apps.open` reads it back through its own schema and its own rules. */
+const seedApp = async (store: VendoStore, doc: Omit<AppDocument, "format">): Promise<void> => {
+  await store.records("vendo_apps").put({
+    id: doc.id,
+    data: { subject: SUBJECT, enabled: true, doc: { format: VENDO_APP_FORMAT, ...doc } },
+    refs: { subject: SUBJECT },
+  });
+};
 
 describe("the MCP door, as an OUTSIDE agent sees it — pinned before door-ctx", () => {
   it("lists the host's tools VERBATIM, plus the apps ride-alongs, with the risk annotations derived from ONE label", async () => {
@@ -233,5 +248,92 @@ describe("the MCP door, as an OUTSIDE agent sees it — pinned before door-ctx",
       body: rpcBody("tools/list"),
     }));
     expect(stolen.status).toBe(404);
+  });
+
+  /**
+   * THE BUILT-APP WORLD (#1623), as the outside agent is told about it: an app
+   * that is sealed, one waiting on its person, one still building, one dead.
+   *
+   * Every case below drives the REAL chain — a real seal, a real app row, the
+   * real `apps.open`, the composed door's real apps port — because the whole
+   * point is whether the producer and the projection agree about one app, and a
+   * harness that answered for either of them could only agree with itself.
+   */
+  it("a SEALED bundle opens as a link-out card carrying the product name and where to open it", async () => {
+    vi.stubEnv("VENDO_BASE_URL", "https://host.test");
+    const { vendo, store } = await composedHost(async () => undefined);
+    const app = "app_built" as AppId;
+    // The same writer the build door lands a box's output through.
+    const bundle = await sealBundleBlobs(
+      app,
+      [{ path: "dist/app.js", bytes: new TextEncoder().encode('document.title = "built";\n') }],
+      "dist/app.js",
+      storeFiles(store),
+    );
+    await seedApp(store, { id: app, name: "Built app", ui: "bundle", bundle });
+    const door = await openDoor(vendo, await bearer(vendo));
+
+    const opened = await door.callTool("vendo_apps_open", { appId: app });
+    // The DEPLOYMENT's own public url: a sealed bundle boots inside the host's
+    // own UI (a sandboxed frame on the host's postMessage bridge), so where the
+    // person opens it is the product itself.
+    expect(opened.isError, opened.text).toBeFalsy();
+    expect(opened.structuredContent).toEqual({
+      kind: "vendo/open-in-product@1",
+      url: "https://host.test",
+      appName: "Built app",
+      productName: expect.any(String),
+    });
+    expect(opened.text).toMatch(/^Open Built app in .+: https:\/\/host\.test$/);
+    // The entry hash — the one thing a bare passthrough gave an agent — is gone.
+    expect(opened.text).not.toContain(bundle.entry);
+  });
+
+  it("an app waiting on its build approval is a NAMED wait, not a not-found error", async () => {
+    const { vendo, store } = await composedHost(async () => undefined);
+    const app = "app_proposed" as AppId;
+    await seedApp(store, {
+      id: app,
+      name: "Proposed app",
+      proposal: { approvalId: "apr_proposed", prompt: "my spending", why: "a screen was not enough", at: new Date().toISOString() },
+    });
+    const door = await openDoor(vendo, await bearer(vendo));
+
+    const opened = await door.callTool("vendo_apps_open", { appId: app });
+    // NOT an error: the person has been asked and has not answered. An agent
+    // that reads this as a broken tool tells the user their app is gone.
+    expect(opened.isError).toBeFalsy();
+    expect(opened.text).toBe("This app is waiting on the user's build approval. Once they approve it, open it again.");
+    expect(opened.structuredContent).toEqual({ kind: "pending", say: opened.text });
+  });
+
+  it("an app still being built says so, and says it as a wait", async () => {
+    const { vendo, store } = await composedHost(async () => undefined);
+    const app = "app_building" as AppId;
+    await seedApp(store, { id: app, name: "Building app", building: new Date().toISOString() });
+    const door = await openDoor(vendo, await bearer(vendo));
+
+    const opened = await door.callTool("vendo_apps_open", { appId: app });
+    expect(opened.isError).toBeFalsy();
+    expect(opened.text).toBe("This app is still being built. Open it again in a moment.");
+    expect(opened.structuredContent).toEqual({ kind: "pending", say: opened.text });
+  });
+
+  it("a build that failed for good comes back as its reason, not as a JSON record", async () => {
+    const { vendo, store } = await composedHost(async () => undefined);
+    const app = "app_failed" as AppId;
+    await seedApp(store, {
+      id: app,
+      name: "Failed app",
+      buildFailed: { reason: "The build ran out of time.", retryable: true, at: new Date().toISOString() },
+    });
+    const door = await openDoor(vendo, await bearer(vendo));
+
+    const opened = await door.callTool("vendo_apps_open", { appId: app });
+    expect(opened.isError).toBeFalsy();
+    expect(opened.text).toBe("The build ran out of time. Asking for it again may work.");
+    // The record still rides underneath, so a loop reads the kind rather than
+    // the English.
+    expect(opened.structuredContent).toMatchObject({ kind: "failed", reason: "The build ran out of time.", retryable: true });
   });
 });

--- a/packages/vendo/tests/screen-escalate-consent.seam.test.ts
+++ b/packages/vendo/tests/screen-escalate-consent.seam.test.ts
@@ -271,8 +271,15 @@ describe("a chat ask bigger than a screen reaches the build lane", () => {
     expect(pending[0]?.call.args).toMatchObject({ prompt: ASK });
     const appId = (pending[0]?.call.args as { appId: AppId }).appId;
 
-    // THE ANSWER the calling agent got is the standard park, aimed at that card.
-    expect(walked.result).toMatchObject({ needs: { kind: "approval", approvalId: pending[0]?.id } });
+    // THE ANSWER the calling agent got is the standard park, aimed at that card —
+    // and its reason is the DOOR's own one line (`say`), not the harness's
+    // generic "This still needs approval.": the refusal is the only thing the
+    // model reads about this call, so a say that never reached it left the model
+    // narrating its own paragraphs under a card already asking the question.
+    expect(walked.result).toMatchObject({
+      reason: expect.stringContaining("the card above"),
+      needs: { kind: "approval", approvalId: pending[0]?.id },
+    });
 
     // THE CARD IN THE THREAD: the wire part the shipped bridge publishes off a
     // `pending-approval` outcome, which is what the receipt could never raise —
@@ -356,7 +363,7 @@ describe("the ask reaches the person on the ONE approval card", () => {
     // THE WORDS, off the shared ladder (`consentAsk`) reading the descriptor the
     // door authored — never a second sentence written for this surface.
     expect(card.textContent).toContain("Build this app for real?");
-    expect(card.textContent).toContain("This changes something in your account, as you.");
+    expect(card.textContent).toContain("This changes something in your account, and it runs as you.");
     // What it said before the descriptor travelled: ungraded, so the note could
     // only say nobody had checked what spending a build machine does.
     expect(card.textContent).not.toContain("This hasn’t been checked");
@@ -367,6 +374,20 @@ describe("the ask reaches the person on the ONE approval card", () => {
     const label = (element: Element) => (element.textContent ?? "").trim();
     expect([...card.querySelectorAll("button")].map(label)).toContain("Approve");
     expect(card.textContent).not.toContain("Remember this decision");
+
+    // AND IT SETTLES once they answer. This ask outlives its turn by design, so
+    // there is no stream left to retire the part it was painted from: without
+    // settling here the buttons stand for good on a question already decided, and
+    // pressing them asks the guard again about a record it has already written.
+    const deny = [...card.querySelectorAll("button")].find((button) => label(button) === "Deny")!;
+    await act(async () => { deny.click(); });
+    const settled = await until("the settled card", () =>
+      document.querySelector<HTMLElement>(".fl-cardshell--settled"));
+    expect(settled.textContent).toContain("Build this app for real");
+    expect(settled.textContent).toContain("Declined — nothing ran");
+    expect([...settled.querySelectorAll("button")].map(label)).not.toContain("Deny");
+    // The person's no reached the real guard, not just the card.
+    expect(await walked.vendo.guard.approvals.pending(principal)).toEqual([]);
   }, 60_000);
 });
 

--- a/packages/vendo/tests/screen-escalate-consent.seam.test.ts
+++ b/packages/vendo/tests/screen-escalate-consent.seam.test.ts
@@ -23,9 +23,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   VENDO_MAKE_TOOL,
+  vendoApprovalPartSchema,
+  type AppId,
   type Principal,
   type RunContext,
   type ToolResult,
+  type VendoApprovalPart,
 } from "@vendoai/core";
 import { makeReceiptSchema } from "@vendoai/apps/contract";
 import type { SandboxAdapter } from "@vendoai/apps";
@@ -134,10 +137,23 @@ async function tempStore(): Promise<VendoStore> {
 interface Walked {
   receipt: ReturnType<typeof makeReceiptSchema.parse> | undefined;
   result: ToolResult | undefined;
+  /** The turn's whole wire, as the browser receives it. */
+  stream: string;
   vendo: ReturnType<typeof createVendo>;
   model: LanguageModel & { toolNamesPerCall: string[][] };
   sandbox: ReturnType<typeof noBoxes>;
 }
+
+/** The `data-vendo-approval` part off that wire, parsed with core's own schema —
+ *  the one shape every native surface builds the in-thread ApprovalCard from. */
+const approvalPartIn = (stream: string): VendoApprovalPart => {
+  const chunk = stream.split("\n")
+    .filter((line) => line.startsWith("data: {"))
+    .map((line) => JSON.parse(line.slice(6)) as { type: string; data: Record<string, unknown> })
+    .find((part) => part.type === "data-vendo-approval");
+  if (chunk === undefined) throw new Error("no data-vendo-approval part was published");
+  return vendoApprovalPartSchema.parse({ type: chunk.type, ...chunk.data });
+};
 
 /** One real turn whose harness does what a calling agent does: ask `vendo_make`
  *  in words, and hand back the receipt. */
@@ -169,10 +185,11 @@ async function walk(options: { turns: Chunk[][]; sandbox?: boolean }): Promise<W
     }),
   }));
   expect(response.status).toBe(200);
-  await response.text();
+  const stream = await response.text();
   return {
     receipt: result?.status === "ok" ? makeReceiptSchema.parse(result.output) : undefined,
     result,
+    stream,
     vendo,
     model,
     sandbox,
@@ -180,7 +197,7 @@ async function walk(options: { turns: Chunk[][]; sandbox?: boolean }): Promise<W
 }
 
 describe("a chat ask bigger than a screen reaches the build lane", () => {
-  it("lands as a standing card and an awaiting-consent receipt, with no box claimed", async () => {
+  it("lands as a standing card, a card part in the thread, and a park, with no box claimed", async () => {
     const walked = await walk({
       turns: [call(ESCALATE_TOOL, { why: WHY }, "c1"), speak("Asked about building it.")],
     });
@@ -188,18 +205,26 @@ describe("a chat ask bigger than a screen reaches the build lane", () => {
     // THE DOOR IS ON THE LOADOUT — the fact that was missing.
     expect(walked.model.toolNamesPerCall[0]).toContain(ESCALATE_TOOL);
 
-    // THE RECEIPT: the ask is alive and waiting on the person, not failed.
-    expect(walked.receipt?.status).toBe("awaiting-consent");
-
     // THE STANDING CARD, on the real guard: one undecided ask for the build,
-    // carrying this app and the person's own words.
+    // carrying this app and the person's own words. STANDING is the whole word:
+    // the turn is over and the ask is still there to be answered — an ordinary
+    // parked call is swept denied at turn end, and sweeping this one tombstoned
+    // the build the moment the turn that asked for it finished.
     const pending = await walked.vendo.guard.approvals.pending(principal);
     expect(pending.map((ask) => ask.call.tool)).toEqual(["vendo_app_build"]);
-    expect(pending[0]?.call.args).toMatchObject({ appId: walked.receipt?.id, prompt: ASK });
+    expect(pending[0]?.call.args).toMatchObject({ prompt: ASK });
+    const appId = (pending[0]?.call.args as { appId: AppId }).appId;
+
+    // THE ANSWER the calling agent got is the standard park, aimed at that card.
+    expect(walked.result).toMatchObject({ needs: { kind: "approval", approvalId: pending[0]?.id } });
+
+    // THE CARD IN THE THREAD: the wire part the shipped bridge publishes off a
+    // `pending-approval` outcome, which is what the receipt could never raise.
+    expect(approvalPartIn(walked.stream).approvalId).toBe(pending[0]?.id);
 
     // THE ROW says "offered, unanswered" — and carries the model's own one line,
     // which is what the person reads on the card.
-    const row = await walked.vendo.apps.get(walked.receipt!.id, ctx);
+    const row = await walked.vendo.apps.get(appId, ctx);
     expect(row?.proposal).toMatchObject({ approvalId: pending[0]?.id, why: WHY });
     expect(row?.building).toBeUndefined();
 
@@ -223,9 +248,9 @@ describe("a chat ask bigger than a screen reaches the build lane", () => {
     // ONE model call: the escalation was the last thing this drive did. The two
     // scripted turns behind it were never reached.
     expect(walked.model.toolNamesPerCall).toHaveLength(1);
-    expect(walked.receipt?.status).toBe("awaiting-consent");
+    const pending = await walked.vendo.guard.approvals.pending(principal);
     // …and the row is still only an OFFER: no screen was written past the ask.
-    const row = await walked.vendo.apps.get(walked.receipt!.id, ctx);
+    const row = await walked.vendo.apps.get((pending[0]?.call.args as { appId: AppId }).appId, ctx);
     expect(row?.proposal).toBeDefined();
     expect(row?.source).toBeUndefined();
     expect(walked.sandbox.claims).toBe(0);

--- a/packages/vendo/tests/screen-escalate-consent.seam.test.ts
+++ b/packages/vendo/tests/screen-escalate-consent.seam.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 /**
  * THE DEAD SEAM — the screen agent's way of asking for a build, and where it
  * lands.
@@ -17,11 +18,18 @@
  * mood) and the sandbox PROVIDER — a stub that refuses to hand out a machine,
  * because the one thing this whole flow must not do before the person's yes is
  * claim a box.
+ *
+ * The last test closes the seam on the READ side too: the shipped `VendoThread`
+ * reads that same turn back over the real client and paints the real
+ * `ApprovalCard`. The producer and the consumer disagreeing about one wire part
+ * is exactly how this ask reached a person mis-graded, so neither side gets to
+ * hold its own copy of it.
  */
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  VENDO_APP_BUILD_TOOL,
   VENDO_MAKE_TOOL,
   vendoApprovalPartSchema,
   type AppId,
@@ -34,15 +42,20 @@ import { makeReceiptSchema } from "@vendoai/apps/contract";
 import type { SandboxAdapter } from "@vendoai/apps";
 import { defineHarness } from "@vendoai/harnesses";
 import { createStore, type VendoStore } from "@vendoai/store";
+import { VendoProvider, createVendoClient } from "@vendoai/ui";
+import { VendoThread } from "@vendoai/ui/chrome";
 import type { LanguageModel } from "ai";
 import { MockLanguageModelV3, simulateReadableStream } from "ai/test";
+import { act, createElement, type ReactElement } from "react";
+import { createRoot } from "react-dom/client";
 import { afterEach, describe, expect, it } from "vitest";
 import { ESCALATE_TOOL, SAVE_APP_TOOL } from "../src/screen-agent.js";
 import { createVendo } from "../src/server.js";
 
-const cleanups: Array<() => Promise<void>> = [];
+const cleanups: Array<() => Promise<void> | void> = [];
 afterEach(async () => {
   for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+  document.body.innerHTML = "";
 });
 
 const principal: Principal = { kind: "user", subject: "user_escalate" };
@@ -196,6 +209,49 @@ async function walk(options: { turns: Chunk[][]; sandbox?: boolean }): Promise<W
   };
 }
 
+// --- the READ side: the shipped thread, painting that same turn --------------
+
+const BASE = "https://host.test/api/vendo";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+/** The client's fetch IS the door — every read the thread makes is answered by
+ *  the composition that just wrote the turn, so nothing painted is arranged. */
+function serve(vendo: Walked["vendo"]): void {
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    // jsdom's AbortSignal is not undici's, and undici's Request rejects it
+    // outright; nothing here aborts, so it is dropped at the boundary.
+    const { signal: _signal, ...rest } = init ?? {};
+    const url = typeof input === "string" || input instanceof URL ? String(input) : (input as { url: string }).url;
+    return await vendo.handler(new Request(url, rest as RequestInit));
+  }) as typeof fetch;
+  cleanups.push(() => { globalThis.fetch = realFetch; });
+}
+
+async function mount(element: ReactElement): Promise<void> {
+  const container = document.createElement("div");
+  document.body.append(container);
+  const root = createRoot(container);
+  cleanups.push(() => act(() => root.unmount()));
+  await act(async () => { root.render(element); });
+}
+
+/** Poll the painted DOM. The budget is the TEST's own — a tighter inner clock
+ *  would report a product bug whenever the machine is merely busy. */
+async function until<T>(what: string, probe: () => T | null | undefined | false): Promise<T> {
+  const deadline = Date.now() + 25_000;
+  for (;;) {
+    let found: T | null | undefined | false;
+    await act(async () => {
+      found = probe();
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    });
+    if (found) return found;
+    if (Date.now() > deadline) throw new Error(`timed out waiting for ${what}`);
+  }
+}
+
 describe("a chat ask bigger than a screen reaches the build lane", () => {
   it("lands as a standing card, a card part in the thread, and a park, with no box claimed", async () => {
     const walked = await walk({
@@ -219,8 +275,18 @@ describe("a chat ask bigger than a screen reaches the build lane", () => {
     expect(walked.result).toMatchObject({ needs: { kind: "approval", approvalId: pending[0]?.id } });
 
     // THE CARD IN THE THREAD: the wire part the shipped bridge publishes off a
-    // `pending-approval` outcome, which is what the receipt could never raise.
-    expect(approvalPartIn(walked.stream).approvalId).toBe(pending[0]?.id);
+    // `pending-approval` outcome, which is what the receipt could never raise —
+    // carrying the ask's OWN descriptor, because the card must speak about the
+    // BUILD. Graded off the calling tool it spoke about `vendo_make`, a read,
+    // and told the person that spending a build machine reads their data.
+    const part = approvalPartIn(walked.stream);
+    expect(part.approvalId).toBe(pending[0]?.id);
+    expect(part.risk).toBe("write");
+    expect(part.descriptor).toMatchObject({
+      name: VENDO_APP_BUILD_TOOL,
+      title: "Build this app for real",
+      risk: "write",
+    });
 
     // THE ROW says "offered, unanswered" — and carries the model's own one line,
     // which is what the person reads on the card.
@@ -266,6 +332,41 @@ describe("a chat ask bigger than a screen reaches the build lane", () => {
 
     expect(walked.model.toolNamesPerCall[0]).not.toContain(ESCALATE_TOOL);
     expect(walked.receipt?.status).toBe("failed");
+  }, 60_000);
+});
+
+describe("the ask reaches the person on the ONE approval card", () => {
+  it("paints the shipped ApprovalCard in the thread, in the build's own words", async () => {
+    const walked = await walk({
+      turns: [call(ESCALATE_TOOL, { why: WHY }, "c1"), speak("Asked about building it.")],
+    });
+    serve(walked.vendo);
+    await mount(createElement(VendoProvider, {
+      client: createVendoClient({ baseUrl: BASE }),
+      children: createElement(VendoThread, { threadId: "thr_escalate" }),
+    }));
+
+    // THE LITERAL CARD — `.fl-approval` is `ApprovalCard`'s own shell, and its
+    // machine attributes say which ask it is grading.
+    const card = await until("the approval card", () =>
+      document.querySelector<HTMLElement>(".fl-approval"));
+    expect(card.getAttribute("data-vendo-tool")).toBe(VENDO_APP_BUILD_TOOL);
+    expect(card.getAttribute("data-risk")).toBe("write");
+
+    // THE WORDS, off the shared ladder (`consentAsk`) reading the descriptor the
+    // door authored — never a second sentence written for this surface.
+    expect(card.textContent).toContain("Build this app for real?");
+    expect(card.textContent).toContain("This changes something in your account, as you.");
+    // What it said before the descriptor travelled: ungraded, so the note could
+    // only say nobody had checked what spending a build machine does.
+    expect(card.textContent).not.toContain("This hasn’t been checked");
+    expect(card.textContent).not.toContain("Nobody has checked what this changes");
+
+    // Answerable, and NOT rememberable: a grant is a standing yes to a call the
+    // person chose to make; this ask is about spending one machine, once.
+    const label = (element: Element) => (element.textContent ?? "").trim();
+    expect([...card.querySelectorAll("button")].map(label)).toContain("Approve");
+    expect(card.textContent).not.toContain("Remember this decision");
   }, 60_000);
 });
 

--- a/packages/vendo/tests/your-agent-docs.docs.test.ts
+++ b/packages/vendo/tests/your-agent-docs.docs.test.ts
@@ -309,11 +309,11 @@ describe("the documented arguments match the real schemas", () => {
 });
 
 describe("the receipt law the docs teach is the real receipt", () => {
-  it("has exactly id, title, status, say — and status's five values", async () => {
+  it("has exactly id, title, status, say — and status's four values", async () => {
     const source = await read("packages/apps/src/contract/make-receipt.ts");
     expect(source).toContain("id: appIdSchema");
     expect(source).toContain("title: z.string().min(1)");
-    expect(source).toContain('status: z.enum(["ready", "partial", "building", "awaiting-consent", "failed"])');
+    expect(source).toContain('status: z.enum(["ready", "partial", "building", "failed"])');
     expect(source).toContain("say: z.string().min(1)");
   });
 


### PR DESCRIPTION
`vendo_apps_open` met the post-bundles world with three answers an outside agent
could do nothing with: a sealed bundle came back as a bare content hash, and the
two build-window waits came back as not-found ERRORS — "your app is gone" to any
agent that reads an error as one.

**A sealed bundle links out.** It is the app, and it is not a page: it boots
inside the host's own UI, in a sandboxed frame whose only way out is the host's
postMessage bridge (`ui/src/tree/frame-bridge.ts`), so the bundle document's own
url is not a place a person can be sent. The card names the PRODUCT instead —
the same `vendo/open-in-product@1` an app with a url of its own already took,
carrying the product name and the deployment's public base: "Open Spending in
Maple: https://…". A deployment that named no public url says the app is built
and ready to open in the product, rather than handing over the hash.

**The two waits are named.** An app whose build the person has not approved
(`proposal`) and one still being built both refuse an open with a not-found
(`apps/src/server/persistence/open.ts`). The door names them — "waiting on the
user's build approval" / "still being built" — on every leg it serves: its own
apps path, the leg the bound registry owns the tool on, and the turn leg. A
build that failed for good comes back as its reason (plus whether asking again
may work) instead of a JSON record to paraphrase. Each answer still rides as
`structuredContent` under its own `kind`, so a loop reads the state, not the
English.

**The umbrella's door port stops narrowing.** It forwarded trees and http
surfaces and threw "this is a server app resuming in-product" at everything else
— a rung that no longer exists, and the reason every built app failed at the
door. Projection is the door's job; the port just forwards.

### Two decisions worth naming

- **Mechanism for the waits: mapped the two refusals, not `{pending:true}`.**
  `pending` cannot reach the approval state at all — a proposal row is not
  `buildInFlight`, so it throws from `serveOpenApp` before the pending branch
  (`open.ts:211` vs `:250`). Passing the flag would have covered one of the two
  states, still needed the message map for the other, and dragged the forming
  tree's geometry onto the MCP wire for the door to strip.
- **The bundle url is the product's, not the app's.** Post-bundles there is no
  per-app page in the product to link to; the closest true thing is where the
  person opens it.

### Tests

Real chain on both legs, no stand-in on either side: a REAL seal
(`sealBundleBlobs`), a real app row, the real `apps.open`, the real door.
`mcp-door-outside-agent.e2e.test.ts` covers the registry leg through a composed
host (bundle card + url, both waits, the failure); `fixtures/mcp-e2e` covers the
door's own apps path and the no-public-url answer. Every one was proven to go
red with its half of the change removed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `vendo_apps_open` speak the built‑app world so agents stop treating successes as failures. Before: sealed bundles returned a hash and in‑flight/awaiting‑approval builds raised not‑found; now: sealed bundles link to the product, waits return pending, and failures explain why.

- Sealed bundles project to `vendo/open-in-product@1` with the product name and public URL when configured; without a public URL, the answer says the app is ready and never shows the hash.
- Approval‑pending and building states return { kind: "pending", say: … } instead of errors on both the door’s own apps path and the bound registry leg.
- Terminal build failures return { kind: "failed" } with a readable reason and retry hint; structuredContent.kind is preserved and narration rides via say.
- The umbrella apps port now forwards non‑tree surfaces unmodified so the door can project them, fixing “server app resuming in‑product” and built‑app failures.
- Versions: `@vendoai/mcp` and `@vendoai/vendo` bumped minor.

<sup>Written for commit 093ab53bf926cd814bb035e621121bdfde8016c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1630?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

