### PR TITLE
test(vendo): a painted remix fork is read back through the flagged open

### DIFF
--- a/.changeset/painted-pending-open-seam-test.md
+++ b/.changeset/painted-pending-open-seam-test.md
@@ -1,0 +1,9 @@
+---
+---
+
+Test-only. Closes a coverage hole rather than changing behaviour, so it carries
+no version bump: a real remix fork, painted by the real floor, is now read back
+through the real `GET /apps/:id/open?pending=1` — the only open the embed ever
+performs. Three suites bracketed that intersection and none covered it, which is
+how a `blocked` refusal raised while painting could 403 the flagged poll forever
+without a red test.

--- a/packages/vendo/tests/remix-fork-pending-open.seam.test.ts
+++ b/packages/vendo/tests/remix-fork-pending-open.seam.test.ts
@@ -1,0 +1,207 @@
+/**
+ * A PAINTED SCREEN HAS TO SURVIVE THE FLAGGED POLL.
+ *
+ * The embed never opens an app any other way: `use-app.ts` always passes
+ * `pending: true`, so `GET /apps/:id/open?pending=1` is the ONLY open a remix
+ * fork ever performs. That flag exists to turn the build window's expected miss
+ * into a quiet `{kind:"pending"}` — but it is also the arm that decides which
+ * failures stay failures (`src/wire/apps.ts` `openApp`), and anything that is
+ * not `not-found` is re-thrown. A `blocked` refusal raised while PAINTING the
+ * screen therefore leaves the flagged poll as an HTTP 403 that repeats forever:
+ * the app exists, the person can see it, and the surface never resolves.
+ *
+ * That is not hypothetical. Until the in-client venue was removed, the painted
+ * path performed a per-open engine read of its own — an approval lookup, done
+ * unguarded, before the payload was returned — and a deployment whose allowlist
+ * had moved past that collection answered every remix open with exactly that
+ * 403. The read is gone, and nothing may quietly put one back.
+ *
+ * THE INTERSECTION THIS PINS, which two suites bracketed and neither covered:
+ *   - `seed-wire.test.ts` drives the real seed and the real `?pending=1` route,
+ *     but configures no model, so the app never gets a screen and the open
+ *     resolves terminal-failed WITHOUT entering the painted path.
+ *   - `app-open-terminal-artifact.seam.test.ts` asserts `?pending=1` for a
+ *     failed app and for a ghost app, and asserts a healthy painted open only
+ *     WITHOUT the flag.
+ *   - `remix-port-seed.e2e.test.ts` paints a real fork, but opens it through
+ *     `vendo.apps.open(...)` with no `pending` option and no wire leg.
+ * So "a real fork, painted, read back through the flagged wire route" had no
+ * test, and a regression living in that intersection ships green.
+ *
+ * Both ends are real: a real PGlite store, a real `createVendo`, the real seed
+ * door, the real checks floor, the real screen in the sealed VM, and the real
+ * composed HTTP handler. Only the MODEL is scripted, because what is measured
+ * is the doors.
+ *
+ * What must be able to fail: call
+ * `assertEngineCollection("vendo_inclient_approvals")` at the top of
+ * `paintedScreenSurface` (`@vendoai/apps` persistence/open.ts) — the same
+ * unguarded read, in the same place — and this goes red with a 403. Note that
+ * routing it through the `venueState` seam instead does NOT reproduce it:
+ * `additionalVenueState` catches, so that hook can only cost the payload a key.
+ */
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { SeedBaseline } from "@vendoai/apps";
+import type { RunContext } from "@vendoai/core";
+import { createStore } from "@vendoai/store";
+import type { LanguageModel } from "ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createVendo } from "../src/server.js";
+
+const originalCwd = process.cwd();
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  process.chdir(originalCwd);
+  vi.restoreAllMocks();
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+const ctx: RunContext = {
+  principal: { kind: "user", subject: "user_fork_pending" },
+  venue: "app",
+  presence: "present",
+  sessionId: "session_fork_pending",
+};
+
+/** The splitter's output for the slot: real TSX in the screen dialect. */
+const PORTED = `import { Stack, Text } from "@vendo/screen";
+
+export default function RentRollTable() {
+  return (
+    <Stack gap={12}>
+      <Text text="Rent roll" variant="heading" />
+      <Text text="24 units" />
+    </Stack>
+  );
+}
+`;
+
+/** In the port's SOURCE and nowhere else — what the loop's find/replace bites on. */
+const PORT_ONLY = 'text="Rent roll"';
+/** What the scripted loop writes in its place, still in source dialect. */
+const PORT_EDITED = 'text="Rent roll, grouped by status"';
+/** …and the same string as the PAINTED tree carries it: a rendered screen is
+ *  nodes and props, never source, so this is the form the open actually serves.
+ *  Asserting on the EDITED text rather than the port's is what makes the paint
+ *  load-bearing — an open that served the unedited port, an empty envelope, or
+ *  no screen at all cannot contain it. */
+const EDITED_TEXT = "Rent roll, grouped by status";
+
+/** The screen agent's own brief — how a prompt is known to be the assembly
+ *  loop's rather than the mandatory reviewer's. */
+const SCREEN_BRIEF_MARKER = "# In this loop";
+
+const ZERO_USAGE = {
+  inputTokens: { total: 0, noCache: 0, cacheRead: 0, cacheWrite: 0 },
+  outputTokens: { total: 0, text: 0, reasoning: 0 },
+} as const;
+
+type Chunk = Record<string, unknown>;
+
+const call = (toolName: string, input: unknown, toolCallId: string): Chunk[] => [
+  { type: "tool-call", toolCallId, toolName, input: JSON.stringify(input) },
+  { type: "finish", usage: ZERO_USAGE, finishReason: { unified: "tool-calls", raw: undefined } },
+];
+
+const speak = (text: string): Chunk[] => [
+  { type: "text-start", id: "t1" },
+  { type: "text-delta", id: "t1", delta: text },
+  { type: "text-end", id: "t1" },
+  { type: "finish", usage: ZERO_USAGE, finishReason: { unified: "stop", raw: undefined } },
+];
+
+/** A model that plays the assembly loop's steps in order. Anything that is not
+ *  the loop — the mandatory reviewer above all — gets plain prose, which the
+ *  reviewer reads as "no findings", so no repair round fires and the run stays
+ *  deterministic. */
+function scripted(steps: Array<() => Chunk[]>): LanguageModel {
+  const remaining = [...steps];
+  const answer = (prompt: string): Chunk[] => {
+    if (!prompt.includes(SCREEN_BRIEF_MARKER)) return speak("nothing to report");
+    const step = remaining.shift();
+    return step === undefined ? speak("nothing more to do") : step();
+  };
+  return {
+    specificationVersion: "v3",
+    provider: "vendo-fork-pending",
+    modelId: "vendo-fork-pending-v1",
+    supportedUrls: {},
+    async doStream(request: { prompt?: unknown }) {
+      const chunks = answer(JSON.stringify(request.prompt ?? ""));
+      return {
+        stream: new ReadableStream({
+          start(controller) {
+            controller.enqueue({ type: "stream-start", warnings: [] });
+            for (const chunk of chunks) controller.enqueue(chunk);
+            controller.close();
+          },
+        }),
+      };
+    },
+  } as unknown as LanguageModel;
+}
+
+const baseline: SeedBaseline = {
+  slot: "RentRollTable",
+  source: "export default function RentRollTable() {\n  return <strong>24 units</strong>;\n}\n",
+  hash: "sha256:keystone-rent-roll-1",
+  exportable: false,
+  capturedAt: "2026-08-25T09:00:00.000Z",
+  ported: { source: PORTED, tools: [], holes: [] },
+};
+
+const request = (path: string): Request =>
+  new Request(`https://host.test/api/vendo${path}`, { method: "GET" });
+
+describe("a painted remix fork opens through the embed's flagged poll", () => {
+  it("serves the painted screen to GET /open?pending=1, instead of 403ing forever", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vendo-fork-pending-"));
+    cleanups.push(async () => rm(root, { recursive: true, force: true }));
+    await mkdir(join(root, ".vendo", "remixable"), { recursive: true });
+    await writeFile(
+      join(root, ".vendo", "remixable", `${baseline.slot}.json`),
+      JSON.stringify(baseline, null, 2),
+    );
+    const store = createStore({ dataDir: join(root, ".data") });
+    cleanups.push(async () => store.close());
+    await store.ensureSchema();
+    process.chdir(root);
+
+    const vendo = createVendo({
+      models: {
+        default: scripted([
+          () => call("edit_app", { edits: [{ find: PORT_ONLY, replace: PORT_EDITED }] }, "e1"),
+          () => speak("Grouped the rows by status."),
+        ]),
+      },
+      principal: async () => ctx.principal,
+      store,
+    });
+
+    // The real fork write path — the ✦ gesture's own door.
+    const app = await vendo.apps.seed.from(
+      { component: baseline.slot, instruction: "group by status with a late subtotal" },
+      ctx,
+    );
+    // The premise: this deployment really painted a screen. Without it a green
+    // assertion below would only prove the open declined politely.
+    expect(app.buildFailed?.reason).toBeUndefined();
+
+    // ── THE ONE THIS FILE EXISTS FOR ────────────────────────────────────────
+    // The real composed handler, the real route, the flag the embed actually
+    // sends. A `blocked` raised while painting arrives here as 403; a painted
+    // screen mistaken for a build in flight arrives as {kind:"pending"} and the
+    // embed skeleton-polls to its deadline. Both are the infinite skeleton.
+    const response = await vendo.handler(request(`/apps/${app.id}/open?pending=1`));
+    expect(response.status).toBe(200);
+
+    const body = await response.json() as { kind: string };
+    expect(body.kind).toBe("tree");
+    // …and it is THIS app's painted screen, not an empty envelope wearing the
+    // right kind: the edited port text exists only if the fork's screen really
+    // rendered and really came back through the flagged route.
+    expect(JSON.stringify(body)).toContain(EDITED_TEXT);
+  }, 120_000);
+});


