### PR TITLE
fix(actions): a wiring file's imports survive a root reached through a symlink

### DIFF
--- a/.changeset/wiring-imports-survive-a-symlinked-root.md
+++ b/.changeset/wiring-imports-survive-a-symlinked-root.md
@@ -1,0 +1,17 @@
+---
+"@vendoai/actions": patch
+---
+
+The generated wiring file imports the host's own modules even when the project
+root is reached through a symlink.
+
+`remix-wiring.ts` binds each ported slot by importing the host's functions and
+components relative to itself, and the two ends of that relative path were
+measured in different spaces: `resolveImportSource` realpaths every module it
+returns, while the generated directory came straight off the root as given. A
+root behind a symlink — a macOS temp directory, a linked checkout — made the two
+disagree, and the emitted import climbed out of the project into an absolute
+machine path (`../../../../../../../../private/var/folders/…/src/lib/api-client`)
+baked into a file the host commits. The generated directory is realpathed before
+the split measures against it, so both ends count the same tree and the import
+comes out as `../../src/lib/api-client` on every machine.

--- a/packages/actions/src/sync/seeds.ts
+++ b/packages/actions/src/sync/seeds.ts
@@ -523,6 +523,7 @@ interface CaptureContext {
   realRoot: string;
   extraRoots: readonly string[];
   remixableDir: string;
+  /** Realpathed — the split measures the wiring file's imports against it. */
   generatedDir: string;
   budgetBytes?: number;
   samplePropsFor?: (file: string, slot: string) => Record<string, Json> | undefined;
@@ -707,6 +708,12 @@ export async function capturePins(
   const files = [...new Set(walked)].sort();
   const remixableDir = path.join(out, "remixable");
   const generatedDir = path.join(out, "generated");
+  // The wiring file's imports are relative paths, so both ends have to be
+  // measured in the SAME space: resolveImportSource realpaths every module it
+  // returns, and a project root reached through a symlink (a macOS temp dir, a
+  // linked checkout) would otherwise emit an import that climbs out of the
+  // project and bakes an absolute machine path into a file the host commits.
+  const realGeneratedDir = path.join(realRoot, path.relative(root, generatedDir));
   const wiring: WiringSlot[] = [];
   const homes = new Map<string, string>();
 
@@ -715,7 +722,7 @@ export async function capturePins(
   const bySlot = await collectResolvedSites(root, realRoot, extra.real, files, result);
 
   const captureCtx: CaptureContext = {
-    root, realRoot, extraRoots: extra.real, remixableDir, generatedDir, budgetBytes, samplePropsFor, ignoreSlots, wiring, homes, result,
+    root, realRoot, extraRoots: extra.real, remixableDir, generatedDir: realGeneratedDir, budgetBytes, samplePropsFor, ignoreSlots, wiring, homes, result,
   };
   for (const [slot, sites] of [...bySlot.entries()].sort(([left], [right]) => left.localeCompare(right))) {
     await captureSlot(slot, sites, captureCtx);

--- a/packages/actions/src/sync/split/index.ts
+++ b/packages/actions/src/sync/split/index.ts
@@ -30,7 +30,9 @@ export interface SplitInput {
   /** Its real path, for resolving the imports it writes. */
   file: string;
   root: string;
-  /** Where the wiring file will sit — the paths it imports are relative to it. */
+  /** Where the wiring file will sit, REALPATHED — the paths it imports are
+   *  relative to it, and every module they point at is realpathed too, so a
+   *  root behind a symlink must not measure the two ends in different spaces. */
   generatedDir: string;
   /** The host's own declared sample props for this component, when a
    *  registration carries them — what the gauntlet paints a props-dependent


### PR DESCRIPTION
## What

`vendo sync` measured the generated wiring file's relative imports against a
realpathed target and a non-realpathed source directory. The generated
directory is now realpathed before the splitter measures against it, so both
ends of every import count the same tree.

## Why

`.vendo/generated/remix-wiring.ts` binds each ported slot by importing the
host's own functions and components relative to itself. `resolveImportSource`
realpaths every module it returns (`common.ts:165`), while `generatedDir` came
straight off the root as given (`seeds.ts:709`) — two different spaces on the
two ends of one `path.relative`.

A project root reached through a symlink made them disagree, and the emitted
import climbed out of the project entirely:

```ts
// wanted
import { api } from "../../src/lib/api-client";
// emitted
import { api } from "../../../../../../../../private/var/folders/mb/8gs…/T/vendo-split-B6UKQI/src/lib/api-client";
```

That is an absolute, machine-specific path baked into a file the host commits
and every teammate builds from.

Latent since #1479 shipped the splitter — the defect and the assertions that
catch it landed in the same commit. It is invisible to CI, whose Linux `/tmp`
is a real directory, and unmissable on macOS, where `os.tmpdir()` is
`/var/folders/…` behind the `/var` → `/private/var` symlink. So
`packages/actions/tests/sync/split.test.ts` has been red 2-of-15 on every macOS
checkout of `main` since that day while `ci` stayed green.

The tests were right the whole time. No test changed.

## Verification

Run on `origin/main` before the fix and after, same worktree, same seed:

- before — `2 failed | 13 passed (15)`
- after — `15 passed (15)`
- control — the pre-fix tree passes 15/15 under a non-symlinked `TMPDIR`,
  confirming the symlink is the whole mechanism

Gate (scoped to the touched packages):

- [x] `@vendoai/actions` full package suite — `687 passed | 4 skipped (691)`
- [x] `turbo run build typecheck --filter=@vendoai/actions...` green
- [x] `node scripts/dependency-guard.mjs` — OK (31 packages checked)
- [x] `node scripts/portability-gate.mjs` — all legs green
- [x] `eslint --config eslint.blocking.config.mjs` on both touched files clean
- [x] Screenshots attached (if UI-affecting) — n/a, no UI surface

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the wiring file's imports when the project root sits behind a symlink — a macOS temp directory or a linked checkout. Previously the splitter measured the generated directory against a realpathed source tree, and a symlinked root made the emitted import climb out of the project into an absolute, machine-specific path. The generated directory is now realpathed before the split, so both ends of every import count the same tree and the emitted path stays relative.

**Bug Fixes**
- Realpaths the generated directory before measuring relative imports against it.
- Adds a changeset marking the fix as a patch to `@vendoai/actions`.

<sup>Written for commit 6bf81cd860b1ff6361042e255f180e86ae0347cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

