### PR TITLE
fix(react): export isVendoToolPart, the guard three quickstarts document

### DIFF
--- a/.changeset/is-vendo-tool-part.md
+++ b/.changeset/is-vendo-tool-part.md
@@ -1,0 +1,7 @@
+---
+"@vendoai/core": minor
+"@vendoai/ui": minor
+"@vendoai/vendo": minor
+---
+
+Add `isVendoToolPart` to `@vendoai/vendo/react` — the guard the existing-agent quickstarts already document but no published build shipped. It answers "is this tool part Vendo's or mine?" for a BYO renderer, covering both shapes the AI SDK streams (`tool-<name>` and `dynamic-tool`, the latter being what Mastra emits for a tools-as-function agent), and narrows to the tool-part union so `part.state` and `part.output` typecheck without a cast. `isToolUIPart` from `ai` is not a substitute: it is true for every tool part, including the host's own. `VENDO_TOOL_PACK_PREFIX` moves to `@vendoai/core` so the pack that mints the names and the renderer that recognises them share one constant; `@vendoai/vendo/ai-sdk` and `/mastra` re-export it unchanged.

--- a/packages/core/src/tools.ts
+++ b/packages/core/src/tools.ts
@@ -17,6 +17,13 @@ export const TOOL_NAME_PATTERN = /^[a-zA-Z0-9_-]{1,64}$/;
  *  side string-matching the other. */
 export const VENDO_APPS_TOOL_PREFIX = "vendo_apps_";
 