### PR DESCRIPTION
Test-only. No behaviour changes, no version bump.

## The premise correction that produced this PR

This lane was opened to remove a surviving reader of `vendo_inclient_approvals`
on the remix-fork load path, reported as killing every remix at 0.42. **There is
no such reader in this repo**, and the fix does not belong here. Verified from
source, not from docs:

- `vendo_inclient_approvals` appears on `main` in exactly one place — the
  allowlist's own history comment, `packages/core/src/engine-collections.ts:8` —
  plus one stale docs page (`docs-site/generated/in-client-venue.mdx`).
- Checked at every release from `0.41.0` through `0.45.0`: absent in all of them.
- Checked in the **published** tarballs pulled from the registry:
  `@vendoai/apps@0.42.0` contains zero occurrences; only `@vendoai/core` carries
  the comment.
- `61cb46ee1` removed both readers cleanly — `packages/apps/src/server/remix/inclient.ts`
  (`const COLLECTION = "vendo_inclient_approvals"`) and
  `packages/store/src/backfill-app-data.ts`.
- No reader anywhere in `vendo-web` on its `origin/main` either.

The live 403 came from a **stale install**, not from library code. In the
`keystone-demo` worktree, `host/package.json` and `pnpm-lock.yaml` both pin
`0.42.0`, but the tree on disk had resolved to `0.39.0`:
`@vendoai/apps@0.39.0/dist/server/remix/inclient.js:12` is the reader, reached
from `dist/server/persistence/open.js:53` (`seams.inClient?.(app)`) on the
painted-screen open. Locally nothing refused it — `@vendoai/core@0.39.0` is
allowlist **v6**, which still contains the collection — but that demo runs on
the **Cloud hosted store**, which is at **v10** and dropped it. Cloud answered
`blocked`, `openApp` re-throws anything that is not `not-found`, and the flagged
poll became a permanent 403.

