### PR TITLE
fix(ui): portal surfaces inherit the spawning surface's theme

### DIFF
--- a/.changeset/portal-surface-theme.md
+++ b/.changeset/portal-surface-theme.md
@@ -1,0 +1,13 @@
+---
+"@vendoai/ui": patch
+---
+
+The last two portal surfaces inherit the spawning surface's theme.
+
+The knowledge citation hovercard and the mobile approval sheet both portal to
+`document.body` but still read the PROVIDER theme, so a surface carrying its own
+`theme` — a dark `VendoOverlay` on a light page — popped a light hovercard out
+of a dark thread. Both now read the enclosing chrome boundary's resolved theme
+through `useChromeTheme()`, the same seam the approval modal, morph toast and
+toast stack already use. Outside any boundary they answer the provider's theme
+exactly as before.

--- a/packages/ui/src/chrome/approval-sheet.tsx
+++ b/packages/ui/src/chrome/approval-sheet.tsx
@@ -1,9 +1,8 @@
 import { useEffect, useRef, type CSSProperties, type ReactNode } from "react";
 import { createPortal } from "react-dom";
-import { useVendoTheme } from "../context.js";
 import { useMobileTakeover } from "../hooks/use-mobile-takeover.js";
 import { themeCssVariables } from "../theme.js";
-import { ensureChromeStyles } from "./chrome-root.js";
+import { ensureChromeStyles, useChromeTheme } from "./chrome-root.js";
 
 /**
  * Below the mobile breakpoint the newest pending approval
@@ -31,7 +30,11 @@ export function ApprovalSheet({ children, label }: {
   /** Accessible name for the dialog, e.g. `Approval for ${title}`. */
   label: string;
 }) {
-  const theme = useVendoTheme();
+  // The spawning surface's resolved theme, not the provider's: the sheet is the
+  // mobile presentation of a consent raised inside a thread, and it portals to
+  // <body>, so context is the only way that surface's own `theme` reaches it.
+  // Outside any boundary this is the provider's theme, unchanged.
+  const theme = useChromeTheme();
   const takeover = useMobileTakeover();
   const sheetRef = useRef<HTMLDivElement>(null);
 

--- a/packages/ui/src/chrome/thread/turn-citations.tsx
+++ b/packages/ui/src/chrome/thread/turn-citations.tsx
@@ -2,8 +2,8 @@ import type { VendoKnowledgeCitation } from "@vendoai/core";
 import type { UIMessage } from "ai";
 import { useCallback, useEffect, useLayoutEffect, useRef, useState, type CSSProperties, type PointerEvent as ReactPointerEvent } from "react";
 import { createPortal } from "react-dom";
-import { useVendoThemeOrDefault } from "../../context.js";
 import { themeCssVariables } from "../../theme.js";
+import { useChromeTheme } from "../chrome-root.js";
 import { sourcesFor } from "./message-data.js";
 
 /** The popover opens 8px below its chip, and that gap belongs to neither: a pure
@@ -58,7 +58,12 @@ function CitationChip({ citation }: { citation: VendoKnowledgeCitation }) {
   // The card portals out of the ChromeRoot that themes it, so it carries the
   // theme variables itself. The stylesheet is already injected — a citation
   // only ever renders inside a thread, which is inside that same root.
-  const theme = useVendoThemeOrDefault();
+  //
+  // It reads THAT root's resolved theme, not the provider's: a thread inside a
+  // surface carrying its own `theme` (a dark VendoOverlay on a light page) must
+  // not pop a provider-themed hovercard out of it. Outside any boundary this
+  // still answers the provider's theme, and the defaults with no provider.
+  const theme = useChromeTheme();
 
   // Stale copies of this closer are harmless — closing a closed chip is a no-op,
   // which is why nothing has to track whose closer is parked in the module slot.

--- a/packages/ui/test/chrome/surface-theme.test.tsx
+++ b/packages/ui/test/chrome/surface-theme.test.tsx
@@ -10,10 +10,12 @@
  */
 import type { ApprovalId, Json, ToolOutcome, UIPayload } from "@vendoai/core";
 import type { VendoTheme } from "@vendoai/apps/contract";
+import type { UIMessage } from "ai";
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { VendoProvider, createVendoClient, defaultVendoTheme, type VendoClient } from "../../src/index.js";
 import {
+  ApprovalSheet,
   ChromeRoot,
   VendoAppEmbed,
   VendoApprovalEmbed,
@@ -24,6 +26,7 @@ import {
   VendoTrigger,
   vendoToast,
 } from "../../src/chrome/index.js";
+import { TurnCitations } from "../../src/chrome/thread/turn-citations.js";
 import { createWireServer } from "../wire-server.js";
 
 let wire: Awaited<ReturnType<typeof createWireServer>>;
@@ -208,6 +211,33 @@ describe("every chrome surface takes one", () => {
   });
 });
 
