### PR TITLE
ci(release): version packages goes through the merge queue like everyone else

### DIFF
--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -1,28 +1,35 @@
 name: Version Packages
 
-# Releasing is a push to main with pending changesets, and nothing else. This
-# workflow consumes them in place: `changeset version` runs HERE, the result is
-# committed straight to main, tagged, and release.yml is dispatched at that tag
-# to publish. There is no "Version Packages" PR any more. That PR cost a second
-# ~15-minute trip through the merge queue to re-prove a diff that is only
-# CHANGELOGs and version fields, on a tree whose real changes had already
-# passed every required check on the way in.
+# Releasing is still a push to main with pending changesets, and nothing else.
+# What changed is how the version bump gets onto main: as a pull request through
+# the merge queue, like every other change. `changeset version` runs HERE, on a
+# `changeset-release/main` branch, and the result rides ONE reusable
+# "chore: version packages" PR — force-pushed on every push to main, so a week of
+# merges accumulates into a single PR rather than a queue of them. Merging that
+# PR is what releases; the post-merge run of this workflow tags it and dispatches
+# release.yml to publish.
 #
-# Pushing to main directly is granted, not stolen: main's merge-queue ruleset
-# and its branch protection both give the repository-admin role an always
-# bypass, and RELEASE_PAT is yousefh409's. GITHUB_TOKEN is not an admin, so
-# without that secret the push below is refused and nothing releases.
+# It used to commit straight to main, and that was faster — one merge-queue trip
+# instead of two. It only ever worked because a repository-admin PAT was there to
+# bypass main's ruleset, and on 2026-08-27 a bulk rewrite of this repo's Actions
+# secrets left RELEASE_PAT out of the new set. Every run from 16:08 UTC that day
+# died on `GH013: Changes must be made through the merge queue`, and the step
+# announced it as a benign "main moved" race — so a pipeline that could not
+# release at all read as bad luck, twenty-three changesets deep. A version PR
+# needs no bypass: it is the one shape of this workflow that a tightening of main
+# cannot break, and the only credential it wants is an ordinary one.
 #
-# The version commit goes up under a real credential, so it triggers this
-# workflow again. That run finds no changesets left, sees the tag it would push
-# already on the remote, and exits green having done nothing. That path is
-# load-bearing twice over: it is what keeps the loop from eating itself, and —
-# because it decides on the remote's tags rather than on what this run did — it
-# is also how a release interrupted between its commit and its tag gets
-# finished by the next push to main instead of vanishing.
+# RELEASE_PAT (fine-grained, this repo only — Contents: read+write, Pull
+# requests: read+write, and NO admin or bypass) is required, not optional.
+# GitHub does not run workflows on branches or PRs pushed with the built-in
+# GITHUB_TOKEN, so a version PR opened under it gets zero checks: the four
+# required checks never report, the merge queue never takes it, and the PR sits
+# open forever looking healthy. Everything downstream — tagging, publishing —
+# waits on a merge that cannot happen, which is why its absence fails this job
+# loudly rather than leaving a notice in a green log.
 #
-# The dispatch is the whole publish automation. GitHub never triggers a workflow
-# from anything pushed with the default GITHUB_TOKEN, so the tag push alone
+# The dispatch at the end is the whole publish automation. GitHub never triggers
+# a workflow from anything pushed with GITHUB_TOKEN, so the tag push alone
 # publishes nothing — v0.23.0 is tagged and published nothing. `workflow_dispatch`
 # is the documented exception GITHUB_TOKEN may trigger, and dispatching
 # release.yml keeps it the top-level workflow of its run, which is what npm's
@@ -35,6 +42,8 @@ on:
 
 permissions:
   contents: write
+  # Opening and updating the version PR.
+  pull-requests: write
   # Dispatching release.yml is an Actions write.
   actions: write
 
@@ -46,9 +55,9 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
-          # The PAT belongs here, not only in a step env: the version commit
-          # goes up with a plain `git push`, which uses the credentials
-          # checkout persists.
+          # The PAT has to be here too, not just on the action: changesets/action
+          # pushes the version branch with a plain `git push`, so it uses the
+          # credentials checkout persists.
           token: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
