### PR TITLE
docs: the true facts from the closed bot PRs, in the site's voice

### DIFF
--- a/docs-site/howto/auth.mdx
+++ b/docs-site/howto/auth.mdx
@@ -182,7 +182,8 @@ every thread, app, and grant the turn creates.
 - **Top-level `principal`, `actAs`, and `oauth` are deprecated aliases.** They
   still work and will keep working through this major, but they are one seam
   each with nowhere to grow — `auth` is the key that holds all six. Mixing the
-  two shapes throws at composition.
+  two shapes throws at composition, and so does `auth` beside the top-level
+  `memberships` seam.
 - **The `vendo:` namespace is reserved.** A resolver that returns one of those
   subjects is refused at the wire — `vendo:webhook:<source>` and
   `vendo:org:<orgId>` are minted by Vendo itself.

--- a/docs-site/product/mount-the-surface.mdx
+++ b/docs-site/product/mount-the-surface.mdx
@@ -96,7 +96,9 @@ mark.
 
 `launcher={{}}` gives you the pill exactly as it ships. `position` takes any
 viewport corner and defaults to `bottom-right`. `offset` nudges the whole
-cluster inward when your own UI already lives in that corner.
+cluster inward when your own UI already lives in that corner. The
+discoverability whisper and the completion toast ride the pill, so with no
+launcher they are quiet too.
 
 ### Where the panel sits
 

--- a/docs-site/production/persistence.mdx
+++ b/docs-site/production/persistence.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "Persistence"
 description: "Where threads, apps, records, grants, approvals, and audit rows live on Vendo Cloud, and what the store refuses."
 ---
 
-Your Cloud key is your database. Threads, apps, records, blobs, state, grants,
+Your Cloud key is your database. Threads, apps, records, blobs, grants,
 approvals, audit, and runs persist in Vendo Cloud's Postgres.
 
 ## The store slot fills itself
@@ -43,6 +43,7 @@ Passing your own `store` adapter also works, and always wins.
 | What | Where it goes | Notes |
 | --- | --- | --- |
 | Threads and messages | `vendo_threads`, `vendo_thread_messages` | Scoped to the principal's subject; a thread never crosses subjects |
+| Harness state | `vendo_threads.harness_state` | One slot per thread, so a session-owning harness resumes across restarts. Writes never bump the thread's `revision` or `updated_at` — resuming is not an edit |
 | Generated apps | `vendo_apps` | Plus their workspace files and history |
 | App data | `app:<appId>:<name>` collections | 256 KB per record, 5 MB per file |
 | Grants and approvals | `vendo_grants`, `vendo_approvals` | What a user has standing consent for |

--- a/docs-site/reference/cli.mdx
+++ b/docs-site/reference/cli.mdx
@@ -113,7 +113,7 @@ Every check's symptom, cause, and fix is on its own [troubleshooting page](/prod
 
 ## `vendo sync`
 
