### PR TITLE
fix(security): exclude devDependencies from the demo-bank runtime image (CVE-2025-68121)

### DIFF
--- a/examples/demo-bank/Dockerfile
+++ b/examples/demo-bank/Dockerfile
@@ -13,6 +13,17 @@ COPY . .
 RUN pnpm install --frozen-lockfile
 RUN pnpm exec turbo run build --filter=demo-bank
 
+# devDependencies stay installed through the build (tailwindcss, typescript,
+# turbo, vitest...) but ship no further: `next start` never touches them, and
+# vite — a devDependency of packages/ui's test suite — pins its own esbuild
+# ^0.25.0 (see the pnpm-workspace.yaml overrides comment), so a CVE-2025-68121
+# copy of esbuild survives in node_modules alongside the fixed 0.28.2 one
+# every real consumer declares. `pnpm prune --prod` doesn't clear it: pnpm's
+# virtual store keeps an unlinked package's extracted files even after no
+# project references it. Only a from-scratch install recomputes the store to
+# just the production graph.
+RUN rm -rf node_modules && pnpm install --prod --frozen-lockfile --config.confirmModulesPurge=false
+
 ENV NODE_ENV=production
 ENV HOSTNAME=0.0.0.0
 ENV PORT=3000


### PR DESCRIPTION
#1651's trivy scan still fails after #1653: `app/node_modules/.pnpm/esbuild@0.25.12` carries CVE-2025-68121 in its Go binary. #1653 bumped every declared esbuild consumer (root, `@vendoai/apps`, `genbench`) to 0.28.2, but `vite` — a devDependency-only test-tooling dep of `packages/ui`'s vitest suite, per its own changeset note — pins its own `esbuild ^0.25.0`, so one vulnerable copy survives. This Dockerfile is a single-stage build that installs full deps (including devDependencies), builds, and runs `pnpm start` straight out of that tree, so the image ships it too.

Fix: after the build, delete `node_modules` and reinstall with `--prod --frozen-lockfile`. `next start` never needs devDependencies. A plain `pnpm prune --prod` is *not* enough — verified locally that it leaves the vulnerable esbuild's extracted files sitting in pnpm's virtual store even once nothing links to them; only a from-scratch install recomputes the store to just the production graph.

Verified locally (Docker unavailable) with the pinned `pnpm@11.10.0`:
- Full `pnpm install --frozen-lockfile` + `turbo build` → `node_modules/.pnpm` has both `esbuild@0.25.12` and `esbuild@0.28.2`.
- `rm -rf node_modules && pnpm install --prod --frozen-lockfile` → 1650 → 903 packages; `esbuild@0.25.12` and every `vite@*` gone; `esbuild@0.28.2` remains and still resolves from `packages/apps`; `next` still resolves from `examples/demo-bank`.

No vite bump, no changeset (Dockerfile-only). CI's `trivy` check on this PR is the proof of record.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the demo-bank runtime image still carrying CVE-2025-68121 by dropping devDependencies after the build.

- Removes the full `node_modules` and reinstalls with `--prod` so the virtual store is recomputed to just the production graph.
- `pnpm prune --prod` alone leaves the vulnerable esbuild's extracted files in the virtual store.
- No dependency bumps or changeset needed; only the Dockerfile changes.

<sup>Written for commit 6e0236436f1a8765dc8fb0095ee68dc35b0c4f63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1655?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