@@ -57,19 +66,21 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
 
-      # The `versioned` output gates the two steps below, so a push with no
-      # pending changesets — an ordinary commit, or the version commit's own
-      # push event — falls through to the tag step having changed nothing.
-      - name: Version the pending changesets
-        id: version
-        run: |
-          set -euo pipefail
-          if [ -z "$(find .changeset -name '*.md' ! -name README.md)" ]; then
-            echo "no pending changesets"
-            exit 0
-          fi
-          pnpm changeset:version
-          echo "versioned=true" >>"$GITHUB_OUTPUT"
+      # Creates `changeset-release/main` if it is missing, hard-resets it to this
+      # push and force-pushes the versioned tree onto it, then opens the version
+      # PR or updates the one already open against that branch — so the whole
+      # step is idempotent however many commits land between releases. A refused
+      # push or a refused PR create throws out of the action, which fails this job
+      # with git's or the API's own message in the log; there is no branch here
+      # that swallows a rejection or renames it into something reassuring.
+      - id: changesets
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
+        with:
+          version: pnpm changeset:version
+          commit: "chore: version packages"
+          title: "chore: version packages"
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
 
       # THE 0.x CEILING — deliberate, not a bug. Vendo does not ship 1.0.0 until
       # Yousef says so, and lifting this ceiling is his call alone: delete this
@@ -78,14 +89,18 @@ jobs:
       # A major is not a one-package event here. All 13 packages are a single
       # changesets `fixed` group, so ONE `major` changeset drags every one of
       # them to 1.0.0 — that is exactly what happened on 2026-08-15, when four
-      # majors put 1.0.0 on all 13 and the numbers had to be walked back by
-      # hand. So this does not look for a literal "1.0.0" in a changeset; it
-      # reads the versions `changeset version` just wrote. It runs before the
-      # commit, so the runner's working tree is the only copy that has ever held
-      # them: failing here leaves main untouched and there is nothing to undo.
-      # Downgrade the changeset to `minor` and this goes green.
+      # majors put 1.0.0 on all 13 and the numbers had to be walked back by hand.
+      # So this does not look for a literal "1.0.0" in a changeset; it reads the
+      # versions that were actually written. The action leaves the checkout ON
+      # `changeset-release/main` (it `git checkout`s that branch and hard-resets
+      # it to this push's SHA before versioning), so `packages/*/package.json`
+      # here is the version PR's own content — the same numbers a human reads off
+      # the PR. Downgrade the changeset to `minor` and this goes green.
       - name: Guard the 0.x ceiling
-        if: steps.version.outputs.versioned == 'true'
+        if: steps.changesets.outputs.pullRequestNumber != ''
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
+          PR: ${{ steps.changesets.outputs.pullRequestNumber }}
         run: |
           set -euo pipefail
           crossed=""
@@ -97,43 +112,61 @@ jobs:
             esac
           done
           if [ -n "$crossed" ]; then
+            # Disarm before failing. Failing this step stops the arming step
+            # below from running, but it cannot un-arm a PR that was already
+            # armed on an earlier, still-0.x push — and that PR would carry
+            # 1.0.0 into main by itself the moment its checks went green.
+            # Disarming an unarmed PR is already a clean no-op, so `|| true` is
+            # here for one reason: nothing gh does may swallow the error below.
+            gh pr merge "$PR" --disable-auto || true
             echo "::error::proposed versions left 0.x —$crossed. Vendo stays below 1.0.0 until Yousef lifts the ceiling; use a minor changeset."
             exit 1
           fi
 
-      # THE CHANGESET RACE, in its only remaining form: a changeset-carrying
-      # commit landing on main while this job runs. The push then is not a
-      # fast-forward and git refuses it — which is the whole guard. Do not
-      # force, and do not retry in-run: a retry would version on top of a tree
-      # this job never checked out. Nothing needs repairing by hand either. The
-      # commit that won the race triggers this workflow itself, and that run
-      # versions every pending changeset, this one's included, under the next
-      # number.
+      # Arm GitHub's native auto-merge so the version PR merges itself the moment
+      # ci/integration/conformance/audit are green — main runs a merge queue
+      # (ruleset merge-queue-main, SQUASH), so this enqueues rather than merges
+      # directly. It sits AFTER the 0.x guard on purpose: a version PR that
+      # crossed the ceiling must never be armed.
       #
