### PR TITLE
fix(cli): theme evidence paths read as files, not platform spellings

### DIFF
--- a/packages/vendo/src/cli/theme/extract-theme.ts
+++ b/packages/vendo/src/cli/theme/extract-theme.ts
@@ -229,7 +229,11 @@ async function collectCss(layout: ContextFile | null, targetDir: string): Promis
         await visit(path.join(targetDir, spec.slice(2)), depth + 1);
       }
     }
-    files.push({ path: path.relative(targetDir, absolute), content });
+    // Repo-relative POSIX spelling: these paths surface as extraction
+    // evidence and the model pass's hints, and are compared as written — a
+    // platform-separator variant reads as a different file everywhere they
+    // are matched against conventional entry names.
+    files.push({ path: path.relative(targetDir, absolute).split(path.sep).join("/"), content });
   };
 
   if (layout !== null) {


### PR DESCRIPTION
Fixes the Windows failure in `packages/vendo/tests/cli/theme/extract-theme.test.ts` ("reads a fully conventional shadcn sheet exactly..."):

```
AssertionError: expected [ 'app/layout.tsx', 'app\globals.css' ] to deeply equal ArrayContaining{…}
```

## Problem

`collectCss` built each `ContextFile.path` with `path.relative(targetDir, absolute)`, which emits platform separators. On Windows the collected CSS paths came out backslash-separated (`app\globals.css`), while every consumer spells these paths POSIX:

- the test asserts them beside conventional entry names (`app/layout.tsx`, a literal from `ENTRY_FILE_CANDIDATES`),
- they surface as `ThemeSummary.evidencePaths` — extraction evidence seeded as hints for the staged model pass, where they are matched as written.

So on any non-POSIX checkout the exact pass reported its own evidence under a spelling nothing else uses, and the suite's allowlist test failed. Verified red on pristine `main` on this machine before the fix (1 failed / 20).

## Fix

Normalize at the single construction site: `path.relative(...).split(path.sep).join("/")`. No other site produces these paths (`layout.path`/`tailwindConfig.path` are POSIX literals from `ENTRY_FILE_CANDIDATES` and the fixed config-name list), and no consumer re-reads disk from them — they flow to provenance, `evidencePathsOf`, and `parseCssVars`' provenance field only. On Linux the normalization is a no-op, so CI behavior is bit-identical.

## Testing

- `pnpm --filter @vendoai/vendo exec vitest run tests/cli/theme/extract-theme.test.ts` → **20 passed** on Windows (was 19 passed / 1 failed on main); unchanged assertions, no test edits.
- Scoped gate: `pnpm --filter @vendoai/vendo build` clean; `pnpm --filter @vendoai/vendo typecheck` (3 tsconfigs) clean; `pnpm lint:packages` clean. (Ran via direct package scripts — turbo's platform binary is broken on this machine with STATUS_DLL_NOT_FOUND.)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalizes theme evidence paths in the CLI extractor to POSIX slashes so comparisons are consistent across platforms. Old behavior used platform separators (e.g., app\globals.css on Windows) and broke evidence matching; new behavior always emits repo‑relative POSIX paths (e.g., app/globals.css).

- Only the collected CSS evidence/provenance paths are affected; no filesystem reads use these values.
- No rollout steps; POSIX platforms see no change, and Windows allowlist tests now pass.

<sup>Written for commit 14b16bbf43f85d19af2e9cad10766395d01e7a5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1633?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

