### PR TITLE
feat(telemetry): send operational events to PostHog Logs, not analytics

### DIFF
--- a/.changeset/telemetry-operational-events-to-logs.md
+++ b/.changeset/telemetry-operational-events-to-logs.md
@@ -1,0 +1,5 @@
+---
+"@vendoai/telemetry": minor
+---
+
+Send the operational events — `doctor_run`, `command_run`, `agent_run` — to PostHog's Logs product instead of the product-analytics stream, so a record of "this ran" lands in a store with enforced 30-day retention rather than being kept indefinitely. Same project key, same allowlist, same scrubbing, same opt-outs, same `VENDO_POSTHOG_HOST` override; only the destination and the retention change, and no event is sent to both. `init_started`, `init_completed`, `init_failed`, `star_prompt` and `error_class` are unchanged.

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -85,7 +85,16 @@ Set `"optedOut": false` in `~/.vendo/telemetry.json` to clear the local opt-out 
 
 ## Where Data Goes
 
-Product events are sent to PostHog US Cloud using a write-only project key. Set `VENDO_POSTHOG_HOST` to send them to your own PostHog instead (`VENDO_POSTHOG_KEY` sets the project key); the path is always `/capture/`.
+Events are sent to PostHog US Cloud using a write-only project key. Set `VENDO_POSTHOG_HOST` to send them to your own PostHog instead (`VENDO_POSTHOG_KEY` sets the project key).
+
+There are two destinations, chosen by event, and nothing is ever sent to both:
+
+| Destination | Events | Path | Retention |
+| --- | --- | --- | --- |
+| Product analytics | `init_started`, `init_completed`, `init_failed`, `star_prompt`, `error_class` | `/capture/` | Kept |
+| Logs | `doctor_run`, `command_run`, `agent_run` | `/i/v1/logs` | 30 days, enforced |
+
+`doctor_run`, `command_run`, and `agent_run` are operational records — "this ran, here is how it went" — not funnel steps, so they go to PostHog's Logs product, which enforces a 30-day retention window. They are sent as OTLP/JSON with `service.name` `vendo-sdk`; the event name rides as both the log record's `eventName` and an `event` attribute, the anonymous id as a `distinct_id` attribute, and each allowlisted property as an attribute of the same name. The allowlist, the scrubbing, and every opt-out below apply identically on both paths — moving an event changes only where it is stored and for how long.
 
 Network calls are fire-and-forget, use a short timeout, and failures are swallowed so telemetry cannot break builds or dev servers. The capture socket is unref'd the moment it exists, so a telemetry POST can never keep the CLI running after a command finishes — on a captive-portal network that accepts the connection and never answers, `vendo init` still exits as soon as it prints its summary.
 

--- a/fixtures/integration/tests/telemetry-wire.e2e.test.ts
+++ b/fixtures/integration/tests/telemetry-wire.e2e.test.ts
@@ -26,8 +26,33 @@ import { createStack, readSse, resetFixture, textTurn, ADA, type Stack } from ".
 interface Capture {
   event: string;
   properties: Record<string, unknown>;
-  api_key: string;
-  distinct_id?: string;
+}
+
+/** One sent body, whichever lane it took. Product analytics arrive as a
+ * capture envelope; the operational events in LOG_EVENTS arrive as OTLP log
+ * records, where every attribute value is a string (that is also how PostHog
+ * stores them, so these assertions read the wire as the Logs explorer will).
+ * Decoding both here keeps the contract below stated once: the allowlist,
+ * the lane markers and the scrubbing are destination-independent. */
+function decode(body: string): Capture {
+  const parsed = JSON.parse(body) as Record<string, unknown>;
+  if (parsed.resourceLogs === undefined) {
+    return { event: parsed.event as string, properties: parsed.properties as Record<string, unknown> };
+  }
+  const record = (parsed as never as {
+    resourceLogs: { scopeLogs: { logRecords: {
+      eventName: string;
+      attributes: { key: string; value: { stringValue: string } }[];
+    }[] }[] }[];
+  }).resourceLogs[0]!.scopeLogs[0]!.logRecords[0]!;
+  const properties: Record<string, unknown> = {};
+  for (const attribute of record.attributes) {
+    // `event` and `distinct_id` are the log record's own identity fields, not
+    // event properties — they are the OTLP spelling of the capture envelope.
+    if (attribute.key === "event" || attribute.key === "distinct_id") continue;
+    properties[attribute.key] = attribute.value.stringValue;
+  }
+  return { event: record.eventName, properties };
 }
 
 /** Stand a real capture endpoint up on loopback and point the client at it
@@ -35,14 +60,20 @@ interface Capture {
  * client posts over a raw socket it can unref (so a stranded telemetry POST
  * can never hold a process open), which a `globalThis.fetch` shim would never
  * see. Every other request — the wire, the host app, host tools — is untouched. */