So the class is not "deleted collection, surviving reader in the repo". It is
**an old pinned client library meeting Cloud's newer allowlist** — the same
shape as the earlier `8813b09`, which exists in neither this repo nor
vendo-web. The demo-side reinstall is being handled in the demos lane and is
deliberately not part of this PR.

## What this PR does instead: closes the hole that let it hide

The symptom was real even if the cause was not ours, and this repo had no test
that would have gone red on it. The embed only ever opens an app one way —
`use-app.ts` always passes `pending: true`, so `GET /apps/:id/open?pending=1` is
the only open a remix fork ever performs. That flag is also the arm deciding
which failures stay failures (`src/wire/apps.ts` `openApp`): anything that is
not `not-found` is re-thrown. A `blocked` raised **while painting the screen**
therefore surfaces as a 403 that repeats forever — the app exists, the person
can see it, and the surface never resolves.

Three suites bracketed that intersection and none covered it:

| Suite | Real seed? | Paints? | `?pending=1`? |
|---|---|---|---|
| `seed-wire.test.ts` | yes | **no** — no model configured, resolves terminal-failed before the painted path | yes |
| `app-open-terminal-artifact.seam.test.ts` | n/a (`authoredScreen`) | yes | **flag only for failed + ghost apps**; the healthy paint is asserted without it |
| `remix-port-seed.e2e.test.ts` | yes | yes | **no** — opens via `vendo.apps.open(...)`, off the wire, no pending option |

