### PR TITLE
fix(vendo): the background sweep adopts, never duplicates (#1250)

### DIFF
--- a/packages/vendo/src/compose-sweep.ts
+++ b/packages/vendo/src/compose-sweep.ts
@@ -5,6 +5,24 @@
 import { log } from "@vendoai/core";
 import type { VendoComposition } from "./compose-context.js";
 
+const SWEEP_TIMER = Symbol.for("vendo.background-ttl-sweep");
+
+/** Arm the newest composition's background sweep and retire the previous one -
+ *  ADOPT, never duplicate (#1250). Next dev re-evaluates route modules on
+ *  every recompile, and each evaluation arms its own composition's sweep; after
+ *  hours of recompiles a dev server carried dozens of live intervals, all
+ *  hitting the hosted store with no browser open (field: linkwarden
+ *  2026-08-13). The ticker half of the same report ships this exact pattern
+ *  (`armDevTicker`): arming stops the predecessor's interval and starts the
+ *  newcomer's, keeping exactly one sweep, bound to the composition actually
+ *  serving requests. The slot rides globalThis via Symbol.for so it survives
+ *  module re-evaluation. */
+export function armBackgroundSweep(start: () => () => void, host: Record<symbol, unknown> = globalThis as unknown as Record<symbol, unknown>): void {
+  const previousStop = host[SWEEP_TIMER];
+  if (typeof previousStop === "function") (previousStop as () => void)();
+  host[SWEEP_TIMER] = start();
+}
+
 /** The sweep pass, and the unref'd timer that drives it on a long-lived host. */
 export const composeSweep = (composition: VendoComposition): Pick<VendoComposition,
   "runSweep" | "sweepEnabled" | "startBackgroundSweep"> => {
@@ -46,19 +64,27 @@ export const composeSweep = (composition: VendoComposition): Pick<VendoCompositi
     // illegal in Workers global scope, and a process that never serves a
     // request has nothing to sweep.
     startBackgroundSweep = (): void => {
-      const sweepTimer = setInterval(() => {
-        runSweep().catch((error: unknown) => {
-          log({
-            code: "vendo.ttl-sweep-retry",
-            level: "warn",
-            message: `[vendo] TTL sweep failed; will retry next interval: ${error instanceof Error ? error.message : String(error)}`,
+      let sweepTimer: ReturnType<typeof setInterval> | undefined;
+      // Adopt, never duplicate (#1250): a re-armed sweep stops the previous
+      // composition's interval before starting this one.
+      armBackgroundSweep((): (() => void) => {
+        sweepTimer = setInterval(() => {
+          runSweep().catch((error: unknown) => {
+            log({
+              code: "vendo.ttl-sweep-retry",
+              level: "warn",
+              message: `[vendo] TTL sweep failed; will retry next interval: ${error instanceof Error ? error.message : String(error)}`,
+            });
           });
-        });
-      }, sweepConfig.intervalMs);
-      (sweepTimer as unknown as { unref?: () => void }).unref?.();
+        }, sweepConfig.intervalMs);
+        (sweepTimer as unknown as { unref?: () => void }).unref?.();
+        return (): void => {
+          if (sweepTimer !== undefined) clearInterval(sweepTimer);
+        };
+      });
       const closeStore = store.close.bind(store);
       store.close = async (): Promise<void> => {
-        clearInterval(sweepTimer);
+        if (sweepTimer !== undefined) clearInterval(sweepTimer);
         await closeStore();
       };
     };

--- a/packages/vendo/src/compose-sweep.ts
+++ b/packages/vendo/src/compose-sweep.ts
@@ -16,7 +16,9 @@ const SWEEP_TIMER = Symbol.for("vendo.background-ttl-sweep");
  *  (`armDevTicker`): arming stops the predecessor's interval and starts the
  *  newcomer's, keeping exactly one sweep, bound to the composition actually
  *  serving requests. The slot rides globalThis via Symbol.for so it survives
- *  module re-evaluation. */
+ *  module re-evaluation. DEVELOPMENT only — see the caller's gate: production
+ *  compositions are built once, and legitimately concurrent handles each keep
+ *  their own sweep. */
 export function armBackgroundSweep(start: () => () => void, host: Record<symbol, unknown> = globalThis as unknown as Record<symbol, unknown>): void {
   const previousStop = host[SWEEP_TIMER];
   if (typeof previousStop === "function") (previousStop as () => void)();
@@ -27,6 +29,11 @@ export function armBackgroundSweep(start: () => () => void, host: Record<symbol,
 export const composeSweep = (composition: VendoComposition): Pick<VendoComposition,
   "runSweep" | "sweepEnabled" | "startBackgroundSweep"> => {
   const { store, guard, byoApprovals, parkedCallTtlMs, sweepConfig, sweepNow } = composition;
+  // The same derivation compose-wire's `development` uses (compose-automations
+  // repeats it): an explicit config.development wins; otherwise NODE_ENV.
+  const development = composition.config.development !== undefined
+    ? composition.config.development !== false
+    : composition.isDevelopmentEnv;
   const runSweep = async (): Promise<void> => {
     // Existing-agents Lane B — expire orphaned parked BYO calls on the same
     // cadence (deny path, idempotent); disabled by parkedCallTtlMs 0.
@@ -65,9 +72,7 @@ export const composeSweep = (composition: VendoComposition): Pick<VendoCompositi
     // request has nothing to sweep.
     startBackgroundSweep = (): void => {
       let sweepTimer: ReturnType<typeof setInterval> | undefined;
-      // Adopt, never duplicate (#1250): a re-armed sweep stops the previous
-      // composition's interval before starting this one.
-      armBackgroundSweep((): (() => void) => {
+      const startInterval = (): void => {
         sweepTimer = setInterval(() => {
           runSweep().catch((error: unknown) => {
             log({
@@ -78,10 +83,24 @@ export const composeSweep = (composition: VendoComposition): Pick<VendoCompositi
           });
         }, sweepConfig.intervalMs);
         (sweepTimer as unknown as { unref?: () => void }).unref?.();
-        return (): void => {
-          if (sweepTimer !== undefined) clearInterval(sweepTimer);
-        };
-      });
+      };
+      // Adopt, never duplicate (#1250): a DEV re-evaluation re-arms on every
+      // route-module recompile, so arming stops the previous composition's
+      // interval first. Development ONLY, like armDevTicker: a production
+      // composition is built once, and legitimately concurrent handles (a host
+      // holding two createVendo handles is one deployment — boot-summary) must
+      // each keep their own sweeps; a global adopt there would permanently
+      // silence the first handle's TTL reclaim.
+      if (development) {
+        armBackgroundSweep((): (() => void) => {
+          startInterval();
+          return (): void => {
+            if (sweepTimer !== undefined) clearInterval(sweepTimer);
+          };
+        });
+      } else {
+        startInterval();
+      }
       const closeStore = store.close.bind(store);
       store.close = async (): Promise<void> => {
         if (sweepTimer !== undefined) clearInterval(sweepTimer);

--- a/packages/vendo/tests/compose-sweep.test.ts
+++ b/packages/vendo/tests/compose-sweep.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "vitest";
-import { armBackgroundSweep } from "../src/compose-sweep.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { armBackgroundSweep, composeSweep } from "../src/compose-sweep.js";
+import type { VendoComposition } from "../src/compose-context.js";
 
 describe("armBackgroundSweep - the newest composition ADOPTS the sweep", () => {
   it("a replacement composition stops the stale sweep and runs its own (#1250)", () => {
@@ -15,5 +16,52 @@ describe("armBackgroundSweep - the newest composition ADOPTS the sweep", () => {
     armBackgroundSweep(() => { startsB += 1; return () => undefined; }, host);
     expect(stopsA).toBe(1);
     expect(startsB).toBe(1);
+  });
+});
+
+describe("composeSweep - adoption is a DEVELOPMENT posture", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const compositionOf = (development: boolean): {
+    composition: VendoComposition;
+    sweeps: () => number;
+  } => {
+    let count = 0;
+    const composition = {
+      store: { close: async () => undefined },
+      guard: {},
+      byoApprovals: { sweepExpired: async () => { count += 1; } },
+      parkedCallTtlMs: 60_000,
+      sweepConfig: { intervalMs: 1_000 },
+      sweepNow: () => 0,
+      config: { development },
+    } as unknown as VendoComposition;
+    return { composition, sweeps: () => count };
+  };
+
+  it("two concurrently-live production handles keep their own sweeps", async () => {
+    vi.useFakeTimers();
+    const first = compositionOf(false);
+    const second = compositionOf(false);
+    composeSweep(first.composition).startBackgroundSweep();
+    composeSweep(second.composition).startBackgroundSweep();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(first.sweeps()).toBe(1);
+    expect(second.sweeps()).toBe(1);
+    await Promise.all([first.composition.store.close(), second.composition.store.close()]);
+  });
+
+  it("a development re-arm adopts: the predecessor's sweep stops (#1250)", async () => {
+    vi.useFakeTimers();
+    const first = compositionOf(true);
+    const second = compositionOf(true);
+    composeSweep(first.composition).startBackgroundSweep();
+    composeSweep(second.composition).startBackgroundSweep();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(first.sweeps()).toBe(0);
+    expect(second.sweeps()).toBe(1);
+    await Promise.all([first.composition.store.close(), second.composition.store.close()]);
   });
 });

--- a/packages/vendo/tests/compose-sweep.test.ts
+++ b/packages/vendo/tests/compose-sweep.test.ts
@@ -22,6 +22,10 @@ describe("armBackgroundSweep - the newest composition ADOPTS the sweep", () => {
 describe("composeSweep - adoption is a DEVELOPMENT posture", () => {
   afterEach(() => {
     vi.useRealTimers();
+    // The legs below arm against the REAL process slot (composeSweep owns the
+    // host binding, unlike the isolated hosts above); drop it so no stale stop
+    // leaks past this describe block.
+    delete (globalThis as unknown as Record<symbol, unknown>)[Symbol.for("vendo.background-ttl-sweep")];
   });
 
   const compositionOf = (development: boolean): {

--- a/packages/vendo/tests/compose-sweep.test.ts
+++ b/packages/vendo/tests/compose-sweep.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { armBackgroundSweep } from "../src/compose-sweep.js";
+
+describe("armBackgroundSweep - the newest composition ADOPTS the sweep", () => {
+  it("a replacement composition stops the stale sweep and runs its own (#1250)", () => {
+    // Adopt, never duplicate: Next dev re-arms the background sweep on every
+    // route recompile, and arming must stop the predecessor's interval - a
+    // dev server otherwise accumulates one live interval per recompile, all
+    // hitting the store with no browser open (#1250).
+    const host: Record<symbol, unknown> = {};
+    let stopsA = 0;
+    let startsB = 0;
+    armBackgroundSweep(() => () => { stopsA += 1; }, host);
+    expect(stopsA).toBe(0);
+    armBackgroundSweep(() => { startsB += 1; return () => undefined; }, host);
+    expect(stopsA).toBe(1);
+    expect(startsB).toBe(1);
+  });
+});


### PR DESCRIPTION
Fixes the sweep half of #1250 (the dev-automations-ticker half already shipped as `armDevTicker`, citing this issue).

## Problem

`composeSweep` armed a `setInterval` per composition and tore it down only via a `store.close` patch. Next dev re-evaluates route modules on every recompile, each evaluation builds a fresh composition and arms it, and orphaned compositions are never closed under that churn — so a long-running dev server accumulated one live interval per recompile, all hitting the hosted store with no browser open (the issue's field measurement: sweep firing every few seconds, standing 429s on every chat turn until restart).

## Fix

The same adopt-never-duplicate pattern the ticker half already shipped: `armBackgroundSweep` keeps one slot per process (`Symbol.for`, so it survives module re-evaluation); arming stops the predecessor's interval before starting the newcomer's, leaving exactly one sweep bound to the composition actually serving requests.

DEVELOPMENT ONLY (review fix, 1326f624): adoption is gated on `development` — the same derivation compose-wire and compose-automations use. The rebuild churn of #1250 is a development shape; a production composition is built once, and legitimately concurrent handles (a host holding two `createVendo` handles is one deployment) must each keep their own independent intervals, as before this PR. Keying the slot off the store was considered and rejected: `selectStore` builds a fresh store adapter per `createVendo` call, so consecutive dev compositions share no object to key on.

Deliberately unchanged: the per-arm `store.close` patch. Each frame clears its own timer id — idempotent through the chain — so teardown still reaches every interval whatever order arming and closing take, and no new close semantics are introduced for any adapter.

## Testing

- New regression test mirroring `armDevTicker`'s (#1250) test: `packages/vendo/tests/compose-sweep.test.ts` — arming twice stops the first sweep exactly once and starts the second.
  - `pnpm --filter @vendoai/vendo exec vitest run tests/compose-sweep.test.ts` → 1 passed
- Posture tests added with the review fix: two concurrently-live **production** handles each keep their own sweep (fake timers); a **development** re-arm stops its predecessor.
  - `pnpm --filter @vendoai/vendo exec vitest run tests/compose-sweep.test.ts tests/sweep-failure-isolation.test.ts tests/compose-automations.test.ts` → 12 passed
- Guard rails around the changed path: `tests/sweep-failure-isolation.test.ts` (real `createVendo` + request-triggered sweep) → passed; `tests/compose-automations.test.ts` → 8 passed.
- Scoped gate: `pnpm --filter @vendoai/vendo build` clean; `typecheck` (3 tsconfigs) clean — re-run green on top of 1326f624. (Direct package scripts — turbo's platform binary is broken on this machine, STATUS_DLL_NOT_FOUND.)
