### PR TITLE
fix(cli): theme extraction reads a Tailwind-v4 palette named with Vendo's own slot names

### DIFF
--- a/packages/vendo/src/cli/theme/extract-theme.ts
+++ b/packages/vendo/src/cli/theme/extract-theme.ts
@@ -300,7 +300,8 @@ type SlotKey = keyof ThemeSlotValues;
  * exactly. The shadcn name is tried FIRST, so an existing shadcn sheet keeps
  * today's reads even where the vocabularies collide — shadcn's hover-wash
  * `--accent` only wins when no `--primary` exists, where it is the best
- * available brand signal.
+ * available brand signal. An alias whose value does not resolve to a color is
+ * treated as absent, never terminal: the next spelling still gets its read.
  */
 const EXACT_COLOR_TOKENS: ReadonlyArray<[SlotKey, string[]]> = [
   ["background", ["--background"]],
@@ -363,9 +364,16 @@ function readExact(vars: CssVarDecl[]): ExactReads {
   };
 
   for (const [slot, names] of EXACT_COLOR_TOKENS) {
-    const decl = lastLightDecl(vars, names);
-    const resolved = decl === undefined ? null : resolveCssVarRefs(decl.value, vars);
-    put(slot, decl, resolved === null ? null : normalizeColor(resolved));
+    // An alias whose value cannot be resolved to a color is treated as absent
+    // (color.ts's law), not terminal — the next spelling still gets its read.
+    for (const name of names) {
+      const decl = lastLightDecl(vars, [name]);
+      const resolved = decl === undefined ? null : resolveCssVarRefs(decl.value, vars);
+      const value = resolved === null ? null : normalizeColor(resolved);
+      if (value === null) continue;
+      put(slot, decl, value);
+      break;
+    }
   }
   for (const [slot, names] of FONT_TOKENS) {
     const decl = lastLightDecl(vars, names);

--- a/packages/vendo/src/cli/theme/extract-theme.ts
+++ b/packages/vendo/src/cli/theme/extract-theme.ts
@@ -289,20 +289,28 @@ type SlotKey = keyof ThemeSlotValues;
 /**
  * The shadcn theme-variable vocabulary (ui.shadcn.com/docs/theming), mapped
  * only where the shadcn semantic IS the Vendo slot semantic. Notably absent:
- * shadcn's `--accent` (a hover wash, not the brand color — `--primary` is),
- * `--muted` (a muted surface, not muted text), `--secondary`, `--popover`,
- * `--input`, `--ring`, `--chart-*`, `--sidebar-*`. Each name is also accepted
- * with the Tailwind-v4 `@theme` namespace prefix (`--color-primary`, ...).
+ * shadcn's `--muted` (a muted surface, not muted text), `--secondary`,
+ * `--popover`, `--input`, `--ring`, `--chart-*`, `--sidebar-*`. Each name is
+ * also accepted with the Tailwind-v4 `@theme` namespace prefix
+ * (`--color-primary`, ...).
+ *
+ * After each shadcn name, Vendo's own slot name is accepted as a fallback
+ * spelling (`--text`, `--surface`, `--accent`, ...), so a Tailwind-v4 host
+ * that names its tokens after the slots they configure still extracts
+ * exactly. The shadcn name is tried FIRST, so an existing shadcn sheet keeps
+ * today's reads even where the vocabularies collide — shadcn's hover-wash
+ * `--accent` only wins when no `--primary` exists, where it is the best
+ * available brand signal.
  */
 const EXACT_COLOR_TOKENS: ReadonlyArray<[SlotKey, string[]]> = [
   ["background", ["--background"]],
-  ["text", ["--foreground"]],
-  ["surface", ["--card"]],
-  ["accent", ["--primary"]],
+  ["text", ["--foreground", "--text"]],
+  ["surface", ["--card", "--surface"]],
+  ["accent", ["--primary", "--accent"]],
   ["accentText", ["--primary-foreground"]],
-  ["mutedText", ["--muted-foreground"]],
+  ["mutedText", ["--muted-foreground", "--muted-text"]],
   ["border", ["--border"]],
-  ["danger", ["--destructive"]],
+  ["danger", ["--destructive", "--danger"]],
 ];
 
 /** Non-color conventions: shadcn `--radius`; Tailwind v4 `--font-*` and

--- a/packages/vendo/tests/cli/theme/extract-theme.test.ts
+++ b/packages/vendo/tests/cli/theme/extract-theme.test.ts
@@ -164,6 +164,39 @@ describe("extractTheme allowlist fast-path", () => {
     expect(result.defaulted).toEqual(["radius", "fontFamily", "headingFamily", "baseSize", "density", "motion"]);
   });
 
+  it("an unreadable higher-priority alias falls through to the next spelling; a readable one keeps precedence", async () => {
+    // A declared-but-unreadable shadcn name (a named color is outside the
+    // exact-read vocabulary) must not shadow a readable Vendo spelling —
+    // color.ts's law: an unreadable value is treated as ABSENT, not terminal.
+    const masked = await fixture({
+      "package.json": "{}\n",
+      "app/layout.tsx": 'import "./global.css";\nexport default function Layout({ children }) { return <html><body>{children}</body></html>; }\n',
+      "app/global.css": `
+        :root {
+          --primary: purple;
+          --accent: #7c3aed;
+        }
+      `,
+    });
+
+    const maskedResult = await extractTheme(masked);
+
+    expect(maskedResult.slots.accent).toBe("#7c3aed");
+    expect(maskedResult.matched["accent"]).toBe("--accent");
+
+    // Both readable: the shadcn name still wins.
+    const both = await fixture({
+      "package.json": "{}\n",
+      "app/layout.tsx": 'import "./global.css";\nexport default function Layout({ children }) { return <html><body>{children}</body></html>; }\n',
+      "app/global.css": ":root { --primary: #1d4ed8; --accent: #7c3aed; }\n",
+    });
+
+    const bothResult = await extractTheme(both);
+
+    expect(bothResult.slots.accent).toBe("#1d4ed8");
+    expect(bothResult.matched["accent"]).toBe("--primary");
+  });
+
   it("lets the IMPORTING sheet win over the sheet it imports, like the real cascade", async () => {
     // `@import` must precede other rules, so an imported declaration behaves as
     // if inserted at the import point — the importer's own later declaration

--- a/packages/vendo/tests/cli/theme/extract-theme.test.ts
+++ b/packages/vendo/tests/cli/theme/extract-theme.test.ts
@@ -122,6 +122,48 @@ describe("extractTheme allowlist fast-path", () => {
     expect(result.usedModel).toBe(false);
   });
 
+  it("accepts Vendo's own slot names as token names, bare and Tailwind-v4 namespaced", async () => {
+    const root = await fixture({
+      "package.json": "{}\n",
+      "app/layout.tsx": 'import "./global.css";\nexport default function Layout({ children }) { return <html><body>{children}</body></html>; }\n',
+      // A Tailwind-v4 host naming tokens the way Vendo's slots are named —
+      // shadcn absent entirely. Before the slot-name fallback spellings this
+      // sheet extracted only `border`, by coincidence.
+      "app/global.css": `
+        @theme {
+          --color-background: #fbfbfa;
+          --color-surface: #ffffff;
+          --color-text: #111111;
+          --color-accent: #7c3aed;
+          --color-muted-text: #6b7280;
+          --color-border: #e5e7eb;
+        }
+        :root { --danger: #b91c1c; }
+      `,
+    });
+
+    const result = await extractTheme(root);
+
+    expect(result.usedModel).toBe(false);
+    expect(result.slots).toMatchObject({
+      background: "#fbfbfa",
+      surface: "#ffffff",
+      text: "#111111",
+      accent: "#7c3aed",
+      mutedText: "#6b7280",
+      border: "#e5e7eb",
+      danger: "#b91c1c",
+    });
+    expect(result.matched["accent"]).toBe("--color-accent");
+    expect(result.matched["danger"]).toBe("--danger");
+    // Every brand-defining color slot was an exact read; what remains for the
+    // staged pass is accentText (derived at assembly) plus the safe defaults.
+    expect(result.needed).toEqual([
+      "accentText", "radius", "fontFamily", "headingFamily", "baseSize", "density", "motion",
+    ]);
+    expect(result.defaulted).toEqual(["radius", "fontFamily", "headingFamily", "baseSize", "density", "motion"]);
+  });
+
   it("lets the IMPORTING sheet win over the sheet it imports, like the real cascade", async () => {
     // `@import` must precede other rules, so an imported declaration behaves as
     // if inserted at the import point — the importer's own later declaration


### PR DESCRIPTION
Fixes #1340

## Problem

The deterministic exact pass (`extractTheme`) reads only shadcn's variable vocabulary — `--primary`, `--card`, `--foreground`, ... plus their Tailwind-v4 `--color-*` spellings. A Tailwind v4 host whose entire palette lives in one `@theme` block named the way Tailwind's own docs name tokens (`--color-bg`, `--color-ink`, ...) extracts almost nothing — the issue's repro got **1 slot of 12**, and a host with no model key lands on the neutral blue defaults from a token sheet that declares every color it needs.

The sharpest edge: Vendo's own slot names were not accepted either. Naming your tokens `--color-surface` and `--color-accent` — the two slots Vendo literally calls `surface` and `accent` — matched neither shadcn's `--card` nor `--primary`.

## Fix

Purely additive, per the issue's suggested fix #1: each slot in `EXACT_COLOR_TOKENS` now also accepts its Vendo slot-name spelling (`--text`, `--surface`, `--accent`, `--muted-text`, `--danger`; `background`/`border` already read their slot names). The `--color-*` namespace variants come free via the existing `lastLightDecl` spelling expansion — no new machinery, no scoring, no inference.

Ordering preserves every existing read: the shadcn name is tried FIRST, so a conventional shadcn sheet is unchanged even where the vocabularies collide — shadcn's hover-wash `--accent` (deliberately unmapped as a primary brand signal) still loses to `--primary` whenever one exists; it only wins when no brand token does, where it is the best available signal.

Deliberately NOT in this diff: the issue's items 2–3 (naming unmatched custom properties when slots default, and documenting the vocabulary). Happy to follow up with either if maintainers want them.

## Testing

- New test in `packages/vendo/tests/cli/theme/extract-theme.test.ts`: a `@theme` sheet named entirely with Vendo slot names (`--color-surface`, ..., plus bare `--danger` in `:root`) now extracts all seven color slots with zero model involvement, provenance recorded per spelling.
  - `pnpm --filter @vendoai/vendo exec vitest run tests/cli/theme/extract-theme.test.ts -t "slot names"` → 1 passed
- Scoped gate on this machine (Windows; turbo's platform binary is broken here — STATUS_DLL_NOT_FOUND — so checks run via direct package scripts):
  - `pnpm --filter @vendoai/vendo build` → clean
  - `pnpm --filter @vendoai/vendo typecheck` (all three tsconfigs) → clean
  - `pnpm lint:packages` + dependency-guard + portability-gate → green
  - Full file run: 20/21 pass; the one failure (`evidencePaths` expecting `app/globals.css`, receiving `app\globals.css`) also fails on pristine main on Windows — pre-existing path-separator issue, unrelated to this change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Theme extraction now reads Tailwind v4 palettes that use Vendo’s slot names. Previously the exact pass only matched shadcn variables, so palettes like `--color-surface`/`--color-accent` extracted almost nothing.

- Accepts fallback spellings for slots: `--text`, `--surface`, `--accent`, `--muted-text`, `--danger` (their `--color-*` forms are picked up via existing expansion).
- Keeps shadcn names first in precedence; existing shadcn-based themes are unchanged, and shadcn `--accent` only wins when no `--primary` exists.
- Adds a test for a `@theme` block using only slot-name tokens; all seven color slots extract without the model.

<sup>Written for commit 0a5d362617f8acf0d71cc880d83c251d4396871d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1631?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

