### PR TITLE
fix(ui): a build's ask is answered on its card, not in a popup over the page

### DIFF
--- a/.changeset/build-ask-is-not-a-toast.md
+++ b/.changeset/build-ask-is-not-a-toast.md
@@ -1,0 +1,19 @@
+---
+"@vendoai/ui": minor
+---
+
+A build's consent ask stops arriving as a toast popup.
+
+The toast stack polls every pending approval and raises a card for each, so a
+build ask reached the person twice: once on the in-thread `ApprovalCard` the
+`data-vendo-approval` part paints, and again as a popup over whatever they were
+doing. The card is the consent surface — the popup asked the same question a
+second time, in a second place, and a yes on either one settled the other.
+
+The toast surface now skips an approval whose call is `vendo_app_build`, and
+only that surface: the launcher badge counts it exactly as before, which is what
+keeps a closed thread from stranding an ask that outlives its turn.
+
+The build's live status line rode that same toast — it was raised only off the
+toast's own Approve — so a build now shows no progress line anywhere. That was
+already the case for anyone who answered on the card instead of the popup.

--- a/packages/ui/src/chrome/vendo-toasts.tsx
+++ b/packages/ui/src/chrome/vendo-toasts.tsx
@@ -177,6 +177,11 @@ function ApprovalToasts({ pollMs }: { pollMs: number }) {
     const dismissers = dismissersRef.current;
     const seen = seenRef.current;
     for (const approval of pending) {
+      // A build's ask is answered on its own in-thread card (ApprovalCard,
+      // painted from the `data-vendo-approval` part), so a toast would ask the
+      // same question a second time. It still counts in the launcher badge —
+      // that is what keeps a closed thread from stranding it.
+      if (approval.call.tool === VENDO_APP_BUILD_TOOL) continue;
       if (seen.has(approval.id) || dismissers.has(approval.id)) continue;
       seen.add(approval.id);
       // Ruling 14's ONE plain-words ladder, the same one the approval card and

--- a/packages/ui/src/chrome/vendo-toasts.tsx
+++ b/packages/ui/src/chrome/vendo-toasts.tsx
@@ -8,11 +8,10 @@
       any code path; automations delivery wires through this).
     - `approvals` — opt-in polling of pending approvals: a NEWLY parked approval
       raises an approval-required toast, decidable in place. */
-import { VENDO_APP_BUILD_TOOL, type AppId } from "@vendoai/core";
-import { useEffect, useRef, useState, useSyncExternalStore, type ReactNode } from "react";
+import { VENDO_APP_BUILD_TOOL } from "@vendoai/core";
+import { useEffect, useRef, useSyncExternalStore, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { useVendoProvider } from "../context.js";
-import { useApp } from "../hooks/use-app.js";
 import { useApprovals } from "../hooks/use-approvals.js";
 import { themeCssVariables } from "../theme.js";
 import { consentAsk, toolPresentation } from "./build-beat.js";
@@ -134,25 +133,6 @@ function useToastQueue(): ToastRecord[] {
   return useSyncExternalStore(subscribe, () => queue, () => EMPTY);
 }
 
-/**
- * FINAL SPEC v1 — "progress = chat status lines only", and for a build there is
- * no chat left to say it in: the yes may land long after the turn that asked is
- * gone, so the build runs detached with no stream to write to. Its own line
- * therefore lands on the surface the yes was GIVEN on, from the same poll the
- * forming card reads, and stands down the moment the app does.
- */
-function BuildProgress({ appId }: { appId: AppId }) {
-  const { status, surface, error } = useApp(appId);
-  useEffect(() => {
-    // Nothing invented: silent until the lane speaks, gone once there is an app
-    // (or a reason there is not) — those speak for themselves on their own
-    // surfaces. The toast's own dismiss handle is the cleanup.
-    if (status === undefined || surface !== undefined || error !== undefined) return undefined;
-    return vendoToast({ text: status, durationMs: 0 });
-  }, [status, surface, error]);
-  return null;
-}
-
 /** Opt-in approval feed: a toast per approval waiting on the user, decidable in
     place, withdrawn once decided anywhere.
 
@@ -169,10 +149,6 @@ function ApprovalToasts({ pollMs }: { pollMs: number }) {
   const { pending, decide } = useApprovals({ pollMs });
   const seenRef = useRef(new Set<string>());
   const dismissersRef = useRef(new Map<string, () => void>());
-  // The builds this person has just authorized here, so their progress has a
-  // surface. Not durable: a build already under way when the page loads speaks
-  // through the app's own embed, which is mounted where that app is.
-  const [builds, setBuilds] = useState<AppId[]>([]);
   useEffect(() => {
     const dismissers = dismissersRef.current;
     const seen = seenRef.current;
@@ -205,10 +181,6 @@ function ApprovalToasts({ pollMs }: { pollMs: number }) {
         void decide(approval.id, { approve }).then(() => {
           dismissers.get(approval.id)?.();
           dismissers.delete(approval.id);
-          const appId = (approval.call.args as { appId?: unknown }).appId;
-          if (approve && approval.call.tool === VENDO_APP_BUILD_TOOL && typeof appId === "string") {
-            setBuilds(current => [...current, appId as AppId]);
-          }
         }).catch(() => {
           // The decide failed — the approval is still parked server-side.
           // Keep the toast so the buttons stay retryable, and un-see the id
@@ -244,7 +216,7 @@ function ApprovalToasts({ pollMs }: { pollMs: number }) {
     for (const dismiss of dismissersRef.current.values()) dismiss();
     dismissersRef.current.clear();
   }, []);
-  return <>{builds.map(appId => <BuildProgress key={appId} appId={appId} />)}</>;
+  return null;
 }
 
 export interface VendoToastsProps {

--- a/packages/ui/test/chrome/standing-consent.test.tsx
+++ b/packages/ui/test/chrome/standing-consent.test.tsx
@@ -1,19 +1,29 @@
 // @vitest-environment jsdom
 /**
- * The last mile of a STANDING consent (FINAL SPEC v1: "user's yes, whenever").
+ * Where a build's standing ask lands — and where it does NOT.
  *
- * A build ask outlives the tab that raised it, so the surface it lands on must
- * show it on arrival AND on every later mount; it must say what it is asking so
- * a person can weigh spending a machine; it must let them say no; and once they
- * say yes, the build's own status line has to reach them — the detached build
- * has no turn to stream into, so this surface is the whole progress channel.
+ * A build ask outlives the tab that raised it, so it has to reach the person on
+ * surfaces that survive: the in-thread `ApprovalCard` the `data-vendo-approval`
+ * part paints (proved end to end in packages/vendo's escalate-consent seam),
+ * and the launcher badge, which is what keeps a closed thread from stranding
+ * it. What it must NOT do is arrive as a toast popup over whatever the person
+ * was doing — that asked the same question a second time, in a second place.
+ *
+ * The filter belongs to the toast surface alone. Applied to the feed all three
+ * surfaces share, the badge would stop counting the ask and a closed thread
+ * really would strand it, so both halves are pinned here.
  */
-import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import type { ApprovalRequest } from "@vendoai/core";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { VendoProvider, createVendoClient } from "../../src/index.js";
-import { VendoToasts, dismissAllVendoToasts } from "../../src/chrome/index.js";
-import { createWireServer, fixtureApp } from "../wire-server.js";
+import { VendoOverlay, VendoToasts, dismissAllVendoToasts } from "../../src/chrome/index.js";
+import { markSeen } from "../../src/chrome/discoverability.js";
+import { createWireServer } from "../wire-server.js";
+
+beforeEach(() => {
+  markSeen("whisper");
+});
 
 afterEach(() => {
   cleanup();
@@ -22,6 +32,9 @@ afterEach(() => {
 
 const BUILD_APP = "app_qr";
 const PROMPT = "A page with a scannable QR code";
+
+const cards = () => [...document.querySelectorAll(".fl-toasts-card")];
+const badge = () => document.querySelector(".fl-launcher-badge");
 
 /** The ask the build door parks: `guard.check` on the build descriptor, with the
  *  app id and the person's own words as its inputs (build-door.ts). */
@@ -50,72 +63,41 @@ function buildAsk(base: ApprovalRequest): ApprovalRequest {
   };
 }
 
-describe("a standing ask survives the tab it was raised in", () => {
-  it("surfaces an approval that was ALREADY pending at mount", async () => {
+describe("a build's ask never arrives as a toast", () => {
+  it("skips the build ask while the ordinary ask beside it still toasts", async () => {
     const wire = await createWireServer();
-    // The reload: the ask is on the wire before anything renders.
+    // Both asks are on the wire before anything renders — the reload case, the
+    // one where the toast stack shows its whole backlog.
     wire.state.approvals.push(buildAsk(wire.state.approvals[0]!));
     const client = createVendoClient({ baseUrl: wire.url });
     render(<VendoProvider client={client}><VendoToasts approvals pollMs={40} /></VendoProvider>);
 
-    await screen.findByText(/Build this app for real/);
-    expect(screen.getAllByRole("button", { name: "Approve" }).length).toBeGreaterThan(0);
-    await wire.close();
-  });
-});
-
-describe("the card says what it is asking, and takes no for an answer", () => {
-  it("carries the ask's own words — the person's request, not just a tool label", async () => {
-    const wire = await createWireServer();
-    wire.state.approvals.push(buildAsk(wire.state.approvals[0]!));
-    const client = createVendoClient({ baseUrl: wire.url });
-    render(<VendoProvider client={client}><VendoToasts approvals pollMs={40} /></VendoProvider>);
-
-    await screen.findByText(/Build this app for real/);
-    expect(screen.getByText(new RegExp(PROMPT))).toBeTruthy();
+    // The ordinary ask is the positive control: it proves the feed reached this
+    // surface, so the build's absence is a decision and not a poll that never
+    // landed.
+    await screen.findByText(/Waiting on you:/);
+    // Several polls later it is still the only card — nothing re-raises the
+    // build on a later tick.
+    await new Promise(resolve => setTimeout(resolve, 120));
+    expect(cards()).toHaveLength(1);
+    expect(cards()[0]!.textContent).not.toContain("Build this app for real");
     await wire.close();
   });
 
-  it("offers Deny, and a denial is what reaches the wire", async () => {
+  it("still counts on the launcher badge, so a closed thread cannot strand it", async () => {
     const wire = await createWireServer();
     wire.state.approvals.push(buildAsk(wire.state.approvals[0]!));
     const client = createVendoClient({ baseUrl: wire.url });
-    render(<VendoProvider client={client}><VendoToasts approvals pollMs={40} /></VendoProvider>);
+    render(
+      <VendoProvider client={client}>
+        <VendoOverlay />
+        <VendoToasts approvals pollMs={40} />
+      </VendoProvider>,
+    );
 
-    await screen.findByText(/Build this app for real/);
-    const cards = document.querySelectorAll(".fl-toasts-card");
-    const card = [...cards].find(item => item.textContent?.includes("Build this app for real"))!;
-    const deny = [...card.querySelectorAll("button")].find(button => button.textContent === "Deny")!;
-    expect(deny).toBeTruthy();
-    fireEvent.click(deny);
-
-    await waitFor(() => expect(wire.state.approvalResolutions.get("apr_build")).toEqual({ state: "declined" }));
-    await waitFor(() => expect(screen.queryByText(/Build this app for real/)).toBeNull());
+    // Two asks waiting, two on the badge, one toast.
+    await waitFor(() => expect(badge()?.textContent).toBe("2"));
+    expect(cards()).toHaveLength(1);
     await wire.close();
   });
-});
-
-describe("progress reaches the person who said yes", () => {
-  it("shows the build's own status line once the yes lands, and drops it when the app does", async () => {
-    const wire = await createWireServer();
-    wire.state.approvals.push(buildAsk(wire.state.approvals[0]!));
-    // A building app: the row exists, and its flagged opens answer the build
-    // window's pending envelope carrying the lane's latest line.
-    wire.state.apps.push(fixtureApp(BUILD_APP, "QR code page"));
-    wire.state.pendingScreens.set(BUILD_APP, 3);
-    wire.state.buildStatus.set(BUILD_APP, "Starting a build machine…");
-    const client = createVendoClient({ baseUrl: wire.url });
-    render(<VendoProvider client={client}><VendoToasts approvals pollMs={40} /></VendoProvider>);
-
-    await screen.findByText(/Build this app for real/);
-    const cards = document.querySelectorAll(".fl-toasts-card");
-    const card = [...cards].find(item => item.textContent?.includes("Build this app for real"))!;
-    const approve = [...card.querySelectorAll("button")].find(button => button.textContent === "Approve")!;
-    fireEvent.click(approve);
-
-    await screen.findByText("Starting a build machine…");
-    // The app lands (pendingScreens runs out) and the progress line stands down.
-    await waitFor(() => expect(screen.queryByText("Starting a build machine…")).toBeNull(), { timeout: 10_000 });
-    await wire.close();
-  }, 20_000);
 });


### PR DESCRIPTION
A build's consent ask reached the person twice: once on the in-thread
`ApprovalCard` the `data-vendo-approval` part paints, and again as a toast popup
over whatever they were doing, because the toast stack raises a card for every
pending approval it polls. A yes on either settled the other, so the popup was
purely a second place to be asked the same question.

`ApprovalToasts` now skips an approval whose call is `vendo_app_build`
(`VENDO_APP_BUILD_TOOL`), and the filter is local to that surface — the shared
`approvalsFeed` is untouched, so `useAttention`/`askCount` and the launcher
badge count the ask exactly as before. That badge is what keeps a closed thread
from stranding an ask that outlives its turn.

## Heads-up: the build's progress line went with it

`BuildProgress` (the live `Starting a build machine…` line) was only ever
mounted off **this toast's own Approve** — nothing else in the tree reads
`useApp(appId).status`. So it is now unreachable, and a build shows no progress
line anywhere. That was already true for anyone who answered on the in-thread
card instead of the popup; this makes it uniformly true. The code is left in
place rather than deleted along with it — worth a call on whether progress gets
a home on the card, or the component goes.

## Tests

`packages/ui/test/chrome/standing-consent.test.tsx` was four tests premised on
the build ask toasting, so its premise inverted. It now pins the new law in two:

- the build ask raises no toast while the ordinary ask beside it still does (the
  ordinary one is the positive control — it proves the feed reached the surface,
  so the build's absence is a decision and not a poll that never landed);
- the launcher badge still reads `2` against two waiting asks while the stack
  shows one card, which is what fails if anyone ever moves the filter into the
  shared feed.

The fourth old test covered `BuildProgress` through the toast's Approve, which
no longer exists as a path.

**Red proof:** with the `continue` removed, both new tests fail
(`expected [...] to have a length of 1 but got 2`); restored, both pass.

## Gate

- `npx vitest run test/chrome/standing-consent.test.tsx test/chrome/affordances-eng225.test.tsx test/chrome/pill-states.test.tsx test/approvals-feed.test.tsx --maxWorkers=2 --minWorkers=1` in `packages/ui` — 44 passed
- `pnpm --filter @vendoai/ui typecheck` — clean
- `pnpm lint` — 4 successful, 0 errors