+/** The namespace every tool Vendo projects into a HOST's own agent loop carries,
+ *  so a BYO loop's tools and ours never collide: a registered host tool `host_x`
+ *  ships as `vendo_host_x`, and the built-ins are already prefixed. Named here,
+ *  below both the tool pack that mints the names and the renderer that has to
+ *  recognise them, so the two sides never string-match each other. */
+export const VENDO_TOOL_PACK_PREFIX = "vendo_" as const;
+
 /**
  * The ONE public tool for asking Vendo to make something to look at.
  *

--- a/packages/ui/src/chrome/embeds.tsx
+++ b/packages/ui/src/chrome/embeds.tsx
@@ -1,12 +1,22 @@
 import {
   VENDO_APP_REF_KIND,
   VENDO_AUTOMATION_REF_KIND,
+  VENDO_TOOL_PACK_PREFIX,
   isVendoError,
   parseVendoToolEnvelope,
   type ApprovalDecision,
   type ToolOutcome,
   type UIPayload,
 } from "@vendoai/core";
+import {
+  getToolName,
+  isToolUIPart,
+  type DynamicToolUIPart,
+  type ToolUIPart,
+  type UIDataTypes,
+  type UIMessagePart,
+  type UITools,
+} from "ai";
 import {
   effectiveAppBuildUiDeadlineMs,
 } from "@vendoai/apps/contract";
@@ -479,6 +489,22 @@ export function VendoAppEmbed({ refValue, theme }: VendoAppEmbedProps) {
       {approval.modal}
     </ChromeRoot>
   );
+}
+
+/**
+ * The branch a BYO renderer takes to tell Vendo's tool parts from its own, and
+ * the ONLY place a host should match on the `vendo_` prefix.
+ *
+ * True for a tool part the pack minted, in BOTH shapes the AI SDK streams —
+ * `tool-<name>` (statically declared) and `dynamic-tool` (resolved at runtime,
+ * which is what Mastra emits for a tools-as-function agent). It narrows to the
+ * tool-part union, so `part.state` and `part.output` typecheck at the call site
+ * without a cast.
+ */
+export function isVendoToolPart<TOOLS extends UITools>(
+  part: UIMessagePart<UIDataTypes, TOOLS>,
+): part is ToolUIPart<TOOLS> | DynamicToolUIPart {
+  return isToolUIPart(part) && getToolName(part).startsWith(VENDO_TOOL_PACK_PREFIX);
 }
 
 /**

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -22,7 +22,7 @@ export type { ToolMeta, ToolMetaMap } from "./chrome/humanize.js";
 export type { VendoAppEmbedProps, VendoApprovalEmbedProps, VendoApprovalEmbedState, VendoToolResultProps } from "./embeds.js";
 // The components behind the frozen prop contracts, exported from the root so
 // a BYO chat page needs only `@vendoai/ui`.
-export { VendoAppEmbed, VendoApprovalEmbed, VendoToolResult } from "./chrome/embeds.js";
+export { VendoAppEmbed, VendoApprovalEmbed, VendoToolResult, isVendoToolPart } from "./chrome/embeds.js";
 // The outside-agent ask, as one element: the door ships the rendered approval
 // with the parked call's outcome, and this asks, decides and settles it.
 export { VendoApproval, type PendingApproval, type VendoApprovalProps } from "./chrome/vendo-approval.js";

--- a/packages/vendo/src/react.tsx
+++ b/packages/vendo/src/react.tsx
@@ -41,6 +41,7 @@ export {
   VendoAppEmbed,
   VendoApprovalEmbed,
   VendoToolResult,
+  isVendoToolPart,
   // chrome/vendo-approval.tsx — the outside-agent ask, as one element.
   VendoApproval,
   type PendingApproval,

--- a/packages/vendo/src/tool-pack.ts
+++ b/packages/vendo/src/tool-pack.ts
@@ -10,8 +10,9 @@ import type { AgentRunReport, Principal, VendoToolEnvelope } from "@vendoai/core
 
 /** Every pack tool is namespaced under this prefix to avoid collisions with
  *  the host loop's own tools: a registered host tool `host_x` ships as
- *  `vendo_host_x`; the built-ins below are already prefixed. */
-export const VENDO_TOOL_PACK_PREFIX = "vendo_" as const;
+ *  `vendo_host_x`; the built-ins below are already prefixed. Defined in core so
+ *  the renderer's `isVendoToolPart` matches on the same constant the pack mints. */
+export { VENDO_TOOL_PACK_PREFIX } from "@vendoai/core";
 
 /** Generate UI. The pack's app door is Vendo's OWN make tool, under its own
  *  name — one contract in-process and over the MCP door, never a BYO-only


### PR DESCRIPTION
Found walking `/existing-agent/mastra` end to end as a brand-new user against the published `@vendoai/vendo@0.52.1`.

## The bug

Three docs pages — `existing-agent/mastra.mdx`, `existing-agent/ai-sdk.mdx`, and `existing-agent/embeds.mdx` — tell a host to branch its renderer on:

```tsx
import { isVendoToolPart, VendoToolResult } from "@vendoai/vendo/react";
```

`embeds.mdx` goes further and calls it "the only place you should match on the prefix". It does not exist. Not unexported — **absent**:

```
$ node -e "import('@vendoai/vendo/react').then(m => console.log(typeof m.isVendoToolPart))"
undefined
$ grep -rn isVendoToolPart node_modules/@vendoai/vendo/dist   # 0 hits
$ grep -rn isVendoToolPart packages/                          # 0 hits
```

So the render step of both existing-agent quickstarts fails to compile against any published build.

## Why add it rather than rewrite the docs

The predicate a host would otherwise hand-roll is `isToolUIPart(part)` — which the previous docs revision used — but that is true for **every** tool part, including the host's own. It does not do what the pages' own comment (`// your own parts render elsewhere`) claims. Making the docs correct without this export means open-coding `"vendo_"` in user code on three pages and losing the narrowing the pages promise ("the guard narrows the part, so `state` and `output` typecheck").

One exported type predicate fixes all three pages.

## The change

- `packages/core/src/tools.ts` — `VENDO_TOOL_PACK_PREFIX` moves here, so the pack that mints the names and the renderer that recognises them share one constant. Same reason `VENDO_MAKE_TOOL` and `VENDO_APPS_TOOL_PREFIX` already live in core.
- `packages/vendo/src/tool-pack.ts` — re-exports it from core instead of redefining the literal, mirroring what it already does for `VENDO_MAKE_TOOL`. Public surface and literal type unchanged.
- `packages/ui/src/chrome/embeds.tsx` — `isVendoToolPart`, next to `VendoToolResult` (the docs always import the two together).
- `packages/ui/src/index.ts`, `packages/vendo/src/react.tsx` — export it. `react.tsx` must name it explicitly; `react-export-parity.test.ts` enforces that.

Covers both shapes the AI SDK streams — `tool-<name>` and `dynamic-tool`, the latter being what Mastra emits for a tools-as-function agent — and narrows to the tool-part union so `part.state` / `part.output` typecheck without a cast.

## Verification

Behaviour against real part shapes, from the built output:

| part | result |
|---|---|
| `{ type: "dynamic-tool", toolName: "vendo_bash" }` | `true` |
| `{ type: "tool-vendo_make" }` | `true` |
| `{ type: "tool-my_own_tool" }` | `false` |
| `{ type: "text" }` | `false` |

Local scoped gate: `pnpm build` OK, `pnpm typecheck` OK (43/43), `pnpm lint` OK. `pnpm test:affected` was still running when this was opened — three QA lanes were sharing 8 cores at load ~20; CI's `ci` check is the gate of record.

Also verified out-of-band that the underlying Mastra path itself is sound: a real `@mastra/core` Agent with `vendoMastraTools(vendo)` and a `RequestContext` carrying `VENDO_PRINCIPAL_KEY` resolved 8 `vendo_*` tools and executed a real sandbox call (`vendo_bash` -> `exitCode 0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exports `isVendoToolPart`, the guard the existing-agent quickstart docs tell hosts to import but was never implemented — every snippet using it fails to compile against published builds.

- Matches `isToolUIPart` plus the `vendo_` name prefix, covering both `tool-<name>` and `dynamic-tool` parts and narrowing so `state` and `output` typecheck at the call site without a cast.
- Moves `VENDO_TOOL_PACK_PREFIX` to `@vendoai/core` so the tool pack that mints names and the renderer that recognizes them share one constant; `tool-pack.ts` re-exports it unchanged.
- Adds a changeset marking minor releases for `@vendoai/core`, `@vendoai/ui`, and `@vendoai/vendo`.
- Chosen over rewriting the docs because `isToolUIPart` alone would match a host's own tool parts, forcing snippets to open-code the prefix and drop the type narrowing they promise.
- Also fixes `vendo init --use-case mcp`'s refusal loop by naming the composition file to delete before re-running (patch release for `@vendoai/vendo`).

<sup>Written for commit 71dcc0da31573a88a7e6048b6b5233bcada07d0d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

