### PR TITLE
fix(apps): a select's value can reach a tool's enum, and a payload fault names the tool

### DIFF
--- a/.changeset/select-value-reaches-a-tools-enum.md
+++ b/.changeset/select-value-reaches-a-tools-enum.md
@@ -1,0 +1,20 @@
+---
+"@vendoai/apps": patch
+---
+
+A select's value can reach a tool's enum, and a payload fault names the tool.
+
+A screen that fed a control's value into a tool whose input declares an ENUM had
+no state it was allowed to hold. Typed to the tool's own union it was refused at
+the handler, because the event a control hands a screen declared `value` as
+`string`; widened to `string` it was refused at the payload. Both arms refused
+correct intent, and the payload arm was stamped with the locus of the BUTTON the
+call sat under — `<Button> prop "onClick"` — so every repair looked like the
+handler and the model rewrote that handler for as long as it was allowed to.
+
+`value` on the change event is `any` now, which is what a control's data really
+is: a Slider reports a number and a multi-select an array, so the type it was
+given was never the type it had. And a value the compiler refuses INSIDE a tool
+payload is read as a payload fault wherever it files it — it names the tool and
+lists the keys the tool's input accepts, the same sentence a misspelled payload
+key already got.

--- a/packages/apps/src/server/checking/screen-typecheck.ts
+++ b/packages/apps/src/server/checking/screen-typecheck.ts
@@ -334,6 +334,13 @@ const typeIssue = (
   if (MISSING_PROPERTY.has(diagnostic.code) || BAD_CALL.has(diagnostic.code) || diagnostic.code === 2322) {
     const handler = changeHandlerMessage(ts, file, checker, node);
     if (handler !== undefined) return at(handler);
+    // A value refused INSIDE a tool payload arrives as 2322 — the assignment to
+    // one nested field rather than the argument as a whole — and the locus a
+    // sentence reads best from is the tool, not the control the call sits under:
+    // an enum fed a widened value was stamped `<Button> prop "onClick"`, so the
+    // repair looked like the handler and the payload was rewritten forever.
+    const payload = badPayloadMessage(ts, file, checker, diagnostic, sentence);
+    if (payload !== undefined) return at(payload);
     const [reused] = translateDiagnostic(ts, file, checker, diagnostic);
     // The wire translator's `where` is a locus its sentence sometimes states
     // itself, and prefixing it anyway said `prop "variant" prop "variant" on

--- a/packages/apps/src/server/checking/screen-typings.ts
+++ b/packages/apps/src/server/checking/screen-typings.ts
@@ -554,8 +554,15 @@ export interface ComponentScreenTypingsInput {
  *  a Checkbox) — this program has no DOM lib to describe the real thing, and
  *  anything wider would reject working code. It is OPTIONAL because most handlers
  *  ignore it, and the return covers both `() => setOpen(true)` and an `async`
- *  handler that awaits a tool. */
-const HANDLER_TYPE = "(event?: { target: { value?: string; checked?: boolean } }) => void | Promise<void>";
+ *  handler that awaits a tool.
+ *
+ *  `value` is `any` deliberately. What a control reports is not a string — a
+ *  Slider gives a number, a multi-select an array (`specs.ts`) — and the type
+ *  no control's data really has closed the one route a picked value has to a
+ *  tool: called `string`, a state typed to a tool's declared ENUM was refused at
+ *  the handler and the same state widened was refused at the payload, which is
+ *  every state a screen could hold. */
+const HANDLER_TYPE = "(event?: { target: { value?: any; checked?: boolean } }) => void | Promise<void>";
 
 /** An identifier a declaration can be written under. A catalog name that is not
  *  one cannot be imported by a screen either. */

--- a/packages/apps/tests/checking/component-screen.test.ts
+++ b/packages/apps/tests/checking/component-screen.test.ts
@@ -1703,6 +1703,70 @@ export default function Window() {
     expect(ranged.issues).toHaveLength(1);
   });
 
+  /**
+   * THE PINCER. A control reports what a person picked through the change event
+   * and nowhere else, so a screen that feeds a Select into a tool whose input
+   * declares an ENUM had two states to choose between and both were refused:
+   * typed to the tool's own union it failed at the handler, because
+   * `event.target.value` was declared `string`; widened to `string` it failed at
+   * the payload. Neither sentence named the enum as the thing to satisfy — the
+   * payload one named the Button its call sat under — so the model rewrote the
+   * handler for as long as it was allowed to.
+   */
+  it("lets a Select's value reach a tool's enum, and names the tool when the value stays wide", async () => {
+    const paying: readonly HostToolInfo[] = [...tools, {
+      name: "record_payment",
+      description: "Record a payment against one transfer",
+      risk: "write",
+      inputSchema: {
+        type: "object",
+        properties: {
+          body: {
+            type: "object",
+            properties: { id: { type: "string" }, method: { type: "string", enum: ["ach", "card", "check"] } },
+            required: ["id", "method"],
+            additionalProperties: false,
+          },
+        },
+        required: ["body"],
+        additionalProperties: false,
+      },
+    }];
+    const paid = async (state: string): Promise<ComponentScreenCheck> => checkComponentScreen({
+      source: `import { useState } from "react";
+import { Button, Select, Stack, tools } from "@vendo/screen";
+
+export default function Pay() {
+  const [method, setMethod] = useState<${state}>("ach");
+  return (
+    <Stack gap={8}>
+      <Select label="Method" options={["ach", "card", "check"]} value={method} onChange={(e) => setMethod(e.target.value)} />
+      <Button label="Record" onClick={() => { void tools.record_payment({ body: { id: "tr_1", method } }); }} />
+    </Stack>
+  );
+}
+`,
+      hostTools: paying,
+      catalog: controls,
+      runQuery: async () => ROWS,
+    });
+
+    // The state typed to the tool's own enum is the CORRECT screen, and the
+    // whole gauntlet takes it.
+    const typed = await paid(`"ach" | "card" | "check"`);
+    expect(typed.issues).toEqual([]);
+    expect(typed.ok).toBe(true);
+
+    // Left wide, the payload is a real fault — and the sentence is about the
+    // TOOL whose schema refused it, not about the button the call sits under.
+    const wide = await paid("string");
+    const [{ code, message }] = wide.issues as [{ code: string; message: string }];
+    expect(code).toBe("types");
+    expect(message).toContain("calls tools.record_payment(…) with an input its schema does not accept");
+    expect(message).toContain(`"ach" | "card" | "check"`);
+    expect(message).not.toContain('prop "onClick"');
+  });
+
   /** A field description written as the bare KEY — the shorthand `Select.options`
    *  already takes. `items` given `string[]` was a whole class of looped repairs;
    *  the type is the union now, so there is nothing left to refuse. */


### PR DESCRIPTION
## The pincer

A screen that lets someone pick something and then sends the pick to a tool is
the most ordinary screen there is. If that tool's input declares an **enum**, the
checks floor had no version of that screen it would accept.

A control reports what a person picked through its change event and nowhere else.
The event the floor declares typed `value` as `string`
(`screen-typings.ts` `HANDLER_TYPE`), while the tool's input printed its enum as a
closed union of literals (`screen-typings.ts:272`, via `toolInputText` at `:686`).
So the screen had two states to choose between and both were refused:

- **State typed to the tool's own union** — the correct screen — was refused at
  the handler: `<Select> prop "onChange" setMethod() does not accept
  e.target.value as its 1st argument` (TS2345).
- **State widened to `string`** — the only repair that sentence suggests — was
  refused at the payload (TS2322).

And the second refusal named the wrong thing. 2322 is absent from `BAD_CALL`
(`screen-typecheck.ts:44`), so `badPayloadMessage` (`:88-116`) never ran, and
`locusOf`/`whereOf` (`screen-program.ts:146-165`) walk up through function
boundaries — so a fault in a tool payload was stamped with the locus of the
Button the call happened to sit under:

```
line 9: <Button> prop "onClick" Type 'string' is not assignable to type '"ach" | "card" | "check"'.
```

Nothing in either sentence names the enum as the thing to satisfy, and one of
them points at a handler that was never wrong. So the model rewrote that handler
for as long as it was allowed to — 9-13 identical rejections per app, and about
three generations in four failing on `keystone-demo`. Pre-existing since 0.15
(`d0a27e543`); #1620 fixed the adjacent half.

## The fix

1. `screen-typings.ts` — the change event's `value` is `any`, not `string`. This
   is what a control's data really is: a Slider reports a number and a
   multi-select an array, both of which the Kit's own examples already feed
   through `e.target.value`. The floor was refusing correct code to buy typing on
   data it never had.
2. `screen-typecheck.ts:337` — the 2322 branch calls `badPayloadMessage` before
   falling through to the generic sentence. It self-gates to `tools.*`/`useQuery`
   callees (`:103`), so nothing else changes shape. The widened arm now reads:

```
line 9: calls tools.record_payment(…) with an input its schema does not accept: Type 'string' is not assignable to type '"ach" | "card" | "check"'. Its input keys are: body (required: body).
```

## Declared test change

`packages/apps/tests/checking/component-screen.test.ts` gains one test in the
controls block of stage 5 — *"lets a Select's value reach a tool's enum, and
names the tool when the value stays wide"*. It declares a tool whose input
carries an enum nested under `body`, then drives both arms of the pincer through
the whole gauntlet:

- the state typed to the tool's own union **passes** (no issues, `ok`);
- the state left as `string` is **refused**, with a sentence that names
  `tools.record_payment` and does **not** say `prop "onClick"`.

No other test was touched.

## Red before, green after

**Both halves absent (`origin/main`)** — the correct screen is refused at the
handler:

```
 FAIL  tests/checking/component-screen.test.ts > stage 5 — the tree the screen painted > lets a Select's value reach a tool's enum, and names the tool when the value stays wide
AssertionError: expected [ { code: 'types', …(1) } ] to deeply equal []

- []
+ [
+   {
+     "code": "types",
+     "message": "line 8: <Select> prop \"onChange\" setMethod() does not accept e.target.value as its 1st argument — that argument takes \"ach\" | \"card\" | \"check\" | ((previous: \"ach\" | \"card\" | \"…. Name one the data really carries.",
+   },
+ ]
```

**Both halves applied:**

```
 ✓ tests/checking/component-screen.test.ts (104 tests | 103 skipped) 262ms

 Test Files  1 passed (1)
      Tests  1 passed | 103 skipped (104)
```

## Reverting either half re-reds the test

Verified, one half at a time.

**Half 2 reverted (typings fixed, `screen-typecheck.ts` at `main`)** — the
handler arm passes and the payload arm mis-names the fault, which is the whole
reason the second half exists:

```
AssertionError: expected 'line 9: <Button> prop "onClick" Type …' to contain 'calls tools.record_payment(…) with an…'

Expected: "calls tools.record_payment(…) with an input its schema does not accept"
Received: "line 9: <Button> prop \"onClick\" Type 'string' is not assignable to type '\"ach\" | \"card\" | \"check\"'."
```

**Half 1 reverted (`screen-typecheck.ts` fixed, `HANDLER_TYPE` at `main`)** — the
correct screen is refused again before the payload is ever reached:

```
AssertionError: expected [ { code: 'types', …(1) } ] to deeply equal []
      Tests  1 failed | 103 skipped (104)
```

## Cross-check: nothing else moved

The diagnosis's regression battery — the refusal classes that depend on the
change event: a bare setter in `onChange`, an arrow passing the event on, `no
DOM`, a misspelled payload key, a field the response does not carry, a tone
outside the union — was run against this branch's own build with and without the
fix. All six are **byte-identical**. The seventh case, a correct screen, is the
only line that moves:

```
- "R7 a correct screen still passes": [
-   "line 7: <Select> prop \"onChange\" setM() does not accept e.target.value as its 1st argument — …"
- ]
+ "R7 a correct screen still passes": []
```

## Noted follow-ups (not fixed here)

Three adjacent traps found in the same diagnosis, each reproduced against this
branch's build. None is touched by this PR.

1. **The prompt tells the model `as const`; the floor prints arrays mutable.**
   `kit-prompt.ts:64-67` instructs `as const` on a hoisted map for an enum-word
   prop, but `screen-typings.ts:207` prints every array prop as mutable
   `Array<…>`, so applying that advice to a hoisted `columns` array is a hard
   error, while the same array *without* `as const` passes:
   ```
   line 5: The type 'readonly [{ readonly key: "buildingName"; … }]' is 'readonly' and cannot be assigned to the mutable type '(string | { key?: string; … })[]'.
   ```
2. **`briefType` truncation still yields self-contradictory sentences.**
   `screen-program.ts:171-177` collapses any long array-ish type to `a list of
   rows`, on both sides of the comparison:
   ```
   line 4: prop "series" on <LineChart> takes a list of rows, but this value is a list of rows — bind a value whose type matches the prop
   ```
3. **Double `line N: line N` prefix.** `screen-typecheck.ts:343` prefixes the
   reused translator's `where`, which is itself `line N` when the fault stands
   outside any JSX, on top of the line prefix `at()` already added:
   ```
   line 2: line 2 Type 'string' is not assignable to type '"ach" | "card" | "check"'.
   ```
   This PR removes it for tool payloads (they take the named-tool sentence now);
   every other 2322 outside JSX still doubles.
