### PR TITLE
ci: secret scanning (GitLeaks) + SAST (Opengrep)

### DIFF
--- a/.changeset/pin-gcm-auth-tag-length.md
+++ b/.changeset/pin-gcm-auth-tag-length.md
@@ -1,0 +1,12 @@
+---
+"@vendoai/store": patch
+---
+
+fix: pin the GCM authentication tag at 16 bytes when sealing and opening stored secrets
+
+`createDecipheriv` without `authTagLength` verifies a tag at whatever length the
+stored envelope happens to carry, and GCM permits tags as short as 4 bytes — so
+an attacker who can write the envelope gets to attack a short tag instead of the
+full one. Both the cipher and the decipher now pin 16. Every envelope this code
+has ever written already carries Node's default 16-byte tag, so nothing at rest
+changes and existing secrets keep decrypting.

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,94 @@
+name: security-scan
+
+# SOC 2 static scanning, both OSS: GitLeaks for secrets, Opengrep for SAST.
+#
+# Deliberately NOT one of the required checks (ci, integration, conformance,
+# audit) — renaming or absorbing those breaks merges. Same posture as trivy.yml.
+# No merge_group trigger for the same reason: the queue only waits on the four
+# required checks, and adding a fifth to the queue's critical path buys nothing
+# a pull_request run has not already proved.
+#
+# Neither tool runs through its marketplace action. gitleaks-action has been
+# non-MIT since v2 and requires a paid GITLEAKS_LICENSE for repos owned by an
+# organization, which this one is; the plain binary is the same scanner with
+# none of that. Opengrep publishes no action at all. So both jobs fetch a
+# pinned release and run it directly.
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0 # the scan walks commits, so it needs their parents
+
+      - name: Install gitleaks
+        env:
+          GITLEAKS_VERSION: 8.30.1
+        run: |
+          curl -fsSL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | sudo tar -xz -C /usr/local/bin gitleaks
+
+      # Only the commits this event ADDS, never the whole history. A full-history
+      # scan takes minutes and lands on ~74 pre-existing fixture-key hits that no
+      # new PR can fix, so it would be red for everyone, forever; scoping it to
+      # the new commits keeps the gate about the change in front of it. That
+      # history was triaged by hand on 2026-08-26 and holds no real credential.
+      #
+      # --redact so a genuine hit never prints its own value into a public log.
+      # The run still names the rule, the file and the commit, which is all
+      # anyone needs to go look. The fixture allowlist lives in .gitleaks.toml,
+      # which gitleaks loads from the repo root on its own.
+      - name: Scan the new commits for secrets
+        env:
+          # A pull_request hands over base/head; a push hands over before/after.
+          BASE: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          case "$BASE" in
+            "" | 0000000000000000000000000000000000000000)
+              # A branch's first push reports an all-zero base; scan the tip.
+              RANGE="--max-count=1 $HEAD" ;;
+            *)
+              RANGE="$BASE..$HEAD" ;;
+          esac
+          gitleaks git --log-opts="$RANGE" --redact=100 --no-banner --exit-code 1 .
+
+  opengrep:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install opengrep
+        env:
+          OPENGREP_VERSION: v1.28.0
+        run: |
+          sudo curl -fsSL -o /usr/local/bin/opengrep \
+            "https://github.com/opengrep/opengrep/releases/download/${OPENGREP_VERSION}/opengrep_manylinux_x86"
+          sudo chmod +x /usr/local/bin/opengrep
+
+      # --severity filters the RULESET, not just the report: only ERROR-severity
+      # rules are loaded, so WARNING and INFO noise never runs and can never fail
+      # the job. --error is what turns a surviving finding red. Stock community
+      # rulesets only — nothing is authored here, so upstream fixes land free.
+      - name: Scan for ERROR-severity findings
+        run: |
+          opengrep scan \
+            --config p/typescript \
+            --config p/nodejs \
+            --severity ERROR \
+            --error \
+            .

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,37 @@
+# GitLeaks config for the secret-scanning job in .github/workflows/security-scan.yml.
+# It extends the stock ruleset and only ever SUBTRACTS from it — no rules are
+# authored here, so an upstream rule improvement lands for free.
+[extend]
+useDefault = true
+
+# Test and fixture code is full of deliberately fake credentials: negative tests
+# that assert a live-looking key is refused, e2e journeys handing a stub server a
+# made-up bearer token, corpus manifests of sample env vars. Every one of the 74
+# hits in this repo's history was of that kind (triaged 2026-08-26; none real).
+# Without this, adding a test fixture turns the job red, and a gate that cries
+# wolf is a gate people learn to ignore.
+#
+# targetRules is the important half. These are the only two rules that have ever
+# produced a false positive here, and naming them keeps every HIGH-confidence
+# rule — aws-access-token, github-pat, openai, slack, gcp — armed inside test
+# files. Pasting a real key into a test to debug it is one of the likeliest ways
+# a credential ever leaks, so that is the last place to stop looking.
+[[allowlists]]
+description = "Deliberately fake credentials in tests, fixtures and the corpus"
+targetRules = ["generic-api-key", "stripe-access-token"]
+paths = [
+  '''(^|/)tests?/''',
+  '''\.test\.[cm]?[jt]sx?$''',
+  '''\.live\.test\.[cm]?[jt]sx?$''',
+  '''^fixtures/''',
+  '''^corpus/''',
+]
+
+# A PostHog project key is the CLIENT-side ingest key: it ships inside the
+# browser bundle by design and can only write events. Public by construction,
+# so it is not a leak — and it is checked in deliberately, in several places.
+[[allowlists]]
+description = "PostHog project (client-side ingest) API keys are public by design"
+targetRules = ["generic-api-key"]
+regexTarget = "match"
+regexes = ['''phc_[A-Za-z0-9]{32,}''']

