### PR TITLE
fix(cli): bound the extracted control radius so themed surfaces aren't ovals

### DIFF
--- a/.changeset/bound-extracted-control-radius.md
+++ b/.changeset/bound-extracted-control-radius.md
@@ -1,0 +1,5 @@
+---
+"@vendoai/vendo": patch
+---
+
+Bound the control radius that `vendo init` extracts from a host's CSS. A stock `create-next-app` declares `border-radius: 128px` on a pill button; read literally that became `radius: { small: 64px, medium: 128px, large: 192px }` in `.vendo/theme.json`, every Vendo surface rendered as an ellipse, and the chat panel's composer row fell outside its own rounded box so clicking Send dismissed the overlay instead of sending. The value is now bounded at both choke points every radius passes through — the exact `--radius` read and `validateSlotValue` — rather than rejected, so a genuinely round brand stays as round as a control can be.

--- a/packages/vendo/src/cli/theme/extract-theme.ts
+++ b/packages/vendo/src/cli/theme/extract-theme.ts
@@ -34,6 +34,27 @@ import { walk } from "./walk.js";
 
 const DEFAULT_RADIUS = { small: "4px", large: "12px" } as const;
 
+/**
+ * This slot is the default CONTROL radius, and a fully-round pill declares one
+ * far larger than its own height to get there — stock `create-next-app` ships
+ * `border-radius: 128px` on exactly such a button. Read literally, that value
+ * survives validation, `toVendoTheme` amplifies it to a 192px `large`, and
+ * every Vendo surface renders as an ellipse: the chat panel's composer row
+ * falls outside its own rounded box and Send stops being clickable. 24px
+ * already reads as fully round on a standard 40px control, so anything above
+ * it is a pill token mistaken for a scale. Bound rather than reject — the
+ * brand stays as round as it can actually be.
+ */
+const MAX_CONTROL_RADIUS_PX = 24;
+
+function normalizeControlRadius(value: string): string | null {
+  const length = normalizeLength(value);
+  if (length === null) return null;
+  return Number(length.slice(0, -2)) > MAX_CONTROL_RADIUS_PX
+    ? `${MAX_CONTROL_RADIUS_PX}px`
+    : length;
+}
+
 /** Slot values → the frozen runtime VendoTheme contract — one derivation law,
  *  never two (theme/provenance.ts leans on this exact derivation). */
 export function toVendoTheme(slots: ThemeSlotValues): VendoTheme {
@@ -366,7 +387,7 @@ function readExact(vars: CssVarDecl[]): ExactReads {
   }
   const radius = lastLightDecl(vars, ["--radius"]);
   const radiusResolved = radius === undefined ? null : resolveCssVarRefs(radius.value, vars);
-  put("radius", radius, radiusResolved === null ? null : normalizeLength(radiusResolved));
+  put("radius", radius, radiusResolved === null ? null : normalizeControlRadius(radiusResolved));
   const baseSize = lastLightDecl(vars, ["--font-size", "--text-base"]);
   const baseResolved = baseSize === undefined ? null : resolveCssVarRefs(baseSize.value, vars);
   put("baseSize", baseSize, baseResolved === null ? null : normalizeLength(baseResolved));
@@ -426,6 +447,7 @@ export function validateSlotValue(slot: SlotKey, raw: string): string | null {
   const value = raw.trim();
   switch (slot) {
     case "radius":
+      return normalizeControlRadius(value);
     case "baseSize":
       return normalizeLength(value);
     case "density":


### PR DESCRIPTION
Found while running the `/product/quickstart` page end-to-end as a brand-new user
against a stock `create-next-app` host.

## What happens today

`create-next-app` ships `border-radius: 128px` on one pill-shaped secondary button in
`app/page.module.css`. `vendo init`'s theme stage reads it as the host's control radius,
nothing bounds it, and `toVendoTheme` amplifies it:

```json
"radius": { "small": "64px", "medium": "128px", "large": "192px" }
```

Every Vendo surface then renders as an ellipse. It is not just ugly — the chat panel's
composer row falls outside its own rounded box, so the **Send** button sits on the
backdrop: clicking it dismisses the panel instead of sending. Enter still works, so the
quickstart's headline surface is only usable by someone who guesses.

## The fix

One bound at the two choke points every radius passes through — the exact `--radius`
read and `validateSlotValue` (which is where model- and human-supplied values land).
24px already reads as fully round on a standard 40px control, so anything above it is a
pill token that got mistaken for a scale. Bound rather than reject, so a genuinely round
brand stays as round as a control can actually be.

`toVendoTheme`'s 0.5x/1.5x derivation and `theme/provenance.ts`'s dependent copy are
untouched — they now derive from a value that can't blow up.

## Verification

- No existing test asserts a radius above 12px, so no assertion changes.
- Scoped gate on the touched package: `pnpm build && pnpm test:affected && pnpm typecheck
  && pnpm lint`.

## Not fixed here

The same QA run turned up a separate, larger issue: a brand-new deployment reads another
deployment's Cloud data (chat history, approvals, apps, slots, knowledge) because the
scaffolded principal is a shared `demo-user`. That is filed in the QA findings, not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds the control radius extracted during `vendo init` theme extraction so themed surfaces stop rendering as ovals, shipped as a patch for `@vendoai/vendo`.

Stock `create-next-app` sets `border-radius: 128px` on a pill-shaped button. That value was read as the host's control radius, `toVendoTheme` amplified it to a 192px `large` radius, and every Vendo surface rendered as an ellipse — the chat panel's composer row fell outside its own rounded box, so clicking the Send button dismissed the panel instead of sending.

- Clamps the radius to 24px at both choke points every radius passes through — the exact `--radius` read and `validateSlotValue` — bounding rather than rejecting, since 24px already reads fully round on a standard 40px control.
- No existing test asserts a radius above 12px, so no test updates are needed.
- A separate QA finding — brand-new deployments read another deployment's Cloud data through a shared `demo-user` principal — is filed elsewhere and is not addressed here.

<sup>Written for commit 903c3ef1110a81e2e930b8899473b3bb195a3977. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

