### PR TITLE
fix(actions): retry host tool loading after initial failure

### DIFF
--- a/.changeset/host-file-load-retries.md
+++ b/.changeset/host-file-load-retries.md
@@ -1,0 +1,5 @@
+---
+"@vendoai/actions": patch
+---
+
+A failed first read of `.vendo/tools.json` (or `overrides.json` / `judgments.json`) no longer freezes the host-tool surface for the life of the process. The next request retries; a successful load still sticks until restart.

--- a/packages/actions/src/runtime/registry.ts
+++ b/packages/actions/src/runtime/registry.ts
@@ -626,7 +626,8 @@ export function createActions(config: RegistryConfig): ActionsRegistry {
   };
 
   function loadHost(): Promise<LoadedHost> {
-    if (!hostPromise) hostPromise = (async () => {
+    if (!hostPromise) {
+      hostPromise = (async () => {
       const emptyOverrides: OverridesFile = { format: VENDO_OVERRIDES_FORMAT, tools: {} };
       const configuredTools = config.tools?.map((tool, index) => parseExtractedTool(tool, `config.tools[${index}]`));
       // cse lane 3 — an injected overrides doc (hosted config or the try
@@ -686,7 +687,12 @@ export function createActions(config: RegistryConfig): ActionsRegistry {
         compounds: overrides.compounds ?? [],
         briefs: overrides.briefs ?? [],
       };
-    })();
+      })();
+      const building = hostPromise;
+      building.catch(() => {
+        if (hostPromise === building) hostPromise = undefined;
+      });
+    }
     return hostPromise.then(warnHostToolSurface);
   }
 

--- a/packages/actions/tests/runtime/registry.test.ts
+++ b/packages/actions/tests/runtime/registry.test.ts
@@ -181,6 +181,24 @@ describe("createActions registry", () => {
     await expect(actions.descriptors()).rejects.toMatchObject({ name: "VendoError", code: "validation" });
   });
 
+  it("recovers from a transient host-file failure after the file is fixed", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vendo-actions-recover-"));
+    roots.push(root);
+    await mkdir(join(root, ".vendo"));
+    await writeFile(join(root, ".vendo", "tools.json"), "{ not json");
+    const actions = createActions({ dir: root });
+
+    await expect(actions.descriptors()).rejects.toMatchObject({ name: "VendoError", code: "validation" });
+
+    await writeFile(
+      join(root, ".vendo", "tools.json"),
+      JSON.stringify({ format: VENDO_TOOLS_FORMAT, tools: [routeTool("host_recovered")] }),
+    );
+
+    const descriptors = await actions.descriptors();
+    expect(descriptors.map((d) => d.name)).toContain("host_recovered");
+  });
+
   it("reserves disabled names and throws conflicts across every source", async () => {
     const actions = createActions({
       tools: [routeTool("same", { disabled: true })],


### PR DESCRIPTION
## What

A failed first read of `.vendo/tools.json` (or `overrides.json` / `judgments.json`) no longer freezes the host-tool surface for the life of the process.

`loadHost()` now drops a rejected promise, matching the existing behavior of `load()` and `cachedDescriptors()`. The next `descriptors()`, `execute()`, or `surfaceMenu()` call can retry, while a successful load remains cached until restart.

## Why

Previously, `loadHost()` memoized its promise even when the initial load failed. Fixing the host file did not recover the same process because the rejected promise was reused until restart.

This also restores the retry behavior already expected by `memoizedSurfaceMenu` and the MCP door for transient host-file failures.

## Verification

- [x] Added a regression test: malformed `tools.json` → reject → rewrite a valid file → same `createActions` instance recovers
- [x] `packages/actions/tests/runtime/registry.test.ts` passes
- [x] `pnpm --filter @vendoai/actions typecheck` passes
- [x] `pnpm build && pnpm test && pnpm typecheck && pnpm lint` green