-      # `git add -A`, not `commit -a`: a package's first CHANGELOG.md is
-      # untracked, and `-a` would leave it out of the release it documents.
-      - name: Commit the version to main
-        if: steps.version.outputs.versioned == 'true'
+      # RELEASE_PAT, and only RELEASE_PAT, for both halves of the same rule.
+      # Without it the version PR gets no checks at all, so required checks never
+      # report and auto-merge waits forever; and the merge it eventually performs
+      # is attributed to whoever armed it, so a GITHUB_TOKEN merge would land on
+      # main without re-triggering this workflow — no tag, no publish. Stepping
+      # over a missing secret here is precisely what a green run that releases
+      # nothing looks like, so it fails instead.
+      - name: Arm auto-merge on the version PR
+        if: steps.changesets.outputs.pullRequestNumber != ''
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+          PR: ${{ steps.changesets.outputs.pullRequestNumber }}
         run: |
           set -euo pipefail
-          git add -A
-          git -c user.name='github-actions[bot]' \
-              -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
-              commit -m "chore: version packages"
-          if ! git push origin HEAD:main; then
-            echo "::error::main moved while this release was being versioned, so the version commit is not a fast-forward and was NOT pushed. Nothing to repair: the next push to main releases these changesets."
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::RELEASE_PAT is not set, so PR #$PR was opened by GITHUB_TOKEN and GitHub will run no checks on it at all. Its required checks can never report, the merge queue can never take it, and nothing can ever be released. Mint the PAT described at the top of this file — this is not a transient failure."
             exit 1
           fi
+          # Re-arming an armed PR is a no-op, so this is safe on every push.
+          gh pr merge "$PR" --auto --squash
 
       # UNGATED, and the remote's tags are what it decides on — not whether this
       # run versioned anything. That is what makes every push to main a retry of
-      # a half-finished release: a run that pushed the version commit and then
-      # died before tagging has consumed its changesets, so nothing would ever
-      # release that version again, silently. Now the next push finds
-      # `v<version>` missing and finishes the job. If instead the tag went up and
-      # only the dispatch below failed, that run is red with the tag already in
-      # place, and the one-line repair is `gh workflow run release.yml --ref
-      # <tag> -f publish=true`.
+      # a half-finished release: a run that saw the version PR land and then died
+      # before tagging has consumed its changesets, so nothing would ever release
+      # that version again, silently. Now the next push finds `v<version>` missing
+      # and finishes the job. It is also what covers the merge queue batching the
+      # version PR together with a changeset-carrying PR — a run that finds both
+      # a fresh untagged version AND pending changesets releases the version and
+      # opens the next PR, instead of skipping and losing the release (phantom
+      # 0.31.0, 2026-08-19). If instead the tag went up and only the dispatch
+      # below failed, that run is red with the tag already in place, and the
+      # one-line repair is `gh workflow run release.yml --ref <tag> -f publish=true`.
+      #
+      # $GITHUB_SHA, never the working tree: when the action versioned, it left
+      # the checkout on `changeset-release/main`, whose package.json holds a
+      # version that is merely PROPOSED and must not be tagged or published.
+      # $GITHUB_SHA is main's tip — what actually merged.
       #
       # The existing-tag skip is also the correct answer for an ordinary commit
       # (tag already pushed, nothing to do) and for any release that leaves the
@@ -154,9 +187,9 @@ jobs:
           TAG_PUSH_URL: https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
         run: |
           set -euo pipefail
-          tag="v$(node -p "require('./packages/vendo/package.json').version")"
-          # Second half of the 0.x ceiling above: that guard keeps a 1.0.0 off
-          # main, this one refuses to tag or publish one that got past it.
+          tag="v$(git show "$GITHUB_SHA:packages/vendo/package.json" | jq -r .version)"
+          # Second half of the 0.x ceiling above: that guard keeps a 1.0.0 out of
+          # the version PR, this one refuses to tag or publish one that got past it.
           case "$tag" in
             v0.*) ;;
             *) echo "::error::$tag left 0.x — Yousef lifts the ceiling, not a release run."; exit 1 ;;
