### PR TITLE
fix(apps): a vendo_make EDIT hands back the builder's own words, not the app's name

### DIFF
--- a/.changeset/edit-receipt-carries-the-builders-words.md
+++ b/.changeset/edit-receipt-carries-the-builders-words.md
@@ -1,0 +1,20 @@
+---
+"@vendoai/apps": patch
+---
+
+A `vendo_make` EDIT hands back the builder's own words, not the app's name.
+
+The create arm has relayed the assembling agent's closing sentence since the
+front door stopped composing one out of the app's title. The edit arm never did:
+every landed change answered `"<name> is updated."` and every refused one
+`"I couldn't make that change to <name>."` — a title and no facts. The floor's
+own reason for the refusal was already computed and carried as far as
+`EditResult.issues`, then dropped at the door.
+
+Handed a title and no facts, a calling agent invents the rest. Across six
+consecutive runs on a demo host, a chat agent told the person a per-client
+document tracker was "still intact" over a stage-by-assignee table it had never
+seen, and reported features that were never on the screen.
+
+`ScreenOutcome.say` now travels the edit path the same way it travels the create
+path, and a refused edit says why in the floor's own sentences.

--- a/packages/apps/src/server/doors/make-tool.ts
+++ b/packages/apps/src/server/doors/make-tool.ts
@@ -267,13 +267,25 @@ const changeExistingApp = async (
   if (result.automation !== undefined && stream !== undefined) {
     publishAutomationCard(stream, result.automation);
   }
+  // THE BUILDER'S OWN WORDS on this arm too (`make-receipt.ts` law 2). The create
+  // arm has relayed them since the front door stopped composing from the app's
+  // name alone; this one never did, so every landed edit answered
+  // "<name> is updated." and every refused one "I couldn't make that change to
+  // <name>" — a title and no facts, which is precisely what the calling agent
+  // invents around. Live 2026-08-27 (TaxDome): told only that, it reported a
+  // per-client document tracker "still intact" over a stage-by-assignee table.
+  // The refusal keeps its own sentence — the floor's lines say what is wrong with
+  // the change, and the builder's last words describe the screen it did not
+  // change.
+  const why = result.issues?.join(" ").trim();
   return receipt({
     id: result.app.id,
     title: result.app.name,
     status: result.failure === undefined ? "ready" : "failed",
     say: result.failure === undefined
-      ? `${result.app.name} is updated.`
-      : `I couldn't make that change to ${result.app.name}.`,
+      ? result.say ?? `${result.app.name} is updated.`
+      : `I couldn't make that change to ${result.app.name}${
+        why === undefined || why === "" ? "." : ` — ${why}`}`,
   });
 };
 

