### PR TITLE
fix(vendo): the build brief tells the truth about the box it runs in

### DIFF
--- a/.changeset/build-brief-names-its-reality.md
+++ b/.changeset/build-brief-names-its-reality.md
@@ -1,0 +1,24 @@
+---
+"@vendoai/vendo": patch
+---
+
+The build brief tells the box what "reality" is, so builds stop hunting for a browser.
+
+A build box is told to "test what you built against reality, and fix what
+fails" — and it was never told what reality it is standing in. The machine
+reaches the npm registry and the inference host, and nothing else. So an agent
+that took the instruction seriously went looking for the reality it knows: a
+real browser to drive Playwright against, then a native canvas to render into.
+Both are unreachable past the box's allowlist, and neither failure is one it can
+be talked out of, so it re-architected the app and tried again.
+
+Measured live on 2026-08-27: four escalated builds died at 15.2–15.4 minutes
+against the 15-minute message budget, on asks as small as "show a QR code". Ask
+weight was never the variable — every build reached the same cul-de-sac, and the
+cul-de-sac costs the same whatever was asked for.
+
+The test step now names the egress it has to live inside: Node, a pure-JS DOM,
+no browser and no native binaries. The instruction to verify is unchanged — a
+build that ships an untested bundle is the failure this brief already guards
+against — and the allowlist is untouched, because it is the security boundary
+and the honest fix is to stop lying to the agent about it.

--- a/.changeset/build-brief-names-its-reality.md
+++ b/.changeset/build-brief-names-its-reality.md
@@ -17,8 +17,23 @@ against the 15-minute message budget, on asks as small as "show a QR code". Ask
 weight was never the variable — every build reached the same cul-de-sac, and the
 cul-de-sac costs the same whatever was asked for.
 
-The test step now names the egress it has to live inside: Node, a pure-JS DOM,
-no browser and no native binaries. The instruction to verify is unchanged — a
-build that ships an untested bundle is the failure this brief already guards
-against — and the allowlist is untouched, because it is the security boundary
-and the honest fix is to stop lying to the agent about it.
+Two more of the same shape were measured once that one was gone: the image's
+baked `@vendoai/ui` predates the frame protocol, so a build that used it lost
+the time to find that out; and `callHost` was named as the way to reach host
+data, which sent an agent hunting the box's disk for a tool list that is
+deliberately absent.
+
+The brief now names the egress it has to live inside — Node, a pure-JS DOM, no
+browser, no native binaries — says to install `@vendoai/ui` from npm rather than
+the stale baked copy, and places `startFrameProtocol`/`callHost` on the runtime
+side of the line: they speak to the embedding page, so they answer for the
+shipped app and never inside the box.
+
+Nothing is withdrawn. The instruction to verify stands, `callHost` stays (it is
+a postMessage to the host page, and dropping it would take the capability with
+it), the allowlist is untouched because it is the security boundary, and
+`MESSAGE_BUDGET_MS` is unchanged because a timeout is a hang-detector, not a
+speed limit.
+
+A build now completes: 836.6s end to end against a real Vendo Cloud box, sealing
+a 257 KB `dist/app.js` from a "show a QR code" ask.