@@ -165,7 +198,7 @@ jobs:
             echo "$tag is already tagged — nothing to release"
             exit 0
           fi
-          git tag "$tag"
+          git tag "$tag" "$GITHUB_SHA"
           # The URL alone was NOT enough, and v0.38.0 proved it: actions/checkout
           # persists its credential as `http.https://github.com/.extraheader:
           # AUTHORIZATION: basic <RELEASE_PAT>`, and that header BEATS basic auth
@@ -174,13 +207,13 @@ jobs:
           # the header for this one command is what actually forces the URL's
           # token; the config itself is left alone for every other git call.
           git -c http.https://github.com/.extraheader= push "$TAG_PUSH_URL" "refs/tags/$tag"
-          echo "pushed $tag -> $(git rev-parse HEAD)"
+          echo "pushed $tag -> $GITHUB_SHA"
           echo "tag=$tag" >>"$GITHUB_OUTPUT"
 
       # The tag push above used GITHUB_TOKEN, so release.yml's `push: tags`
       # trigger did NOT fire (by GitHub's design) — dispatching it here is what
-      # turns a versioned main into a published release. `--ref "$TAG"` pins the
-      # publish to the exact commit that was tagged, not to whatever main has
+      # turns a merged version PR into a published release. `--ref "$TAG"` pins
+      # the publish to the exact commit that was tagged, not to whatever main has
       # drifted to.
       - name: Publish the tag
         if: steps.tag.outputs.tag != ''


### PR DESCRIPTION
## What broke

Releases have been dead since 2026-08-27 16:08 UTC. Every `Version Packages` run fails on the same line:

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - Changes must be made through the merge queue
remote: - Changes must be made through a pull request.
 ! [remote rejected]     HEAD -> main (push declined due to repository rule violations)
##[error]main moved while this release was being versioned, so the version commit is
        not a fast-forward and was NOT pushed. Nothing to repair: the next push to
        main releases these changesets.