-async function captureTelemetry(): Promise<{ captures: Capture[]; restore: () => Promise<void> }> {
+async function captureTelemetry(): Promise<{
+  captures: Capture[];
+  paths: string[];
+  restore: () => Promise<void>;
+}> {
   const captures: Capture[] = [];
+  const paths: string[] = [];
   const server = createServer((request, response) => {
     const chunks: Buffer[] = [];
     request.on("data", (chunk: Buffer) => chunks.push(chunk));
     request.on("end", () => {
       try {
-        captures.push(JSON.parse(Buffer.concat(chunks).toString("utf8")) as Capture);
+        captures.push(decode(Buffer.concat(chunks).toString("utf8")));
+        paths.push(request.url ?? "");
       } catch {
         // A malformed body would itself be a telemetry regression; record nothing.
       }
@@ -56,6 +87,7 @@ async function captureTelemetry(): Promise<{ captures: Capture[]; restore: () =>
   process.env.VENDO_POSTHOG_HOST = `http://127.0.0.1:${address.port}`;
   return {
     captures,
+    paths,
     restore: () => new Promise<void>((resolve) => server.close(() => resolve())),
   };
 }
@@ -133,8 +165,12 @@ describe("J11: telemetry emits only allowlisted events, and nothing when opted o
         expect(allowed.has(key), `prop ${key} on ${capture.event}`).toBe(true);
       }
     }
-    // The wire turn's event is agent_run (the only runtime emitter).
+    // The wire turn's event is agent_run (the only runtime emitter)...
     expect(telemetry.captures.some((capture) => capture.event === "agent_run")).toBe(true);
+    // ...and it is operational, so it went to Logs (30-day retention) rather
+    // than the analytics stream. Asserting the PATH is the point: this is the
+    // only place the real composed client's destination is observable.
+    expect(telemetry.paths.every((path) => path.startsWith("/i/v1/logs"))).toBe(true);
   });
 
   it("(opt-out) the identical turn under VENDO_TELEMETRY_DISABLED emits nothing", async () => {
@@ -196,7 +232,7 @@ describe("J11b: anonymous and cloud lanes through the real client", () => {
     await telemetry.track("agent_run", { projectName: "smuggled-host-app" });
 
     expect(bodies.length).toBe(1);
-    const capture = JSON.parse(bodies[0]!) as Capture;
+    const capture = decode(bodies[0]!);
     expect(capture.event).toBe("agent_run");
     // This repo has a project identity, so the salted hash is present: 64 hex.
     expect(capture.properties.projectIdHash).toMatch(/^[0-9a-f]{64}$/);
@@ -222,10 +258,11 @@ describe("J11b: anonymous and cloud lanes through the real client", () => {
     expect(bodies.length).toBe(1);
     // The raw key appears NOWHERE in the serialized body — only its hash does.
     expect(bodies[0]).not.toContain(FAKE_CLOUD_KEY);
-    const capture = JSON.parse(bodies[0]!) as Capture;
+    const capture = decode(bodies[0]!);
     expect(capture.event).toBe("command_run");
     expect(capture.properties.command).toBe("extract");
-    expect(capture.properties.cloud).toBe(true);
+    // command_run rides the logs lane, where OTLP renders every value a string.
+    expect(capture.properties.cloud).toBe("true");
     expect(capture.properties.cloudKeyHash).toBe(
       createHash("sha256").update(FAKE_CLOUD_KEY).digest("hex"),
     );

--- a/packages/vendo-telemetry/src/client.ts
+++ b/packages/vendo-telemetry/src/client.ts
@@ -3,11 +3,12 @@ import { request as httpRequest, type ClientRequest } from "node:http";
 import { request as httpsRequest } from "node:https";
 import { resolveConsent, truthy } from "./consent.js";
 import { baseProps, projectProps, type ProjectProps } from "./base-props.js";
-import { CLOUD_PROP_KEYS, EVENT_ALLOWLIST, type EventName } from "./events.js";
+import { CLOUD_PROP_KEYS, EVENT_ALLOWLIST, LOG_EVENTS, type EventName } from "./events.js";
 import { scrubErrorDetail } from "./scrub.js";
 import type { TelemetryConfig } from "./config.js";
 
 const POSTHOG_ENDPOINT = "https://us.i.posthog.com/capture/";
+const POSTHOG_LOGS_PATH = "/i/v1/logs";
 const TIMEOUT_MS = 1500;
 
 /**
@@ -174,6 +175,59 @@ function captureEndpoint(env: Record<string, string | undefined>): string {
   }
 }
 
+/** Where LOG_EVENTS go: PostHog's Logs product, which speaks OTLP over HTTP
+ *  and keeps records for a bounded 30 days rather than forever. Same project
+ *  key, same VENDO_POSTHOG_HOST override. The key rides as `?token=` — the
+ *  endpoint's documented alternative to a bearer header — so both transports
+ *  above stay header-free. */
+function logsEndpoint(env: Record<string, string | undefined>, key: string): string {
+  const host = env.VENDO_POSTHOG_HOST?.trim();
+  let url: URL;
+  try {
+    url = new URL(POSTHOG_LOGS_PATH, host || POSTHOG_ENDPOINT);
+  } catch {
+    url = new URL(POSTHOG_LOGS_PATH, POSTHOG_ENDPOINT);
+  }
+  url.searchParams.set("token", key);
+  return url.toString();
+}
+
+/**
+ * OTLP/JSON, the only shape the Logs endpoint accepts. Every attribute is a
+ * string — PostHog stores them that way whatever the OTLP type says — and the
+ * event name rides as `eventName` AND an `event` attribute, so a query written
+ * against the explorer's facets and one written against the body both find it.
+ * The anonymous id becomes `distinct_id` so per-install grouping survives the
+ * move exactly as it worked on the capture lane.
+ */
+function logBody(event: EventName, distinctId: string, properties: Record<string, unknown>): string {
+  const nanos = `${Date.now()}000000`;
+  const attribute = (key: string, value: string): unknown => ({ key, value: { stringValue: value } });
+  return JSON.stringify({
+    resourceLogs: [{
+      resource: { attributes: [attribute("service.name", "vendo-sdk")] },
+      scopeLogs: [{
+        scope: { name: "vendo-telemetry" },
+        logRecords: [{
+          timeUnixNano: nanos,
+          observedTimeUnixNano: nanos,
+          severityNumber: 9,
+          severityText: "INFO",
+          eventName: event,
+          body: { stringValue: event },
+          attributes: [
+            attribute("event", event),
+            attribute("distinct_id", distinctId),
+            ...Object.entries(properties)
+              .filter(([, value]) => value !== null && value !== undefined)
+              .map(([key, value]) => attribute(key, String(value))),
+          ],
+        }],
+      }],
+    }],
+  });
+}
+
 /** Shape of a Vendo Cloud API key. Anything else leaves the lane anonymous. */
 const CLOUD_KEY_RE = /^vnd_[0-9a-f]{40}$/;
 
@@ -229,14 +283,19 @@ export function createTelemetry(deps: TelemetryDeps): Telemetry {
           ...cloudMarkers,
           ...internalMarker,
         };
-        const body = JSON.stringify({
-          api_key: deps.posthogKey,
-          event,
-          distinct_id: deps.config.anonymousId,
-          properties,
-        });
+        // Operational events go to the Logs product, product analytics to
+        // capture. Destination only — an event is never sent to both.
+        const toLogs = LOG_EVENTS.has(event);
+        const body = toLogs
+          ? logBody(event, deps.config.anonymousId, properties)
+          : JSON.stringify({
+              api_key: deps.posthogKey,
+              event,
+              distinct_id: deps.config.anonymousId,
+              properties,
+            });
 
-        await post(endpoint, body);
+        await post(toLogs ? logsEndpoint(deps.env, deps.posthogKey) : endpoint, body);
       } catch {
         // Telemetry must never break a build or dev server. Intentional silent failure.
       }

--- a/packages/vendo-telemetry/src/events.ts
+++ b/packages/vendo-telemetry/src/events.ts
@@ -104,3 +104,16 @@ export const EVENT_ALLOWLIST: Record<EventName, ReadonlySet<string>> = {
   agent_run: new Set([...BASE_PROP_KEYS]),
   error_class: new Set([...BASE_PROP_KEYS, "errorClass"]),
 } as const;
+
+/**
+ * The events that are operational records rather than product analytics: they
+ * say "this ran, here is how it went", and nobody funnels or retains them.
+ * They go to PostHog's Logs product instead of `/capture/` — same key, same
+ * consent, same allowlist, but a store with enforced 30-day retention. The
+ * split is by destination only; an event is never sent to both.
+ */
+export const LOG_EVENTS: ReadonlySet<EventName> = new Set<EventName>([
+  "doctor_run",
+  "command_run",
+  "agent_run",
+]);

--- a/packages/vendo-telemetry/src/index.ts
+++ b/packages/vendo-telemetry/src/index.ts
@@ -4,7 +4,7 @@ import { createTelemetry, DEFAULT_POSTHOG_KEY, type Telemetry } from "./client.j
 
 export { envOptOut } from "./consent.js";
 export { loadConfig, type TelemetryConfig } from "./config.js";
-export { EVENT_ALLOWLIST, type EventName } from "./events.js";
+export { EVENT_ALLOWLIST, LOG_EVENTS, type EventName } from "./events.js";
 export { type Telemetry } from "./client.js";
 export { PROJECT_ID_SALT, repoHost, type RepoHost } from "./base-props.js";
 export { scrubErrorDetail } from "./scrub.js";

--- a/packages/vendo-telemetry/tests/client.test.ts
+++ b/packages/vendo-telemetry/tests/client.test.ts
@@ -85,7 +85,7 @@ describe("createTelemetry.track", () => {
         env: { npm_config_user_agent: "pnpm/9.1.0 npm/? node/v20.11.0 darwin arm64" },
       });
       const t = createTelemetry(deps);
-      await t.track("agent_run", {});
+      await t.track("error_class", {});
       const body = JSON.parse((deps.fetchImpl.mock.calls[0]![1] as { body: string }).body);
       expect(body.properties.packageManager).toBe("pnpm");
       expect(body.properties.projectIdHash).toMatch(/^[0-9a-f]{64}$/);
@@ -99,7 +99,7 @@ describe("createTelemetry.track", () => {
     try {
       const deps = makeDeps({ cwd });
       const t = createTelemetry(deps);
-      await t.track("agent_run", {});
+      await t.track("error_class", {});
       const body = JSON.parse((deps.fetchImpl.mock.calls[0]![1] as { body: string }).body);
       expect("projectIdHash" in body.properties).toBe(false);
       expect("packageManager" in body.properties).toBe(false);
@@ -111,7 +111,7 @@ describe("createTelemetry.track", () => {
   it("never throws when fetch rejects", async () => {
     const deps = makeDeps({ fetchImpl: vi.fn().mockRejectedValue(new Error("network")) });
     const t = createTelemetry(deps);
-    await expect(t.track("agent_run", {})).resolves.toBeUndefined();
+    await expect(t.track("error_class", {})).resolves.toBeUndefined();
   });
 
   it("sends to a VENDO_POSTHOG_HOST override instead of the shipped cloud", async () => {
@@ -284,7 +284,7 @@ describe("cloud lane (VENDO_API_KEY)", () => {
   it("marks every event with cloud + cloudKeyHash when a valid key is set", async () => {
     const deps = makeDeps({ env: { VENDO_API_KEY: CLOUD_KEY } });
     const t = createTelemetry(deps);
-    await t.track("agent_run", {});
+    await t.track("error_class", {});
     const props = sentProps(deps);
     expect(props.cloud).toBe(true);
     // Unsalted sha256 of the key itself — the console joins on this hash.
@@ -302,7 +302,7 @@ describe("cloud lane (VENDO_API_KEY)", () => {
   ])("stays anonymous when the key is %s", async (_label, key) => {
     const deps = makeDeps({ env: { VENDO_API_KEY: key } });
     const t = createTelemetry(deps);
-    await t.track("agent_run", {});
+    await t.track("error_class", {});
     const props = sentProps(deps);
     expect("cloud" in props).toBe(false);
     expect("cloudKeyHash" in props).toBe(false);
@@ -339,20 +339,20 @@ describe("cloud lane (VENDO_API_KEY)", () => {
   it("still drops non-allowlisted keys when the lane is active", async () => {
     const deps = makeDeps({ env: { VENDO_API_KEY: CLOUD_KEY } });
     const t = createTelemetry(deps);
-    await t.track("agent_run", { sourceCode: "secret" } as never);
+    await t.track("error_class", { sourceCode: "secret" } as never);
     expect("sourceCode" in sentProps(deps)).toBe(false);
   });
 
   it("callers cannot spoof cloud or cloudKeyHash", async () => {
     // Inactive lane: the caller-passed markers are stripped outright.
     const anon = makeDeps();
-    await createTelemetry(anon).track("agent_run", { cloud: true, cloudKeyHash: "ff" } as never);
+    await createTelemetry(anon).track("error_class", { cloud: true, cloudKeyHash: "ff" } as never);
     expect("cloud" in sentProps(anon)).toBe(false);
     expect("cloudKeyHash" in sentProps(anon)).toBe(false);
 
     // Active lane: producer-set values win over caller-passed ones.
     const cloud = makeDeps({ env: { VENDO_API_KEY: CLOUD_KEY } });
-    await createTelemetry(cloud).track("agent_run", { cloud: false, cloudKeyHash: "ff" } as never);
+    await createTelemetry(cloud).track("error_class", { cloud: false, cloudKeyHash: "ff" } as never);
     const props = sentProps(cloud);
     expect(props.cloud).toBe(true);
     expect(props.cloudKeyHash).toBe(createHash("sha256").update(CLOUD_KEY).digest("hex"));
@@ -388,7 +388,7 @@ describe("cloud lane (VENDO_API_KEY)", () => {
   it("bounds cloud prop values like any other prop", async () => {
     const deps = makeDeps({ env: { VENDO_API_KEY: CLOUD_KEY } });
     const t = createTelemetry(deps);
-    await t.track("agent_run", {
+    await t.track("error_class", {
       projectName: "a".repeat(5000),
       errorDetail: { nested: "secret" },
     } as never);
@@ -402,7 +402,7 @@ describe("internal lane (VENDO_INTERNAL)", () => {
   it.each([["1"], ["true"]])("marks every event with internal: true when VENDO_INTERNAL=%s", async (value) => {
     const deps = makeDeps({ env: { VENDO_INTERNAL: value } });
     const t = createTelemetry(deps);
-    await t.track("agent_run", {});
+    await t.track("error_class", {});
     expect(sentProps(deps).internal).toBe(true);
   });
 
@@ -415,35 +415,113 @@ describe("internal lane (VENDO_INTERNAL)", () => {
   ])("omits the internal key when VENDO_INTERNAL is %s", async (_label, value) => {
     const deps = makeDeps({ env: { VENDO_INTERNAL: value } });
     const t = createTelemetry(deps);
-    await t.track("agent_run", {});
+    await t.track("error_class", {});
     expect("internal" in sentProps(deps)).toBe(false);
   });
 
   it("callers cannot spoof internal", async () => {
     // Flag unset: the caller-passed marker is stripped outright.
     const external = makeDeps();
-    await createTelemetry(external).track("agent_run", { internal: true } as never);
+    await createTelemetry(external).track("error_class", { internal: true } as never);
     expect("internal" in sentProps(external)).toBe(false);
 
     // Flag set: the producer-set value wins over a caller-passed one.
     const internal = makeDeps({ env: { VENDO_INTERNAL: "1" } });
-    await createTelemetry(internal).track("agent_run", { internal: false } as never);
+    await createTelemetry(internal).track("error_class", { internal: false } as never);
     expect(sentProps(internal).internal).toBe(true);
   });
 
   it("does not weaken consent: opt-outs still send nothing with the flag set", async () => {
     const deps = makeDeps({ env: { VENDO_INTERNAL: "1", DO_NOT_TRACK: "1" } });
     const t = createTelemetry(deps);
-    await t.track("agent_run", {});
+    await t.track("error_class", {});
     expect(deps.fetchImpl).not.toHaveBeenCalled();
   });
 
   it("composes with the cloud lane markers", async () => {
     const deps = makeDeps({ env: { VENDO_INTERNAL: "1", VENDO_API_KEY: CLOUD_KEY } });
     const t = createTelemetry(deps);
-    await t.track("agent_run", {});
+    await t.track("error_class", {});
     const props = sentProps(deps);
     expect(props.internal).toBe(true);
     expect(props.cloud).toBe(true);
+  });
+});
+
+/** The log record's attributes, flattened. OTLP carries every value as a
+ *  string, which is also how PostHog stores them — so these assertions read
+ *  the wire exactly as the Logs explorer will. */
+function sentAttributes(deps: ReturnType<typeof makeDeps>): Record<string, string> {
+  const body = JSON.parse((deps.fetchImpl.mock.calls[0]![1] as { body: string }).body);
+  const record = body.resourceLogs[0].scopeLogs[0].logRecords[0];
+  return Object.fromEntries(
+    (record.attributes as { key: string; value: { stringValue: string } }[])
+      .map((a) => [a.key, a.value.stringValue]),
+  );
+}
+
+describe("logs lane (LOG_EVENTS)", () => {
+  it("sends an operational event to the logs endpoint as OTLP, not to capture", async () => {
+    const deps = makeDeps();
+    await createTelemetry(deps).track("doctor_run", { failures: 2, warnings: 1, wired: true });
+
+    const [url, init] = deps.fetchImpl.mock.calls[0]!;
+    expect(String(url)).toBe("https://us.i.posthog.com/i/v1/logs?token=phc_test");
+    const body = JSON.parse((init as { body: string }).body);
+    // No capture-shaped keys: the analytics stream must not receive this at all.
+    expect("event" in body).toBe(false);
+    expect("api_key" in body).toBe(false);
+
+    const record = body.resourceLogs[0].scopeLogs[0].logRecords[0];
+    expect(body.resourceLogs[0].resource.attributes)
+      .toContainEqual({ key: "service.name", value: { stringValue: "vendo-sdk" } });
+    // Greppable from either direction: the facet column and the body.
+    expect(record.eventName).toBe("doctor_run");
+    expect(record.body.stringValue).toBe("doctor_run");
+
+    const attributes = sentAttributes(deps);
+    expect(attributes.event).toBe("doctor_run");
+    expect(attributes.distinct_id).toBe("id-1");
+    expect(attributes.failures).toBe("2");
+    expect(attributes.wired).toBe("true");
+    expect(attributes.vendoVersion).toBe("9.9.9");
+  });
+
+  it.each([["doctor_run"], ["command_run"], ["agent_run"]])(
+    "routes %s to logs while analytics events stay on capture",
+    async (event) => {
+      const logged = makeDeps();
+      await createTelemetry(logged).track(event as "doctor_run", {});
+      expect(String(logged.fetchImpl.mock.calls[0]![0])).toContain("/i/v1/logs");
+
+      const captured = makeDeps();
+      await createTelemetry(captured).track("init_started", { framework: "next" });
+      expect(String(captured.fetchImpl.mock.calls[0]![0])).toContain("/capture/");
+    },
+  );
+
+  it("applies the allowlist, the lane markers and consent exactly as capture does", async () => {
+    const deps = makeDeps({ env: { VENDO_API_KEY: CLOUD_KEY, VENDO_INTERNAL: "1" } });
+    await createTelemetry(deps).track("command_run", {
+      command: "sync",
+      ok: true,
+      sourceCode: "secret",
+    } as never);
+    const attributes = sentAttributes(deps);
+    expect(attributes.command).toBe("sync");
+    expect("sourceCode" in attributes).toBe(false);
+    expect(attributes.cloud).toBe("true");
+    expect(attributes.internal).toBe("true");
+
+    const optedOut = makeDeps({ env: { DO_NOT_TRACK: "1" } });
+    await createTelemetry(optedOut).track("command_run", { command: "sync" });
+    expect(optedOut.fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("follows VENDO_POSTHOG_HOST to a self-hosted instance", async () => {
+    const deps = makeDeps({ env: { VENDO_POSTHOG_HOST: "https://posthog.internal:8000" } });
+    await createTelemetry(deps).track("agent_run", {});
+    expect(String(deps.fetchImpl.mock.calls[0]![0]))
+      .toBe("https://posthog.internal:8000/i/v1/logs?token=phc_test");
   });
 });

--- a/packages/vendo/src/cli/telemetry.test-util.ts
+++ b/packages/vendo/src/cli/telemetry.test-util.ts
@@ -10,6 +10,31 @@ export interface CapturedEvent {
 }
 
 /**
+ * One sent body, whichever destination the event took. Product analytics go to
+ * `/capture/` as an envelope; the operational events in LOG_EVENTS go to the
+ * Logs product as OTLP records, where the name and the anonymous id are
+ * attributes and every value is a string (that is how PostHog stores them
+ * either way). Decoding both here keeps command tests asserting on what the
+ * command reported, not on which endpoint it happened to use.
+ */
+function decode(body: string): CapturedEvent {
+  const parsed = JSON.parse(body) as Record<string, unknown>;
+  if (parsed.resourceLogs === undefined) return parsed as unknown as CapturedEvent;
+  const record = (parsed as never as {
+    resourceLogs: { scopeLogs: { logRecords: {
+      eventName: string;
+      attributes: { key: string; value: { stringValue: string } }[];
+    }[] }[] }[];
+  }).resourceLogs[0]!.scopeLogs[0]!.logRecords[0]!;
+  const properties: Record<string, unknown> = {};
+  for (const attribute of record.attributes) {
+    if (attribute.key === "event" || attribute.key === "distinct_id") continue;
+    properties[attribute.key] = attribute.value.stringValue;
+  }
+  return { event: record.eventName, properties };
+}
+
+/**
  * Injected telemetry seam for command tests: a REAL telemetry client pointed
  * at a mock PostHog fetch and a temp home, with a clean consent env (no
  * CI/DO_NOT_TRACK — the explicit `env` beats the suite-wide
@@ -27,7 +52,7 @@ export async function telemetryCapture(env: Record<string, string | undefined> =
   onTestFinished(() => rm(home, { recursive: true, force: true }));
   const fetchMock = vi.fn().mockResolvedValue({ ok: true });
   const events = (): CapturedEvent[] =>
-    fetchMock.mock.calls.map((call) => JSON.parse((call[1] as { body: string }).body) as CapturedEvent);
+    fetchMock.mock.calls.map((call) => decode((call[1] as { body: string }).body));
   return {
     home,
     telemetry: { home, env, posthogKey: "phc_test", fetchImpl: fetchMock as unknown as typeof fetch },

--- a/packages/vendo/tests/cli/cloud-init.test.ts
+++ b/packages/vendo/tests/cli/cloud-init.test.ts
@@ -379,8 +379,8 @@ describe("cloud-init telemetry", () => {
       cloudProbe: async () => ({ present: true, ok: true, unlocks: [] }),
       telemetry: ok.telemetry,
     });
-    expect(ok.event("command_run").properties).toMatchObject({ command: "cloud-init", ok: true });
-    expect(typeof ok.event("command_run").properties.durationMs).toBe("number");
+    expect(ok.event("command_run").properties).toMatchObject({ command: "cloud-init", ok: "true" });
+    expect(Number(ok.event("command_run").properties.durationMs)).not.toBeNaN();
 
     const invalid = await telemetryCapture();
     cleanup.push(() => rm(invalid.home, { recursive: true, force: true }));
@@ -394,7 +394,7 @@ describe("cloud-init telemetry", () => {
     });
     expect(invalid.event("command_run").properties).toMatchObject({
       command: "cloud-init",
-      ok: false,
+      ok: "false",
       failedStep: "key-invalid",
     });
   });
@@ -413,7 +413,7 @@ describe("cloud-init telemetry", () => {
       confirm: async () => false,
       telemetry: declined.telemetry,
     });
-    expect(declined.event("command_run").properties).toMatchObject({ command: "cloud-init", ok: true });
+    expect(declined.event("command_run").properties).toMatchObject({ command: "cloud-init", ok: "true" });
 
     const thrown = await telemetryCapture();
     cleanup.push(() => rm(thrown.home, { recursive: true, force: true }));
@@ -427,7 +427,7 @@ describe("cloud-init telemetry", () => {
     })).rejects.toThrow("probe exploded");
     expect(thrown.event("command_run").properties).toMatchObject({
       command: "cloud-init",
-      ok: false,
+      ok: "false",
       errorClass: "TypeError",
     });
   });

--- a/packages/vendo/tests/cli/cloud/device-login.test.ts
+++ b/packages/vendo/tests/cli/cloud/device-login.test.ts
@@ -956,8 +956,8 @@ describe("login telemetry (runLoginCommand)", () => {
       isTty: false,
       telemetry: ok.telemetry,
     })).toBe(0);
-    expect(ok.event("command_run").properties).toMatchObject({ command: "login", ok: true });
-    expect(typeof ok.event("command_run").properties.durationMs).toBe("number");
+    expect(ok.event("command_run").properties).toMatchObject({ command: "login", ok: "true" });
+    expect(Number(ok.event("command_run").properties.durationMs)).not.toBeNaN();
 
     const denied = await telemetryCapture();
     cleanup.push(() => rm(denied.home, { recursive: true, force: true }));
@@ -974,6 +974,6 @@ describe("login telemetry (runLoginCommand)", () => {
       isTty: false,
       telemetry: denied.telemetry,
     })).toBe(1);
-    expect(denied.event("command_run").properties).toMatchObject({ command: "login", ok: false });
+    expect(denied.event("command_run").properties).toMatchObject({ command: "login", ok: "false" });
   });
 });

--- a/packages/vendo/tests/cli/mcp/index.test.ts
+++ b/packages/vendo/tests/cli/mcp/index.test.ts
@@ -41,7 +41,7 @@ describe("mcp telemetry", () => {
     expect(await runMcp(["unknown"], { output: output().sink, telemetry: failed.telemetry })).toBe(1);
     expect(failed.event("command_run").properties).toMatchObject({
       command: "mcp",
-      ok: false,
+      ok: "false",
       failedStep: "unknown-command",
     });
   });

--- a/packages/vendo/tests/cli/sync.test.ts
+++ b/packages/vendo/tests/cli/sync.test.ts
@@ -493,8 +493,8 @@ describe("sync telemetry", () => {
 
     const ok = await telemetryCapture();
     expect(await runSync({ targetDir: ".", output, fetchImpl, sync: async () => report(), telemetry: ok.telemetry })).toBe(0);
-    expect(ok.event("command_run").properties).toMatchObject({ command: "sync", ok: true });
-    expect(typeof ok.event("command_run").properties.durationMs).toBe("number");
+    expect(ok.event("command_run").properties).toMatchObject({ command: "sync", ok: "true" });
+    expect(Number(ok.event("command_run").properties.durationMs)).not.toBeNaN();
 
     const gated = await telemetryCapture();
     expect(await runSync({
@@ -505,7 +505,7 @@ describe("sync telemetry", () => {
       sync: async () => report([{ tool: "host_x", change: "removed" }]),
       telemetry: gated.telemetry,
     })).toBe(2);
-    expect(gated.event("command_run").properties).toMatchObject({ command: "sync", ok: false });
+    expect(gated.event("command_run").properties).toMatchObject({ command: "sync", ok: "false" });
 
     await rm(ok.home, { recursive: true, force: true });
     await rm(gated.home, { recursive: true, force: true });
@@ -545,7 +545,7 @@ describe("telemetry project attribution + cloud-key sourcing (P1 review)", () =>
     dirs.push(tele.home);
     await runSync({ targetDir: dir, output: quiet, fetchImpl: offline, sync: async () => report(), telemetry: tele.telemetry });
     const props = tele.event("command_run").properties;
-    expect(props.cloud).toBe(true);
+    expect(props.cloud).toBe("true");
     expect(props.cloudKeyHash).toBe(createHash("sha256").update(CLOUD_KEY).digest("hex"));
   });
 


### PR DESCRIPTION
## What

`doctor_run`, `command_run` and `agent_run` are records of work — "this ran, here is how it went" — not funnel steps. They now go to PostHog's **Logs** product (OTLP over HTTP, `/i/v1/logs`), where retention is enforced at 30 days by the org's `logs_retention_30d` add-on, instead of the product-analytics stream that keeps events indefinitely.

Everything else about them is unchanged: same public write-only project key, same closed allowlist, same `errorDetail` scrubbing, same cloud/internal lane markers, same opt-outs, same `VENDO_POSTHOG_HOST` override. Nothing is dual-written — `LOG_EVENTS` in `events.ts` is the whole switch. `init_started`, `init_completed`, `init_failed`, `star_prompt` and `error_class` still go to `/capture/`.

Existing historical rows stay in analytics and age out on their own; that is accepted.

## Why these three

Checked every consumer in project 397743 before touching code: 18 insights, 5 dashboards, 1 action, 2 cohorts, 15 destinations. **None** references `doctor_run`, `command_run` or `agent_run`. Nothing breaks.

## Contract

`TELEMETRY.md` is the published contract and is updated with the destination table, the OTLP shape, and the retention. Credential stays public-by-design (the same `phc_` key, which the Logs endpoint accepts as `?token=` — its documented alternative to a bearer header, so both transports stay header-free).

## Seam proof

Write and read are independent — no stub on either side:

1. Ran the real CLI: `vendo doctor` from `packages/vendo/bin/vendo.mjs`, real socket transport, temp `HOME`, consent granted.
2. Read it back through PostHog's HogQL `logs` table by the run's `distinct_id`:

```
timestamp     2026-08-27T04:24:47Z
service_name  vendo-sdk
event_name    doctor_run
attributes    { event: doctor_run, distinct_id: 018f9688-…, failures: "6",
                warnings: "5", wired: "false", vendoVersion: "0.51.1",
                osPlatform: darwin, nodeVersion: v24.2.0, projectIdHash: 2c57a3e6…,
                internal: "true" }
```

3. Queried the analytics stream for the same `distinct_id` over the same window: **zero rows**. The event moved; it is not duplicated.

## Test changes (stated out loud)

`client.test.ts` used `agent_run` as its generic carrier for the base-props, lane-marker and allowlist assertions. Since `agent_run` now takes the logs lane, those 15 uses move to `error_class` — an analytics-lane event with the same base-only shape — so each assertion keeps its exact meaning. A new `logs lane` block covers the new destination: endpoint, OTLP shape, `service.name`, the `eventName`/`event`/`distinct_id` fields, the routing split, and that the allowlist, lane markers and consent behave identically there.

The J11 wire seam (`fixtures/integration`) decodes both wire shapes and now asserts the **path** the real composed client posts to — the only place the destination is observable end to end.

Verified the new tests can fail: removing `doctor_run` from `LOG_EVENTS` turns 2 of them red; restored.

## Gate

`pnpm build` ✅ · `pnpm typecheck` ✅ (43/43) · `pnpm lint` ✅ (0 errors) · touched-scope tests ✅ — `packages/vendo-telemetry` 133/133, `fixtures/integration` telemetry-wire 5/5.

⚠️ The full `pnpm test:affected` could not complete on this machine: the disk is at 100% (~120 MiB free) and several unrelated packages failed with `No space left on device` (PGlite could not create its data dir, corpus-harness could not write a git config). CI is the gate of record.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves `doctor_run`, `command_run`, and `agent_run` from PostHog's product-analytics stream to PostHog's Logs product, so operational "this ran" records land in a store with enforced 30-day retention instead of being kept indefinitely. They're now sent as OTLP/JSON to `/i/v1/logs` with the same write-only project key, allowlist, scrubbing, opt-outs, and `VENDO_POSTHOG_HOST` override; no event is dual-written, and `init_started`, `init_completed`, `init_failed`, `star_prompt`, and `error_class` keep going to `/capture/`.

**Notes**
- `TELEMETRY.md` now documents both destinations, the OTLP shape, and the retention.
- The logs lane renders every property value as a string (`ok` arrives as `"true"`, not `true`); the CLI command-test seam decodes both shapes so tests assert in the right spelling.
- No consumer in project 397743 references the moved events, so nothing breaks.
- Historical rows stay in analytics and age out on their own; no migration needed.

<sup>Written for commit 90bff89f6a1780ea8162617f49fc6c2c6ae31637. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1654?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

