### PR TITLE
follow-ups: one-door playbook, memberships throw, loud policy warning

### DIFF
--- a/.changeset/memberships-joins-the-auth-throw.md
+++ b/.changeset/memberships-joins-the-auth-throw.md
@@ -1,0 +1,28 @@
+---
+"@vendoai/vendo": minor
+---
+
+A top-level `memberships` beside `auth` now throws instead of vanishing.
+
+`createVendo` already refused `principal`, `actAs` and `oauth` alongside `auth`
+— one preset or the per-seam keys, never both. `memberships` was missing from
+that list, so it was read only when `auth` was unset and otherwise dropped in
+silence.
+
+That silence had teeth. An unset memberships seam is exactly how a keyed
+deployment opts INTO the Cloud tenant directory, so a host who wrote
+`memberships: async () => []` beside an `auth` preset to say "this deployment
+has no orgs" was overruled without a word: Vendo built the directory and asked
+Cloud who the caller's orgs were.
+
+```ts
+createVendo({
+  auth: clerk(),
+  memberships: async () => [],   // was: ignored. now: throws at compose time.
+});
+```
+
+The fix is the one the error names — move it inside the door:
+`auth: { ...clerk(), memberships: async () => [] }`. A top-level `memberships`
+on its own, next to the deprecated `principal` key, is unchanged and still the
+per-seam escape hatch it always was.

--- a/.changeset/policy-file-missing-says-so.md
+++ b/.changeset/policy-file-missing-says-so.md
@@ -1,0 +1,31 @@
+---
+"@vendoai/vendo": minor
+---
+
+A missing `.vendo/policy.json` now says so, at boot and in `vendo doctor`.
+
+A deployment wired the way `vendo init` writes it — `guard: guard({ policy: {} })`
+— reads its rules from `.vendo/policy.json`. If that file is not there, the
+guard swallows it and keeps serving on its built-in posture. Nothing refused,
+nothing logged: the host's own rules simply stopped applying, and the first
+sign was an action that should have asked and didn't.
+
+The fallback is deliberate and unchanged — a missing policy file still never
+stops a boot. What changes is that it is no longer silent. The boot block gains
+a warning row:
+
+```
+◆  vendo ready
+│  ✓ guard     rules    createVendo({ guard })
+│  ⚠ guard     .vendo/policy.json is missing — this deployment's rules are NOT in force.
+│              Defaults are in effect: destructive and ungraded actions ask, everything else runs.
+│              Restore the file, or pass the rules inline: guard({ policy: { rules: [ … ] } }).
+```
+
+and `vendo doctor` gains the static twin, `wiring/policy-file` (E-CFG-001, a
+warning — doctor still exits on the same rules it did before).
+
+Both are scoped to a deployment that is actually waiting on that file. Rules
+passed inline, a preset name, and a policy config with an explicitly named
+`file` all say something different and stay silent — the first two replace the
+file outright, and a missing explicit path already throws on its own.

--- a/docs-site/agents/index.mdx
+++ b/docs-site/agents/index.mdx
@@ -426,9 +426,8 @@ when you put the choice to your human, rather than after they pick.
 
 **Both walkthroughs build on one file.** Init writes the `createVendo` call in
 `lib/vendo.ts` (`src/lib/vendo.ts` when the app lives under `src/`), with the
-wire route a thin handler over it. The caller resolver beside it is YOURS to
-add — init does not write it, and a chat route that imports a name nobody
-exported is a compile error on your human's first build:
+wire route a thin handler over it. Init exports the caller resolver beside it —
+verify both exports exist before you wire a chat route to them:
 
 ```ts lib/vendo.ts
 export const resolvePrincipal = (req: Request) => auth.principal(req);
@@ -536,8 +535,9 @@ the answer once they have an https origin to point it at.
    with the present user's session, and a door call has none.
 
    Top-level `principal`, `actAs`, and `oauth` are the deprecated spelling of
-   those same members: they still work, but pass one beside `auth` and
-   `createVendo` throws naming the mixed keys.
+   those same members, and `memberships` has a top-level spelling too: each
+   still works alone, but pass any of the four beside `auth` and `createVendo`
+   throws naming the mixed keys.
 
 2. **The discovery route.** The door's discovery documents live at ORIGIN-ROOT
    paths, outside `/api/vendo`, so the catch-all route never sees them and that

--- a/docs-site/agents/index.mdx
+++ b/docs-site/agents/index.mdx
@@ -491,12 +491,12 @@ the answer once they have an https origin to point it at.
 
 1. **`mcp: true` plus the OAuth adapter.** The door mints its own principals
    through a `HostOAuthAdapter`, and `createVendo` THROWS at composition
-   without one. Every named preset carries it, so `--auth
+   without one. `auth` is the one door that holds it: hand it a preset, or
+   hand it the object a preset returns and write the members yourself —
+   `oauth` is a member either way. Every named preset fills it, so `--auth
    authJs|clerk|supabase|auth0` (or `jwt({ secret })`) is the whole answer;