```

That last line is the workflow's own error handler, and it is wrong twice: the push was not a fast-forward race, and there very much is something to repair. Twenty-three changesets are now sitting unreleased on main.

**Root cause, and it is not the ruleset.** `merge-queue-main` still grants the repository-admin role an always-bypass and classic protection still has `enforce_admins: false`, unchanged since 2026-08-23 — the last successful direct-push release ran at 04:51 UTC on 2026-08-27 under exactly these rules. At 05:02 UTC every one of this repo's Actions secrets was rewritten in one batch, and the new set does not contain `RELEASE_PAT` (or `VENDO_WEB_PAT`). `secrets.RELEASE_PAT || secrets.GITHUB_TOKEN` silently fell through to `GITHUB_TOKEN`, which is not an admin, so main started refusing the push.

## What this changes

The version bump goes back through the front door. `changeset version` still runs in this workflow, but the result is force-pushed to `changeset-release/main` and rides one reusable "chore: version packages" PR through the merge queue. Merging that PR is what releases. A version PR needs no bypass at all, which is the point: it is the one shape of this workflow that a tightening of main cannot break.

The mechanism is `changesets/action@v1.9.0`, pinned by SHA — the same action this repo used until #1596, restored with the fixes made since.

**Publish semantics are unchanged.** The post-merge run finds no changesets left, reads the version off main, tags `v<version>` with `GITHUB_TOKEN` (so `push: tags` stays silent and the dispatch remains the single publish trigger), and dispatches `release.yml` at that tag. Nothing about the publish path was keyed on the direct push, so nothing had to be split out.

Two things did have to change for PR mode:

- **The tag step reads and tags `$GITHUB_SHA`, not the working tree.** `changesets/action` does `git checkout changeset-release/main && git reset --hard $GITHUB_SHA` before versioning, so when it versions it leaves the checkout on the version branch — whose `package.json` holds a version that is only *proposed*. Verified against the action's source at the pinned SHA (`src/git.ts:94` `prepareBranch`, `src/run.ts:290`).
- **The tag step stays ungated.** Keeping it keyed on the remote's tags rather than on what the run did preserves the half-finished-release retry, and it also covers the merge queue batching the version PR together with a changeset-carrying PR — the case that produced the phantom 0.31.0 on 2026-08-19. The old PR-mode code needed a separate alarm step for that; this needs none.

## The 0.x ceiling is preserved on both halves

Unchanged in substance, only in where it reads from. The guard reads the versions the action actually wrote (`packages/*/package.json` on the version branch — the same numbers a human reads off the PR), disarms auto-merge before failing so an already-armed PR cannot carry 1.0.0 into main on its own, and the tag step still refuses to tag or publish anything outside `v0.`.

Proven locally against main's 23 pending changesets: they version to `0.53.0` across all 13 lockstep packages (`@vendoai/telemetry` independently to 0.6.0), all inside 0.x, and the guard's loop reads exactly those numbers.

## ⚠️ This does not release anything until `RELEASE_PAT` is minted

GitHub does not run workflows on branches or PRs pushed with the built-in `GITHUB_TOKEN`. A version PR opened under it gets zero checks, so its four required checks never report, the merge queue never takes it, and it sits open forever looking healthy.

There is no suitable secret in the repo today — the full inventory is `ANTHROPIC_API_KEY` plus infrastructure keys, no org-level secrets are visible to the repo, and both PATs the workflows reference are gone. So this PR fails loudly instead of stepping over the gap the way the old code's `::notice::` did.

**Needed:** a fine-grained PAT on `runvendo/vendo` only — **Contents: read+write, Pull requests: read+write**, and no admin or bypass — stored as `RELEASE_PAT`. Notably weaker than the one this replaces, which needed admin to bypass main. It also has to be added wherever the 05:02 secret sync sources from, or the next sync will drop it again exactly like this one did.

`VENDO_WEB_PAT` is missing from the same sync and is a separate, still-open break: `release.yml`'s `bump-console` job will now skip the vendo-web dependency bump and stay green while doing it.

## Verification

- `actionlint` clean on the changed file (the only findings in `.github/workflows` are pre-existing SC2086 infos in `ci.yml`).
- `pnpm changeset:version` run locally on a simulated `changeset-release/main` branch: produces 0.53.0, and `git show $GITHUB_SHA:packages/vendo/package.json` still reads 0.52.1 from that branch — which is the proof the tag step's `$GITHUB_SHA` pinning is load-bearing.
- The action's branch/PR idempotency (force-push the branch, reuse the one open PR matched on `head:owner:changeset-release/main`, `base:main`) read from its source at the pinned SHA rather than assumed.
- All four required checks already handle the version PR and have since #1342 — `cone` sets `heavy=false` for `changeset-release/*`, `changeset-required` skips with it, `conformance` has its own skip, `ci`/`integration` are `always()` aggregates that count a skip as success, and `audit` runs and passes.

Only the first real run can prove the end-to-end path; the test plan is in the thread.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Releases move from a direct push to main to a reusable "chore: version packages" pull request through the merge queue, so versioning no longer depends on an admin bypass. This requires a new fine-grained `RELEASE_PAT`; until it's created, releases stay blocked and the workflow fails loudly instead of silently skipping.

**Behavior changes**
- `changesets/action` now creates or updates `changeset-release/main` and opens/reuses the version PR on every push.
- Publish semantics are unchanged: the post-merge run tags `v<version>` from `$GITHUB_SHA` (main's tip) and dispatches `release.yml`.
- The 0.x ceiling guard reads versions from the version branch, disarms auto-merge before failing, and the tag step still refuses anything outside `v0`.
- Auto-merge is armed only with `RELEASE_PAT`; a `GITHUB_TOKEN`-opened PR would get no checks and never merge, so its absence fails the job.

**Required rollout**
- Create a fine-grained PAT on this repo with `Contents: read+write` and `Pull requests: read+write`, no admin or bypass, and store it as `RELEASE_PAT`.
- Add the secret to the same source that rewrites Actions secrets, or the next sync will drop it again.

<sup>Written for commit 03f366a4b9748f9a9e9b45ad480d9519cf299748. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1678?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

