### PR TITLE
fix(agents): the model-required error names the zero-key path

### DIFF
--- a/.changeset/model-error-names-the-shortest-path.md
+++ b/.changeset/model-error-names-the-shortest-path.md
@@ -1,0 +1,5 @@
+---
+"@vendoai/agents": patch
+---
+
+The `agent({ model }) is required` error now names the zero-key path first. It fires precisely when no credential rung resolved, yet it listed only the bring-your-own escape hatches — `model: anthropic(...)` and `harness: claudeCode()` — and never mentioned `npx vendoai@latest login` / `VENDO_API_KEY`, which is the cheapest fix and the one the backend quickstart recommends. A reader of the error had no way to learn about it from the error.

--- a/packages/agents/src/agent.ts
+++ b/packages/agents/src/agent.ts
@@ -356,7 +356,8 @@ export function agent(config: AgentConfig): VendoAgent {
     if ((await resolveDevCredential()).rung !== "none") return;
     throw new VendoError(
       "validation",
-      "agent({ model }) is required — vendo(), the default brain, thinks with it. Pass one — "
+      "agent({ model }) is required — vendo(), the default brain, thinks with it. The shortest "
+      + "way is `npx vendoai@latest login`, which mints a VENDO_API_KEY. Or pass your own — "
       + "`model: anthropic(\"claude-sonnet-4-6\")`, importing `anthropic` from `@ai-sdk/anthropic` "
       + "— or name a harness that brings its own, e.g. `harness: claudeCode()`, importing "
       + "`claudeCode` from `@vendoai/harnesses/claude-code`.",


### PR DESCRIPTION
Found by following `/backend/quickstart` verbatim from an empty project, as a
brand-new user, in a QA sweep of the quickstarts.

`agent({ name })` + `chat()` with no credential throws:

```
VendoError: agent({ model }) is required — vendo(), the default brain, thinks
with it. Pass one — `model: anthropic("claude-sonnet-4-6")` … — or name a
harness that brings its own, e.g. `harness: claudeCode()` …
```

That error fires *precisely* when `resolveDevCredential()` found no rung
(`packages/agents/src/agent.ts:356`), yet it lists only the bring-your-own
escape hatches. It never mentions `npx vendoai@latest login` / `VENDO_API_KEY`
— the cheapest fix, and the one the quickstart calls "the shortest way to give
it one" one paragraph below the snippet that just threw. A reader of the error
had no way to learn about it from the error.

One string. The message now leads with the zero-key path and keeps both BYO
options after it. Both substrings the existing test matches on
(`agent({ model }) is required`, `harness: claudeCode()`) are preserved; no test
file touched.

**Gate:** `pnpm build` green. `pnpm test:affected` ran on a box shared by three
concurrent QA lanes (load average 25-37 on 8 cores) and five `@vendoai/agents`
tests reported `Test timed out` — sibling tests in the same files took 16-25s
against 20-30s budgets, so this is starvation, not a regression from an error
string. CI on a clean runner is the arbiter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the `agent({ model }) is required` error so it opens with the zero-key path — `npx vendoai@latest login` / `VENDO_API_KEY` — instead of only listing the bring-your-own `model:` and `harness:` escape hatches. The error fires precisely when no credential resolved, so it now names the cheapest fix first.

- Adds a `@vendoai/agents` patch changeset for the message change.
- No test changes; substrings existing tests match on are preserved.

<sup>Written for commit 633a47629c7ff58bd45f2ab9fefb4c1a69fbf7d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1657?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

