### PR TITLE
fix(ui): the build consent card says what a build actually does

### DIFF
--- a/.changeset/build-consent-card-authored-copy.md
+++ b/.changeset/build-consent-card-authored-copy.md
@@ -1,0 +1,7 @@
+---
+"@vendoai/core": patch
+"@vendoai/ui": patch
+"@vendoai/apps": patch
+---
+
+fix: the build consent card says what a build actually does. Ruling 14 keeps a descriptor's description off the consent ladder, so the authored build sentence never reached the card and a person approving a build machine read the generic "This changes something in your account, and it runs as you." The copy Vendo writes by hand for its own tools now lives beside `VENDO_TOOL_TITLES` as `VENDO_TOOL_NOTES`, which the ladder reads under the host's own `ToolMeta.description` — so the card and the words-only surfaces (`BUILD_CONSENT_ASK`) say one thing, and nothing extracted can reach that rung.

--- a/packages/apps/src/server/doors/build-door.ts
+++ b/packages/apps/src/server/doors/build-door.ts
@@ -11,6 +11,7 @@
 import {
   VENDO_APP_BUILD_TOOL,
   VENDO_APP_FORMAT,
+  VENDO_TOOL_NOTES,
   VENDO_TOOL_TITLES,
   VendoError,
   type AppBuildProposal,
@@ -46,22 +47,20 @@ const BUILD_TOOL = VENDO_APP_BUILD_TOOL;
 // §3 consumer voice — the shared table, like every other Vendo descriptor.
 // Without it the card asked the person to authorize "Vendo app build".
 const BUILD_TITLE = VENDO_TOOL_TITLES[BUILD_TOOL]!;
-const BUILD_DESCRIPTION = "Build this app for real: a sandbox installs the packages it needs, writes and tests the code,"
-  + " and the result is sealed. It spends a build machine, so it needs the person's yes.";
+const BUILD_DESCRIPTION = VENDO_TOOL_NOTES[BUILD_TOOL]!;
 
-/** This ask in words, for the surfaces that render no card. `consentAsk`'s own
- *  ladder (ui/chrome/build-beat.tsx) read off the descriptor below — its title as
- *  the question, its authored sentence as the note — so what an outside caller is
- *  handed and what the person in the thread is shown come from one source. */
+/** This ask in words, for the surfaces that render no card. Both halves come
+ *  from the shared core tables, which is what makes this the SAME ask the card
+ *  shows: `consentAsk` (ui/chrome/build-beat.tsx) reads them too, because
+ *  ruling 14 keeps the descriptor's own sentence off the consent ladder. */
 export const BUILD_CONSENT_ASK: Omit<PendingApproval, "id"> = {
   question: `${BUILD_TITLE}?`,
   notes: [BUILD_DESCRIPTION],
 };
 
-/** THE authored ask, and the source both surfaces read: the CARD derives its
- *  words from this descriptor (`consentAsk` off the `data-vendo-approval` part's
- *  copy of it), and {@link BUILD_CONSENT_ASK} above is the same ask already in
- *  words for the surfaces that render no card. One author, two renderings. */
+/** The descriptor the guard parks the ask on. Its `description` is the MODEL's
+ *  copy of the same sentence; the words a person reads reach the card through
+ *  `VENDO_TOOL_NOTES`, never through here. */
 export const buildDescriptor = (): ToolDescriptor => ({
   name: BUILD_TOOL,
   title: BUILD_TITLE,

--- a/packages/core/src/tools.ts
+++ b/packages/core/src/tools.ts
@@ -162,6 +162,25 @@ export const VENDO_TOOL_TITLES: Readonly<Record<string, string>> = {
   vendo_report_capability_miss: "Note what I can't do",
 };
 
+/**
+ * The consumer-voice SENTENCE for the tools Vendo itself projects — {@link
+ * VENDO_TOOL_TITLES}' other half, here for the same reason: the consent card
+ * and the words-only surfaces must say one thing, and neither can read the
+ * other's copy.
+ *
+ * Ruling 14 keeps a DESCRIPTOR's `description` off the consent ladder at every
+ * rung, and this table does not reopen that door: a descriptor's sentence is
+ * authored for the MODEL or minted by extraction, while nothing can reach this
+ * table except copy Vendo wrote by hand for a person to read. Host tools are
+ * not here — a host's own sentence is its `ToolMeta.description`, and that
+ * still outranks this.
+ */
+export const VENDO_TOOL_NOTES: Readonly<Record<string, string>> = {
+  [VENDO_APP_BUILD_TOOL]: "Build this app for real: a sandbox installs the packages it needs,"
+    + " writes and tests the code, and the result is sealed. It spends a build machine,"
+    + " so it needs the person's yes.",
+};
+
 /** Prettify a raw tool id / slug into a human label:
     `host_email_send` → "Email send", `fn:listInvoices` → "List invoices",
     `gmail_GMAIL_CREATE_EMAIL_DRAFT` → "Gmail create email draft".

--- a/packages/ui/src/chrome/build-beat.tsx
+++ b/packages/ui/src/chrome/build-beat.tsx
@@ -162,7 +162,11 @@ export function consentAsk(
   rows: readonly CardFieldRow[],
   meta?: ToolMeta,
 ): ConsentAsk {
-  const host = (meta?.description ?? presentation.note)?.trim();
+  // `||`, not `??`: a host that authors a BLANK description has authored no
+  // sentence, and `??` would keep the empty string and suppress the rung below
+  // it — the generic consequence line all over again, which is the bug this
+  // ladder exists to fix.
+  const host = meta?.description?.trim() || presentation.note?.trim();
   const authored = host !== undefined && host.length > 0 && host !== presentation.title ? host : undefined;
   const question = presentation.question ?? `${presentation.title}?`;
   const does = authored === undefined && presentation.question === undefined

--- a/packages/ui/src/chrome/build-beat.tsx
+++ b/packages/ui/src/chrome/build-beat.tsx
@@ -3,6 +3,7 @@ import {
   type Json,
   type JsonSchema,
   USE_SERVICE_TOOL,
+  VENDO_TOOL_NOTES,
 } from "@vendoai/core";
 import type { DynamicToolUIPart, ToolUIPart } from "ai";
 import { useEffect, useRef, useState } from "react";
@@ -71,6 +72,10 @@ export interface ToolPresentation {
   /** When approving takes effect and whose authority it runs on ("Sends now,
       as you"), in the ask's own verb — the promise under the question. */
   agency: string;
+  /** Vendo's own hand-written sentence for a tool VENDO ships
+      ({@link VENDO_TOOL_NOTES}), when there is one. Ranks below the host's
+      `ToolMeta.description` and above the consequence class. */
+  note?: string;
 }
 
 const agencyLine = (verb: string, trigger?: string): string => `${verb} ${trigger ?? "now"}, as you`;
@@ -134,8 +139,9 @@ const GRADE_NOTE: Record<string, string[]> = {
  * across the pair). Precedence, most local authority first:
  *   1. the question synthesized from the REAL inputs (names the actual money and
  *      counterparty), else the ask's own humanized label as a question;
- *   2. the HOST's own sentence for this tool (in-code `ToolMeta.description`) —
- *      the only human-authored copy in the system;
+ *   2. the HOST's own sentence for this tool (in-code `ToolMeta.description`),
+ *      else Vendo's own for a tool Vendo ships (`VENDO_TOOL_NOTES`) — the
+ *      human-authored copy in the system;
  *   3. the agency phrase — when it happens, and that it happens as the person
  *      approving;
  *   4. the consequence CLASS (`consentClassLine`) when neither 1 nor 2 spoke —
@@ -156,7 +162,7 @@ export function consentAsk(
   rows: readonly CardFieldRow[],
   meta?: ToolMeta,
 ): ConsentAsk {
-  const host = meta?.description?.trim();
+  const host = (meta?.description ?? presentation.note)?.trim();
   const authored = host !== undefined && host.length > 0 && host !== presentation.title ? host : undefined;
   const question = presentation.question ?? `${presentation.title}?`;
   const does = authored === undefined && presentation.question === undefined
@@ -363,7 +369,10 @@ export function toolPresentation(
         : `Sends ${money.shown} to ${to} as you`;
     }
   }
-  return { title, description, sub, toolkit, logoUrl, question, questionKeys, agency };
+  // Keyed on the PRESENTED name so a connector dispatch is read by its slug,
+  // exactly like the title above.
+  const note = VENDO_TOOL_NOTES[presented];
+  return { title, description, sub, toolkit, logoUrl, question, questionKeys, agency, note };
 }
 
 /** Live elapsed clock for an in-flight line; 0 (never ticking) under

--- a/packages/vendo/tests/screen-escalate-consent.seam.test.ts
+++ b/packages/vendo/tests/screen-escalate-consent.seam.test.ts
@@ -30,6 +30,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   VENDO_APP_BUILD_TOOL,
+  VENDO_TOOL_NOTES,
   VENDO_MAKE_TOOL,
   vendoApprovalPartSchema,
   type AppId,
@@ -360,10 +361,15 @@ describe("the ask reaches the person on the ONE approval card", () => {
     expect(card.getAttribute("data-vendo-tool")).toBe(VENDO_APP_BUILD_TOOL);
     expect(card.getAttribute("data-risk")).toBe("write");
 
-    // THE WORDS, off the shared ladder (`consentAsk`) reading the descriptor the
-    // door authored — never a second sentence written for this surface.
+    // THE WORDS, off the shared ladder (`consentAsk`) reading the copy the door
+    // authored — never a second sentence written for this surface. Asserted
+    // against the table itself, so the card and `BUILD_CONSENT_ASK` cannot drift
+    // apart again without this failing.
     expect(card.textContent).toContain("Build this app for real?");
-    expect(card.textContent).toContain("This changes something in your account, and it runs as you.");
+    expect(card.textContent).toContain(VENDO_TOOL_NOTES[VENDO_APP_BUILD_TOOL]);
+    // The generic consequence class is what a person read while the authored
+    // sentence had no rung to arrive on — it says nothing about a machine.
+    expect(card.textContent).not.toContain("This changes something in your account");
     // What it said before the descriptor travelled: ungraded, so the note could
     // only say nobody had checked what spending a build machine does.
     expect(card.textContent).not.toContain("This hasn’t been checked");


### PR DESCRIPTION
## What was wrong

A person approving a **build machine** — the hero beat of the escalate-to-box flow — read the generic consequence line instead of the sentence Vendo authored for exactly that card:

> This changes something in your account, and it runs as you.

The authored copy lived at `packages/apps/src/server/doors/build-door.ts:49` and never reached the card. `consentAsk` (`packages/ui/src/chrome/build-beat.tsx:162`) reads only the host's `ToolMeta.description`, and `vendo_app_build` is a tool **Vendo** ships, so no host meta exists for it — the ladder fell straight through to `consentClassLine("write")`.

This was a real divergence, not a cosmetic one: `BUILD_CONSENT_ASK` (`build-door.ts:56`) ships the authored sentence to the surfaces that render no card (text, MCP, an outside agent), so the same ask said two different things depending on where you answered it. `PendingApproval`'s own contract (`packages/core/src/tools.ts:419-423`) says that pair is "never a second vocabulary for one ask".

The doc comment at `build-door.ts:61-64` claimed the card derived its words from the descriptor. It didn't — ruling 14 (`build-beat.tsx:145-151`) had already taken descriptor descriptions off the ladder at every rung, and the comment was left behind.

## The fix

`VENDO_TOOL_NOTES` in core, beside `VENDO_TOOL_TITLES`, for the same stated reason that table exists: two sides must say the same words and neither can read the other's copy. The consent ladder reads it **under** the host's own `ToolMeta.description` and above the consequence class.

Ruling 14 is untouched. It bans a *descriptor's* description because that sentence is authored for the model or minted by extraction; nothing extracted can land in a table Vendo writes by hand.

## Gate

`pnpm build` · `test` (core, ui, apps) · `typecheck` · `lint` — all EXIT 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the build consent card so a person approving a build machine sees Vendo's authored sentence instead of the generic consequence line, and the card and the text-only surfaces now say one thing.

**Bug Fixes**
- The authored sentence now sits in `VENDO_TOOL_NOTES` in core and is read as a fallback under the host's own `ToolMeta.description`.
- A host that authors a blank description falls through to that note; the ladder uses `||` instead of `??` so an empty string can't suppress the rung below it.
- The seam test pins the card's words against `VENDO_TOOL_NOTES` itself and asserts the generic line never appears, so the two surfaces can't drift apart again.
- Ruling 14 is untouched: descriptor descriptions stay off the consent ladder, and only copy Vendo writes by hand can reach the card.

<sup>Written for commit fad2deccc95fe40fe0cbdc6d70820d1f4c6da612. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1661?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