So "a real fork, painted, read back through the flagged wire route" had no test,
and a regression living in that intersection ships green. That is the one line
worth keeping: **`remix-fork-pending-open.seam.test.ts` now pins painted ×
pending on the real fork path**, so any per-open read that starts refusing —
a dropped collection or anything else raising `blocked` mid-paint — goes red
here instead of reaching a browser.

## Declared test change

One new file, `packages/vendo/tests/remix-fork-pending-open.seam.test.ts`. No
existing test was modified, and no source file was touched.

Both ends are real per the repo's seam rule: real PGlite store, real
`createVendo`, real seed door, real checks floor, the screen really rendering in
the sealed VM, and the real composed HTTP handler on the real route. Only the
**model** is scripted. The load-bearing assertion is the *edited* port text —
`"Rent roll, grouped by status"` — which exists only if the fork's screen really
rendered and really came back through the flagged route; an unedited port, an
empty envelope, or no screen at all cannot contain it.

## Red/green proof

The class simulated at the exact spot the historical reader sat — an unguarded
`assertEngineCollection("vendo_inclient_approvals")` at the top of
`paintedScreenSurface` in `packages/apps/src/server/persistence/open.ts`:

```
 × a painted remix fork opens through the embed's flagged poll > serves the
   painted screen to GET /open?pending=1, instead of 403ing forever 1773ms
   → expected 403 to be 200 // Object.is equality
AssertionError: expected 403 to be 200 // Object.is equality
+ 403
 Test Files  1 failed (1)
      Tests  1 failed (1)
```

That is the live symptom exactly. Patch reverted, `main` as-is:

```
 ✓ tests/remix-fork-pending-open.seam.test.ts (1 test) 1819ms
   ✓ a painted remix fork opens through the embed's flagged poll > serves the
     painted screen to GET /open?pending=1, instead of 403ing forever  1819ms
 Test Files  1 passed (1)
      Tests  1 passed (1)
```

Worth recording: routing the same failure through the `venueState` hook does
**not** reproduce it. `additionalVenueState` catches (open.ts:113-122), so that
seam can only ever cost the payload a key — the historical read was dangerous
precisely because it was unguarded.

## Gate

`pnpm build` ✅ · `pnpm typecheck` ✅ (43 tasks) · `pnpm lint` ✅ ·
target spec red-then-green above ✅.

The touched package's whole suite, run in 4 shards with vitest capped at 2
workers (min and max): **2781 passed, 0 failed** (784 / 682 / 683 / 632).

`test:affected` fans out past the touched scope to 31 tasks (fixtures, demo-bank)
over ~12 minutes, which is beyond a sensible local gate for a change that adds no
source — and this repo's rule is that the full suite is CI's job. CI's `ci` check
is the gate of record for that fan-out.
