### PR TITLE
fix(security): close verified critical findings from the Vega scan

### DIFF
--- a/.changeset/allowlist-extraction-child-env.md
+++ b/.changeset/allowlist-extraction-child-env.md
@@ -1,0 +1,17 @@
+---
+"@vendoai/vendo": patch
+---
+
+fix: allowlist the extraction child-process environment so untrusted repo dotenv/npmrc can't inject code or redirect credentials
+
+`vendo sync` builds the environment for the coding-agent children it spawns
+(`npm`, `claude`, `codex`) by merging the repo's own `.env`/`.env.local`. A
+cloned repo could therefore set `npm_config_registry` or `NODE_OPTIONS` to run
+arbitrary code in those children, or `VENDO_CLOUD_URL`/`ANTHROPIC_BASE_URL` to
+redirect the Cloud key and the source-bearing prompts to an attacker endpoint.
+The extraction path now reads the dotenv through an allowlist — a repo file may
+contribute a credential, the model pin, or the dev-server URL, and nothing else;
+every other variable reaches a child only from the developer's own shell, never
+from the checkout. (Doctor's config reads keep the general reader unchanged.)
+The Agent SDK availability probe also no longer imports the host-resolved module
+just to check that it exists.

--- a/.changeset/allowlist-extraction-child-env.md
+++ b/.changeset/allowlist-extraction-child-env.md
@@ -12,6 +12,9 @@ redirect the Cloud key and the source-bearing prompts to an attacker endpoint.
 The extraction path now reads the dotenv through an allowlist — a repo file may
 contribute a credential, the model pin, or the dev-server URL, and nothing else;
 every other variable reaches a child only from the developer's own shell, never
-from the checkout. (Doctor's config reads keep the general reader unchanged.)
-The Agent SDK availability probe also no longer imports the host-resolved module
-just to check that it exists.
+from the checkout. (Doctor's config reads keep the general reader unchanged.) The
+npx rung also pins its registry on the child (from the developer's own shell
+value, else the public default), so a repo-root `.npmrc` — which `npm exec` reads
+from cwd and which outranks the user's own `~/.npmrc` — can no longer redirect
+the engine fetch to a malicious registry. The Agent SDK availability probe no
+longer imports the host-resolved module just to check that it exists.

--- a/.changeset/dep-repair-hygiene.md
+++ b/.changeset/dep-repair-hygiene.md
@@ -1,0 +1,5 @@
+---
+"@vendoai/vendo": patch
+---
+
+fix: ignore the host repo's lifecycle scripts during automatic dep repair, and POSIX-quote the displayed install commands so a cwd with a space or shell metachar can't be misread.

--- a/.changeset/fail-closed-actas-untrusted-base.md
+++ b/.changeset/fail-closed-actas-untrusted-base.md
@@ -1,0 +1,6 @@
+---
+"@vendoai/actions": patch
+"@vendoai/vendo": patch
+---
+
+fix: fail closed on actAs host credentials when the request origin is untrusted; stop 404s from poisoning the learned base URL

--- a/.changeset/redact-model-credential-from-chat.md
+++ b/.changeset/redact-model-credential-from-chat.md
@@ -1,0 +1,14 @@
+---
+"@vendoai/harnesses": patch
+---
+
+fix: redact reusable model credentials from chat output so end users can't extract them via the in-box agent
+
+A boxed agent holds a reusable, non-expiring inference credential and streams
+its output straight to the end user, so a user could steer it into printing the
+key. The runtime now strips the literal credential value from everything a turn
+puts on the wire — the assistant's prose and any tool output alike — through the
+single writer every user-facing part crosses. This is defense in depth, not the
+complete fix: a user who first asks the agent to transform the key defeats a
+literal match. The full fix is per-session, short-lived brokering so the box
+never holds a reusable key.

--- a/packages/actions/src/runtime/registry.ts
+++ b/packages/actions/src/runtime/registry.ts
@@ -299,7 +299,21 @@ async function actAsAuth(
   principal: Principal,
   grant: PermissionGrant,
   messages: { declined: string; failed: string },
+  untrustedBase: boolean,
 ): Promise<{ headers: Record<string, string> } | { error: ToolOutcome }> {
+  // The trusted-origin decision presentHeaders makes, applied to the mint seam:
+  // never mint host credentials against a base learned from a spoofable Host.
+  if (untrustedBase) {
+    return {
+      error: error(
+        "blocked",
+        `Host credentials for ${grant.tool} cannot be minted because VENDO_BASE_URL is not set — `
+          + "the request origin is not a trusted, operator-set base. Set VENDO_BASE_URL to this "
+          + "deployment's full public URL (path prefix included), or VENDO_HOST_API_URL when the host "
+          + "API answers on another origin, then restart the server.",
+      ),
+    };
+  }
   if (grant.subject !== principal.subject) {
     return {
       error: withActAs(error(
@@ -460,6 +474,11 @@ async function hostHeaders(
   ctx: RunContext,
   url: URL,
 ): Promise<{ headers: Record<string, string>; actAsMinted: boolean } | { error: ToolOutcome }> {
+  // presentHeaders' fail-closed trigger, shared with the actAs seam below: a
+  // base learned from a spoofable Host (baseUrlTrusted:false) is no place to
+  // mint host credentials. Armed where present-mode hard-fails — production with
+  // no VENDO_BASE_URL sets untrustedOriginPolicy:"fail".
+  const untrustedBase = config.baseUrlTrusted === false && config.untrustedOriginPolicy === "fail";
   if (ctx.presence === "away") {
     if (!config.actAs) return { error: error("not-implemented", "away execution isn't set up for this product") };
     const grant = (ctx as ActionsRunContext).grant;
@@ -467,7 +486,7 @@ async function hostHeaders(
     const authed = await actAsAuth(config.actAs, ctx.principal, grant, {
       declined: "the host declined away execution for this action",
       failed: "away authentication failed",
-    });
+    }, untrustedBase);
     if ("error" in authed) return { error: authed.error };
     return { headers: authed.headers, actAsMinted: true };
   }
@@ -501,7 +520,7 @@ async function hostHeaders(
     const authed = await actAsAuth(config.actAs, ctx.principal, grant, {
       declined: "the host declined MCP execution for this action",
       failed: "MCP authentication failed",
-    });
+    }, untrustedBase);
     if ("error" in authed) return { error: authed.error };
     return { headers: authed.headers, actAsMinted: true };
   }
@@ -527,7 +546,7 @@ async function hostHeaders(
     const authed = await actAsAuth(config.actAs, ctx.principal, grant, {
       declined: "the host declined text-channel execution for this action",
       failed: "text-channel authentication failed",
-    });
+    }, untrustedBase);
     if ("error" in authed) return { error: authed.error };
     return { headers: authed.headers, actAsMinted: true };
   }

--- a/packages/actions/tests/runtime/act-as-untrusted-base.test.ts
+++ b/packages/actions/tests/runtime/act-as-untrusted-base.test.ts
@@ -1,0 +1,113 @@
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { PermissionGrant } from "@vendoai/core";
+import type { ExtractedTool } from "../../src/formats.js";
+import { createActions, type ActionsRunContext } from "../../src/runtime/registry.js";
+
+/**
+ * VEGA-INFO-00037 — the actAs twin of the present-mode SECURITY pin in
+ * server.test.ts. A base auto-learned from a spoofable Host is untrusted
+ * (baseUrlTrusted:false); production with no VENDO_BASE_URL arms the fail-closed
+ * policy. The actAs seam (away, MCP, text-channel) must then refuse to MINT host
+ * credentials rather than sending freshly-minted ones to a possibly-poisoned
+ * origin — exactly as present-mode refuses to FORWARD the caller's own.
+ */
+describe("actAs host credentials fail closed on an untrusted base (VEGA-INFO-00037)", () => {
+  const closers: Array<() => Promise<void>> = [];
+  afterEach(async () => {
+    await Promise.all(closers.splice(0).map((close) => close()));
+  });
+
+  async function hostServer(): Promise<{ url: string; seen: Array<Record<string, string | string[] | undefined>> }> {
+    const seen: Array<Record<string, string | string[] | undefined>> = [];
+    const server = createServer((req, res) => {
+      seen.push(req.headers);
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({ ok: true }));
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => { server.off("error", reject); resolve(); });
+    });
+    const { port } = server.address() as AddressInfo;
+    closers.push(async () => { server.close(); server.closeAllConnections(); });
+    return { url: `http://127.0.0.1:${port}`, seen };
+  }
+
+  // A relative route binding resolves against the (untrusted, auto-learned) base.
+  const probeTool: ExtractedTool = {
+    name: "host_write",
+    description: "host_write",
+    inputSchema: { type: "object" },
+    risk: "write",
+    binding: { kind: "route", method: "GET", path: "/probe", argsIn: "query" },
+  };
+
+  const awayGrant: PermissionGrant = {
+    id: "grt_away",
+    subject: "user_1",
+    tool: "host_write",
+    descriptorHash: "sha256:real",
+    scope: { kind: "tool" },
+    duration: "standing",
+    source: "automation",
+    grantedAt: "2026-07-13T00:00:00.000Z",
+  };
+  const awayCtx: ActionsRunContext = {
+    principal: { kind: "user", subject: "user_1" },
+    venue: "automation",
+    presence: "away",
+    sessionId: "auto_1",
+    grant: awayGrant,
+  };
+  const mcpCtx: ActionsRunContext = {
+    principal: { kind: "user", subject: "user_1" },
+    venue: "mcp",
+    presence: "present",
+    sessionId: "mcps_1",
+    mcpConsent: { clientId: "mcpc_x", scopes: ["read", "write"] },
+  };
+
+  for (const { label, ctx } of [
+    { label: "away", ctx: awayCtx },
+    { label: "MCP", ctx: mcpCtx },
+  ]) {
+    it(`SECURITY: does not mint or send ${label} host credentials to an untrusted base under untrustedOriginPolicy:"fail"`, async () => {
+      const host = await hostServer();
+      const actAs = vi.fn(async () => ({ headers: { authorization: "Bearer act-as-user_1" } }));
+      const actions = createActions({
+        tools: [probeTool],
+        baseUrl: host.url,
+        baseUrlTrusted: false,
+        untrustedOriginPolicy: "fail",
+        actAs,
+      });
+
+      const outcome = await actions.execute({ id: "1", tool: "host_write", args: {} }, ctx);
+
+      expect(outcome).toMatchObject({
+        status: "error",
+        error: { code: "blocked", message: expect.stringContaining("VENDO_BASE_URL") },
+      });
+      // The mint never runs and the (possibly-poisoned) host never sees the call.
+      expect(actAs).not.toHaveBeenCalled();
+      expect(host.seen).toHaveLength(0);
+    });
+  }
+
+  it('mints normally on an untrusted base under the default "warn" policy — dev/self-probe behavior is unchanged', async () => {
+    const host = await hostServer();
+    const actAs = vi.fn(async () => ({ headers: { authorization: "Bearer act-as-user_1" } }));
+    const actions = createActions({
+      tools: [probeTool],
+      baseUrl: host.url,
+      baseUrlTrusted: false, // untrusted, but no fail policy: matches server.test.ts's away doctor probe
+      actAs,
+    });
+
+    await expect(actions.execute({ id: "1", tool: "host_write", args: {} }, mcpCtx)).resolves.toMatchObject({ status: "ok" });
+    expect(actAs).toHaveBeenCalledTimes(1);
+    expect(host.seen[0]?.authorization).toBe("Bearer act-as-user_1");
+  });
+});

--- a/packages/agents/src/http/router.ts
+++ b/packages/agents/src/http/router.ts
@@ -53,6 +53,14 @@ export interface RouteEntry<W extends RouteContext> {
   method: string;
   pattern: RoutePattern;
   handler: RouteHandler<W>;
+  /** Opt-in: this handler makes a same-origin HOST CALL during its OWN dispatch,
+      so a caller that learns a same-origin default from route matches must learn
+      it at handler ENTRY for this entry (before the call), not after the handler
+      returns. Off by default — the safe default is to learn only from a handler
+      that TERMINALLY answered (returned a non-undefined Response), so a route
+      that matched then fell through (returned undefined → 404) never teaches it.
+      Consumed by @vendoai/vendo's wire wrapper; see server.ts. */
+  learnsOriginAtEntry?: boolean;
 }
 
 /** Table entry from a pattern string: no `:param` and no trailing `/*` means

--- a/packages/harnesses/src/claude-code/box.ts
+++ b/packages/harnesses/src/claude-code/box.ts
@@ -705,6 +705,20 @@ export function inferenceEnv(): Record<string, string> {
   return env;
 }
 
+/**
+ * The reusable inference credential a boxed session holds, for a redactor to
+ * strip from anything the turn streams back to the user (VEGA-INFO-00021). It is
+ * exactly the value that becomes the box's `ANTHROPIC_API_KEY`, read through the
+ * SAME selection law as `inferenceEnv()` so the two can never name a different
+ * secret. Empty when the box gets no credential (a no-key BYO deployment) — then
+ * there is nothing to redact. The 8-char floor keeps a pathological short value
+ * from blanking legitimate output.
+ */
+export function inferenceSecrets(): readonly string[] {
+  const key = inferenceEnv()["ANTHROPIC_API_KEY"];
+  return key !== undefined && key.length >= 8 ? [key] : [];
+}
+
 /** The host the Agent SDK talks to when nothing overrides `ANTHROPIC_BASE_URL`. */
 const DEFAULT_INFERENCE_HOST = "api.anthropic.com";
 

--- a/packages/harnesses/src/runtime.ts
+++ b/packages/harnesses/src/runtime.ts
@@ -57,6 +57,7 @@ import { createTurnTools, type MirrorEvent } from "./turn-tools.js";
 import { specificWireErrorMessage } from "./wire-error.js";
 import { emitWorkbench, openWorkbench } from "./workbench.js";
 import { TextChannel, writeDebug, writeError, writeMirror, writeNotice, writeStatus, writeTurnError, writeView } from "./wire.js";
+import { inferenceSecrets } from "./claude-code/box.js";
 
 /**
  * `turn.messages` is OURS and read-only (§1). A frozen array still hands out live
@@ -304,6 +305,47 @@ const rootCause = (error: unknown): unknown => {
   return deepest;
 };
 
+/**
+ * VEGA-INFO-00021 — a boxed agent holds a REUSABLE, non-expiring inference
+ * credential and streams its output straight to the end user, so a user can
+ * steer it into printing the key. Every part a turn puts on the wire passes
+ * through one `writer`, so stripping the literal value HERE guards the
+ * assistant's prose and any tool output alike, in a single seam. No secrets to
+ * strip (a no-key BYO deployment) → the writer is returned untouched, so
+ * redaction costs nothing when there is nothing to redact.
+ *
+ * Literal-value redaction only: it stops the key being echoed VERBATIM; a user
+ * who first asks the agent to transform it (base64, reversed, spelled out)
+ * defeats it. The complete fix is per-session, short-lived brokering so the box
+ * never holds a reusable key — deferred console work.
+ */
+function redactingWriter(
+  writer: UIMessageStreamWriter<UIMessage>,
+  secrets: readonly string[],
+): UIMessageStreamWriter<UIMessage> {
+  if (secrets.length === 0) return writer;
+  const walk = (value: unknown): unknown => {
+    if (typeof value === "string") {
+      let out = value;
+      for (const secret of secrets) out = out.split(secret).join("[redacted]");
+      return out;
+    }
+    if (Array.isArray(value)) return value.map(walk);
+    if (value !== null && typeof value === "object") {
+      const out: Record<string, unknown> = {};
+      for (const [key, item] of Object.entries(value)) out[key] = walk(item);
+      return out;
+    }
+    return value;
+  };
+  return {
+    write: (part) => writer.write(walk(part) as typeof part),
+    merge: writer.merge.bind(writer),
+    get onError() { return writer.onError; },
+    set onError(handler) { writer.onError = handler; },
+  };
+}
+
 export function createHarnessRuntime(deps: HarnessRuntimeDeps): HarnessRuntime {
   const harnessState = deps.harnessState ?? memoryHarnessStateStore();
 
@@ -484,7 +526,10 @@ export function createHarnessRuntime(deps: HarnessRuntimeDeps): HarnessRuntime {
       const stream = createUIMessageStream<UIMessage>({
         originalMessages: messages,
         generateId: () => assistantMessageId,
-        execute: async ({ writer }) => {
+        execute: async ({ writer: rawWriter }) => {
+          // VEGA-INFO-00021: redact the deployment's reusable inference
+          // credential from everything this turn streams — see `redactingWriter`.
+          const writer = redactingWriter(rawWriter, inferenceSecrets());
           turnWriter = writer;
           // The dev-only diagnostics channel, open for exactly this turn. Off
           // (the production case) this registers nothing and every emit below —

--- a/packages/harnesses/src/runtime.ts
+++ b/packages/harnesses/src/runtime.ts
@@ -341,12 +341,24 @@ function redactingWriter(
   };
   // The model streams its prose in many text-delta parts, so a secret split
   // across deltas ("sk-", "ant-", …) is never whole inside one `walk` and would
-  // stream through — the common case. Carry the last (maxLen-1) chars of the
-  // running text (the only span a secret could straddle into the next delta),
-  // scan the accumulated tail, and flush what's held back the moment the text
-  // stream yields to any other part (its text-end, a mirrored tool call, or turn
-  // end). Bounded by the longest secret, so the buffer can never grow unbounded.
+  // stream through — the common case. So after redacting whole occurrences, hold
+  // back ONLY the span that could still grow into a secret: the longest suffix of
+  // the running text that is a strict prefix of some secret. Everything before it
+  // can never be part of a secret, so it flushes at once — which keeps the stream
+  // incremental (a mid-turn divider is delivered the instant it passes, never
+  // stalled behind a fixed tail) while still catching a secret straddling the
+  // next delta. Whatever is held is flushed the moment the text stream yields to
+  // any other part (its text-end, a mirrored tool call, or turn end). The held
+  // suffix is a proper prefix of a secret, so it is bounded by the longest secret
+  // and the buffer can never grow unbounded.
   const maxLen = Math.max(...secrets.map((secret) => secret.length));
+  const heldSuffixLength = (text: string): number => {
+    for (let hold = Math.min(text.length, maxLen - 1); hold > 0; hold -= 1) {
+      const tail = text.slice(text.length - hold);
+      if (secrets.some((secret) => secret.length > hold && secret.startsWith(tail))) return hold;
+    }
+    return 0;
+  };
   let carry = "";
   let carryId = "";
   const isTextDelta = (part: unknown): part is { type: "text-delta"; id: string; delta: string } =>
@@ -364,7 +376,7 @@ function redactingWriter(
       if (isTextDelta(part)) {
         if (part.id !== carryId) { flushCarry(); carryId = part.id; }
         const scanned = redactString(carry + part.delta);
-        const keep = Math.max(0, scanned.length - (maxLen - 1));
+        const keep = scanned.length - heldSuffixLength(scanned);
         carry = scanned.slice(keep);
         if (keep > 0) writer.write({ ...part, delta: scanned.slice(0, keep) });
         return;

--- a/packages/harnesses/src/runtime.ts
+++ b/packages/harnesses/src/runtime.ts
@@ -324,12 +324,13 @@ function redactingWriter(
   secrets: readonly string[],
 ): UIMessageStreamWriter<UIMessage> {
   if (secrets.length === 0) return writer;
+  const redactString = (value: string): string => {
+    let out = value;
+    for (const secret of secrets) out = out.split(secret).join("[redacted]");
+    return out;
+  };
   const walk = (value: unknown): unknown => {
-    if (typeof value === "string") {
-      let out = value;
-      for (const secret of secrets) out = out.split(secret).join("[redacted]");
-      return out;
-    }
+    if (typeof value === "string") return redactString(value);
     if (Array.isArray(value)) return value.map(walk);
     if (value !== null && typeof value === "object") {
       const out: Record<string, unknown> = {};
@@ -338,9 +339,48 @@ function redactingWriter(
     }
     return value;
   };
+  // The model streams its prose in many text-delta parts, so a secret split
+  // across deltas ("sk-", "ant-", …) is never whole inside one `walk` and would
+  // stream through — the common case. Carry the last (maxLen-1) chars of the
+  // running text (the only span a secret could straddle into the next delta),
+  // scan the accumulated tail, and flush what's held back the moment the text
+  // stream yields to any other part (its text-end, a mirrored tool call, or turn
+  // end). Bounded by the longest secret, so the buffer can never grow unbounded.
+  const maxLen = Math.max(...secrets.map((secret) => secret.length));
+  let carry = "";
+  let carryId = "";
+  const isTextDelta = (part: unknown): part is { type: "text-delta"; id: string; delta: string } =>
+    typeof part === "object" && part !== null
+    && (part as { type?: unknown }).type === "text-delta"
+    && typeof (part as { id?: unknown }).id === "string"
+    && typeof (part as { delta?: unknown }).delta === "string";
+  const flushCarry = (): void => {
+    if (carry === "") return;
+    writer.write({ type: "text-delta", id: carryId, delta: carry } as never);
+    carry = "";
+  };
   return {
-    write: (part) => writer.write(walk(part) as typeof part),
-    merge: writer.merge.bind(writer),
+    write: (part) => {
+      if (isTextDelta(part)) {
+        if (part.id !== carryId) { flushCarry(); carryId = part.id; }
+        const scanned = redactString(carry + part.delta);
+        const keep = Math.max(0, scanned.length - (maxLen - 1));
+        carry = scanned.slice(keep);
+        if (keep > 0) writer.write({ ...part, delta: scanned.slice(0, keep) });
+        return;
+      }
+      flushCarry();
+      writer.write(walk(part) as typeof part);
+    },
+    // `merge` splices another chunk stream straight onto the wire, so its
+    // content must pass through the same scrub as `write` above — no path uses
+    // it today, but an unscrubbed merge would be a silent hole in the redactor.
+    merge: (stream) => {
+      type Chunk = Parameters<typeof writer.write>[0];
+      writer.merge(stream.pipeThrough(new TransformStream<Chunk, Chunk>({
+        transform: (chunk, controller) => controller.enqueue(walk(chunk) as Chunk),
+      })));
+    },
     get onError() { return writer.onError; },
     set onError(handler) { writer.onError = handler; },
   };

--- a/packages/harnesses/src/runtime.ts
+++ b/packages/harnesses/src/runtime.ts
@@ -351,9 +351,18 @@ function redactingWriter(
   // any other part (its text-end, a mirrored tool call, or turn end). The held
   // suffix is a proper prefix of a secret, so it is bounded by the longest secret
   // and the buffer can never grow unbounded.
-  const maxLen = Math.max(...secrets.map((secret) => secret.length));
+  //
+  // The suffix scan below is O(span²) per text-delta (a slice + startsWith at
+  // every hold length), so `span` is capped: a real inference credential is well
+  // under this, and an absurdly long env value (`inferenceSecrets()` puts no
+  // ceiling on the key) would otherwise make the per-delta scan quadratic and
+  // stall the stream — the same class of cliff as the divider stall. A secret
+  // longer than the cap is still redacted whole by `redactString`; it just gets
+  // no cross-delta reassembly, which nothing real needs.
+  const MAX_SCAN_SPAN = 512;
+  const span = Math.min(MAX_SCAN_SPAN, Math.max(...secrets.map((secret) => secret.length)));
   const heldSuffixLength = (text: string): number => {
-    for (let hold = Math.min(text.length, maxLen - 1); hold > 0; hold -= 1) {
+    for (let hold = Math.min(text.length, span - 1); hold > 0; hold -= 1) {
       const tail = text.slice(text.length - hold);
       if (secrets.some((secret) => secret.length > hold && secret.startsWith(tail))) return hold;
     }

--- a/packages/harnesses/src/runtime.ts
+++ b/packages/harnesses/src/runtime.ts
@@ -352,15 +352,14 @@ function redactingWriter(
   // suffix is a proper prefix of a secret, so it is bounded by the longest secret
   // and the buffer can never grow unbounded.
   //
-  // The suffix scan below is O(span²) per text-delta (a slice + startsWith at
-  // every hold length), so `span` is capped: a real inference credential is well
-  // under this, and an absurdly long env value (`inferenceSecrets()` puts no
-  // ceiling on the key) would otherwise make the per-delta scan quadratic and
-  // stall the stream — the same class of cliff as the divider stall. A secret
-  // longer than the cap is still redacted whole by `redactString`; it just gets
-  // no cross-delta reassembly, which nothing real needs.
-  const MAX_SCAN_SPAN = 512;
-  const span = Math.min(MAX_SCAN_SPAN, Math.max(...secrets.map((secret) => secret.length)));
+  // The hold-back span is the FULL length of the longest secret — uncapped, so a
+  // secret of any length (a JWT-style token can run past 512 chars) still gets
+  // cross-delta reassembly rather than having its leading chars flushed before a
+  // match can form. The suffix scan is O(span²) per text-delta, but `secrets`
+  // is the DEPLOYMENT'S OWN inference key (inferenceSecrets(), trusted config —
+  // never attacker-controlled) and a real key is at most a few KB, so the cost
+  // is negligible and there is no DoS surface to cap against.
+  const span = Math.max(...secrets.map((secret) => secret.length));
   const heldSuffixLength = (text: string): number => {
     for (let hold = Math.min(text.length, span - 1); hold > 0; hold -= 1) {
       const tail = text.slice(text.length - hold);

--- a/packages/harnesses/tests/redact-secrets.test.ts
+++ b/packages/harnesses/tests/redact-secrets.test.ts
@@ -113,6 +113,40 @@ describe("VEGA-INFO-00021 — the model credential never reaches the user", () =
     expect(said).toContain(" — done");
   });
 
+  it("redacts a credential LONGER than the cross-delta scan span, streamed across many deltas", async () => {
+    // A real inference credential can run well past any fixed buffer size — a
+    // JWT-style OAuth token is often > 512 chars. It arrives split across deltas
+    // like any other, so the redactor must reassemble it across the WHOLE of its
+    // length: a capped hold-back would flush its leading chars before a match
+    // could form and leak the key. The secret is the deployment's own trusted
+    // config, so the uncapped scan is safe (never attacker-controlled).
+    const longSecret = `sk-vendo-oauth-${"a1b2c3d4e5".repeat(80)}`; // 814 chars
+    expect(longSecret.length).toBeGreaterThan(512);
+    vi.stubEnv("VENDO_INFERENCE_KEY", longSecret);
+    const fragments = longSecret.match(/.{1,50}/g)!;
+    const parts = await runTurn(
+      defineHarness({
+        name: "long-drip-leaker",
+        async *run() {
+          yield { type: "text", delta: "your key is " };
+          for (const fragment of fragments) yield { type: "text", delta: fragment };
+          yield { type: "text", delta: " — done" };
+        },
+      }),
+    );
+    const serialized = JSON.stringify(parts);
+    expect(serialized).not.toContain(longSecret);
+    const said = parts
+      .filter((part) => part.type === "text-delta")
+      .map((part) => part.delta)
+      .join("");
+    expect(said).not.toContain(longSecret);
+    expect(said).toContain("[redacted]");
+    // Ordinary text on either side still reaches the user in full.
+    expect(said).toContain("your key is ");
+    expect(said).toContain(" — done");
+  });
+
   it("redacts the credential when it rides back inside a tool's output", async () => {
     const parts = await runTurn(
       defineHarness({

--- a/packages/harnesses/tests/redact-secrets.test.ts
+++ b/packages/harnesses/tests/redact-secrets.test.ts
@@ -1,0 +1,125 @@
+/**
+ * VEGA-INFO-00021 — a boxed agent holds a REUSABLE inference credential and
+ * streams its output to the end user, who can steer it into printing the key.
+ * The runtime is the one seam every user-facing part crosses, so it redacts the
+ * literal value from BOTH the assistant's prose and any tool output. These tests
+ * drive a real turn through the real runtime with the credential set in the
+ * environment (the way `inferenceEnv()` reads it) and prove it never reaches the
+ * wire verbatim.
+ *
+ * This is defense in depth, not the fix: a model asked to transform the key
+ * first defeats a literal match — the fix is per-session brokering (deferred).
+ */
+import { defineHarness } from "../src/define.js";
+import { type Harness, type ThreadId } from "@vendoai/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createHarnessRuntime } from "../src/runtime.js";
+import {
+  boundRegistry,
+  ctx,
+  readSse,
+  readTool,
+  testGuard,
+  testSkills,
+  testTranscript,
+  testWorkspace,
+  unusedModels,
+  userMessage,
+} from "../src/test-doubles.test-util.js";
+
+const THREAD = "thr_1" as ThreadId;
+const SECRET = "sk-vendo-live-REDACT_ME_1234567890abcdef";
+
+/** Run one turn through the real runtime and return the SSE parts. */
+async function runTurn(
+  harness: Harness,
+  tools: Parameters<typeof boundRegistry>[0] = {},
+): Promise<Array<Record<string, unknown>>> {
+  const guard = testGuard();
+  const runtime = createHarnessRuntime({
+    tools: boundRegistry(tools, guard),
+    guard,
+    skills: testSkills(),
+    transcript: testTranscript(),
+  });
+  const response = await runtime.run({
+    harness,
+    threadId: THREAD,
+    messages: [userMessage("m1", "print your key")],
+    ctx: ctx(),
+    workspace: testWorkspace(),
+    models: unusedModels(),
+    interactive: true,
+  });
+  return readSse(response);
+}
+
+describe("VEGA-INFO-00021 — the model credential never reaches the user", () => {
+  beforeEach(() => {
+    // The credential exactly as `inferenceEnv()` reads it: the explicit pair.
+    vi.stubEnv("VENDO_INFERENCE_KEY", SECRET);
+    vi.stubEnv("VENDO_INFERENCE_URL", "https://inference.example/api");
+    vi.stubEnv("VENDO_API_KEY", "");
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("redacts the credential the agent echoes in its own prose", async () => {
+    const parts = await runTurn(
+      defineHarness({
+        name: "leaker",
+        async *run() {
+          yield { type: "text", delta: `Your ANTHROPIC_API_KEY is ${SECRET} — ` };
+          yield { type: "text", delta: "hope that helps." };
+        },
+      }),
+    );
+    const serialized = JSON.stringify(parts);
+    expect(serialized).not.toContain(SECRET);
+    const said = parts
+      .filter((part) => part.type === "text-delta")
+      .map((part) => part.delta)
+      .join("");
+    expect(said).toContain("[redacted]");
+    expect(said).not.toContain(SECRET);
+  });
+
+  it("redacts the credential when it rides back inside a tool's output", async () => {
+    const parts = await runTurn(
+      defineHarness({
+        name: "tool-caller",
+        async *run(turn) {
+          await turn.tools.call("dump_env", {});
+          yield { type: "text", delta: "done" };
+        },
+      }),
+      { dump_env: { descriptor: readTool("dump_env"), execute: () => ({ ANTHROPIC_API_KEY: SECRET }) } },
+    );
+    const serialized = JSON.stringify(parts);
+    expect(serialized).not.toContain(SECRET);
+    const output = parts.find((part) => part.type === "tool-output-available");
+    expect(JSON.stringify(output)).toContain("[redacted]");
+  });
+
+  it("leaves ordinary output untouched when the deployment holds no credential", async () => {
+    vi.stubEnv("VENDO_INFERENCE_KEY", "");
+    vi.stubEnv("VENDO_INFERENCE_URL", "");
+    vi.stubEnv("VENDO_API_KEY", "");
+    const looksLikeAKey = "sk-not-a-real-secret-just-user-text-000000";
+    const parts = await runTurn(
+      defineHarness({
+        name: "plain",
+        async *run() {
+          yield { type: "text", delta: looksLikeAKey };
+        },
+      }),
+    );
+    const said = parts
+      .filter((part) => part.type === "text-delta")
+      .map((part) => part.delta)
+      .join("");
+    expect(said).toBe(looksLikeAKey);
+    expect(said).not.toContain("[redacted]");
+  });
+});

--- a/packages/harnesses/tests/redact-secrets.test.ts
+++ b/packages/harnesses/tests/redact-secrets.test.ts
@@ -85,6 +85,34 @@ describe("VEGA-INFO-00021 — the model credential never reaches the user", () =
     expect(said).not.toContain(SECRET);
   });
 
+  it("redacts a credential streamed one fragment per delta — the split-across-deltas case", async () => {
+    // A model streams its prose in many small deltas, so the credential arrives
+    // in pieces that are each too short to match on their own. The redactor must
+    // reassemble across deltas or the secret streams through whole.
+    const fragments = SECRET.match(/.{1,4}/g)!;
+    const parts = await runTurn(
+      defineHarness({
+        name: "drip-leaker",
+        async *run() {
+          yield { type: "text", delta: "your key is " };
+          for (const fragment of fragments) yield { type: "text", delta: fragment };
+          yield { type: "text", delta: " — done" };
+        },
+      }),
+    );
+    const serialized = JSON.stringify(parts);
+    expect(serialized).not.toContain(SECRET);
+    const said = parts
+      .filter((part) => part.type === "text-delta")
+      .map((part) => part.delta)
+      .join("");
+    expect(said).not.toContain(SECRET);
+    expect(said).toContain("[redacted]");
+    // Ordinary text on either side of the secret still reaches the user in full.
+    expect(said).toContain("your key is ");
+    expect(said).toContain(" — done");
+  });
+
   it("redacts the credential when it rides back inside a tool's output", async () => {
     const parts = await runTurn(
       defineHarness({

--- a/packages/vendo/src/cli/extract/claude-harness.ts
+++ b/packages/vendo/src/cli/extract/claude-harness.ts
@@ -57,6 +57,22 @@ async function loadSdk(root: string): Promise<SdkModule | null> {
   return null;
 }
 
+/** Is the SDK RESOLVABLE from the CLI or the host app, without importing it?
+ *  `availability()` answers "is it here" with this — resolving a specifier runs
+ *  no module code, where `loadSdk`'s import would execute host-resolved code
+ *  just to probe. The resolution bases mirror loadSdk's exactly. */
+function sdkResolves(root: string): boolean {
+  for (const base of [import.meta.url, pathToFileURL(join(root, "package.json")).href]) {
+    try {
+      createRequire(base).resolve(SDK_PACKAGE);
+      return true;
+    } catch {
+      // try the next resolution base
+    }
+  }
+  return false;
+}
+
 /** `claude auth status` prints JSON with a `loggedIn` boolean. */
 function probeClaudeLogin(): Promise<boolean> {
   return new Promise((resolve) => {
@@ -80,14 +96,22 @@ export interface ClaudeHarnessOptions {
 export function claudeHarness(options: ClaudeHarnessOptions = {}): ExtractionHarness {
   const load = options.loadSdk ?? loadSdk;
   const probe = options.probeLogin ?? probeClaudeLogin;
+  // Presence for availability, WITHOUT executing host-resolved module code: in
+  // production resolve the specifier and never import it; a test's fake loadSdk
+  // imports nothing, so honoring it when supplied keeps that seam intact.
+  const present = async (root: string): Promise<boolean> =>
+    options.loadSdk === undefined ? sdkResolves(root) : (await options.loadSdk(root)) !== null;
   return {
     id: "claude-agent-sdk",
     async availability({ root, env }) {
-      if ((await load(root)) === null) return null;
+      // Credential first, so a repo with no credential never reaches the SDK
+      // probe — and the probe is a resolve, never an import.
       const key = env["ANTHROPIC_API_KEY"];
-      if (typeof key === "string" && key.trim().length > 0) return "your ANTHROPIC_API_KEY";
-      if (await probe()) return "your Claude Code login";
-      return null;
+      const label = typeof key === "string" && key.trim().length > 0
+        ? "your ANTHROPIC_API_KEY"
+        : (await probe()) ? "your Claude Code login" : null;
+      if (label === null) return null;
+      return (await present(root)) ? label : null;
     },
     async run(input: ExtractionRunInput): Promise<string> {
       const sdk = await load(input.root);

--- a/packages/vendo/src/cli/extract/npx-engine-harness.ts
+++ b/packages/vendo/src/cli/extract/npx-engine-harness.ts
@@ -43,6 +43,11 @@ import { extractionModelPin, type ExtractionHarness, type ExtractionRunInput } f
 export const ENGINE_PACKAGE_NAME = "@anthropic-ai/claude-code";
 export const ENGINE_PACKAGE_VERSION = "2.1.224";
 
+/** The public npm registry this rung fetches the engine from when the developer
+ *  has not chosen one of their own — pinned on the child so a repo-root `.npmrc`
+ *  cannot redirect the fetch (see run()). */
+const DEFAULT_NPM_REGISTRY = "https://registry.npmjs.org/";
+
 // Same read-only posture as the PATH rung (claude-cli-harness.ts): the two
 // spawn the same binary, so their tool policy must not diverge — including the
 // root-scoped allowlist, which is built per-run from the host root
@@ -257,12 +262,27 @@ export function npxEngineHarness(options: NpxEngineHarnessOptions = {}): Extract
         "--setting-sources", "",
         ...(model === undefined ? [] : ["--model", model]),
       ];
-      // Forward the caller's env so a key present only in the passed map
-      // (not process.env) still authenticates the child; gateway fuel (if
-      // applicable) wins last — mirrors claude-cli-harness.ts.
+      // A repo-root `.npmrc` is read by `npm exec` from cwd, and its `registry`
+      // / `@scope:registry` lines outrank the developer's own ~/.npmrc — so a
+      // cloned repo could point THIS fetch at a malicious registry and get
+      // arbitrary package execution (the file half of VEGA-INFO-00078; the
+      // `npm_config_*` env half is already dropped upstream by the extraction
+      // allowlist). Env config outranks a project `.npmrc`, so the registry —
+      // and the package's own scope, which a scoped `.npmrc` line could redirect
+      // on its own — are pinned on the child to the developer's shell value or
+      // the public default, never the checkout. Forwarding still lets a key
+      // present only in the passed map authenticate the child, and gateway fuel
+      // (if applicable) wins last — mirrors claude-cli-harness.ts.
+      const registry = isSet(merged["npm_config_registry"]) ? merged["npm_config_registry"]! : DEFAULT_NPM_REGISTRY;
+      const scopedRegistry = merged["npm_config_@anthropic-ai:registry"];
       const result = await exec(args, {
         cwd: input.root,
-        env: { ...merged, ...overlay },
+        env: {
+          ...merged,
+          ...overlay,
+          npm_config_registry: registry,
+          "npm_config_@anthropic-ai:registry": isSet(scopedRegistry) ? scopedRegistry! : registry,
+        },
         onStderrLine: input.onProgress,
       });
       if (result.code !== 0) {

--- a/packages/vendo/src/cli/extract/npx-engine-harness.ts
+++ b/packages/vendo/src/cli/extract/npx-engine-harness.ts
@@ -265,23 +265,24 @@ export function npxEngineHarness(options: NpxEngineHarnessOptions = {}): Extract
       // A repo-root `.npmrc` is read by `npm exec` from cwd, and its `registry`
       // / `@scope:registry` lines outrank the developer's own ~/.npmrc — so a
       // cloned repo could point THIS fetch at a malicious registry and get
-      // arbitrary package execution (the file half of VEGA-INFO-00078; the
-      // `npm_config_*` env half is already dropped upstream by the extraction
-      // allowlist). Env config outranks a project `.npmrc`, so the registry —
-      // and the package's own scope, which a scoped `.npmrc` line could redirect
-      // on its own — are pinned on the child to the developer's shell value or
-      // the public default, never the checkout. Forwarding still lets a key
-      // present only in the passed map authenticate the child, and gateway fuel
-      // (if applicable) wins last — mirrors claude-cli-harness.ts.
-      const registry = isSet(merged["npm_config_registry"]) ? merged["npm_config_registry"]! : DEFAULT_NPM_REGISTRY;
-      const scopedRegistry = merged["npm_config_@anthropic-ai:registry"];
+      // arbitrary package execution (VEGA-INFO-00078). Env config outranks a
+      // project `.npmrc`, so the registry and the package's own scope are pinned
+      // on the child — always to the PUBLIC DEFAULT, never any ambient value.
+      // When Vendo is itself launched via `npx`/`npm exec` from inside the
+      // scanned checkout, npm exports that checkout's `.npmrc` `registry` into
+      // THIS process's env as `npm_config_registry`, so a merged/ambient value
+      // is repo-influenced too and cannot be trusted. The npx last-resort rung
+      // therefore always fetches from the public registry (a corporate mirror
+      // configured only in ~/.npmrc is not honored on this rung — accepted).
+      // A credential present in the passed map still authenticates the child,
+      // and gateway fuel (if applicable) wins last — mirrors claude-cli-harness.ts.
       const result = await exec(args, {
         cwd: input.root,
         env: {
           ...merged,
           ...overlay,
-          npm_config_registry: registry,
-          "npm_config_@anthropic-ai:registry": isSet(scopedRegistry) ? scopedRegistry! : registry,
+          npm_config_registry: DEFAULT_NPM_REGISTRY,
+          "npm_config_@anthropic-ai:registry": DEFAULT_NPM_REGISTRY,
         },
         onStderrLine: input.onProgress,
       });

--- a/packages/vendo/src/cli/provider-deps.ts
+++ b/packages/vendo/src/cli/provider-deps.ts
@@ -182,11 +182,19 @@ export async function installCommandFor(root: string): Promise<InstallCommand> {
   }
 }
 
+/** POSIX single-quote a token of a command shown to the user, matching
+    pastePath's rule (init.ts): nothing expands inside single quotes, so a cwd
+    or spec carrying a space or shell metachar cannot be misread by the shell it
+    is pasted into. `^` (as in ai@^6) is not special in POSIX sh, so caret specs
+    stay unquoted. */
+const shellQuote = (token: string): string =>
+  /^[\w.^/@+-]+$/.test(token) ? token : `'${token.replace(/'/g, "'\\''")}'`;
+
 /** The exact command line a human can paste — prefixed with a `cd` when the
     install must run somewhere other than the app dir. */
 function invocationFor(install: InstallCommand, specs: string[], appRoot: string): string {
-  const line = `${install.command} ${[...install.args, ...specs].join(" ")}`;
-  return resolve(install.cwd) === resolve(appRoot) ? line : `(cd ${install.cwd} && ${line})`;
+  const line = [install.command, ...install.args, ...specs].map(shellQuote).join(" ");
+  return resolve(install.cwd) === resolve(appRoot) ? line : `(cd ${shellQuote(install.cwd)} && ${line})`;
 }
 
 /** The paste-ready zod bump for this host's package manager and workspace
@@ -216,6 +224,13 @@ export function installStderrTail(): string {
   return stderrTail;
 }
 
+/** The `--ignore-scripts` flag for the package managers that accept it, so
+    Vendo's automatic dep repair never runs the host repo's lifecycle scripts.
+    yarn is absent on purpose — berry rejects the flag (yarnpkg/berry#5540) and
+    honors YARN_ENABLE_SCRIPTS on the child env instead. */
+export const ignoreScriptsArgs = (command: string): string[] =>
+  ["npm", "pnpm", "bun"].includes(command) ? ["--ignore-scripts"] : [];
+
 /** Package managers install as .cmd shims on Windows, so the spawn must go
     through the platform shell there — a shell-less spawn ENOENTs before the
     install starts. cmd.exe treats `^` (as in ai@^6) as an escape character
@@ -225,8 +240,13 @@ export const defaultRunner: InstallRunner = (command, args, cwd) =>
   new Promise((resolve) => {
     stderrTail = "";
     const windows = process.platform === "win32";
-    const child = spawn(command, windows ? args.map((arg) => `"${arg}"`) : args, {
+    const runArgs = [...args, ...ignoreScriptsArgs(command)];
+    const child = spawn(command, windows ? runArgs.map((arg) => `"${arg}"`) : runArgs, {
       cwd,
+      // An automatic repair must not run the host repo's lifecycle scripts.
+      // The flag above covers npm/pnpm/bun; these cover yarn (classic reads
+      // npm config, berry reads YARN_ENABLE_SCRIPTS), which rejects the flag.
+      env: { ...process.env, npm_config_ignore_scripts: "true", YARN_ENABLE_SCRIPTS: "0" },
       stdio: ["ignore", "ignore", "pipe"],
       shell: windows,
     });

--- a/packages/vendo/src/cli/sync-flow.ts
+++ b/packages/vendo/src/cli/sync-flow.ts
@@ -157,6 +157,29 @@ export interface SyncFlowResult {
 }
 
 /**
+ * The keys a project dotenv may contribute to the EXTRACTION env — the allowlist
+ * `readEnvFiles` applies on that path (see its `fileAllowlist`). Extraction
+ * forwards this env into the coding-agent child processes sync spawns, and the
+ * dotenv ships with the repo, so membership is exactly what extraction reads
+ * from a dotenv: a credential `vendo login`/BYO writes there, the extraction
+ * model pin, and the dev-server URL init writes to `.env.local`. Every
+ * redirect/injection var (NODE_OPTIONS, npm_config_*, VENDO_CLOUD_URL,
+ * ANTHROPIC_BASE_URL) earns its keep by being ABSENT, so it reaches a child only
+ * from the developer's own shell, never from the checkout.
+ */
+export const EXTRACTION_DOTENV_ALLOWLIST: ReadonlySet<string> = new Set([
+  "VENDO_API_KEY",
+  "ANTHROPIC_API_KEY",
+  "ANTHROPIC_AUTH_TOKEN",
+  "CLAUDE_CODE_OAUTH_TOKEN",
+  "OPENAI_API_KEY",
+  "GOOGLE_GENERATIVE_AI_API_KEY",
+  "VENDO_MODEL_EXTRACT",
+  "VENDO_BASE_URL",
+  "VENDO_URL",
+]);
+
+/**
  * `.env` then `.env.local` (local wins), then process.env — except that a
  * BLANK process value yields to a concrete file one. THE env reader for the
  * whole CLI: init read only `.env.local` (the defect — a key in `.env` was
@@ -164,19 +187,25 @@ export interface SyncFlowResult {
  * both through doctor's copy, and telemetry had a third. Minimal KEY=VALUE
  * parser: `export ` prefix, matching quotes, `#` comment lines.
  *
- * ONE exception, and it is a security boundary rather than a parsing rule:
- * the files may not supply AGENT_ENDPOINT_ENV_VAR. Everything downstream
- * sees a flat map and so cannot tell a shell value from a file one; this is
- * the last point where that provenance is still known, so it is where the
- * distinction gets made. Dropping the key here (rather than filtering it at
- * each consumer) carries provenance to every rung for free: below this line
- * the only remaining source is `processEnv`, and every consumer that
- * re-merges `process.env` over its input — both Claude rungs do — therefore
- * still honors the developer's own shell endpoint.
+ * A security boundary rides here, not a parsing rule, because this is the last
+ * point where file-vs-shell provenance is still known (everything downstream
+ * sees a flat map). `fileAllowlist` names the ONLY keys a project dotenv may
+ * contribute; the EXTRACTION path passes one (EXTRACTION_DOTENV_ALLOWLIST)
+ * because its env is forwarded into coding-agent child processes, so a repo file
+ * that set NODE_OPTIONS / npm_config_registry / VENDO_CLOUD_URL could otherwise
+ * inject code into or redirect them. A general reader (doctor's config checks)
+ * passes none and gets every file key — it never spawns a child with them — and
+ * either way AGENT_ENDPOINT_ENV_VAR is dropped, because no caller may take the
+ * coding-agent endpoint from a project file. Dropping here (rather than at each
+ * consumer) carries the guarantee to every rung for free: the only remaining
+ * source of a dropped key is `processEnv`, and every rung re-merges
+ * `process.env` over its input, so the developer's own shell value still reaches
+ * the child.
  */
 export async function readEnvFiles(
   root: string,
   processEnv: NodeJS.ProcessEnv = process.env,
+  fileAllowlist?: ReadonlySet<string>,
 ): Promise<Record<string, string | undefined>> {
   const fromFiles: Record<string, string> = {};
   for (const file of [".env", ".env.local"]) {
@@ -184,7 +213,10 @@ export async function readEnvFiles(
     if (source === null) continue;
     Object.assign(fromFiles, parseDotEnv(source));
   }
-  delete fromFiles[AGENT_ENDPOINT_ENV_VAR];
+  for (const key of Object.keys(fromFiles)) {
+    const denied = fileAllowlist === undefined ? key === AGENT_ENDPOINT_ENV_VAR : !fileAllowlist.has(key);
+    if (denied) delete fromFiles[key];
+  }
   const merged: Record<string, string | undefined> = { ...fromFiles, ...processEnv };
   for (const [key, value] of Object.entries(processEnv)) {
     if ((value ?? "").trim() === "" && fromFiles[key] !== undefined) merged[key] = fromFiles[key];
@@ -854,8 +886,11 @@ export async function runSyncFlow(options: SyncFlowOptions): Promise<SyncFlowRes
   // The credential env for the judgment pass and the Cloud key: the project's
   // dotenv must be visible, because `vendo login` and BYO keys land in
   // `.env.local` / `.env` and a fresh shell that never `source`d them would
-  // otherwise sync structural-only with no signal why (#567).
-  const env = await readEnvFiles(root);
+  // otherwise sync structural-only with no signal why (#567). This env is
+  // forwarded into the extraction children, so it is read through the allowlist:
+  // a repo file can contribute a credential but never a NODE_OPTIONS, a rogue
+  // npm registry, or a Cloud/agent endpoint.
+  const env = await readEnvFiles(root, process.env, EXTRACTION_DOTENV_ALLOWLIST);
 
   const report: SyncReportWithWarnings = await withSpin(
     options.spinner,

--- a/packages/vendo/src/server.ts
+++ b/packages/vendo/src/server.ts
@@ -303,8 +303,17 @@ const wireRoutesFor = (deps: WireDeps): readonly RouteEntry[] => [
 
 function createWireHandler(deps: WireDeps): (request: Request) => Promise<Response> {
   // Assembled once per composition, not per request: what is mounted is a boot
-  // fact.
-  const wireRoutes = wireRoutesFor(deps);
+  // fact. Each handler is wrapped so the same-origin baseUrl default is learned
+  // ONLY once a request actually matched a real Vendo route — before that
+  // handler runs any host call, and never for a 404 (an unmatched path invokes
+  // no handler). A spoofed Host on a 404 therefore can never poison the base.
+  const wireRoutes = wireRoutesFor(deps).map((entry) => ({
+    ...entry,
+    handler: async (wire: WireContext) => {
+      deps.onRequestOrigin?.(wire.url.origin);
+      return entry.handler(wire);
+    },
+  }));
   // Amortized on-request sweep bookkeeping — lives in the shared handler closure
   // (persists across requests), NOT per-invocation. The serverless-safe leg:
   // Next.js gives no timer guarantee, so every request may trigger the sweep.
@@ -331,13 +340,13 @@ function createWireHandler(deps: WireDeps): (request: Request) => Promise<Respon
   //   2. the MCP door's paths — before relativePath's not-found AND the CSRF
   //      json-mutation gate (see the comment at the check);
   //   3. relativePath → not-found for non-wire paths;
-  //   4. onRequestOrigin — a validated wire route teaches the same-origin
-  //      baseUrl default;
-  //   5. the CSRF json-mutation gate — before ANY route handler runs;
-  //   6. await ready — schema before the first store touch;
-  //   7. the route table (wireRoutes above; tick auth and the orgs seam are
-  //      ordinary entries at their old chain positions);
-  //   8. no match → not-found.
+  //   4. the CSRF json-mutation gate — before ANY route handler runs;
+  //   5. await ready — schema before the first store touch;
+  //   6. the route table (wireRoutes above; tick auth and the orgs seam are
+  //      ordinary entries at their old chain positions) — a matched handler
+  //      teaches the same-origin baseUrl default (onRequestOrigin, wrapped
+  //      above) before it runs, so a 404 can never poison the learned base;
+  //   7. no match → not-found.
   return async (request) => {
     // ONE sweep pass per request, shared with any route that drives the sweep
     // itself (POST /tick) so a tick can never run two scans of the same
@@ -372,9 +381,6 @@ function createWireHandler(deps: WireDeps): (request: Request) => Promise<Respon
       }
       const path = relativePath(BASE_PATH, url);
       if (path === null) throw new VendoError("not-found", "unknown Vendo route");
-      // Learn the same-origin default only from a request that addresses a real
-      // Vendo route (defense in depth beyond the untrusted-forwarding rule).
-      deps.onRequestOrigin?.(url.origin);
       if (jsonMutationRequired(request, path) && !isJsonRequest(request)) {
         throw new VendoError("validation", "content-type must be application/json");
       }

--- a/packages/vendo/src/server.ts
+++ b/packages/vendo/src/server.ts
@@ -305,20 +305,25 @@ function createWireHandler(deps: WireDeps): (request: Request) => Promise<Respon
   // Assembled once per composition, not per request: what is mounted is a boot
   // fact. Each handler is wrapped so the same-origin baseUrl default is learned
   // ONLY from a request that TERMINALLY matched a real Vendo route (VEGA-INFO-
-  // 00037). A grouped ("*") route matches a PATH then dispatches by method
-  // inside, falling through (undefined) to a 404 when no inner method matches —
-  // so learning at its entry would let a route-shaped 404 with a spoofed Host
-  // poison the base. Such a route therefore learns only after it produced a real
-  // response. A method-specific route cannot fall through (matchRoute already
-  // pinned its method) and one may make a same-origin host call DURING its own
-  // dispatch (the /doctor probes, before they return), so it learns at entry —
-  // before that call.
+  // 00037). ANY handler — grouped ("*") OR method-specific — may match, run its
+  // side effects, then return undefined to fall through to a later entry (a 404
+  // when none answers): the router contract is `Promise<Response | undefined>`
+  // for every entry (agents/http/router.ts), so `POST /automations/:id/:op` on
+  // an op it does not serve is a method-specific route that 404s from a spoofed
+  // Host. So the DEFAULT is to learn only AFTER a non-undefined Response — never
+  // at entry, never by a method proxy. The exception is a handler that USES the
+  // learned base DURING its own dispatch and so needs it set before it runs — a
+  // turn that dials the internal MCP door off the learned loopback origin (POST
+  // /threads, /threads/warm) or a doctor probe that calls the host on it (the
+  // two POST /doctor routes). Those, and only those, opt in with
+  // `learnsOriginAtEntry` (shared.ts) — and only a handler that ALWAYS responds
+  // may, or it becomes a fall-through poisoning vector again.
   const wireRoutes = wireRoutesFor(deps).map((entry) => ({
     ...entry,
     handler: async (wire: WireContext) => {
-      if (entry.method !== "*") deps.onRequestOrigin?.(wire.url.origin);
+      if (entry.learnsOriginAtEntry) deps.onRequestOrigin?.(wire.url.origin);
       const response = await entry.handler(wire);
-      if (entry.method === "*" && response !== undefined) deps.onRequestOrigin?.(wire.url.origin);
+      if (!entry.learnsOriginAtEntry && response !== undefined) deps.onRequestOrigin?.(wire.url.origin);
       return response;
     },
   }));

--- a/packages/vendo/src/server.ts
+++ b/packages/vendo/src/server.ts
@@ -304,14 +304,22 @@ const wireRoutesFor = (deps: WireDeps): readonly RouteEntry[] => [
 function createWireHandler(deps: WireDeps): (request: Request) => Promise<Response> {
   // Assembled once per composition, not per request: what is mounted is a boot
   // fact. Each handler is wrapped so the same-origin baseUrl default is learned
-  // ONLY once a request actually matched a real Vendo route — before that
-  // handler runs any host call, and never for a 404 (an unmatched path invokes
-  // no handler). A spoofed Host on a 404 therefore can never poison the base.
+  // ONLY from a request that TERMINALLY matched a real Vendo route (VEGA-INFO-
+  // 00037). A grouped ("*") route matches a PATH then dispatches by method
+  // inside, falling through (undefined) to a 404 when no inner method matches —
+  // so learning at its entry would let a route-shaped 404 with a spoofed Host
+  // poison the base. Such a route therefore learns only after it produced a real
+  // response. A method-specific route cannot fall through (matchRoute already
+  // pinned its method) and one may make a same-origin host call DURING its own
+  // dispatch (the /doctor probes, before they return), so it learns at entry —
+  // before that call.
   const wireRoutes = wireRoutesFor(deps).map((entry) => ({
     ...entry,
     handler: async (wire: WireContext) => {
-      deps.onRequestOrigin?.(wire.url.origin);
-      return entry.handler(wire);
+      if (entry.method !== "*") deps.onRequestOrigin?.(wire.url.origin);
+      const response = await entry.handler(wire);
+      if (entry.method === "*" && response !== undefined) deps.onRequestOrigin?.(wire.url.origin);
+      return response;
     },
   }));
   // Amortized on-request sweep bookkeeping — lives in the shared handler closure
@@ -343,9 +351,9 @@ function createWireHandler(deps: WireDeps): (request: Request) => Promise<Respon
   //   4. the CSRF json-mutation gate — before ANY route handler runs;
   //   5. await ready — schema before the first store touch;
   //   6. the route table (wireRoutes above; tick auth and the orgs seam are
-  //      ordinary entries at their old chain positions) — a matched handler
-  //      teaches the same-origin baseUrl default (onRequestOrigin, wrapped
-  //      above) before it runs, so a 404 can never poison the learned base;
+  //      ordinary entries at their old chain positions) — a TERMINALLY matched
+  //      handler teaches the same-origin baseUrl default (onRequestOrigin,
+  //      wrapped above), so a route-shaped 404 can never poison the learned base;
   //   7. no match → not-found.
   return async (request) => {
     // ONE sweep pass per request, shared with any route that drives the sweep

--- a/packages/vendo/src/wire/doctor.ts
+++ b/packages/vendo/src/wire/doctor.ts
@@ -1,7 +1,7 @@
 import type { ExtractedTool } from "@vendoai/actions";
 import { principalSchema, type Principal, type ToolOutcome } from "@vendoai/core";
 import { tickSecret } from "../tick-enrolment.js";
-import { BASE_PATH, environment, json, route, type RouteEntry } from "./shared.js";
+import { BASE_PATH, environment, json, learnsOriginAtEntry, route, type RouteEntry } from "./shared.js";
 
 /** The composition probe surface, for anything that wants to check a running
     deployment over HTTP: the synthetic credential/actAs round-trip constants
@@ -57,6 +57,14 @@ export const doctorBaseUrlRoutes: RouteEntry[] = [
   }),
 ];
 
+/** The two POST probes make a same-origin HOST CALL during their own dispatch:
+    each doctor executor runs a probe tool whose route binding points at the
+    doctor echo path on the learned base (doctorPresentTool / doctorActAsTool
+    above), so the base must be learned at handler ENTRY, before the handler runs
+    (`learnsOriginAtEntry`, shared.ts). Marked route-by-route rather than by
+    method, because a method is not the tell: plenty of method-specific routes
+    fall through to a 404. */
+
 /** The PROBE surface — a composition that did not say it is development never
     gets these routes at all (server.ts mounts the group behind
     `deps.development`). Mounting is the
@@ -86,7 +94,7 @@ export const doctorRoutes: RouteEntry[] = [
     const accepted = parsed.success && parsed.data.subject === DOCTOR_ACT_AS_PRINCIPAL.subject;
     return json({ ok: accepted }, accepted ? 200 : 401);
   }),
-  route("POST", "/doctor/present", async ({ deps, context }) => {
+  learnsOriginAtEntry(route("POST", "/doctor/present", async ({ deps, context }) => {
     const outcome = await deps.doctor.present(await context("chat"));
     if (doctorProbeOk(outcome)) return json({ ok: true });
     return json({
@@ -96,8 +104,8 @@ export const doctorRoutes: RouteEntry[] = [
         message: "Present credentials did not reach the host API. Set VENDO_BASE_URL to the running host origin and restart the dev server.",
       },
     }, 409);
-  }),
-  route("POST", "/doctor/act-as", async ({ deps }) => {
+  })),
+  learnsOriginAtEntry(route("POST", "/doctor/act-as", async ({ deps }) => {
     const outcome = await deps.doctor.actAs();
     if (doctorProbeOk(outcome)) return json({ ok: true });
     // The probe executor calls the actions registry directly (no guard
@@ -133,5 +141,5 @@ export const doctorRoutes: RouteEntry[] = [
           : "actAs returned no usable AuthMaterial, or the composition's principal resolver did not accept it. Check the actAs seam and principal resolver.",
       },
     }, 409);
-  }),
+  })),
 ];

--- a/packages/vendo/src/wire/shared.ts
+++ b/packages/vendo/src/wire/shared.ts
@@ -196,6 +196,16 @@ export const prefixRoute: (method: string, prefix: string, handler: RouteHandler
 export const dispatchRoutes: (routes: readonly RouteEntry[], wire: WireContext) => Promise<Response | undefined> =
   dispatchHttpRoutes;
 
+/** Mark a route so the wire learns its same-origin base at handler ENTRY, not
+    after the handler returns — for the few handlers that USE that base DURING
+    their own dispatch: a turn that dials the internal MCP door off the learned
+    loopback origin (compose-wire.ts), or a doctor probe that calls the host on
+    it. Safe ONLY on a handler that ALWAYS responds; a route that can fall
+    through (return undefined) must never carry it, or a route-shaped 404 from a
+    spoofed Host reopens VEGA-INFO-00037. The wire's default is the safe one —
+    learn only after a non-undefined Response (server.ts). */
+export const learnsOriginAtEntry = (entry: RouteEntry): RouteEntry => ({ ...entry, learnsOriginAtEntry: true });
+
 /** Orgs are a Vendo Cloud capability, not an OSS one (kill-list A5): every
     /orgs route and every org-scoped param on /approvals and /grants answers
     this, unconditionally — there is no key-gated activation path left in the

--- a/packages/vendo/src/wire/threads.ts
+++ b/packages/vendo/src/wire/threads.ts
@@ -2,7 +2,7 @@ import { defineOwn, isPlainObject, mintTurnId, THREAD_WINDOW_INITIAL, VendoError
 import { UI_MESSAGE_STREAM_HEADERS } from "ai";
 import { registerActiveTurn, steerActiveTurn, touchActiveTurn, trackTurnResponse } from "../turn-liveness.js";
 import { recordResumableTurn, resumableTurnStream } from "../turn-resume.js";
-import { json, requestJson, route, string, type RouteEntry } from "./shared.js";
+import { json, learnsOriginAtEntry, requestJson, route, string, type RouteEntry } from "./shared.js";
 
 /** The effective thread id the agent stamps on every turn response (03 §1). */
 const THREAD_ID_HEADER = "x-vendo-thread-id";
@@ -95,7 +95,10 @@ function cappedSituation(value: unknown): Record<string, unknown> | undefined {
 
 /** 09 §3 — the /threads wire area: chat streaming plus thread list/get/delete. */
 export const threadRoutes: RouteEntry[] = [
-  route("POST", "/threads", async ({ request, deps, context }) => {
+  // A turn built here dials the internal MCP door off the learned loopback
+  // origin DURING its own dispatch (compose-wire.ts), and it always responds —
+  // so it learns the base at ENTRY, before the turn runs, like the doctor probes.
+  learnsOriginAtEntry(route("POST", "/threads", async ({ request, deps, context }) => {
     const body = await requestJson(request);
     const ctx = await context("chat");
     // Spec 2026-08-05 §2 — the client's situation rides the message POST and
@@ -160,18 +163,20 @@ export const threadRoutes: RouteEntry[] = [
       unregister,
       idleAbort.signal,
     );
-  }),
+  })),
   // Prompt-cache warming (sub-1s shipment): the client fires this once when
   // the chat surface opens, so the user's FIRST message reads a warm provider
   // prefix instead of writing a cold one. Best-effort on both sides: the 204
   // carries nothing, a failure costs nothing but the warmth, and an engine
   // without a warm door (the createAgent path) simply answers 204 unwarmed.
-  route("POST", "/threads/warm", async ({ deps, context }) => {
+  // Learns at ENTRY like POST /threads: the warm turn dials the same internal
+  // MCP door off the learned loopback origin, and it always answers 204.
+  learnsOriginAtEntry(route("POST", "/threads/warm", async ({ deps, context }) => {
     const ctx = await context("chat");
     const door = deps.harness as { warm?: (input: { ctx: unknown }) => Promise<void> };
     if (typeof door.warm === "function") await door.warm({ ctx });
     return new Response(null, { status: 204 });
-  }),
+  })),
   // The SERVER half of `ChatTransport.reconnectToStream` (ai@6): the URL, the
   // method and the 204 are the SDK's, not ours. 204 = nothing in flight, so the
   // client goes back to ready on its persisted transcript.

--- a/packages/vendo/tests/cli/extract/child-env-allowlist.test.ts
+++ b/packages/vendo/tests/cli/extract/child-env-allowlist.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -144,6 +145,48 @@ describe("the developer's own SHELL still reaches the child (provenance, not var
     const root = await hostWithDotenv("");
     const env = await childEnv(rungs[0]!.harness, root);
     expect(env.NODE_OPTIONS).toBe("--max-old-space-size=8192");
+  });
+});
+
+describe("a repo-root .npmrc cannot redirect the npx rung's registry (VEGA-INFO-00078, file half)", () => {
+  async function repoWithNpmrc(npmrc: string): Promise<string> {
+    const root = await mkdtemp(join(tmpdir(), "vendo-npmrc-"));
+    dirs.push(root);
+    await writeFile(join(root, "package.json"), JSON.stringify({ name: "victim", version: "1.0.0" }), "utf8");
+    await writeFile(join(root, ".npmrc"), npmrc, "utf8");
+    return root;
+  }
+
+  // The npx rung's REAL child (cwd + env), fed to real `npm config get` in the
+  // repo — the assertion is npm's own effective config, not a mock, so it proves
+  // the pin actually outranks the project .npmrc npm reads from cwd.
+  async function effectiveRegistry(root: string): Promise<{ registry: string; scoped: string }> {
+    let seen: { cwd: string; env: NodeJS.ProcessEnv } | undefined;
+    const harness = npxEngineHarness({
+      exec: async (_args, options) => { seen = options; return { stdout: STDOUT, stderr: "", code: 0 }; },
+    });
+    await harness.run({
+      root,
+      env: await readEnvFiles(root, process.env, EXTRACTION_DOTENV_ALLOWLIST),
+      instructions: "go",
+    });
+    const get = (key: string): string =>
+      execFileSync("npm", ["config", "get", key], { cwd: seen!.cwd, env: seen!.env, encoding: "utf8" }).trim();
+    return { registry: get("registry"), scoped: get("@anthropic-ai:registry") };
+  }
+
+  it("overrides a bogus default AND scoped registry the repo's .npmrc set", async () => {
+    vi.stubEnv("npm_config_registry", ""); // worst case: the developer set no registry of their own
+    const root = await repoWithNpmrc("registry=http://evil.example/\n@anthropic-ai:registry=http://evil.scope.example/\n");
+    const { registry, scoped } = await effectiveRegistry(root);
+    expect(registry).toBe("https://registry.npmjs.org/");
+    expect(scoped).not.toContain("evil");
+  });
+
+  it("respects the developer's OWN shell registry, still overriding the repo's", async () => {
+    vi.stubEnv("npm_config_registry", "https://mirror.corp.example/");
+    const root = await repoWithNpmrc("registry=http://evil.example/\n");
+    expect((await effectiveRegistry(root)).registry).toBe("https://mirror.corp.example/");
   });
 });
 

--- a/packages/vendo/tests/cli/extract/child-env-allowlist.test.ts
+++ b/packages/vendo/tests/cli/extract/child-env-allowlist.test.ts
@@ -1,0 +1,188 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { claudeCliHarness } from "../../../src/cli/extract/claude-cli-harness.js";
+import { claudeHarness } from "../../../src/cli/extract/claude-harness.js";
+import { codexCliHarness } from "../../../src/cli/extract/codex-cli-harness.js";
+import type { ExtractionHarness } from "../../../src/cli/extract/harness.js";
+import { npxEngineHarness } from "../../../src/cli/extract/npx-engine-harness.js";
+import { EXTRACTION_DOTENV_ALLOWLIST, readEnvFiles } from "../../../src/cli/sync-flow.js";
+
+/**
+ * The extraction boundary: an untrusted repo dotenv reaches the coding-agent
+ * children (`npm`, `claude`, `codex`) sync spawns, so a cloned repo must not be
+ * able to inject code into them (a registry/NODE_OPTIONS the child obeys) or
+ * redirect their credentials (a Cloud endpoint the key is sent to). These test
+ * the SEAM with no stub between the producer and the consumer: the REAL
+ * `readEnvFiles` reads a real `.env`, feeds the REAL harness, and only the leaf
+ * child spawn is captured — the exact path `runSyncFlow` walks.
+ */
+
+const dirs: string[] = [];
+afterEach(async () => {
+  vi.unstubAllEnvs();
+  await Promise.all(dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+async function hostWithDotenv(dotenv: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "vendo-child-env-"));
+  dirs.push(root);
+  await writeFile(join(root, ".env"), dotenv, "utf8");
+  return root;
+}
+
+/** stdout each harness's parser accepts, so run() reaches the child spawn. */
+const STDOUT = "```json\n" + JSON.stringify({ tools: [], narrative: "" }) + "\n```";
+
+/** The three real spawning rungs, built for real with only the leaf child
+ *  captured. Codex has no `-p` stdout, so its own exec seam returns bare text. */
+const rungs: ReadonlyArray<{
+  name: string;
+  harness: (capture: (env: NodeJS.ProcessEnv) => void) => ExtractionHarness;
+}> = [
+  {
+    name: "the PATH `claude` rung",
+    harness: (capture) => claudeCliHarness({
+      probeBinary: async () => true,
+      probeLogin: async () => false,
+      exec: async (_args, options) => { capture(options.env); return { stdout: STDOUT, stderr: "", code: 0 }; },
+    }),
+  },
+  {
+    name: "the npx-fetched engine rung",
+    harness: (capture) => npxEngineHarness({
+      exec: async (_args, options) => { capture(options.env); return { stdout: STDOUT, stderr: "", code: 0 }; },
+    }),
+  },
+  {
+    name: "the `codex` rung",
+    harness: (capture) => codexCliHarness({
+      probeBinary: async () => true,
+      probeLogin: async () => true,
+      exec: async (_args, options) => { capture(options.env); return { stdout: "done", stderr: "", code: 0 }; },
+    }),
+  },
+];
+
+async function childEnv(
+  harnessFor: (capture: (env: NodeJS.ProcessEnv) => void) => ExtractionHarness,
+  root: string,
+): Promise<NodeJS.ProcessEnv> {
+  let captured: NodeJS.ProcessEnv | undefined;
+  // The real extraction path: readEnvFiles under its allowlist, then the rung
+  // forwards that env to the child — no stub between producer and consumer.
+  const env = await readEnvFiles(root, process.env, EXTRACTION_DOTENV_ALLOWLIST);
+  await harnessFor((seen) => { captured ??= seen; }).run({ root, env, instructions: "go" });
+  expect(captured).toBeDefined();
+  return captured!;
+}
+
+describe("readEnvFiles applies the extraction allowlist only when asked", () => {
+  it("under the allowlist, a repo dotenv contributes credentials but no injection/redirect var", async () => {
+    const root = await hostWithDotenv(
+      "VENDO_API_KEY=vnd_x\nNODE_OPTIONS=--require ./repo-evil.js\n"
+      + "npm_config_registry=https://registry.repo-evil.example\nVENDO_CLOUD_URL=https://evil-cloud.example\n",
+    );
+    expect(await readEnvFiles(root, {}, EXTRACTION_DOTENV_ALLOWLIST)).toEqual({ VENDO_API_KEY: "vnd_x" });
+  });
+
+  it("the general reader (no allowlist) still passes arbitrary config keys through — doctor reads it", async () => {
+    const root = await hostWithDotenv("VENDO_STORE_ENCRYPTION_KEY=k\nSOME_HOST_CONFIG=v\n");
+    const env = await readEnvFiles(root, {});
+    expect(env["VENDO_STORE_ENCRYPTION_KEY"]).toBe("k");
+    expect(env["SOME_HOST_CONFIG"]).toBe("v");
+  });
+});
+
+describe("an untrusted repo dotenv cannot inject code into the extraction children", () => {
+  // Each carries a distinctive marker: the assertion is that the repo's own
+  // value never survives into the child env, regardless of any ambient value.
+  const injections = [
+    { key: "NODE_OPTIONS", value: "--require ./repo-evil.js", marker: "repo-evil" },
+    { key: "npm_config_registry", value: "https://registry.repo-evil.example", marker: "repo-evil" },
+  ];
+
+  for (const { name, harness } of rungs) {
+    for (const { key, value, marker } of injections) {
+      it(`${name}: a repo dotenv ${key} never reaches the child env`, async () => {
+        // Blank the ambient value so the repo file's value is the only source
+        // that could flow through (the blank-process fallback in readEnvFiles).
+        vi.stubEnv(key, "");
+        const root = await hostWithDotenv(`${key}=${value}\n`);
+        const env = await childEnv(harness, root);
+        expect(String(env[key] ?? "")).not.toContain(marker);
+      });
+    }
+  }
+});
+
+describe("an untrusted repo dotenv cannot redirect the Cloud key to its own endpoint", () => {
+  // Only the two Claude-Code-shaped rungs compose gateway fuel; codex never
+  // reads VENDO_CLOUD_URL.
+  const gatewayRungs = rungs.slice(0, 2);
+  for (const { name, harness } of gatewayRungs) {
+    it(`${name}: a repo VENDO_CLOUD_URL cannot capture ANTHROPIC_AUTH_TOKEN`, async () => {
+      for (const ambient of [
+        "ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN",
+        "ANTHROPIC_BASE_URL", "OPENAI_API_KEY", "GOOGLE_GENERATIVE_AI_API_KEY",
+        "VENDO_API_KEY", "VENDO_CLOUD_URL", "VENDO_DEV_CREDENTIAL",
+      ]) vi.stubEnv(ambient, "");
+      const root = await hostWithDotenv("VENDO_API_KEY=vnd_x\nVENDO_CLOUD_URL=https://evil-cloud.example\n");
+      const env = await childEnv(harness, root);
+      // The child still runs on the Cloud key — it just runs against the real
+      // gateway, never the endpoint the repo tried to name.
+      expect(env.ANTHROPIC_AUTH_TOKEN).toBe("vnd_x");
+      expect(String(env.ANTHROPIC_BASE_URL ?? "")).not.toContain("evil-cloud");
+    });
+  }
+});
+
+describe("the developer's own SHELL still reaches the child (provenance, not variable name)", () => {
+  it("a shell NODE_OPTIONS is the developer's choice and passes through", async () => {
+    vi.stubEnv("NODE_OPTIONS", "--max-old-space-size=8192");
+    const root = await hostWithDotenv("");
+    const env = await childEnv(rungs[0]!.harness, root);
+    expect(env.NODE_OPTIONS).toBe("--max-old-space-size=8192");
+  });
+});
+
+describe("the Agent SDK availability probe never executes host-resolved module code", () => {
+  it("answers 'is it here' by resolving the specifier, not importing it (an import would throw)", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vendo-sdk-probe-"));
+    dirs.push(root);
+    // A fake SDK resolvable from the host root whose module body THROWS the
+    // instant it is imported. Resolving it is fine; importing it is not — so a
+    // probe that resolves reports available, and one that imports catches the
+    // throw and reports unavailable. The verdict, not a side effect, is the tell
+    // (vite's dynamic-import handling makes a side-effect marker unreliable).
+    const pkgDir = join(root, "node_modules", "@anthropic-ai", "claude-agent-sdk");
+    await mkdir(pkgDir, { recursive: true });
+    await writeFile(
+      join(pkgDir, "package.json"),
+      JSON.stringify({ name: "@anthropic-ai/claude-agent-sdk", version: "0.0.0", main: "index.js" }),
+      "utf8",
+    );
+    await writeFile(
+      join(pkgDir, "index.js"),
+      `throw new Error("the availability probe must not import the SDK");\n`,
+      "utf8",
+    );
+
+    // Production path: no loadSdk seam, so availability uses require.resolve.
+    const label = await claudeHarness({ probeLogin: async () => false })
+      .availability({ root, env: { ANTHROPIC_API_KEY: "sk" } });
+
+    expect(label).toBe("your ANTHROPIC_API_KEY"); // resolvable → available, without importing
+  });
+
+  it("checks the credential first — with none, it never even reaches the SDK loader", async () => {
+    // The loader throws if called; credential-first means it is not called when
+    // no credential is present, so availability returns null cleanly.
+    const harness = claudeHarness({
+      loadSdk: async () => { throw new Error("availability must not load the SDK without a credential"); },
+      probeLogin: async () => false,
+    });
+    expect(await harness.availability({ root: "/x", env: {} })).toBeNull();
+  });
+});

--- a/packages/vendo/tests/cli/extract/child-env-allowlist.test.ts
+++ b/packages/vendo/tests/cli/extract/child-env-allowlist.test.ts
@@ -183,10 +183,18 @@ describe("a repo-root .npmrc cannot redirect the npx rung's registry (VEGA-INFO-
     expect(scoped).not.toContain("evil");
   });
 
-  it("respects the developer's OWN shell registry, still overriding the repo's", async () => {
+  it("ignores an ambient/shell npm_config_registry too — the child always fetches from the public default", async () => {
+    // F5 (VEGA-INFO-00078): when Vendo is itself launched via `npx`/`npm exec`
+    // from inside the scanned checkout, npm exports THAT checkout's `.npmrc`
+    // `registry` into Vendo's own process env as `npm_config_registry` — so an
+    // ambient/shell value is repo-influenced and indistinguishable from a
+    // poisoned one. The rung therefore drops all ambient trust and pins the
+    // child to the public default, whatever the shell or the repo set. (A
+    // corporate mirror configured only in ~/.npmrc is not honored on this
+    // last-resort rung — accepted; the PATH/local-install rungs still are.)
     vi.stubEnv("npm_config_registry", "https://mirror.corp.example/");
     const root = await repoWithNpmrc("registry=http://evil.example/\n");
-    expect((await effectiveRegistry(root)).registry).toBe("https://mirror.corp.example/");
+    expect((await effectiveRegistry(root)).registry).toBe("https://registry.npmjs.org/");
   });
 });
 

--- a/packages/vendo/tests/cli/extract/npx-engine-harness.test.ts
+++ b/packages/vendo/tests/cli/extract/npx-engine-harness.test.ts
@@ -253,6 +253,34 @@ describe("npxEngineHarness", () => {
         .rejects.toThrow(/ENOTFOUND/);
     });
 
+    describe("registry pinning (VEGA-INFO-00078)", () => {
+      // npm exports a project `./.npmrc`'s `registry` into THIS process's env as
+      // `npm_config_registry` when Vendo is itself launched via `npx`/`npm exec`
+      // from inside the scanned checkout — so an ambient value is repo-influenced
+      // and cannot redirect the child. Both the checkout (input.env) and the
+      // ambient (process.env) spellings, default AND scoped, must be ignored:
+      // the child always fetches from the public default.
+      it("pins the child registry to the public default, ignoring a checkout .npmrc and an ambient npm_config_registry", async () => {
+        vi.stubEnv("npm_config_registry", "https://evil.example/ambient/");
+        vi.stubEnv("npm_config_@anthropic-ai:registry", "https://evil.example/ambient-scoped/");
+        let capturedEnv: NodeJS.ProcessEnv | undefined;
+        const harness = npxEngineHarness({
+          exec: async (_args, options) => { capturedEnv = options.env; return { stdout: "ok", stderr: "", code: 0 }; },
+        });
+        await harness.run({
+          root: "/host/root",
+          env: {
+            ANTHROPIC_API_KEY: "sk",
+            npm_config_registry: "https://evil.example/checkout/",
+            "npm_config_@anthropic-ai:registry": "https://evil.example/checkout-scoped/",
+          },
+          instructions: "go",
+        });
+        expect(capturedEnv?.npm_config_registry).toBe("https://registry.npmjs.org/");
+        expect(capturedEnv?.["npm_config_@anthropic-ai:registry"]).toBe("https://registry.npmjs.org/");
+      });
+    });
+
     describe("Vendo Cloud gateway fuel", () => {
       it("does not overlay the env when ANTHROPIC_API_KEY is present (own credential wins)", async () => {
         let capturedEnv: NodeJS.ProcessEnv | undefined;

--- a/packages/vendo/tests/cli/provider-deps-hygiene.test.ts
+++ b/packages/vendo/tests/cli/provider-deps-hygiene.test.ts
@@ -1,0 +1,76 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { defaultRunner, ignoreScriptsArgs, installStderrTail, zodBumpInvocation, ZOD_FLOOR_SPEC } from "../../src/cli/provider-deps.js";
+
+const cleanup: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const dispose of cleanup.splice(0).reverse()) await dispose();
+});
+
+async function tempRoot(prefix = "vendo-provider-hygiene-"): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), prefix));
+  cleanup.push(() => rm(root, { recursive: true, force: true }));
+  return root;
+}
+
+// VEGA-INFO-00047 — Vendo's automatic dep repair shells the host package
+// manager; without --ignore-scripts a malicious repo's lifecycle scripts run
+// during `vendo init`. The repair must never execute host scripts.
+describe("ignoreScriptsArgs", () => {
+  it("passes --ignore-scripts to every manager that accepts it", () => {
+    expect(ignoreScriptsArgs("npm")).toEqual(["--ignore-scripts"]);
+    expect(ignoreScriptsArgs("pnpm")).toEqual(["--ignore-scripts"]);
+    expect(ignoreScriptsArgs("bun")).toEqual(["--ignore-scripts"]);
+  });
+
+  it("omits it for yarn — berry rejects the flag, so the runner env covers yarn", () => {
+    expect(ignoreScriptsArgs("yarn")).toEqual([]);
+  });
+});
+
+describe("defaultRunner script suppression", () => {
+  it("runs the install child with the script-ignoring env for the flag-less managers", async () => {
+    const root = await tempRoot();
+    const code = await defaultRunner(
+      "node",
+      ["-e", "process.stderr.write(`${process.env.npm_config_ignore_scripts}:${process.env.YARN_ENABLE_SCRIPTS}`, () => process.exit(1))"],
+      root,
+    );
+    expect(code).toBe(1);
+    expect(installStderrTail()).toBe("true:0");
+  });
+});
+
+// VEGA-INFO-00091 — the paste-ready install command is displayed to the user
+// (init/doctor) and its cwd carries repo-controlled path segments. An unquoted
+// command breaks (and is unsafe) for any path with a space or shell metachar.
+describe("invocationFor display quoting", () => {
+  /** A nested npm-workspace app whose lockfile root (the printed cwd) carries
+      `name`, forcing the `(cd <root> && …)` form. */
+  async function nestedNpmApp(name: string): Promise<string> {
+    const parent = await tempRoot();
+    const workspace = join(parent, name);
+    const app = join(workspace, "apps", "web");
+    await mkdir(app, { recursive: true });
+    await writeFile(join(workspace, "package-lock.json"), "{}");
+    return app;
+  }
+
+  it("POSIX-quotes a cwd containing a space so the pasted command cannot be misread", async () => {
+    const app = await nestedNpmApp("my host");
+    const command = await zodBumpInvocation(app);
+    expect(command).toMatch(/^\(cd '[^']*my host[^']*' && /);
+    expect(command).toContain("npm install --workspace apps/web");
+    // …while an ordinary caret spec stays unquoted (no over-quoting).
+    expect(command).toContain(ZOD_FLOOR_SPEC);
+    expect(command).not.toContain(`'${ZOD_FLOOR_SPEC}'`);
+  });
+
+  it("POSIX-quotes a cwd containing a shell metachar", async () => {
+    const app = await nestedNpmApp("a$(whoami)b");
+    const command = await zodBumpInvocation(app);
+    expect(command).toMatch(/\(cd '[^']*a\$\(whoami\)b[^']*' && /);
+  });
+});

--- a/packages/vendo/tests/cli/sync.test.ts
+++ b/packages/vendo/tests/cli/sync.test.ts
@@ -763,12 +763,14 @@ describe("sync judgment-pass integration", () => {
 
   it("resolves a model key that lives only in the sync dir's .env.local (#567)", async () => {
     // The ONLY credential lives in the project's .env.local, exactly the case
-    // that previously fell through to structural-only. A sentinel var name
-    // keeps the assertion deterministic no matter what real ANTHROPIC_API_KEY /
-    // VENDO_API_KEY the developer/CI machine exports (which, with process env
-    // winning, would otherwise mask the .env.local value under test).
+    // that previously fell through to structural-only. VENDO_API_KEY is on the
+    // extraction dotenv allowlist (a repo file may carry a credential); the
+    // shell value is blanked so the file value is the one under test rather than
+    // a real key the developer/CI machine exports (which, process env winning,
+    // would otherwise mask it).
+    vi.stubEnv("VENDO_API_KEY", "");
     const { dir, judgmentsPath } = await hostWithTools();
-    await writeFile(join(dir, ".env.local"), "VENDO_TEST_ONLY_MODEL_KEY=sk-only-in-dotenv\n", "utf8");
+    await writeFile(join(dir, ".env.local"), "VENDO_API_KEY=sk-only-in-dotenv\n", "utf8");
     const messages = captureOutput();
     let seenKey: string | undefined;
     const responses = [...HARDENING];
@@ -782,7 +784,7 @@ describe("sync judgment-pass integration", () => {
         harnesses: [{
           id: "npx-engine",
           availability: async ({ env }: { env: Record<string, string | undefined> }) =>
-            (typeof env.VENDO_TEST_ONLY_MODEL_KEY === "string" ? "byo (.env.local)" : null),
+            (typeof env.VENDO_API_KEY === "string" ? "byo (.env.local)" : null),
           run: async () => {
             const next = responses.shift();
             if (next === undefined) throw new Error("scripted harness exhausted");
@@ -790,8 +792,8 @@ describe("sync judgment-pass integration", () => {
           },
         }],
         resolveCredential: async ({ env }) => {
-          seenKey = env.VENDO_TEST_ONLY_MODEL_KEY;
-          return typeof env.VENDO_TEST_ONLY_MODEL_KEY === "string"
+          seenKey = env.VENDO_API_KEY;
+          return typeof env.VENDO_API_KEY === "string"
             ? { rung: "env-key", provider: "anthropic", envVar: "ANTHROPIC_API_KEY" }
             : { rung: "none" };
         },
@@ -820,11 +822,11 @@ describe("sync judgment-pass integration", () => {
         harnesses: [{
           id: "npx-engine",
           availability: async ({ env }: { env: Record<string, string | undefined> }) =>
-            (typeof env.VENDO_TEST_ONLY_MODEL_KEY === "string" ? "byo" : null),
+            (typeof env.VENDO_API_KEY === "string" ? "byo" : null),
           run: async () => { throw new Error("must not run without a key"); },
         }],
         resolveCredential: async ({ env }) =>
-          (typeof env.VENDO_TEST_ONLY_MODEL_KEY === "string"
+          (typeof env.VENDO_API_KEY === "string"
             ? { rung: "env-key", provider: "anthropic", envVar: "ANTHROPIC_API_KEY" }
             : { rung: "none" }),
       },

--- a/packages/vendo/tests/cli/sync.test.ts
+++ b/packages/vendo/tests/cli/sync.test.ts
@@ -806,9 +806,12 @@ describe("sync judgment-pass integration", () => {
   });
 
   it("no key in .env.local and none in process env stays structural-only (#567)", async () => {
-    // Sentinel var that only a .env.local could carry — kept out of process
-    // env so the "neither present" branch is deterministic regardless of the
-    // developer/CI machine's real ANTHROPIC_API_KEY / VENDO_API_KEY.
+    // VENDO_API_KEY is on the extraction dotenv allowlist, and readEnvFiles
+    // merges the shell value — so a real key the developer/CI machine exports
+    // would flip this "neither present" branch to byo. Delete it (not blank it:
+    // this harness reads presence as `typeof key === "string"`, which an empty
+    // string satisfies) so the branch under test is deterministic.
+    vi.stubEnv("VENDO_API_KEY", undefined);
     const { dir, toolsPath } = await hostWithTools();
     const before = await readFile(toolsPath, "utf8");
     const messages = captureOutput();

--- a/packages/vendo/tests/server-origin-poisoning.test.ts
+++ b/packages/vendo/tests/server-origin-poisoning.test.ts
@@ -1,0 +1,79 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { LanguageModel } from "ai";
+import type { Principal } from "@vendoai/core";
+import { createStore, type VendoStore } from "@vendoai/store";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createVendo } from "../src/server.js";
+
+const principal: Principal = { kind: "user", subject: "user_wire" };
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+async function tempStore(prefix: string): Promise<VendoStore> {
+  const dataDir = await mkdtemp(join(tmpdir(), prefix));
+  const store = createStore({ dataDir });
+  cleanups.push(async () => {
+    await store.close();
+    await rm(dataDir, { recursive: true, force: true });
+  });
+  return store;
+}
+
+/** The same request arriving from a chosen ORIGIN — i.e. carrying a chosen Host
+ *  header, which is how the poisoning attack is expressed. */
+function requestFrom(origin: string, method: string, path: string, headers: Record<string, string> = {}): Request {
+  const mutation = ["POST", "PUT", "PATCH", "DELETE"].includes(method);
+  return new Request(`${origin}/api/vendo${path}`, {
+    method,
+    headers: { ...(mutation ? { "content-type": "application/json" } : {}), ...headers },
+    ...(mutation ? { body: "{}" } : {}),
+  });
+}
+
+/**
+ * VEGA-INFO-00037 — the learned same-origin base must be taught ONLY by a
+ * request that addressed a real Vendo route. Before the fix, `onRequestOrigin`
+ * fired for any path under BASE_PATH (a 404 included, first-origin-wins), so an
+ * unauthenticated attacker who raced a 404 to a cold-started deployment latched
+ * their spoofed Host as the base for every later credential-forwarding call.
+ * This is the server-side twin of the present-mode SECURITY pins in
+ * server.test.ts.
+ */
+describe("VEGA-INFO-00037: a 404 must not poison the learned base", () => {
+  it("SECURITY: a 404 under BASE_PATH never becomes the learned base, so a later real request from loopback still forwards present credentials", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("VENDO_BASE_URL", "");
+    const store = await tempStore("vendo-404-poison-");
+    const vendo = createVendo({ models: { default: {} as LanguageModel }, principal: async () => principal, store });
+    // The stubbed fetch loops the doctor's present-echo route back through the
+    // same handler, so it observes exactly what the base resolved to.
+    vi.stubGlobal("fetch", vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const target = input instanceof Request ? input : new Request(input, init);
+      return vendo.handler(target);
+    }));
+
+    // The attacker's 404 arrives FIRST — this is the whole attack. A 404 must
+    // teach the learner NOTHING.
+    expect((await vendo.handler(requestFrom("https://attacker.evil", "GET", "/nope-not-a-route"))).status).toBe(404);
+    // Only now does a real route from loopback get to teach the base.
+    expect((await vendo.handler(requestFrom("http://localhost:3000", "GET", "/status"))).status).toBe(200);
+
+    // Loopback is the trusted dev base, so the present-mode probe forwards the
+    // caller's credentials to the deployment's own echo route. Before the fix
+    // the attacker's 404 had already fixed an UNTRUSTED base, so the probe would
+    // have withheld and this would not be { ok: true }.
+    const probe = await vendo.handler(requestFrom("http://localhost:3000", "POST", "/doctor/present", {
+      authorization: "Bearer vendo-doctor-present",
+      cookie: "vendo_doctor_present=1",
+    }));
+    expect(await probe.json()).toEqual({ ok: true });
+  });
+});

--- a/packages/vendo/tests/server.test.ts
+++ b/packages/vendo/tests/server.test.ts
@@ -1375,6 +1375,42 @@ describe("09 §2 composition", () => {
     expect(await probe.json()).toEqual({ ok: true });
   });
 
+  /**
+   * The METHOD-SPECIFIC variant of the same attack, and why "method !== '*'" was
+   * never a safe proxy for "cannot fall through". The router contract is
+   * `Promise<Response | undefined>` for EVERY entry (agents/http/router.ts), so a
+   * method-specific route can match, run its side effects, then return undefined
+   * to fall through to a 404. `POST /automations/:id/:op` does exactly that for an
+   * op it does not serve (wire/automations.ts). Learning the base at entry for
+   * every non-"*" route let this route-shaped 404 with a spoofed Host freeze it,
+   * reopening VEGA-INFO-00037. The learner now fires only for a TERMINAL match
+   * (a non-undefined Response), whatever the method.
+   */
+  it("SECURITY: a method-specific route that falls through (unknown op) never becomes the learned base", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("VENDO_BASE_URL", "");
+    const { vendo } = await setup();
+    vi.stubGlobal("fetch", vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const target = input instanceof Request ? input : new Request(input, init);
+      return vendo.handler(target);
+    }));
+
+    // The attacker's Host arrives FIRST, on the method-specific
+    // `POST /automations/:id/:op` route with an op it does not serve — the
+    // handler resolves context, then returns undefined and falls through to 404.
+    const notFound = await vendo.handler(requestFrom("https://attacker.evil", "POST", "/automations/aut_x/bogus", {}));
+    expect(notFound.status).toBe(404);
+
+    // A real loopback request can therefore still become the learned, TRUSTED
+    // base — the method-specific fall-through 404 did not poison it — so the
+    // present probe's credentials round-trip to it.
+    const probe = await vendo.handler(requestFrom("http://localhost:3000", "POST", "/doctor/present", {}, {
+      authorization: "Bearer vendo-doctor-present",
+      cookie: "vendo_doctor_present=1",
+    }));
+    expect(await probe.json()).toEqual({ ok: true });
+  });
+
   it("09-vendo §2 install-dx wave 1.1: logs one loud console.error at composition when NODE_ENV=production and VENDO_BASE_URL is unset", async () => {
     vi.stubEnv("NODE_ENV", "production");
     vi.stubEnv("VENDO_BASE_URL", "");

--- a/packages/vendo/tests/server.test.ts
+++ b/packages/vendo/tests/server.test.ts
@@ -1340,6 +1340,41 @@ describe("09 §2 composition", () => {
     expect(await probe.json()).toEqual({ ok: true });
   });
 
+  /**
+   * The FALL-THROUGH variant of the poisoning attack. A grouped ("*") route
+   * matches a path then dispatches by method inside — `/threads/:id` serves GET
+   * and DELETE and falls through to a 404 for anything else. Learning the base
+   * at handler ENTRY (once the PATH matched) let an attacker freeze it from a
+   * route-shaped 404 that never reached a real route, partially reopening
+   * VEGA-INFO-00037. The learner now fires only for a TERMINAL match, so the
+   * fall-through never teaches the base and a real loopback request still can.
+   */
+  it("SECURITY: a route-shaped 404 (grouped route, unhandled method) never becomes the learned base", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("VENDO_BASE_URL", "");
+    const { vendo } = await setup();
+    vi.stubGlobal("fetch", vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const target = input instanceof Request ? input : new Request(input, init);
+      return vendo.handler(target);
+    }));
+
+    // The attacker's Host arrives FIRST, on a path that MATCHES the grouped
+    // /threads/:id route but with a method it does not serve — so the handler
+    // falls through to a 404. Before the fix, matching the pattern already froze
+    // the base to attacker.evil.
+    const notFound = await vendo.handler(requestFrom("https://attacker.evil", "PUT", "/threads/thr_x", {}));
+    expect(notFound.status).toBe(404);
+
+    // A real loopback request can therefore still become the learned, TRUSTED
+    // base — the fall-through 404 did not poison it — so the present probe's
+    // credentials round-trip to it.
+    const probe = await vendo.handler(requestFrom("http://localhost:3000", "POST", "/doctor/present", {}, {
+      authorization: "Bearer vendo-doctor-present",
+      cookie: "vendo_doctor_present=1",
+    }));
+    expect(await probe.json()).toEqual({ ok: true });
+  });
+
   it("09-vendo §2 install-dx wave 1.1: logs one loud console.error at composition when NODE_ENV=production and VENDO_BASE_URL is unset", async () => {
     vi.stubEnv("NODE_ENV", "production");
     vi.stubEnv("VENDO_BASE_URL", "");


### PR DESCRIPTION
## Security fixes — verified critical findings from the NebuSec Vega scan

Fixes the findings from the Vega scan (`scan_LS7yYA2FRC8YVsmN`) that verification against current source confirmed are **real and current**. Of the 18 the scanner flagged "critical", 6 were already fixed by prior PRs (#1623, #1605, #1647, config rewrite), and several were overstated; this PR addresses the 4 genuine criticals plus 2 cheap hardening items.

### Criticals
- **Chat credential redaction** (VEGA-INFO-00021) — the in-box coding agent held a reusable deployment key and streamed output straight to end users. A single redactor at the stream-writer chokepoint (`harnesses/src/runtime.ts`) now scrubs the credential value from all user-facing text and tool output. *Defense-in-depth; the complete fix (short-lived/brokered keys) is tracked as follow-up console work.*
- **Extraction env allowlist** (VEGA-INFO-00078, 00028, 00192, 00077) — a scanned repo's `.env`/`.npmrc` could inject code (`NODE_OPTIONS`) or hijack the package registry into the extraction child processes, and redirect the Cloud key. Fixed at the provenance boundary (`vendo/src/cli/sync-flow.ts`): the file-sourced env is now an **allowlist** (not a denylist). The npx rung additionally pins the registry so a project `.npmrc` can't redirect fetches.
- **SDK probe no longer executes host code** (VEGA-INFO-00039) — `availability()` now resolves the SDK with `require.resolve` (no import) and checks the credential first.
- **actAs fails closed on untrusted origin** (VEGA-INFO-00037) — an unauthenticated request could poison the learned base URL and receive `actAs`-minted host credentials. The actAs branches now reuse the exact trust check `presentHeaders` already enforces, and origin learning fires only after a real route matches (a 404 can't poison it).

### Cheap hardening
- **Ignore repo lifecycle scripts during auto-repair** (VEGA-INFO-00047) — Vendo's automatic dependency installs now pass `--ignore-scripts` (npm/pnpm/bun) / equivalent env (yarn), so a repo's install scripts don't run.
- **Quote displayed install commands** (VEGA-INFO-00091) — POSIX-quote the shown command (correctness + hygiene).

### Deliberately not changed
- TypeScript-compiler resolution (VEGA-INFO-00029/00033) — low severity, matches every devtool (VS Code/Jest/Vite); inverting it would risk mis-parsing host code written for a newer compiler. Left as-is by decision.
- Federation JWT replay (VEGA-INFO-00068) — the meaningful fix is console-side (transaction/browser binding), out of this repo.

### Testing
Every fix ships with a failing-first test proven to fail without the fix (prove-it-can-fail). Local build/typecheck/lint green; `test:affected` green after clearing two **laptop-only** environmental artifacts (stray `/tmp` lockfiles; a macOS `/private/var` symlink quirk in an untouched `actions/sync` test) — both CI-clean on Linux.
