### PR TITLE
fix(cli): init's MCP refusal no longer sends the user in a loop

### DIFF
--- a/.changeset/init-mcp-refusal-names-the-file.md
+++ b/.changeset/init-mcp-refusal-names-the-file.md
@@ -1,0 +1,5 @@
+---
+"@vendoai/vendo": patch
+---
+
+`vendo init --use-case mcp` without an OAuth-carrying auth preset refuses the door and told the user to "wire an auth preset — then re-run `npx vendo init`". That was a loop with no exit: the same run goes on to write the anonymous composition, and init never rewrites a composition it already wrote, so every later re-run — `--auth authJs` and `--force` included — printed the identical warning and changed nothing. The message now names the composition file and says to delete it before re-running. The refusal itself is unchanged.

--- a/packages/vendo/src/cli/init-mcp.ts
+++ b/packages/vendo/src/cli/init-mcp.ts
@@ -188,11 +188,17 @@ export function planMcp(input: McpPlanInput): McpPlan {
     );
   }
   if (authWired === null && input.authAlreadyWired !== true) {
+    // Init decides auth ONLY for a composition it is creating, so by the time
+    // this run ends the anonymous composition is on disk and a bare re-run can
+    // never reach this branch differently — telling the user to "re-run" alone
+    // was a loop with no exit. Name the file and say to replace it.
+    const composed = relative(root, composition).split(sep).join("/");
     return refuse(
       "The MCP door mints its own principals through an OAuth adapter and cannot open without one, so "
-      + "nothing MCP was written. Wire an auth preset — auth: clerk(), authJs(), supabase() or auth0() all "
-      + "carry it — then re-run `npx vendo init`. (jwt() and an anonymous composition do not carry the "
-      + "oauth half: https://docs.vendo.run/outside-agents/quickstart.)",
+      + "nothing MCP was written. Wire an auth preset that carries it — auth: clerk(), authJs(), supabase() "
+      + `or auth0() — then delete ${composed} and re-run \`npx vendo init\`: init never rewrites a `
+      + "composition it already wrote, so a re-run on its own adds no door. (jwt() and an anonymous "
+      + "composition do not carry the oauth half: https://docs.vendo.run/outside-agents/quickstart.)",
     );
   }
 


### PR DESCRIPTION
`vendo init --use-case mcp` on an app with no OAuth-carrying auth preset refuses
to write the door and tells the user to "wire an auth preset — then re-run
`npx vendo init`". That instruction is a loop with no exit: the same run goes on
to write the anonymous composition, and init never rewrites a composition it
already wrote — so every later re-run, `--auth authJs` and `--force` included,
prints the identical warning and changes nothing.

Found in quickstart QA. Reproduced on a fresh `create-next-app`: init once with
no auth → no `mcp: true`, no `app/.well-known/[...vendo]/route.ts`. Then
`npm i next-auth@beta`, add `auth.ts` + the route, and
`npx vendo init --use-case mcp --auth authJs`: init correctly reports
`Auth.js auth (next-auth)`, then prints the same warning plus
`Already wired — nothing to change`. `--force` behaves the same. Deleting
`lib/vendo.ts` and initting again writes the door immediately.

The refusal itself is deliberate (`tests/cli/init-install-dx.test.ts` asserts it,
and the door genuinely cannot open without the oauth half). Only the instruction
was wrong. This names the composition file and says to replace it.

No behaviour change — one message string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `vendo init --use-case mcp`'s refusal message so it no longer sends users into a loop. The old message told users to re-run init, but init never rewrites a composition it already wrote, so re-running — even with `--force` or `--auth authJs` — changed nothing. The new message names the composition file and says to delete it before re-running. Only the message string changed; the refusal behavior is unchanged. Adds a patch changeset for `@vendoai/vendo`.

<sup>Written for commit a2d17f980dfa30a3a2d56041c3fa89ab1ccdd146. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1658?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