+/** One assistant turn carrying a knowledge citation, so the hovercard has a
+ *  real chip to open from. */
+function citationsTurn(): UIMessage {
+  return {
+    id: "msg_knowledge",
+    role: "assistant",
+    parts: [
+      {
+        type: "data-vendo-citations",
+        data: {
+          toolCallId: "call_search",
+          outcome: "answered",
+          citations: [{
+            docId: "doc-refunds",
+            chunkId: "doc-refunds#0",
+            title: "Refunds & cancellations",
+            source: "docs/refunds.md",
+            kind: "docs",
+            visibility: "public",
+            snippet: "If you cancel mid-cycle we do not charge again.",
+          }],
+        },
+      } as UIMessage["parts"][number],
+    ],
+  };
+}
+
 /** A pinned generated view that parks its press on the guard — the real path
  *  from a press inside a slot to the approval modal on <body>. */
 const PARKING_PIN = {
@@ -286,6 +316,51 @@ describe("surfaces that portal out of the boundary still wear its theme", () => 
       return found!;
     });
     expectProvider(bare);
+  });
+
+  /** The knowledge citation hovercard portals to <body> out of the thread that
+   *  themes it. A dark overlay must not pop a light provider-themed card. */
+  it("the citation hovercard carries the enclosing surface's theme", () => {
+    withProvider(
+      <ChromeRoot theme={SURFACE_THEME}>
+        <TurnCitations message={citationsTurn()} />
+      </ChromeRoot>,
+    );
+    fireEvent.pointerEnter(document.querySelector<HTMLElement>(".fl-cite")!);
+    const card = document.querySelector("[data-vendo-portal=\"citation\"]");
+    expect(card, "expected the portaled citation card").not.toBeNull();
+    expectMerged(card!);
+  });
+
+  it("the citation hovercard falls back to the provider theme with no surface theme", () => {
+    withProvider(
+      <ChromeRoot>
+        <TurnCitations message={citationsTurn()} />
+      </ChromeRoot>,
+    );
+    fireEvent.pointerEnter(document.querySelector<HTMLElement>(".fl-cite")!);
+    expectProvider(document.querySelector("[data-vendo-portal=\"citation\"]")!);
+  });
+
+  /** The mobile presentation of a consent — same portal, same rule. */
+  it("the mobile approval sheet carries the enclosing surface's theme", () => {
+    withProvider(
+      <ChromeRoot theme={SURFACE_THEME}>
+        <ApprovalSheet label="Approval for Send the report"><p>Send the report?</p></ApprovalSheet>
+      </ChromeRoot>,
+    );
+    const layer = document.querySelector(".fl-approval-sheet-layer");
+    expect(layer, "expected the portaled approval sheet").not.toBeNull();
+    expectMerged(layer!);
+  });
+
+  it("the mobile approval sheet falls back to the provider theme with no surface theme", () => {
+    withProvider(
+      <ChromeRoot>
+        <ApprovalSheet label="Approval for Send the report"><p>Send the report?</p></ApprovalSheet>
+      </ChromeRoot>,
+    );
+    expectProvider(document.querySelector(".fl-approval-sheet-layer")!);
   });
 });
 


### PR DESCRIPTION
Follow-up flagged in #1626: `turn-citations.tsx` and `approval-sheet.tsx` portal out of a chrome boundary but still read the provider theme. Both now read the spawning surface's resolved theme from `ChromeRootContext` via `useChromeTheme()` (provider fallback unchanged), matching the approval modal and toasts.

- 2 call sites changed, 4 new tests in `surface-theme.test.tsx` asserting the portal carries the surface theme
- Changeset: patch `@vendoai/ui`

Local gate on the touched scope: `@vendoai/ui` 1528/1528 green, typecheck green, lint green. The `@vendoai/vendo` dep-check suite shows 22 laptop-environment failures in files this PR does not touch (package is byte-identical to main); CI is the gate of record.