-   `--auth none` is NOT — it writes a demo `principal` and no oauth seam, so
-   the door stays shut until that seam is filled. An `auth` preset owns the
-   seam outright: pass `oauth` (or `principal`, or `actAs`) beside `auth` and
-   `createVendo` THROWS naming the mixed keys. Which preset:
+   `--auth none` is NOT — it writes `auth: { principal }` and no `oauth`
+   member, so the door stays shut until that member is filled. Which preset:
    [host auth](/howto/auth).
 
    ```ts
@@ -507,18 +507,20 @@ the answer once they have an https origin to point it at.
    ```
 
    **No login yet?** No preset applies — there is no session to read, and
-   installing a provider's SDK is not a login. Fill two seams yourself instead,
-   never beside `auth` (one preset or the per-seam trio; mixing throws at
-   composition): keep the demo `principal` `--auth none` wrote, and add an
-   `oauth` whose `session` hands the door that same subject instead of bouncing
-   a browser — the door still renders its own consent page.
+   installing a provider's SDK is not a login. Write the two members yourself,
+   in the same `auth` object `--auth none` already wrote: keep its demo
+   `principal`, and add an `oauth` whose `session` hands the door that same
+   subject instead of bouncing a browser — the door still renders its own
+   consent page.
 
    ```ts
    export const vendo = createVendo({
-     principal: async () => ({ kind: "user", subject: "demo-user" }),
-     oauth: {
-       session: async () => ({ subject: "demo-user" }),
-       principal: async (subject) => ({ kind: "user", subject }),
+     auth: {
+       principal: async () => ({ kind: "user", subject: "demo-user" }),
+       oauth: {
+         session: async () => ({ subject: "demo-user" }),
+         principal: async (subject) => ({ kind: "user", subject }),
+       },
      },
      mcp: true,
    });
@@ -532,6 +534,10 @@ the answer once they have an https origin to point it at.
    not a multi-user product. Server-action-bound tools answer
    `not-implemented` over MCP whatever `actAs` says — they execute in-process
    with the present user's session, and a door call has none.
+
+   Top-level `principal`, `actAs`, and `oauth` are the deprecated spelling of
+   those same members: they still work, but pass one beside `auth` and
+   `createVendo` throws naming the mixed keys.
 
 2. **The discovery route.** The door's discovery documents live at ORIGIN-ROOT
    paths, outside `/api/vendo`, so the catch-all route never sees them and that

--- a/packages/vendo/src/boot-summary.ts
+++ b/packages/vendo/src/boot-summary.ts
@@ -331,6 +331,21 @@ export function bootSummaryFor(composition: VendoComposition): BootSummary {
       detail: config.guard === undefined ? "createVendo({ profile })" : "createVendo({ guard })",
     });
   }
+  // …and the file that posture is waiting on, when it is not there. The guard
+  // falls back silently by design (guard/src/policy.ts:115) and keeps serving,
+  // so this line is the only place a deployment running on defaults says so.
+  // Judged by its OWNER at compose (compose-guard.ts) and read here as a
+  // property, exactly like the ephemeral-disk warning: this block may not stat.
+  if (composition.policyFileMissing !== undefined) {
+    warnings.push({
+      label: "guard",
+      lines: [
+        `${composition.policyFileMissing} is missing — this deployment's rules are NOT in force.`,
+        "Defaults are in effect: destructive and ungraded actions ask, everything else runs.",
+        "Restore the file, or pass the rules inline: guard({ policy: { rules: [ … ] } }).",
+      ],
+    });
+  }
 
   return { rows, warnings };
 }