--- a/packages/apps/src/server/doors/write-surface.ts
+++ b/packages/apps/src/server/doors/write-surface.ts
@@ -362,6 +362,7 @@ const createEditDoor = (
     return ({
       app,
       version,
+      ...(edited.say === undefined ? {} : { say: edited.say }),
       ...(issues.length === 0 ? {} : { issues }),
       ...(automation === undefined ? {} : { automation }),
       ...(graduated === undefined ? {} : { graduated }),

--- a/packages/apps/src/server/persistence/edit-journal.ts
+++ b/packages/apps/src/server/persistence/edit-journal.ts
@@ -342,7 +342,10 @@ const createEditAssembler = (
     instruction: string,
     ctx: RunContext,
   ): Promise<
-    | { kind: "assembled"; app: AppDocument }
+    /** `say` is the run's own closing words, and it travels for the same reason
+     *  the create arm's does: only the thing that changed the screen knows what
+     *  is on it now. */
+    | { kind: "assembled"; app: AppDocument; say?: string }
     /** The CHANGE needs the builder — the escalation ladder, from an app that
      *  already exists. `why` is the escalating agent's own one line; the
      *  document is untouched and still serving. */
@@ -390,7 +393,11 @@ const createEditAssembler = (
     // document every other door hands out — the row is the answer and it must
     // read identically wherever it is read.
     try {
-      return { kind: "assembled", app: await requireOwned(appId, ctx) };
+      return {
+        kind: "assembled",
+        app: await requireOwned(appId, ctx),
+        ...(outcome.say === undefined ? {} : { say: outcome.say }),
+      };
     } catch (error) {
       // Only a MISSING row means nothing rendered. A store that could not answer
       // has said nothing about the screen — the save landed — so reporting it as

--- a/packages/apps/src/server/runtime/runtime-context.ts
+++ b/packages/apps/src/server/runtime/runtime-context.ts
@@ -155,7 +155,7 @@ export interface AppsRuntimeContext {
     instruction: string,
     ctx: RunContext,
   ): Promise<
-    | { kind: "assembled"; app: AppDocument }
+    | { kind: "assembled"; app: AppDocument; say?: string }
     | { kind: "escalate"; why: string }
     | { kind: "failed"; issues: string[] }
   >;

--- a/packages/apps/src/server/runtime/types.ts
+++ b/packages/apps/src/server/runtime/types.ts
@@ -260,6 +260,10 @@ export interface AppsConfig {
 export interface EditResult {
   app: AppDocument;
   version: VersionEntry;
+  /** What the assembling agent SAID when it finished this edit — its own closing
+   *  words, verbatim (`ScreenOutcome.say`), which `vendo_make` puts in the
+   *  receipt's `say`. Absent when the run said nothing; the door falls back. */
+  say?: string;
   issues?: string[];
   /** Additive failure detail: when present, no edit was persisted. */
   failure?: EditFailure;

--- a/packages/vendo/tests/screen-route.e2e.test.ts
+++ b/packages/vendo/tests/screen-route.e2e.test.ts
@@ -186,6 +186,8 @@ async function tempStore(): Promise<VendoStore> {
 interface Walked {
   /** What the calling agent got back from `vendo_make` — words, never UI. */
   result: ToolResult | undefined;
+  /** The second `vendo_make`, naming the app the first one made: the EDIT arm. */
+  edited: ToolResult | undefined;
   /** Everything that crossed the wire to the surface. */
   chunks: Array<Record<string, unknown>>;
   vendo: ReturnType<typeof createVendo>;
@@ -208,10 +210,14 @@ async function walk(options: {
   review?: LanguageModel;
   /** This host's own design rules, exactly as a deployment sets them. */
   designRules?: string;
+  /** A follow-up ask, aimed at the app the first call made — the EDIT arm of the
+   *  same door, driven by the same scripted model. */
+  then?: string;
 }): Promise<Walked> {
   const store = await tempStore();
   const model = scripted(options.turns);
   let result: ToolResult | undefined;
+  let edited: ToolResult | undefined;
   const harness = defineHarness({
     name: "make-probe",
     async *run(turn) {
@@ -226,6 +232,10 @@ async function walk(options: {
       result = await turn.tools.call(VENDO_MAKE_TOOL, {
         request: options.request ?? "show me what I spent this month",
       });
+      if (options.then !== undefined) {
+        const made = makeReceiptSchema.parse((result as { output: unknown }).output);
+        edited = await turn.tools.call(VENDO_MAKE_TOOL, { app: made.id, request: options.then });
+      }
       yield { type: "text", delta: "ok" };
     },
   });
@@ -250,7 +260,7 @@ async function walk(options: {
     .split("\n\n")
     .filter((block) => block.startsWith("data: ") && !block.includes("[DONE]"))
     .map((block) => JSON.parse(block.slice("data: ".length)) as Record<string, unknown>);
-  return { result, chunks, vendo, model };
+  return { result, edited, chunks, vendo, model };
 }
 
 describe("vendo_make routed through the screen agent (blueprint §1 point 2)", () => {
@@ -405,6 +415,53 @@ describe("vendo_make routed through the screen agent (blueprint §1 point 2)", (
     expect(walked.chunks.filter((chunk) => chunk["type"] === "data-vendo-view")).toHaveLength(0);
     expect(walked.model.calls).toBe(2);
   }, 60_000);
+
+  /**
+   * THE EDIT ARM ANSWERS THE SAME WAY THE CREATE ARM DOES.
+   *
+   * Live 2026-08-27 (TaxDome, six consecutive runs): a `vendo_make` naming an
+   * `app` answered `"<name> is updated."` and `"I couldn't make that change to
+   * <name>."` — the front door composing a sentence out of the app's name, which
+   * is exactly the shape the create arm was cured of. Handed a title and no
+   * facts, the calling agent invented the rest: it reported a per-client document
+   * tracker "still intact" over a stage-by-assignee table it had never seen.
+   *
+   * Both halves are the seam and neither is stubbed: the words are written by the
+   * screen agent at the far end of a REAL edit (real store, real floor, real
+   * paint), and read back off the receipt the calling agent actually got.
+   */
+  it("relays the builder's own words on an EDIT, and the reason a refused one failed", async () => {
+    const landed = await walk({
+      then: "add the total for the month",
+      turns: [
+        call("save_app", { content: SPENDING }, "c1"),
+        speak("Your spending for this month is on your screen."),
+        // The edit's own drive, on the same scripted model.
+        call("save_app", { content: SPENDING.replace("This month", "This month, totalled") }, "c2"),
+        speak("The month's total is on it now — nothing else moved."),
+      ],
+    });
+    const changed = makeReceiptSchema.parse((landed.edited as { output: unknown }).output);
+    expect(changed.status).toBe("ready");
+    expect(changed.say).toBe("The month's total is on it now — nothing else moved.");
+    expect(changed.say).not.toBe("Spending is updated.");
+
+    // …and a change the floor refuses says WHY, in the floor's own sentences,
+    // instead of a name and a shrug.
+    const refused = await walk({
+      then: "add the total for the month",
+      turns: [
+        call("save_app", { content: SPENDING }, "c1"),
+        speak("Your spending for this month is on your screen."),
+        call("save_app", { content: LYING }, "c2"),
+        speak("done"),
+      ],
+    });
+    const declined = makeReceiptSchema.parse((refused.edited as { output: unknown }).output);
+    expect(declined.status).toBe("failed");
+    expect(declined.say).toContain("I couldn't make that change to Spending — ");
+    expect(declined.say).toContain("nope_notATool");
+  }, 120_000);
 });
 
 /**


### PR DESCRIPTION
## What was wrong

The `vendo_make` create arm has relayed the assembling agent's own closing
sentence since the front door stopped composing one out of the app's title —
`make-receipt.ts` law 2: *"only the thing that built the screen knows what is on
it… A sentence composed here from the app's name alone gave the calling agent a
title and no facts, and it invented the rest."*

**The edit arm never got that fix.** Three places, in order:

- `packages/apps/src/server/persistence/edit-journal.ts:393` — `assembleEdit`
  drops `ScreenOutcome.say` on the floor.
- `packages/apps/src/server/runtime/types.ts:260` — `EditResult` has nowhere to
  put it.
- `packages/apps/src/server/doors/make-tool.ts:270` — so the receipt is composed
  from the name: `"<name> is updated."` when it landed,
  `"I couldn't make that change to <name>."` when it did not. The floor's own
  reason was already computed and carried as far as `EditResult.issues`, and was
  discarded at the door too.

## What it cost

Captured verbatim off a real TaxDome turn (2026-08-27), from the tool-result
stream the calling agent reads:

```json
{"id":"app_3002…","title":"Firm ops","status":"failed",
 "say":"I couldn't make that change to Firm ops."}
```

Told only that, the agent told the person *"The document-collection portal
itself is still intact"* — over a stage-by-assignee table with no document
tracking on it at all. Six consecutive runs on that host had narration and DOM
disagree 6 out of 6 times.

## The fix

`say` travels the edit path the same way it travels the create path, and a
refused edit says why in the floor's own sentences. Same real turn, after:

```json
{"status":"failed",
 "say":"I couldn't make that change to Firm dashboard — line 72: prop
        \"columns\" on <DataTable> takes a list of rows, but this value is a
        list of rows — bind a value whose type matches the prop; …"}
```

(That refusal contradicting itself is a separate, already-fixed bug — #1662.
This change is what makes it visible to the caller at all.)

## Proof

- New seam test in `packages/vendo/tests/screen-route.e2e.test.ts` — a real edit
  through the real store, real checks floor, real paint and the real front door,
  read back off the receipt the calling agent actually got. Nothing stubbed on
  either side; only the model's words are scripted, as everywhere else in that
  file.
- Negative control: with the door change reverted, the new test fails with
  `expected 'Spending is updated.' to be 'The month's total is on it now…'`.
- Live: the two JSON receipts above are from a real browser turn against a real
  TaxDome host with a real model, before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `vendo_make` EDIT arm so it hands back the builder's own words instead of a sentence composed from the app's name. Landed edits previously answered `"<name> is updated."` and refused ones `"I couldn't make that change to <name>."`; a calling agent handed only a title filled in the facts itself, producing narration that disagreed with the screen. Now `ScreenOutcome.say` travels the edit path exactly as it does the create path, and a refused edit says why in the floor's own sentences.

- Threads `say` from the edit journal through `EditResult` and into the receipt, keeping the name-based fallback when the builder says nothing.
- Attaches the floor's refusal issues to the failure receipt instead of discarding them at the door.
- Adds an e2e seam test covering a landed and a refused edit through the real store, floor, and front door.

<sup>Written for commit dcbc341fa9870b4a146bfbf769bef4aeaa245add. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1674?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