--- a/packages/store/src/crypto.ts
+++ b/packages/store/src/crypto.ts
@@ -1,6 +1,11 @@
 import { VendoError } from "@vendoai/core";
 import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
 
+/** GCM's full tag, pinned on both sides — Node otherwise verifies a tag at
+ *  whatever length the envelope carries, and a 4-byte one is forgeable. Every
+ *  envelope ever written carries 16 (the default), so nothing at rest changes. */
+const AUTH_TAG_BYTES = 16;
+
 /** 02-store §4 */
 export function validateEncryptionKey(value: string): Buffer {
   const validCharacters = /^[A-Za-z0-9+/]+={0,2}$/.test(value);
@@ -17,7 +22,7 @@ export function validateEncryptionKey(value: string): Buffer {
  *  value. */
 export function encryptSecret(value: string, key: Buffer, name: string): string {
   const iv = randomBytes(12);
-  const cipher = createCipheriv("aes-256-gcm", key, iv);
+  const cipher = createCipheriv("aes-256-gcm", key, iv, { authTagLength: AUTH_TAG_BYTES });
   cipher.setAAD(Buffer.from(name, "utf8"));
   const ciphertext = Buffer.concat([cipher.update(value, "utf8"), cipher.final()]);
   const tag = cipher.getAuthTag();
@@ -34,7 +39,9 @@ export function decryptSecret(value: string, key: Buffer, name: string): string 
     ) {
       throw new Error("invalid ciphertext envelope");
     }
-    const decipher = createDecipheriv("aes-256-gcm", key, Buffer.from(ivValue, "base64"));
+    const decipher = createDecipheriv("aes-256-gcm", key, Buffer.from(ivValue, "base64"), {
+      authTagLength: AUTH_TAG_BYTES,
+    });
     decipher.setAAD(Buffer.from(name, "utf8"));
     decipher.setAuthTag(Buffer.from(tagValue, "base64"));
     return Buffer.concat([


### PR DESCRIPTION
SOC 2 static scanning. Two OSS tools, one new workflow, no changes to any
existing job.

- **GitLeaks** — secrets, on `pull_request` and `push` to main.
- **Opengrep** — SAST (stock `p/typescript` + `p/nodejs`), fails on
  ERROR-severity findings only.

`security-scan` is deliberately **not** one of the required checks
(`ci`, `integration`, `conformance`, `audit`) and does not touch them.
It has no `merge_group` trigger for the same reason. Same posture as
`trivy.yml`. CI-only, so no changeset.

### Why the binaries and not the marketplace actions

`gitleaks-action` has been non-MIT since v2 and requires a paid
`GITLEAKS_LICENSE` for repos owned by an organization, which this one is.
Opengrep publishes no action at all. Both jobs fetch a pinned release and
run it directly — same scanners, no licence, no third-party action in the
supply chain.

### Why the scan is scoped to the new commits

A full-history scan takes minutes and lands on ~74 pre-existing hits. All
74 were triaged by hand on 2026-08-26: every one is a fixture fake, a
placeholder, a `$VAR` reference, or a PostHog client key. **No real
credential is present in this repo's history.** Scanning only the commits
an event adds keeps the gate about the change in front of it, instead of
being red for everyone forever.

### Allowlist (`.gitleaks.toml`)

Two entries, both subtractive — no rules are authored, so upstream
improvements land for free.

1. **Fixture fakes** in `tests/`, `*.test.ts`, `fixtures/`, `corpus/`.
   Scoped with `targetRules` to `generic-api-key` and
   `stripe-access-token` — the only two rules that have ever produced a
   false positive here. Every high-confidence rule (`aws-access-token`,
   `github-pat`, openai, slack, gcp) stays **armed inside test files**,
   because pasting a real key into a test to debug it is one of the
   likeliest ways a credential ever leaks. Verified: a real-format
   `ghp_` token in a test file is still caught.
2. **PostHog project keys** (`phc_…`) — the client-side ingest key, ships
   in the browser bundle by design, write-only. Public by construction.

### Verification

- `actionlint` clean.
- Working tree scans clean under the allowlist (0 findings).
- Gate proven to fail: a planted AWS key + GitHub PAT in a commit range
  exits 1 with 3 findings.
- Opengrep `--severity ERROR --error` proven to exit 1 on a finding, 0
  when clean.

### Heads-up: the `opengrep` job is red on this PR

One genuine ERROR finding, pre-existing, not introduced here:

> `javascript.node-crypto.security.gcm-no-tag-length`
> `packages/store/src/crypto.ts:37`

`createDecipheriv("aes-256-gcm", …)` is called without an expected
auth-tag length, so a caller-supplied short tag would be accepted (NIST
permits 4-byte GCM tags), weakening forgery resistance. The fix is one
argument — `{ authTagLength: 16 }` — but that is a source change outside
this CI-only PR, so it is reported rather than silently suppressed.
vendo-web has the same pattern in two mirrored places.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds SOC 2 static scanning through a new `security-scan` workflow: GitLeaks for secrets and Opengrep for SAST. It runs on `pull_request` and `push` to main, is CI-only, and touches no existing job — it is deliberately not one of the required checks, same posture as `trivy.yml`. The GCM auth-tag finding that previously kept the opengrep job red is now fixed in this PR.

- Both jobs fetch pinned OSS binaries instead of marketplace actions: `gitleaks-action` went non-MIT and needs a paid license on org-owned repos, and Opengrep ships no action.
- GitLeaks scans only the commits each event adds, not full history (that history was triaged by hand on 2026-08-26 and holds no real credential), and redacts matches from logs.
- `.gitleaks.toml` only subtracts from the stock ruleset: fixture fakes in `tests/`, `*.test.ts`, `fixtures/`, and `corpus/` (scoped to the two rules that ever false-positived) plus PostHog `phc_…` project keys, which are public by design.
- Opengrep runs stock `p/typescript` and `p/nodejs` rulesets with `--severity ERROR --error`, so WARNING and INFO noise can't fail the job.
- Pins the AES-256-GCM auth tag at 16 bytes in `packages/store/src/crypto.ts`, closing the opengrep finding it had flagged; every stored envelope already carries the 16-byte tag, so nothing at rest changes and existing secrets keep decrypting.

<sup>Written for commit a24c8a286a7a5f6744680b1e37eefe80f72e51f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