--- a/packages/vendo/src/build-agent.ts
+++ b/packages/vendo/src/build-agent.ts
@@ -118,6 +118,15 @@ const checkoutOf = (source: Record<string, AppSourceFile> | undefined, directory
  *  whatever was asked for. The allowlist is the security boundary and does not
  *  move, so the brief tells the truth about it instead.
  *
+ *  Two more of the same kind, measured the same day once the first was gone: the
+ *  image's baked `@vendoai/ui` predates the frame protocol, so a build that used
+ *  it lost the time to find that out; and `callHost` is named here as the way to
+ *  reach host data, which sent an agent hunting this disk for a tool list that
+ *  is deliberately absent (no `toolDoor`, below). `callHost` is real — it is a
+ *  postMessage to the embedding page, so it answers at RUNTIME and never in
+ *  here — so the brief says which side of that line it is on rather than
+ *  dropping it and taking the capability with it.
+ *
  *  `briefing` is the rendered pack, appended as its own SECTION on the same join
  *  the screen agent's brief uses: the instructions above it are this rung's own,
  *  the product knowledge below it is the bytes the other rung read. */
@@ -131,14 +140,18 @@ WHY A GENERATED SCREEN WAS NOT ENOUGH:
 ${request.why}
 
 HOW IT SHIPS
-- Write the source under ${directory}/src and install whatever npm packages it needs.
+- Write the source under ${directory}/src and install whatever npm packages it
+  needs. Install @vendoai/ui from npm rather than using the copy already on this
+  machine: the baked one predates the frame protocol below and does not have it.
 - The document that serves your bundle is one <div id="root"></div>: mount into
   that element, and once your first render is really in the DOM (an empty mount
   measures as height 0, which the host renders as a collapsed frame) call
-  startFrameProtocol(mount) from @vendoai/ui/kit — install it like any other
-  package. That is what sizes the frame and applies the host's brand tokens, and
-  callHost(tool, args) from the same module is the only way to reach the host's
-  data.
+  startFrameProtocol(mount) from @vendoai/ui/kit. That is what sizes the frame
+  and applies the host's brand tokens, and callHost(tool, args) from the same
+  module is how the SHIPPED app reaches the host's data. Both speak to the page
+  that embeds the app, so neither answers in here: there is no host on this
+  machine and no tool list to read. Write against them and move on — looking for
+  the host's tools on this disk finds nothing and costs you the build.
 - Bundle it with esbuild to ${directory}/${ENTRY}: ONE self-contained file, no
   imports left at runtime and no network calls at all — the sealed bundle renders
   in an iframe where every request is blocked.

--- a/packages/vendo/src/build-agent.ts
+++ b/packages/vendo/src/build-agent.ts
@@ -108,6 +108,16 @@ const checkoutOf = (source: Record<string, AppSourceFile> | undefined, directory
 
 /** `directory` is the DISK spelling — this text is read by a shell.
  *
+ *  The test step NAMES the box's egress, because an agent told to verify against
+ *  reality will otherwise go looking for the reality it knows. Measured live
+ *  2026-08-27: four escalated builds died at 15.2–15.4 min against the 15-minute
+ *  message budget — on asks as small as "show a QR code" — every one of them
+ *  trying to install a browser for Playwright and then a native canvas, both
+ *  unreachable past `BUILD_ALLOWED_DOMAINS`, and re-architecting the app between
+ *  attempts. Ask weight was not the variable; the cul-de-sac costs the same
+ *  whatever was asked for. The allowlist is the security boundary and does not
+ *  move, so the brief tells the truth about it instead.
+ *
  *  `briefing` is the rendered pack, appended as its own SECTION on the same join
  *  the screen agent's brief uses: the instructions above it are this rung's own,
  *  the product knowledge below it is the bytes the other rung read. */
@@ -132,7 +142,11 @@ HOW IT SHIPS
 - Bundle it with esbuild to ${directory}/${ENTRY}: ONE self-contained file, no
   imports left at runtime and no network calls at all — the sealed bundle renders
   in an iframe where every request is blocked.
-- Test what you built against reality, and fix what fails.
+- Test what you built against reality, and fix what fails. Reality here is Node:
+  this machine reaches the npm registry and nothing else, so no browser can be
+  fetched or driven and nothing with a native binary will build. Render the
+  bundle under a pure-JS DOM (jsdom) and assert what it produces; hunting for a
+  real browser only spends the clock you need for the build.
 - If your own test does not pass, DELETE ${directory}/${ENTRY} and stop. Its
   absence is how this host is told the build did not work; a broken one left
   behind is shipped to the person as if it worked.`, briefing]


### PR DESCRIPTION
Escalated builds stopped finishing. Four in a row died at **15.2–15.4 min** against the 15-minute message budget, on asks as small as *"show a QR code"* — so ask weight was never the variable.

The cause was not capacity, not the model, and not Vendo Cloud: a trivial box turn answers in **13.5s** on the same account. It was the brief. A build box is told to *"test what you built against reality"* and to reach host data through `callHost`, and it was never told which reality it is standing in. It reaches `registry.npmjs.org` and the inference host, and nothing else.

So an agent that took the brief seriously went looking for the reality it knows. Three separate dead ends, each measured from the box's own transcript — captured by temporarily restoring the events the lane discards at `build-agent.ts:184` (`emit: () => undefined`), which is why this was invisible for four runs:

1. **A browser, then a native canvas.** *"No network access for browser binaries… Node-canvas isn't installable here."* It re-architected the app between attempts.
2. **The baked `@vendoai/ui`.** `/opt/vendo-box` ships a copy that predates the frame protocol, so the build spent the time discovering that and switching to npm.
3. **A host tool list.** `callHost` was named as the way to reach host data, so it hunted `/app/.vendo` and `/opt/vendo-box/template/.vendo` for schemas that are deliberately absent — this box gets no `toolDoor` (`build-agent.ts:179`).

### The change

The brief now names the egress it lives inside (Node, a pure-JS DOM, no browser, no native binaries), says to install `@vendoai/ui` from npm rather than the stale baked copy, and puts `startFrameProtocol`/`callHost` on the **runtime** side of the line: they speak to the embedding page, so they answer for the shipped app and never inside the box.

**Nothing is withdrawn.** The instruction to verify stands — shipping an untested bundle is the failure this brief already guards against. `callHost` stays: it is a `postMessage` to the host page, and dropping it would take the capability with it. The egress allowlist is untouched because it is the security boundary. `MESSAGE_BUDGET_MS` is unchanged because a timeout is a hang-detector, not a speed limit.

### Proof — the real path

`appBuilder` itself, its own brief, its own egress, its own 15-minute budget, against a real Vendo Cloud box.

**BUILT in 836.6s**, sealing `dist/app.js` at **257,426 bytes**, alongside `src/App.tsx`, `src/QrCode.tsx`, `src/index.tsx` and `package-lock.json`. The first completed escalated build since 2026-08-24.

Progression across runs, all live:

| | outcome |
|---|---|
| before any fix | 910s, 646s, 905s — budget exhausted / box vanished |
| after this PR | **836.6s — built and sealed** |

### Known risk, stated plainly

836.6s against a 900s budget is **~64s of headroom**, and observed run-to-run spread is wide. A slower run can still exhaust the budget. This PR does not change that budget, and should not.

Related: run 1 above independently confirmed #1676 on the live lane — the failure reads `the build ran out of its time budget`, `retryable=false`, instead of "busy, try again shortly".

🤖 Generated with [Claude Code](https://claude.com/claude-code)