### PR TITLE
fix(apps): a build that outran its budget is not a busy service

### DIFF
--- a/.changeset/budget-timeout-is-not-capacity.md
+++ b/.changeset/budget-timeout-is-not-capacity.md
@@ -1,0 +1,22 @@
+---
+"@vendoai/apps": patch
+---
+
+A build that runs out of time says so, instead of blaming capacity.
+
+A box gives one turn a fixed message budget, and a turn that outruns it throws
+`unavailable` — the same code a genuinely busy service answers with. The
+classifier that turns a build throw into the sentence on the person's failure
+card read that code and nothing else, so it answered "busy, try again shortly"
+for both.
+
+For a busy service that sentence is true and useful. For a budget it is two
+lies: the failure is not capacity, and waiting cannot help — a budget expires on
+schedule, so the next attempt spends the whole window and dies at the same
+mark. It also invites the retry it cannot survive; four escalated builds in a
+row were reported this way, each dying at 15.2–15.4 minutes against a 15-minute
+budget, on asks as small as "show a QR code".
+
+Budget exhaustion is now told apart from capacity by the sentence the box throws
+with it, and reported as "the build ran out of its time budget", non-retryable.
+The number stays out of it: the bound is internal and a person cannot act on it.

--- a/packages/apps/src/server/doors/build-messages.ts
+++ b/packages/apps/src/server/doors/build-messages.ts
@@ -103,6 +103,26 @@ export const buildWatchdogMs = effectiveBuildWatchdogMs;
  */
 const QUOTA_SIGNAL = /\bquota\b|insufficient_quota|\bbilling\b|\b402\b/i;
 const TIMEOUT_SIGNAL = /time?d?\s*out|timeout|abort/i;
+/**
+ * A box turn that used its whole message budget, which arrives as `unavailable`
+ * — the SAME code a busy service answers with, and the reason four escalated
+ * builds were reported as capacity ("busy, try again shortly") when what really
+ * happened is that each one ran the budget out to the millisecond. That sentence
+ * invites a retry, so the lane retried, and every retry spent the full window
+ * again. A budget is a hang-detector: it expires deterministically, so waiting
+ * cannot help and the answer is not retryable.
+ *
+ * Wording, not the word "budget" alone: `TIMEOUT_SIGNAL` above deliberately
+ * does not match this line, so nothing else classifies it first.
+ *
+ * BYTE-FOR-BYTE COUPLED to a sentence in another package this one may not
+ * import — `@vendoai/harnesses`' claude-code rungs (`box.ts` and `local.ts`
+ * throw it identically). Same coupling, and the same hazard, as
+ * `MODEL_UNAVAILABLE_SIGNAL` below; the seam is driven against the real throw in
+ * the umbrella's tests/build-budget-reason.test.ts, the one package that sees
+ * both sides.
+ */
+const BUDGET_SIGNAL = /outran its \d+ms message budget/;
 /** The engine's stream-catch marker (generation/engine.ts askModel). It is the
  *  ONLY thing that distinguishes a provider's own error line from a validation
  *  finding once both are strings in the terminal throw's `issues`. */
@@ -176,7 +196,9 @@ export const buildFailureReason = (
   // dropped connection. "generation failed" reads as a verdict on the ask, so the
   // person rewrites a request that was never the problem; this one says wait.
   if (isVendoError(error) && error.code === "unavailable") {
-    return { reason: "busy, try again shortly", retryable: true };
+    return BUDGET_SIGNAL.test(error.message)
+      ? { reason: "the build ran out of its time budget", retryable: false }
+      : { reason: "busy, try again shortly", retryable: true };
   }
   return { reason: "generation failed", retryable: true };
 };

