### PR TITLE
fix(apps): a screen prop refusal that contradicts itself names no repair

### DIFF
--- a/.changeset/screen-tautological-prop-refusal.md
+++ b/.changeset/screen-tautological-prop-refusal.md
@@ -1,0 +1,5 @@
+---
+"@vendoai/apps": patch
+---
+
+Stop a component screen's prop refusal from contradicting itself. When the value bound to a Kit prop differed from the prop's own type in one nested field — a `columns` array hoisted out of the JSX, so `align: "end"` widened to `string` before the enum saw it — the long-type summarizer collapsed BOTH sides to the same words and the screen agent was handed `prop "columns" on <DataTable> takes a list of rows, but this value is a list of rows`. A refusal that contradicts itself names no repair, so the agent retried forever, never painted, never errored and never escalated. Where the two summaries come out identical the check now falls through to the compiler's own nested sentence, which names the field that disagrees and the values it will take.

--- a/packages/apps/src/server/checking/screen-program.ts
+++ b/packages/apps/src/server/checking/screen-program.ts
@@ -319,12 +319,19 @@ const attributeValueFinding = (
   if (attribute === undefined || !ts.isJsxAttribute(attribute) || attribute.initializer === undefined) return undefined;
   const value = ts.isJsxExpression(attribute.initializer) ? attribute.initializer.expression : attribute.initializer;
   if (value === undefined) return undefined;
-  const wanted = checker.getContextualType(value);
+  const wanted = briefType(ts, checker, checker.getContextualType(value));
+  const written = briefType(ts, checker, checker.getTypeAtLocation(value));
+  // The other way the sentence contradicts itself: the two types really do
+  // differ, but {@link briefType} SUMMARIZED both to the same words — a hoisted
+  // `columns` array whose `align: "end"` widened to `string` differs from the
+  // prop in one nested field, and both sides print as `a list of rows`. The
+  // compiler's own nested sentence names the field that disagrees.
+  if (wanted === written) return undefined;
   return {
     severity: "block",
     where,
-    message: `prop "${locus.prop}" on <${locus.element.tagName.getText(file)}> takes ${briefType(ts, checker, wanted)},`
-      + ` but this value is ${briefType(ts, checker, checker.getTypeAtLocation(value))}`
+    message: `prop "${locus.prop}" on <${locus.element.tagName.getText(file)}> takes ${wanted},`
+      + ` but this value is ${written}`
       + " — bind a value whose type matches the prop",
   };
 };

--- a/packages/apps/tests/checking/component-screen.test.ts
+++ b/packages/apps/tests/checking/component-screen.test.ts
@@ -1139,6 +1139,43 @@ export default function Ledger() {
 
     expect(result.issues.map(({ message }) => message).join("\n")).toContain('prop "columns" on <DataTable> takes');
   });