--- a/packages/vendo/src/cli/doctor-wiring-checks.ts
+++ b/packages/vendo/src/cli/doctor-wiring-checks.ts
@@ -1,7 +1,7 @@
 import { readFile } from "node:fs/promises";
 import { dirname, join, relative } from "node:path";
 import { installedVersion } from "./dep-versions.js";
-import { CLERK_PRESET_IMPORT, composesOwnStore, detectFramework, detectVendoWiring, SUPABASE_PRESET_IMPORT, wiresClerkAuth, wiresSupabaseAuth, wiresTenantConnectors, type VendoWiring } from "./framework.js";
+import { CLERK_PRESET_IMPORT, composesOwnStore, detectFramework, detectVendoWiring, SUPABASE_PRESET_IMPORT, wiresClerkAuth, wiresPolicyFile, wiresSupabaseAuth, wiresTenantConnectors, type VendoWiring } from "./framework.js";
 import { vendoPackageInvocation } from "./provider-deps.js";
 import { compositionModulePath, importsGeneratedMap, importsSplitComposition, missingRegistrations, registrationKey, requiredServerActions, serverActionsWiring } from "./init-scaffolds.js";
 import { readUseCase } from "./install-record.js";
@@ -290,6 +290,34 @@ async function checkTenantConnectorVault(run: DoctorRun): Promise<void> {
       : " VENDO_API_KEY does not cover it here: this host passes its own createStore(), and an explicitly passed store wins."));
 }
 