--- a/packages/vendo/tests/build-budget-reason.test.ts
+++ b/packages/vendo/tests/build-budget-reason.test.ts
@@ -1,0 +1,85 @@
+/**
+ * The SEAM: what a box turn that outran its budget is finally CALLED.
+ *
+ * `@vendoai/harnesses` throws the budget error and `@vendoai/apps` turns a throw
+ * into the sentence on the person's failure card — and apps cannot import
+ * harnesses, so the two only meet in the umbrella. They disagreed silently for
+ * exactly that reason: the budget throw carries code `unavailable`, which the
+ * mapper read as a busy service, so four escalated builds on 2026-08-27 died at
+ * 15.2–15.4 minutes and every one of them told the person "busy, try again
+ * shortly". Deterministic exhaustion, reported as transient capacity — which is
+ * an invitation to retry, and the lane retried three more times.
+ *
+ * Nothing is stubbed on either side: the REAL box poll loop runs out its REAL
+ * deadline, and the REAL classifier reads the throw it really produced. A test
+ * that asserted the sentence against a hand-written VendoError would have passed
+ * on the broken code, because the hand-written one is where the bug was.
+ */
+import { VendoError } from "@vendoai/core";
+import { buildFailureReason } from "@vendoai/apps";
+import {
+  boxMachine,
+  disposeSessionMachines,
+  type SandboxAdapterLike,
+} from "@vendoai/harnesses/claude-code";
+import { afterEach, describe, expect, it } from "vitest";
+
+/** Well under the test timeout: the budget is the hang-detector here, not a
+ *  second speed limit (see the testing note in CLAUDE.md). */
+const BUDGET_MS = 300;
+
+const encoder = new TextEncoder();
+
+/** A box that is perfectly HEALTHY and simply never finishes the message — it
+ *  greets, takes the message, and answers every poll "nothing yet". That is the
+ *  shape a build budget exists for, and the shape whose reason was wrong. */
+const neverFinishingBox = (): SandboxAdapterLike => {
+  const answer = (body: unknown) => ({
+    status: 200,
+    headers: {},
+    body: encoder.encode(JSON.stringify(body)),
+  });
+  const machine = {
+    id: "box_build_budget",
+    request: async (req: { path: string }) => {
+      if (req.path === "/session/message") return answer({ messageId: "msg_1" });
+      if (req.path.endsWith("/poll")) return answer({ events: [], done: false, cursor: 0 });
+      return answer({ ok: true });
+    },
+    files: { read: async () => new Uint8Array(), write: async () => undefined, list: async () => [] },
+    url: async () => "https://box_build_budget.fake-provider.test",
+    destroy: async () => undefined,
+  };
+  return { create: async () => machine as never, destroy: async () => undefined };
+};
+
+afterEach(async () => { await disposeSessionMachines(); });
+
+describe("a build that outran its budget is not told it is a busy service", () => {
+  it("says the time budget ran out, and does not invite a retry", async () => {
+    const machine = await boxMachine({
+      sandbox: neverFinishingBox(),
+      threadId: "thr_build_budget",
+      env: {},
+      allowedDomains: [],
+      messageBudgetMs: BUDGET_MS,
+    });
+
+    const thrown = await machine
+      .send({ prompt: "build this for real", emit: () => undefined })
+      .then(() => undefined, (error: unknown) => error);
+
+    // The real throw, not one this test wrote.
+    expect(thrown).toBeInstanceOf(VendoError);
+    expect((thrown as VendoError).code).toBe("unavailable");
+
+    const { reason, retryable } = buildFailureReason(thrown);
+    expect(reason).toBe("the build ran out of its time budget");
+    // The mislabel itself: `unavailable` used to mean capacity and nothing else.
+    expect(reason).not.toBe("busy, try again shortly");
+    // A budget expires on schedule, so waiting cannot help — and `retryable`
+    // is what tells the calling agent "asking for it again may work"
+    // (@vendoai/mcp door.ts).
+    expect(retryable).toBe(false);
+  }, 20_000);
+});


### PR DESCRIPTION
A box gives one turn a fixed message budget, and a turn that outruns it throws `unavailable` — the same code a genuinely busy service answers with. `buildFailureReason` read the code and nothing else, so both got the capacity sentence: **"busy, try again shortly"**.

For a busy service that sentence is true and useful. For a budget it is two lies at once — the failure is not capacity, and waiting cannot help. A budget expires on schedule, so the retry it invites spends the whole window and dies at the same mark.

### Measured

Four escalated builds on 2026-08-27 died at **15.2, 15.3, 15.4 and 15.2 minutes** against a 15-minute budget, and every one wrote `buildFailed: {"reason":"busy, try again shortly"}` onto the app row. Three of the four were retries the sentence itself asked for. Ask weight was not the variable — it reproduced on a heavy ask, a medium ask, and a deliberately trivial "just show a QR code".

### The change

`packages/apps/src/server/doors/build-messages.ts` — budget exhaustion is told apart from capacity by the sentence the box throws with it, and reported as `the build ran out of its time budget`, non-retryable. `retryable` is what tells a calling agent "Asking for it again may work" (`@vendoai/mcp` door.ts), so the deterministic case now stops the loop instead of starting it.

Byte-for-byte coupled to a sentence in `@vendoai/harnesses` — the same coupling, in the same file, as the dev-model lines, and for the same reason: `apps` may not import `harnesses`. Both claude-code rungs (`box.ts`, `local.ts`) throw it identically, so both are covered. The millisecond figure stays out of what the person reads: the bound is internal and nobody can act on it.

### Proof

`packages/vendo/tests/build-budget-reason.test.ts` — the umbrella is the one package that sees both sides. The **real** box poll loop runs out its **real** deadline and the **real** classifier reads the throw it really produced; nothing is stubbed on either side. Asserting against a hand-written `VendoError` would have proved nothing, since that is exactly where the two packages' disagreement was invisible.

Verified **red** against the previous build of `@vendoai/apps`, **green** against this one.

### Not in scope

- The stall itself. Box turns complete fine on Vendo Cloud right now (verified live: cold boot 3.3s, real turn answered in 13.5s), so this is not a Cloud outage — but why the *build* turn exhausts its window is a separate investigation, and this PR deliberately does not touch `MESSAGE_BUDGET_MS`. A timeout is a hang-detector, not a speed limit to relax.
- A failed build still never surfaces in the thread — the consent card reads "Approved — under way" indefinitely, because that line is a client-side optimistic terminal (`ui/chrome/thread/parts.tsx`) and the detached build lane writes only the app row. Separate root cause, separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
A build that outran its message budget was reported as "busy, try again shortly" — the same reason a genuinely busy service gets — which invited retries that died at the same mark. Budget exhaustion is now told apart and reported as "the build ran out of its time budget" and marked non-retryable.

- Detection keys off the message the box throws with the `unavailable` code; the millisecond figure stays out of the user-facing reason.
- Adds a test where the real box loop exhausts its real budget and the real classifier reads the throw it produces, with nothing stubbed on either side.

<sup>Written for commit 0c01da1ab2676d86843fe7936cbebf8448d5d61d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