+
+  /** The other boundary, and the one that hung a live host for 20 minutes: the
+   *  value really IS the wrong shape, but only in one nested field, and both
+   *  sides of the prop-shaped sentence summarized to the same words — `takes a
+   *  list of rows, but this value is a list of rows`. A refusal that contradicts
+   *  itself names no repair, so the screen agent retried until the watchdog
+   *  killed it and never reached a terminal state.
+   *
+   *  A SEAM test on purpose: the `align` enum below is printed from the real
+   *  zod `tableColumn` (`contract/kit/specs.ts`) by the real typings printer and
+   *  refused by the real compiler, so nothing here can agree with itself. */
+  it("falls back to the compiler's sentence when both sides summarize alike", async () => {
+    const result = await checkComponentScreen({
+      // Hoisted out of the JSX — the shape the prompt's own `.map()` habit leads
+      // to — so tsc widens `align: "end"` to `string` with no contextual type to
+      // hold the literal.
+      source: `import { DataTable, useQuery } from "@vendo/screen";
+
+const columns = [{ key: "recipient", label: "To" }, { key: "amount_cents", label: "Amount", align: "end" }];
+
+export default function Ledger() {
+  const pending = useQuery("list_pending_transfers");
+  return <DataTable rows={pending.data} columns={columns} />;
+}
+`,
+      hostTools: tools,
+      catalog: [...catalog, "DataTable"],
+      runQuery: async () => ROWS,
+    });
+
+    const text = result.issues.map(({ message }) => message).join("\n");
+    expect(text).not.toContain("takes a list of rows, but this value is a list of rows");
+    // The repair the compiler's own nested sentence carries: the field that
+    // disagrees, and the values it will take.
+    expect(text).toContain("Types of property 'align' are incompatible");
+    expect(text).toContain('Type \'string\' is not assignable to type \'"end" | "start" | "center"\'');
+  });
 });
 
 describe("stage 4 — it runs the screen for real", () => {


### PR DESCRIPTION
## What broke

Generated screens on the TaxDome host never reached a terminal state — "Building your view…" until a 20-minute watchdog killed it. Never painted, never errored, and never escalated, which blocked the escalate-to-sandbox consent card entirely (escalation is downstream of the assembler terminating).

## Root cause

The screen agent hoisted its `columns` array out of the JSX:

```tsx
const stageColumns = [{ key: "stage", label: "Stage" }, { key: "count", label: "Jobs", align: "end" }];
```

With no contextual type at the `const`, tsc widens `align: "end"` to `string`, which the Kit's `align?: "start" | "center" | "end"` refuses. A real error — but `briefType` (`screen-program.ts:171`) collapses any array type longer than 60 characters to the fixed phrase `a list of rows`, and **both** sides of the comparison are long array types. So `attributeValueFinding` emitted:

> prop `columns` on `<DataTable>` takes a list of rows, but this value **is a list of rows** — bind a value whose type matches the prop

No edit satisfies that sentence, so the agent retried forever.

The module already knew about this failure mode — the comment at `screen-program.ts:308-313` guards the one *other* way the sentence collapses (a fault inside a callback the prop carries) and says in as many words that "a refusal that contradicts itself has no repair that satisfies it, so the model retries until it gives up". Summarizer collapse is the second way in, and it was unguarded.

## The fix

Where both sides summarize to the same words, return `undefined` and let `translate` fall through to the compiler's own nested sentence, which reaches the field that disagrees:

> Types of property 'align' are incompatible. Type 'string' is not assignable to type '"end" | "start" | "center"'.

## Not the cause

The type surface is **fine**. It is derived from the zod specs by `zodTypeText`, and `componentScreenTypings(["DataTable"])` prints `align?: "start" | "center" | "end"` and `cell?: VendoRowSlot` today — the zod schema, the prompt examples and the TS type surface all agree. The `Its keys are: key, label` line in the live log comes from a *different* path and is described below.

## Proof

Reproduced the live sentence verbatim through `checkComponentScreen` (real esbuild, real acorn scan, real tsc, real VM) before the fix, and confirmed the actionable sentence after. The new test is red without the fix and green with it.

## Separate, NOT fixed here

The other misleading sentence in the same log — `writes the key "align", which columns on <DataTable> does not accept … Its keys are: key, label` — is a different function in a different file (`badKeyMessage`, `screen-typecheck.ts:129`) and arrives when the columns array is built with `.concat()`. Its holder walk (`:154-158`) blames the nearest JSX attribute while the key list came from `concat`'s parameter type, so it asserts something false: `columns` *does* accept `align`. Reproduced, characterized, left alone — the correct fix is a design question, not a one-liner, and it is not the blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the screen agent's retry-forever loop on generated screens. When a value bound to a Kit prop differed from the prop's type in one nested field (a hoisted `columns` array whose `align: "end"` widened to `string`), the long-type summarizer collapsed both sides to the same words, producing `prop "columns" on <DataTable> takes a list of rows, but this value is a list of rows` — a refusal no edit can satisfy. The check now falls through to the compiler's own nested sentence, which names the field that disagrees and the values it accepts.

**Bug Fixes**
- Screens stuck on "Building your view…" never painted, errored, or escalated until the watchdog killed them, which blocked the escalate-to-sandbox consent card.
- Added a seam test that reproduces the collapse through the real zod specs, typings printer, compiler, and translator.
- The misleading `Its keys are: key, label` message from `badKeyMessage` in `screen-typecheck.ts` is a separate bug, reproduced but intentionally left unfixed here.

<sup>Written for commit 429817d8b1eb548933b86cd46b61e03557ba4450. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1662?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