+/** The static twin of the boot block's ⚠ guard row (boot-summary.ts): a host
+ *  whose guard reads its rules from a file, and no file. The guard swallows a
+ *  missing default path (guard/src/policy.ts:115) and keeps serving on its
+ *  built-in posture, so nothing at runtime refuses and nothing in the product
+ *  says the host's own rules stopped applying.
+ *
+ *  Distinct from `config/policy.json`, which answers the inventory question
+ *  ("is the file there?") for all five surfaces alike: this one answers whether
+ *  the file's absence COSTS this deployment anything, which only its wiring can
+ *  say. A host that passes its rules inline is correctly configured with no
+ *  file, and must not be told its rules are not in force.
+ *
+ *  A warning, not a failure: the deployment serves, and Yousef's call is that a
+ *  missing policy file may never stop a boot. */
+async function checkPolicyFile(run: DoctorRun): Promise<void> {
+  const { root } = run;
+  if (!await wiresPolicyFile(root)) return;
+  if (await exists(join(root, ".vendo", "policy.json"))) {
+    run.pass("wiring/policy-file", "the guard's rules are where its wiring reads them (.vendo/policy.json)");
+    return;
+  }
+  run.warn("wiring/policy-file", "E-CFG-001",
+    "this host wires guard({ policy: {} }), which reads .vendo/policy.json, and that file is missing — "
+    + "the guard boots anyway on its built-in posture (destructive and ungraded actions ask, everything "
+    + "else runs), so YOUR rules are not in force and nothing at runtime refuses. Restore the file (`vendo "
+    + "init` writes a starter one), or pass the rules inline: guard({ policy: { rules: [ … ] } }).");
+}
+
 /** The static half of doctor: is this host wired at all, does anything visible
  *  reach the agent, and is the dependency declared. No network. */
 export async function checkWiring(run: DoctorRun): Promise<void> {
@@ -326,6 +354,7 @@ export async function checkWiring(run: DoctorRun): Promise<void> {
   await checkMcpSignInKeys(run);
   await checkPresetEnv(run);
   await checkTenantConnectorVault(run);
+  await checkPolicyFile(run);
 
   if (await hasDependency(root)) run.pass("wiring/dependency", "@vendoai/vendo dependency is declared");
   else run.fail("wiring/dependency", "E-WIRE-005", "@vendoai/vendo (or vendoai alias) is not declared");

--- a/packages/vendo/src/cli/framework.ts
+++ b/packages/vendo/src/cli/framework.ts
@@ -197,6 +197,17 @@ export async function wiresTenantConnectors(root: string): Promise<boolean> {
   return hostSourceMatches(root, /\.tenantConnectors\b/);
 }
 
+/** Whether the host's guard is wired to read its rules from a FILE. The empty
+    policy object is that and nothing else — it is what `vendo init` writes
+    (cli/init-scaffolds.ts) and the one spelling whose only meaning is "the
+    rules live at the default path". Inline rules, a preset name and an
+    explicitly named `file` all say something different and are deliberately
+    not matched: the first two replace the file, the third fails loud on its
+    own (guard/src/policy.ts:115). */
+export async function wiresPolicyFile(root: string): Promise<boolean> {
+  return hostSourceMatches(root, /\bpolicy\s*:\s*\{\s*\}/);
+}
+
 /** Whether the host builds its OWN store. Load-bearing for anything that reads
     a key as evidence of a Cloud seam: an explicitly passed store always wins
     over VENDO_API_KEY (the adapter rule, compose-store.ts's `selectStore`), so

--- a/packages/vendo/src/compose-config.ts
+++ b/packages/vendo/src/compose-config.ts
@@ -132,15 +132,19 @@ export const composeConfig = (input: CreateVendoConfig): Pick<VendoComposition,
   // before anything is constructed, rather than as a dead link months later.
   validateRouteConfig(config.routes);
   validateUploadMaxBytes(config.uploadMaxBytes);
-  // 09-vendo §2.1 — one preset or the per-seam trio, never mixed. Checked
+  // 09-vendo §2.1 — one preset or the per-seam keys, never mixed. Checked
   // before anything is constructed so a miswired config leaks no resources.
+  // `memberships` is in the list for the reason the others are, and harder: it
+  // decides whether Vendo asks Cloud who the caller's orgs are, so a top-level
+  // one lost to `auth.memberships` handed a host the directory they thought
+  // they had just declined.
   if (config.auth !== undefined) {
-    const mixed = (["principal", "actAs", "oauth"] as const)
+    const mixed = (["principal", "actAs", "oauth", "memberships"] as const)
       .filter((key) => config[key] !== undefined);
     if (mixed.length > 0) {
       throw new VendoError(
         "validation",
-        `createVendo({ auth }) already fills the principal, actAs, and oauth seams from one preset (09-vendo §2.1); remove ${mixed.map((key) => `\`${key}\``).join(", ")} or drop \`auth\` — one preset or the per-seam trio, never mixed.`,
+        `createVendo({ auth }) already fills the principal, actAs, oauth and memberships seams from one preset (09-vendo §2.1); remove ${mixed.map((key) => `\`${key}\``).join(", ")} or drop \`auth\` — one preset or the per-seam keys, never mixed.`,
       );
     }
   }

--- a/packages/vendo/src/compose-context.ts
+++ b/packages/vendo/src/compose-context.ts
@@ -179,6 +179,9 @@ export interface VendoComposition {
   /** The app-then-broker risk chain the guard AND the automations engine take. */
   resolveRisk: RiskResolver;
   warnPresentCredentialsNotForwarded: VendoActionsConfig["onPresentCredentialsNotForwarded"];
+  /** The policy file this deployment expects and does not have, judged at
+      compose so the boot block can read it as a fact (boot-summary.ts). */
+  policyFileMissing: string | undefined;
 
   // ── compose-actions.ts ─────────────────────────────────────────────────────
   configuredBaseUrl: string | undefined;

--- a/packages/vendo/src/compose-guard.ts
+++ b/packages/vendo/src/compose-guard.ts
@@ -20,12 +20,44 @@ import {
   type VendoGuard,
 } from "@vendoai/guard";
 import type { VendoComposition } from "./compose-context.js";
+import { readFileSyncOrUndefined } from "./dot-vendo.js";
 import { orgPolicyPath, orgPolicyResolver, workspacePolicySource } from "./org-policy.js";
+
+/** The file the guard reads when a policy config names none of its own
+ *  (guard/src/policy.ts's DEFAULT_POLICY_FILE) — relative to the process cwd,
+ *  exactly as it reads it, so the two can never name different documents. */
+const DEFAULT_POLICY_FILE = ".vendo/policy.json";
+
+/**
+ * The policy file this deployment is waiting on and does not have.
+ *
+ * A judgment made HERE and carried on the composition, for the same reason the
+ * store's ephemeral-disk one is (boot-summary.ts): the boot block may only read
+ * composed facts, and this one needs to look at a disk.
+ *
+ * The fallback it reports STAYS — a missing file on the default path is
+ * swallowed (guard/src/policy.ts:115) so a deployment boots on the built-in
+ * posture rather than refusing, which is the right call for a file that is not
+ * required. What was missing is anyone saying it happened. And it is never the
+ * never-configured case: `vendo init` always writes a starter policy.json
+ * (cli/init.ts's `wireAndScaffold`), so file-based policy with no file means
+ * rules that went away.
+ *
+ * Silent for every config that is not waiting on that file: no policy at all
+ * (the guard reports `unconfigured`, and the chrome already says so), inline
+ * rules or a preset name (both replace the file with no merge, ibid. :141),
+ * and an explicitly named `file` (a missing one already throws, ibid. :115).
+ */
+const missingPolicyFile = (policy: PolicyConfig | undefined): string | undefined =>
+  typeof policy === "object" && policy.file === undefined && policy.rules === undefined
+    && readFileSyncOrUndefined(DEFAULT_POLICY_FILE) === undefined
+    ? DEFAULT_POLICY_FILE
+    : undefined;
 
 /** ADAPTER RULE, guard seam: a built VendoGuard is this deployment's choke
  *  point verbatim; a spec is completed here. ONE constructor either way. */
 export const composeGuard = (composition: VendoComposition): Pick<VendoComposition,
-  "guard" | "resolveRisk" | "warnPresentCredentialsNotForwarded"> => {
+  "guard" | "resolveRisk" | "warnPresentCredentialsNotForwarded" | "policyFileMissing"> => {
   const { config, store, ops } = composition;
   // profile.policy is the parsed policy.json document held in memory, for a
   // deployment with no filesystem — `vendo init` writes the file instead
@@ -136,6 +168,7 @@ export const composeGuard = (composition: VendoComposition): Pick<VendoCompositi
     guard,
     resolveRisk,
     warnPresentCredentialsNotForwarded: presentCredentialsWarning(guard),
+    policyFileMissing: missingPolicyFile(configPolicy),
   };
 };
 

--- a/packages/vendo/src/types.ts
+++ b/packages/vendo/src/types.ts
@@ -182,8 +182,9 @@ export interface CreateVendoConfig {
       reserved to the preset path — `facts`, `pools`, `memberships`, `actAs` and
       `oauth` are all hand-writable ({@link HostAuthPreset}).
 
-      Mutually exclusive with the deprecated per-seam `principal`/`actAs`/`oauth`
-      trio: mixing throws VendoError("validation") at compose time. */
+      Mutually exclusive with the per-seam `principal`/`actAs`/`oauth`/
+      `memberships` keys: mixing throws VendoError("validation") at compose
+      time. */
   auth?: HostAuthPreset;
   /** Host session → principal.
       @deprecated Use the one door: `auth: { principal }`. Same function, same
@@ -195,8 +196,10 @@ export interface CreateVendoConfig {
       `auth.memberships` for a host on the deprecated `principal` trio. Same
       seam, same precedence as `actAs` and `oauth` — set it and it wins outright.
 
-      Read ONLY when `auth` is unset: `auth` carries its own `memberships`, so a
-      config with both silently keeps the one inside `auth`. Put it there.
+      Read ONLY when `auth` is unset, and mutually exclusive with it: `auth`
+      carries its own `memberships`, so a config with both throws
+      VendoError("validation") at compose time rather than quietly keeping the
+      one inside `auth`. Put it there.
 
       This is also how a keyed deployment DECLINES the Cloud tenant directory:
       with `VENDO_API_KEY` set and this seam unset, Vendo resolves memberships

--- a/packages/vendo/tests/boot-summary.test.ts
+++ b/packages/vendo/tests/boot-summary.test.ts
@@ -322,10 +322,14 @@ describe("the composed facts", () => {
         process.chdir(before);
       }
     };
+    // Only the guard's own warnings are this suite's claim — the store adds an
+    // ephemeral-disk warning of its own on CI runners, which is not under test.
+    const guardWarnings = (warnings: readonly { label: string }[]) =>
+      warnings.filter((warning) => warning.label === "guard");
 
     it("warns, naming the path and the posture now deciding instead", () => {
       const empty = fs.mkdtempSync(join(tmpdir(), "vendo-policy-absent-"));
-      expect(inside(empty, () => summaryFor(filePolicy)).warnings).toEqual([{
+      expect(guardWarnings(inside(empty, () => summaryFor(filePolicy)).warnings)).toEqual([{
         label: "guard",
         lines: [
           ".vendo/policy.json is missing — this deployment's rules are NOT in force.",
@@ -339,7 +343,7 @@ describe("the composed facts", () => {
       const project = fs.mkdtempSync(join(tmpdir(), "vendo-policy-present-"));
       fs.mkdirSync(join(project, ".vendo"), { recursive: true });
       fs.writeFileSync(join(project, ".vendo", "policy.json"), '{"format":"vendo/policy@1","rules":[]}');
-      expect(inside(project, () => summaryFor(filePolicy)).warnings).toEqual([]);
+      expect(guardWarnings(inside(project, () => summaryFor(filePolicy)).warnings)).toEqual([]);
     });
 
     // The opt-out the config honestly supports: rules passed in code replace the
@@ -348,9 +352,9 @@ describe("the composed facts", () => {
     // `unconfigured`, earns no row, and this warning would be about nothing.
     it("says nothing for rules passed inline, or for no policy at all", () => {
       const empty = fs.mkdtempSync(join(tmpdir(), "vendo-policy-inline-"));
-      expect(inside(empty, () => summaryFor({ ...base, guard: { policy: { rules: [] } } })).warnings)
+      expect(guardWarnings(inside(empty, () => summaryFor({ ...base, guard: { policy: { rules: [] } } })).warnings))
         .toEqual([]);
-      expect(inside(empty, () => summaryFor(base)).warnings).toEqual([]);
+      expect(guardWarnings(inside(empty, () => summaryFor(base)).warnings)).toEqual([]);
     });
   });
 

--- a/packages/vendo/tests/boot-summary.test.ts
+++ b/packages/vendo/tests/boot-summary.test.ts
@@ -301,6 +301,59 @@ describe("the composed facts", () => {
     });
   });
 
+  /**
+   * The guard reads `.vendo/policy.json` and finds nothing — the one config
+   * failure the runtime is DESIGNED to swallow (guard/src/policy.ts:115). The
+   * fallback stays; the silence does not.
+   *
+   * Composed for real against a real working directory, because the whole claim
+   * is that the judgment looks at a disk: `guard({ policy: {} })` is the
+   * file-based spelling `vendo init` writes, and the only difference between
+   * these two cases is whether the file is there.
+   */
+  describe("the policy file behind that posture", () => {
+    const filePolicy: CreateVendoConfig = { ...base, guard: { policy: {} } };
+    const inside = <T>(directory: string, run: () => T): T => {
+      const before = process.cwd();
+      process.chdir(directory);
+      try {
+        return run();
+      } finally {
+        process.chdir(before);
+      }
+    };
+
+    it("warns, naming the path and the posture now deciding instead", () => {
+      const empty = fs.mkdtempSync(join(tmpdir(), "vendo-policy-absent-"));
+      expect(inside(empty, () => summaryFor(filePolicy)).warnings).toEqual([{
+        label: "guard",
+        lines: [
+          ".vendo/policy.json is missing — this deployment's rules are NOT in force.",
+          "Defaults are in effect: destructive and ungraded actions ask, everything else runs.",
+          "Restore the file, or pass the rules inline: guard({ policy: { rules: [ … ] } }).",
+        ],
+      }]);
+    });
+
+    it("says nothing when the file is there", () => {
+      const project = fs.mkdtempSync(join(tmpdir(), "vendo-policy-present-"));
+      fs.mkdirSync(join(project, ".vendo"), { recursive: true });
+      fs.writeFileSync(join(project, ".vendo", "policy.json"), '{"format":"vendo/policy@1","rules":[]}');
+      expect(inside(project, () => summaryFor(filePolicy)).warnings).toEqual([]);
+    });
+
+    // The opt-out the config honestly supports: rules passed in code replace the
+    // file with no merge (guard/src/policy.ts:141), so there is no file to miss.
+    // Same for a deployment that configured no policy at all — the guard reports
+    // `unconfigured`, earns no row, and this warning would be about nothing.
+    it("says nothing for rules passed inline, or for no policy at all", () => {
+      const empty = fs.mkdtempSync(join(tmpdir(), "vendo-policy-inline-"));
+      expect(inside(empty, () => summaryFor({ ...base, guard: { policy: { rules: [] } } })).warnings)
+        .toEqual([]);
+      expect(inside(empty, () => summaryFor(base)).warnings).toEqual([]);
+    });
+  });
+
   // The row's whole value is knowing WHICH auth is live, so it is read off the
   // real preset factories — not off a `name` a test wrote itself, which would
   // only prove the test agrees with the test.

--- a/packages/vendo/tests/cli/doctor-policy-file.test.ts
+++ b/packages/vendo/tests/cli/doctor-policy-file.test.ts
@@ -1,0 +1,96 @@
+/**
+ * The static twin of the boot block's ⚠ guard row: a host whose guard reads its
+ * rules from a file, and no file. Doctor is static, so the whole fixture is two
+ * things on disk — the wiring's spelling, and whether `.vendo/policy.json` is
+ * there.
+ *
+ * The one that must be able to fail: drop the file test and phase 2 goes red;
+ * drop the source marker and phase 1 goes red.
+ */
+import { mkdtemp, mkdir, rm, unlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { runDoctor } from "../../src/cli/doctor.js";
+import type { DoctorCheck } from "../../src/cli/doctor-report.js";
+
+const cleanup: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const dispose of cleanup.splice(0).reverse()) await dispose();
+});
+
+/** A pinned model credential, so the fixtures below are about THIS check. */
+const MODEL_PINNED = { VENDO_DEV_CREDENTIAL: "env-key:anthropic", ANTHROPIC_API_KEY: "sk-test" };
+
+/** How this host spells its guard. `file` is what `vendo init` writes; `inline`
+ *  is the opt-out — rules in code replace the file entirely; `none` wires no
+ *  policy at all. */
+type Wiring = "file" | "inline" | "none";
+
+const GUARD_LINE: Record<Wiring, string> = {
+  file: "guard: guard({ policy: {} }),",
+  inline: "guard: guard({ policy: { rules: [{ match: { risk: \"destructive\" }, action: \"ask\" }] } }),",
+  none: "",
+};
+
+async function host(wiring: Wiring, policyFile: boolean): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "vendo-doctor-policy-"));
+  cleanup.push(() => rm(root, { recursive: true, force: true }));
+  const write = async (relative: string, body: string): Promise<void> => {
+    const path = join(root, relative);
+    await mkdir(join(path, ".."), { recursive: true });
+    await writeFile(path, body);
+  };
+  await write("package.json", JSON.stringify({ dependencies: { "@vendoai/vendo": "0.3.0" } }));
+  await write("src/server.ts",
+    'import { createVendo, guard } from "@vendoai/vendo/server";\n'
+    + `export const vendo = createVendo({ principal, ${GUARD_LINE[wiring]} });\n`);
+  await write("src/client.tsx", "export const App = () => <VendoProvider><VendoOverlay /></VendoProvider>;\n");
+  for (const file of ["tools.json", "overrides.json", "policy.json", "brief.md", "theme.json"]) await write(`.vendo/${file}`, "{}\n");
+  await write(".vendo/data/.gitignore", "*\n");
+  // Removed rather than never written, so the fixture differs from the healthy
+  // one in exactly the thing under test.
+  if (!policyFile) await unlink(join(root, ".vendo", "policy.json"));
+  return root;
+}
+
+/** Doctor's own report for one host. */
+async function policyCheck(wiring: Wiring, policyFile: boolean): Promise<DoctorCheck | undefined> {
+  const lines: string[] = [];
+  await runDoctor({
+    targetDir: await host(wiring, policyFile),
+    json: true,
+    env: MODEL_PINNED,
+    output: { log: (line) => lines.push(line), error: () => undefined },
+  });
+  const report = JSON.parse(lines.at(-1) ?? "{}") as { checks?: DoctorCheck[] };
+  return report.checks?.find((check) => check.id === "wiring/policy-file");
+}
+
+describe("the policy-file check", () => {
+  it("warns that the host's own rules are not in force, and how to get them back", async () => {
+    const check = await policyCheck("file", false);
+    expect(check).toMatchObject({ status: "warning", error_code: "E-CFG-001" });
+    expect(check?.message).toContain(".vendo/policy.json");
+    // The consequence, which mere absence does not say: the deployment SERVES,
+    // on a posture the host did not write.
+    expect(check?.message).toContain("YOUR rules are not in force");
+    expect(check?.message).toContain("destructive and ungraded actions ask");
+    expect(check?.message).toContain("guard({ policy: { rules: [ … ] } })");
+    // The code is in the PATH, not a fragment: a fragment never reaches the
+    // server, so it could not select the code's own troubleshooting page.
+    expect(check?.fix_ref).toContain("/production/troubleshooting/e-cfg-001");
+  });
+
+  it("passes the same host once the file is there", async () => {
+    expect(await policyCheck("file", true)).toMatchObject({ status: "ok" });
+  });
+
+  // A host with its rules in code is correctly configured with no file, and
+  // telling it otherwise would be a lie — the inventory check (config/policy.json)
+  // already reports mere absence for every surface alike.
+  it("says nothing at all to a host that does not read its rules from a file", async () => {
+    expect(await policyCheck("inline", false)).toBeUndefined();
+    expect(await policyCheck("none", false)).toBeUndefined();
+  });
+});

