### PR TITLE
fix(voice): keep tool identifiers and run-on sentences out of the answer

### DIFF
--- a/.changeset/tool-ids-out-of-the-answer.md
+++ b/.changeset/tool-ids-out-of-the-answer.md
@@ -1,0 +1,10 @@
+---
+"@vendoai/core": patch
+"@vendoai/harnesses": patch
+---
+
+fix: keep internal tool identifiers and run-on sentences out of the answer a user reads.
+
+`modelToolDescription` dropped the human label whenever a host authored no `title` (or the listing's title had fallen back to the tool's own name), so on a host whose `.vendo/tools.json` carries descriptions but no titles the identifier was the only proper noun the model held — and it printed `host_getClient`, `host_listJobs` and `host_getRevenueByMonth` in a live answer, on a host whose own design rules forbid showing an internal id. The label now falls back down the same ladder the render layer already walks (Vendo's own title table, then the prettified id), so the beat on screen and the model's vocabulary say the same words instead of the screen saying "Get client" while the model has nothing but `host_getClient`. Nothing about the CALL name changes.
+
+`vendo()` also dropped the model's own text-block boundaries, and the wire opens a fresh transcript part only when a tool call is mirrored — so two adjacent blocks ran together mid-sentence ("…exposed here.No matching tool exists…"). A block boundary now travels as a paragraph break.

--- a/packages/core/src/tools.ts
+++ b/packages/core/src/tools.ts
@@ -200,16 +200,22 @@ export function humanizeToolName(raw: string): string {
  * identifier stays the CALL name; this is the one place the human label enters
  * the model's vocabulary.
  *
- * A title equal to the name adds nothing (`ToolListing.title` falls back to the
- * name) and would teach exactly the wrong vocabulary, so it is dropped.
+ * A title equal to the name is no title at all (`ToolListing.title` falls back to
+ * the name), and neither is a missing one — so the label falls back down the SAME
+ * ladder the render layer walks (`toolTitle`, ui/humanize.ts): our own table, then
+ * the prettified id. Dropping the label instead is what leaked
+ * `host_getClient` into a TaxDome answer — the screen's beat said "Get client"
+ * while the model, told to say the title and given none, had only the identifier.
+ * Both sides now read one ladder, so they cannot say different words.
  */
 export function modelToolDescription(
   tool: { name: string; title?: string; description: string },
 ): string {
-  const title = tool.title?.trim();
-  return title === undefined || title === "" || title === tool.name
-    ? tool.description
-    : `${title} — ${tool.description}`;
+  const authored = tool.title?.trim();
+  const title = authored === undefined || authored === "" || authored === tool.name
+    ? VENDO_TOOL_TITLES[tool.name] ?? humanizeToolName(tool.name)
+    : authored;
+  return `${title} — ${tool.description}`;
 }
 
 /** The message prefix the apps runtime stamps on a terminally failed BUILD's

--- a/packages/core/tests/tools.test.ts
+++ b/packages/core/tests/tools.test.ts
@@ -70,12 +70,25 @@ describe("modelToolDescription — the model can only speak a title it was told"
     })).toBe("Send money — Send money to a person from the user's checking account.");
   });
 
-  it("leaves the description alone when there is no title to add", () => {
-    expect(modelToolDescription({ name: "host_x", description: "Does a thing." })).toBe("Does a thing.");
-    expect(modelToolDescription({ name: "host_x", title: "  ", description: "Does a thing." })).toBe("Does a thing.");
-    // `ToolListing.title` falls back to the NAME; repeating the identifier as a
-    // label would teach the model exactly the wrong vocabulary.
-    expect(modelToolDescription({ name: "host_x", title: "host_x", description: "Does a thing." })).toBe("Does a thing.");
+  // This case used to assert that an untitled tool kept its bare description,
+  // which is the DEFECT: a TaxDome host whose `.vendo/tools.json` authored no
+  // titles left the model with identifiers as the only names it had, and it
+  // printed `host_getClient` in an answer. Falling back is not inventing a
+  // label — it is reading the SAME ladder the render layer already walks, so
+  // the beat on screen and the model's vocabulary cannot say different words.
+  it("falls back to the prettified id when the host authored no title", () => {
+    expect(modelToolDescription({ name: "host_getClient", description: "Does a thing." }))
+      .toBe("Get client — Does a thing.");
+    expect(modelToolDescription({ name: "host_getClient", title: "  ", description: "Does a thing." }))
+      .toBe("Get client — Does a thing.");
+    // `ToolListing.title` falls back to the NAME, which is no title at all.
+    expect(modelToolDescription({ name: "host_getClient", title: "host_getClient", description: "Does a thing." }))
+      .toBe("Get client — Does a thing.");
+  });
+
+  it("prefers Vendo's own table for Vendo's own tools", () => {
+    expect(modelToolDescription({ name: "vendo_apps_open", description: "Opens it." }))
+      .toBe("Open the app — Opens it.");
   });
 });
 

--- a/packages/harnesses/src/vendo/vendo.ts
+++ b/packages/harnesses/src/vendo/vendo.ts
@@ -663,6 +663,13 @@ export function vendo(deps: VendoHarnessDeps = {}): Harness<VendoHarnessOptions>
 
       /** The turn's single retry, spent. */
       let retried = false;
+      /** Whether the model closed a text block that nothing has followed yet. The
+       *  wire's `TextChannel` starts a fresh part only when a tool call is
+       *  mirrored, so two ADJACENT blocks — what interleaved thinking produces —
+       *  ran together mid-sentence ("…exposed here.No matching tool exists…" in a
+       *  TaxDome answer). A block boundary is a paragraph boundary; carrying it as
+       *  markdown keeps `HarnessEvent` closed (§1.5). */
+      let blockEnded = false;
       for (;;) {
         /** Set when THIS attempt died on a prompt that did not fit. */
         let overflowed = false;
@@ -670,7 +677,11 @@ export function vendo(deps: VendoHarnessDeps = {}): Harness<VendoHarnessOptions>
           for await (const part of loop.result.fullStream) {
             switch (part.type) {
               case "text-delta":
-                yield { type: "text", delta: part.text };
+                yield { type: "text", delta: blockEnded ? `\n\n${part.text}` : part.text };
+                blockEnded = false;
+                break;
+              case "text-end":
+                blockEnded = true;
                 break;
               case "finish-step":
                 // Which model actually served it, which a lazy seat cannot say

--- a/packages/harnesses/tests/answer-voice.test.ts
+++ b/packages/harnesses/tests/answer-voice.test.ts
@@ -1,0 +1,110 @@
+/**
+ * What the USER reads, proven end to end: the real `vendo()` loop, the real
+ * runtime, the real wire. Both defects here were photographed in one TaxDome
+ * answer, and both were invisible to a suite that stopped at the harness events
+ * — the leak is in what the loop TELLS the model, and the run-on only exists
+ * once `TextChannel` has folded the loop's deltas into transcript parts.
+ */
+import type { ThreadId, ToolDescriptor } from "@vendoai/core";
+import { simulateReadableStream } from "ai";
+import { MockLanguageModelV3 } from "ai/test";
+import { expect, it } from "vitest";
+import { createHarnessRuntime } from "../src/runtime.js";
+import { vendo } from "../src/vendo/vendo.js";
+import {
+  boundRegistry,
+  ctx,
+  readSse,
+  seats,
+  testGuard,
+  testSkills,
+  testTranscript,
+  testWorkspace,
+  userMessage,
+  ZERO_USAGE,
+  type StreamPart,
+} from "../src/test-doubles.test-util.js";
+
+const THREAD = "thr_voice" as ThreadId;
+
+/** A host tool shaped the way TaxDome's really are: an operational description
+ *  and NO authored title, which is what `.vendo/tools.json` holds when sync's
+ *  enrichment never wrote one. */
+const untitled: ToolDescriptor = {
+  name: "host_getClient",
+  description: "Look up one client account by id.",
+  inputSchema: { type: "object", properties: {}, additionalProperties: true },
+  risk: "read",
+};
+
+/** One model step carrying SEVERAL text blocks and no tool call — the shape
+ *  interleaved thinking produces, and the one nothing mirrors. */
+function textBlocks(...blocks: string[]): StreamPart[] {
+  return [
+    ...blocks.flatMap((text, index): StreamPart[] => [
+      { type: "text-start", id: `t${index}` },
+      { type: "text-delta", id: `t${index}`, delta: text },
+      { type: "text-end", id: `t${index}` },
+    ]),
+    { type: "finish", usage: ZERO_USAGE, finishReason: { unified: "stop", raw: undefined } },
+  ];
+}
+
+/** Drive one turn through the shipped rails, keeping both the toolset the model
+ *  was handed and the parts the transcript received. */
+async function turn(chunks: StreamPart[]) {
+  const guard = testGuard();
+  const registry = boundRegistry(
+    { host_getClient: { descriptor: untitled, execute: () => ({ ok: true }) } },
+    guard,
+  );
+  const offered: Array<{ name: string; description?: string }> = [];
+  const model = new MockLanguageModelV3({
+    doStream: async (request) => {
+      offered.push(...request.tools ?? []);
+      return { stream: simulateReadableStream({ chunks }) };
+    },
+  });
+  const runtime = createHarnessRuntime({
+    tools: registry,
+    guard,
+    skills: testSkills(),
+    transcript: testTranscript(),
+  });
+  const parts = await readSse(await runtime.run({
+    harness: vendo(),
+    threadId: THREAD,
+    messages: [userMessage("m1", "file these under the right clients")],
+    ctx: ctx(),
+    workspace: testWorkspace(),
+    models: seats(model),
+    interactive: true,
+  }));
+  return { offered, parts };
+}
+
+it("hands the model a human title for a host tool that authored none", async () => {
+  const { offered } = await turn(textBlocks("done"));
+  // The identifier stays the CALL name — it has to. What must not be the only
+  // proper noun the model holds is that identifier: told to say a tool's title
+  // and given none, it said `host_getClient` to a TaxDome user whose own design
+  // rules forbid printing an internal id.
+  expect(offered.find(tool => tool.name === "host_getClient")?.description)
+    .toBe("Get client — Look up one client account by id.");
+});
+
+it("keeps two of the model's own text blocks from running together", async () => {
+  const { parts } = await turn(textBlocks(
+    "There's no document upload/filing capability exposed here.",
+    "No matching tool exists for filing a document under a client in this host.",
+  ));
+  const answer = parts
+    .filter(part => part.type === "text-delta")
+    .map(part => part.delta as string)
+    .join("");
+  expect(answer).not.toContain("here.No matching");
+  expect(answer).toBe(
+    "There's no document upload/filing capability exposed here."
+    + "\n\nNo matching tool exists for filing a document under a client in this host.",
+  );
+});


### PR DESCRIPTION
Two defects photographed in one TaxDome answer, both legible in the payoff frame of the sales GIF.

## 1 · the model had no word for a tool but its identifier

`modelToolDescription` (`packages/core/src/tools.ts`) dropped the human label whenever the listing carried no authored `title` — and `ToolListing.title` falls back to the tool's own NAME (`packages/harnesses/src/turn-tools.ts:248`), so "no title" is the ordinary case for a host whose `.vendo/tools.json` has descriptions and nothing else. TaxDome is exactly that host: **zero** of its 15 tools author a title.

So the model was handed `description` alone, leaving the identifier as the only proper noun it held — and it printed `host_getClient`, `host_listJobs` and `host_getRevenueByMonth` to a user whose own `designRules` forbid showing an internal id.

The prompt already promised this could not happen (`packages/vendo/src/prompt.ts:44` — *"Each tool's description leads with its human title before an em dash; say the title, never the identifier — not even in backticks"*). The instruction was unfollowable: there was no title to say. This makes the promise true by walking the **same ladder the render layer already walks** (`toolTitle`, `packages/ui/src/chrome/humanize.ts:54`) — Vendo's own table, then the prettified id. The screen's beat already said "Get client"; now the model has the same word. Two sides, one ladder, so they cannot say different things. The CALL name is untouched.

## 2 · two of the model's own paragraphs ran together mid-sentence

`vendo()` forwarded `text-delta` but dropped the SDK's `text-start`/`text-end` block boundaries into its `default` case, and the wire's `TextChannel` opens a fresh transcript part only when a **tool call** is mirrored. Two adjacent text blocks therefore landed in one part with no separator: `"…exposed here.No matching tool exists…"`. A block boundary now travels as a paragraph break, which keeps the `HarnessEvent` union closed (§1.5).

## Proof on the real path

New seam test `packages/harnesses/tests/answer-voice.test.ts` drives the **real** `vendo()` loop through the **real** runtime and reads the **real** wire parts — no stub on either side; only the model provider is scripted. Both assertions fail on `main` with exactly the photographed symptoms:

```
AssertionError: expected 'Look up one client account by id.' to be 'Get client — Look up one client accou…'
AssertionError: expected 'There\'s no document upload/filing ca…' not to contain 'here.No matching'
```

## Test change, stated out loud

`modelToolDescription`'s case *"leaves the description alone when there is no title to add"* asserted the **defect** — it pinned the behaviour that leaked the identifier. It is rewritten to assert the fallback, plus one new case pinning Vendo's own table for Vendo's own tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two defects that appeared in one live TaxDome answer: the model named tools by their internal identifiers (like `host_getClient`) instead of human titles, and its own adjacent text blocks ran together without a separator.

**Bug Fixes**
- `modelToolDescription` now falls back to a human title from Vendo's own title table, then the prettified id, when a host authors no tool title; the CALL name is unchanged.
- `vendo()` now renders model text-block boundaries as paragraph breaks instead of dropping them.
- A new seam test drives the real loop and wire, and the old test that pinned the leaking behavior now asserts the fallback.

<sup>Written for commit c16b566ed35ee7668548afb1a546f816a0e14e61. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1673?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