-Runs the build-step scan manually: tool extraction, remix baselines, the host component catalog, and the theme.
+Runs the build-step scan manually: tool extraction, [remix baselines](/generated/import-and-fork#what-sync-captures), the host component catalog, and the theme.
 
 Sync fails soft. An extraction failure still exits `0`, because a sync problem must never break a build.
 

--- a/docs-site/reference/handler-options.mdx
+++ b/docs-site/reference/handler-options.mdx
@@ -15,7 +15,7 @@ Exactly one key is required: an identity, as `auth`.
 | `models` | The model seats, keyed by job. See [below](#models) |
 | `auth` | The one door for identity — a preset's result (`authJs()`) or an object you write. Holds `principal`, `facts`, `pools`, `memberships`, `actAs`, and `oauth`. See [below](#identity) |
 | `principal` | **Deprecated alias** for `auth.principal`. Still works; mutually exclusive with `auth` |
-| `memberships` | `(principal) => Promise<Membership[]>`, the twin of `auth.memberships` for a host on the deprecated aliases. Set it and it wins outright. With `VENDO_API_KEY` and this seam unset, memberships come from Vendo Cloud, so `async () => []` is how a deployment with no orgs declines the tenant directory. Ignored when `auth` is set — put it in `auth` instead |
+| `memberships` | `(principal) => Promise<Membership[]>`, the twin of `auth.memberships` for a host on the deprecated aliases. Set it and it wins outright. With `VENDO_API_KEY` and this seam unset, memberships come from Vendo Cloud, so `async () => []` is how a deployment with no orgs declines the tenant directory. Mutually exclusive with `auth` — setting both throws, so put it in `auth` instead |
 | `tools` | Host tool declarations in memory, the same `ExtractedTool[]` sync writes to `.vendo/tools.json`, and executable tools. The two shapes are told apart by `execute` |
 | `skills` | `Skill[]` mounted at `/host/skills` for the harness to list cheaply and load on demand. A name collision fails at boot naming both |
 | `components` | Host components exposed to the generation prompt, merged with `.vendo/catalog.json` with explicit entries winning by name. The same object `<VendoProvider components>` takes |
@@ -90,7 +90,7 @@ Named presets: `"cautious"` lets reads run and asks before writes or destructive
 
 `"cautious"` makes one exception to that prompt: the agent's `bash` runs without asking. It is still graded `write`, so it takes an audit row per call and answers to your own rules and the kill switch — but an automation has nobody to answer an approval card, and a prompt here would mean the shell could never run unattended. Add your own rule for the `bash` tool to put the prompt back.
 
-`guard({ policy: {} })` reads the default `.vendo/policy.json`, which is what `vendo init` scaffolds. It reads fail-soft, so a missing file also auto-runs with no notice; keep the file in version control.
+`guard({ policy: {} })` reads the default `.vendo/policy.json`, which is what `vendo init` scaffolds. It reads fail-soft, so a missing file also auto-runs with no notice; keep the file in version control. `vendo doctor` is what tells you it is gone — `config/policy.json` fails with [E-CFG-001](/production/troubleshooting/e-cfg-001).
 
 Omitting the `guard` key entirely surfaces an unconfigured-policy notice in the shipped chrome. Past either breaker, a would-be auto-run parks for approval until the window clears.
 
@@ -253,6 +253,6 @@ If you want logged-out visitors served, resolve them to a principal of your own 
 
 The seams `facts`, `pools`, and `memberships` run once per context resolution. `facts` becomes the prompt's `[User]` block, `pools` feeds the limits policy, and `memberships` answers `can()`. Every asserted membership is already a pool named `org:<orgId>`, so an org cap needs no `pools` seam of its own.
 
-The top-level `principal`, `actAs`, and `oauth` keys are deprecated aliases for the members of the same name. They keep working for this whole major, but each is one seam with nowhere to grow — `facts` and `pools` never had a top-level twin, which is the reason the door consolidated. Passing `auth` beside any of the three throws `VendoError("validation")` naming the mixed keys.
+The top-level `principal`, `actAs`, and `oauth` keys are deprecated aliases for the members of the same name. They keep working for this whole major, but each is one seam with nowhere to grow — `facts` and `pools` never had a top-level twin, which is the reason the door consolidated. Passing `auth` beside any of the three — or beside the top-level `memberships` seam, which fills the same slot — throws `VendoError("validation")` naming the mixed keys.
 
 See [Your users](/users-orgs/your-users) for `facts` and [Orgs & memberships](/users-orgs/orgs-and-memberships) for `memberships`.

--- a/docs-site/reference/tool-overrides.mdx
+++ b/docs-site/reference/tool-overrides.mdx
@@ -137,18 +137,32 @@ Each step still crosses the guard on its own descriptor, so approvals, grants,
 and audit apply per step. A compound-level grant never rides into a step's
 `actAs`.
 
-## Remix opt-outs and briefs
+## Remix scanning and briefs
 
-`remix.ignoreSlots` names the `<Remixable>` slots sync should leave alone. A
-slot listed here is never captured, so it gets no baseline and no ✦.
+`remix` has two keys, both read by `vendo sync`.
+
+| Field | Type | What it does |
+| --- | --- | --- |
+| `ignoreSlots` | string array | `<Remixable>` slots sync should leave alone. A slot listed here is never captured, so it gets no baseline and no ✦ |
+| `sources` | string array | Extra directories to scan for `<Remixable>` wrappers, on top of the directory sync runs in |
 
 ```json .vendo/overrides.json
 {
   "format": "vendo/overrides@3",
   "tools": {},
-  "remix": { "ignoreSlots": ["PricingTable"] }
+  "remix": {
+    "ignoreSlots": ["PricingTable"],
+    "sources": ["../demos"]
+  }
 }
 ```
+
+Each source resolves from your project root and may sit outside it, which is how
+an app in `host/` and its screens in `../demos/` land in one sync. Captured
+module ids stay relative to the project root, so a file under an extra source
+reads as `../demos/maple/NetWorth.tsx`. A path that is not a readable directory
+warns and names itself rather than quietly contributing no wrappers. See
+[Import & fork](/generated/import-and-fork#components-outside-your-project-root).
 
 `briefs` is the last top-level key: `{ name, text, tools? }` entries of reviewed
 prose attached to primitive tools. It parses and validates today, but nothing

--- a/docs-site/users-orgs/erasing-a-user.mdx
+++ b/docs-site/users-orgs/erasing-a-user.mdx
@@ -36,13 +36,16 @@ table; the ordinary store door refuses that.
 ## What it removes
 
 Apps the subject owns go first, to close the write gate, and each one takes its own
-data with it: records, the version history, blob namespaces, state, that app's
-grants, and quarantine rows.
+data with it: records, the version history, blob namespaces, that app's grants, and
+quarantine rows.
 
 Then everything keyed to the subject: threads and their messages, automations and
 the runs those fired, permission grants, effects, approvals, audit rows, records
 that reference them, usage, MCP clients and grants, knowledge docs and chunks, and
 their workspace files and history.
+
+A thread's harness state is a column on the thread row, so deleting the thread takes
+it with it. There is nothing separate to sweep.
 
 Workspace content is deleted **through the files adapter**, not just as rows — the
 cascade reads each row's blob reference before deleting it, because that reference
@@ -86,8 +89,11 @@ This is the part worth reading twice.
 const report = await erase.byApp(appId);
 ```
 
-The app's row, its record collections, blob namespaces, state, app-scoped grants,
-and audit rows. Useful for tearing down a test build.
+The app's row, its record collections, blob namespaces, app-scoped grants, and audit
+rows. Useful for tearing down a test build.
+
+`byApp` never touches `vendo_threads`, so a conversation that built the app — and the
+harness state on its row — survives. Only `bySubject` reaches those.
 
 ---
 


### PR DESCRIPTION
Three auto-generated docs PRs (#1670, #1671, #1672) were reviewed and closed. This hand-writes only the facts that survived that review, each verified against source.

## Live errors fixed

- **`memberships` beside `auth` throws** (`compose-config.ts:141-148` checks four keys, not three). `reference/handler-options.mdx` said "Ignored when `auth` is set" and "any of the three"; `howto/auth.mdx` omitted it from the mixed-keys list. All three now agree.
- **Stale `state` mentions removed.** `vendo_state` is gone (store schema v12, `store/src/schema.ts:538-555`), so `production/persistence.mdx` and `users-orgs/erasing-a-user.mdx` (x2) no longer list it.

## Facts nothing on the site covered

- **Harness state** gets a row in the persistence table: it lives on `vendo_threads.harness_state`, and writes never bump `revision` or `updated_at` (`store/src/harness-state.ts:145-152`).
- **Erasure**: thread deletion takes harness state with it (`erase.ts:232`); `erase.byApp` never touches `vendo_threads` (`erase.ts:312-347`).
- **`remix.sources`** is documented on `reference/tool-overrides.mdx`, which `dot-vendo.mdx` already promised covers it (schema `actions/src/formats.ts:406-416`, behavior `sync/seeds.ts:669-690`).
- **No launcher means no whisper and no toast** — both ride the pill (`vendo-overlay.tsx:1191,1205`). One clause on the overlay section.
- **`vendo doctor` flags a missing `.vendo/policy.json`** with `E-CFG-001` (`doctor-config-checks.ts:22-27`). One line beside the existing fail-soft note.
- Cross-links from `reference/cli.mdx` and `reference/tool-overrides.mdx` to `/generated/import-and-fork`.

Deliberately **not** carried over: the bot's sync exit-code prose, which conflated uncapturable wrappers (exit 2, `sync.ts:244`) with unattributed pins (warning only, `sync-flow.ts:249`).

## Verification

- 7 docs-parity suites in `packages/vendo`, 88 tests, green
- `pnpm typecheck` green (43 tasks)
- `pnpm lint` green (0 errors)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes documentation errors and adds missing facts about persistence, identity config, remix scanning, and the launcher, all verified against source.

- Corrects `auth` next to top-level `memberships` throwing an error.
- Removes stale `vendo_state` references from the persistence and erasure pages.
- Adds harness state to the persistence table, including that writes never bump `revision` or `updated_at`.
- Documents thread deletion removing harness state and that `byApp` never touches `vendo_threads`.
- Documents `remix.sources` for extra scan directories with relative module paths.
- Notes that the discoverability whisper and completion toast ride the launcher pill.
- Adds `vendo doctor`'s `E-CFG-001` for a missing `policy.json`.
- Adds cross-links to `/generated/import-and-fork`.

<sup>Written for commit 51d2d13d7cf83750a23cc2aa376586f1ac31a565. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1675?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