--- a/packages/vendo/tests/compose-directory.test.ts
+++ b/packages/vendo/tests/compose-directory.test.ts
@@ -54,6 +54,18 @@ describe("the memberships seam's Cloud default", () => {
     expect(composed.directory).toBeUndefined();
     vi.unstubAllEnvs();
   });
+
+  // …and mixing the twin with the one door is refused rather than resolved. The
+  // top-level key used to lose silently to `auth.memberships`, so a host who
+  // wrote `memberships: async () => []` beside an `auth` preset believed they
+  // had declined the Cloud directory and got it anyway — the seam that decides
+  // whether a deployment has orgs is the last one allowed to fail quietly.
+  it("refuses `memberships` beside `auth` instead of quietly dropping it", () => {
+    expect(() => composeConfig({
+      auth: { principal: async () => ({ kind: "user", subject: "dev" }) },
+      memberships: async () => [],
+    } as CreateVendoConfig)).toThrow(/memberships[\s\S]*never mixed/);
+  });
 });
 
 import { composeLimits } from "../src/limits.js";


### PR DESCRIPTION
Four small approved follow-ups to #1656:
- **fix(vendo):** a top-level `memberships` beside `auth` now throws with the other loose keys instead of being silently ignored (minor changeset).
- **feat(vendo):** a missing `.vendo/policy.json` (when file-based policy is configured) warns loudly at boot and in `vendo doctor` — the guard's safe default fallback is unchanged (minor changeset).
- **docs(agents):** the machine playbook teaches the one-door `auth` object; the deprecated loose keys survive as one compat line.
- **docs(agents):** two truth fixes — init does write `resolvePrincipal`, and the compat line names all four loose keys.

The planned CSRF prompt sentence was dropped: main's built-apps rework sealed apps into no-network iframes, dissolving the concern entirely.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Follow-ups to the one-door `auth` work: `memberships` beside `auth` now throws instead of vanishing, a missing `.vendo/policy.json` warns when the guard reads it, and the agents playbook teaches the one-door `auth` object.

**Bug Fixes**
- Top-level `memberships` beside `auth` used to be silently dropped, so hosts thinking they declined the Cloud directory got it anyway; now `createVendo` throws at compose time telling you to move it inside `auth`.
- A deployment wired `guard({ policy: {} })` with no policy file boots on the fallback posture but now warns at boot and in `vendo doctor` (`E-CFG-001`).

**Docs**
- The agents playbook now writes `auth: { principal, oauth }` instead of the deprecated loose keys, with a compat line for the old spellings.
- Fixes two truth errors: init does export `resolvePrincipal`, and the compat line names all four loose keys.

<sup>Written for commit 69d75c2b2408665f0d32b535dbeecc69843de992. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1663?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

