### PR TITLE
ci(release): the release chain runs on a GitHub App, not personal PATs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,32 +122,36 @@ jobs:
   # own without claiming the publish failed — the publish really did succeed,
   # and the packages really are on npm.
   #
-  # GITHUB_TOKEN is scoped to this repo alone, so this needs its own cross-repo
-  # credential; without it the job says so and stops green, because a missing
-  # optional secret is not a failure.
+  # GITHUB_TOKEN is scoped to this repo alone, so this mints a vendo-release-bot
+  # App token narrowed to vendo-web. vendo-web's vendoai-bump-merge workflow
+  # gates on the PR's author, so the identity opening it is a contract: change
+  # the credential here and change BUMP_AUTHOR there in the same breath.
   bump-console:
     needs: publish
     if: github.event_name == 'push' || inputs.publish
     runs-on: ubuntu-latest
     # Narrower than the workflow default: this job reads this repo and talks to
-    # vendo-web with VENDO_WEB_PAT. It publishes nothing, so it has no business
+    # vendo-web with an App token. It publishes nothing, so it has no business
     # holding the OIDC token that `publish` mints npm credentials with.
     permissions:
       contents: read
     steps:
+      - id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          owner: runvendo
+          repositories: vendo-web
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
       - name: Open the vendo-web dep bump PR
         env:
-          GH_TOKEN: ${{ secrets.VENDO_WEB_PAT }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
-          if [ -z "$GH_TOKEN" ]; then
-            echo "::notice::VENDO_WEB_PAT is not set — skipping the vendo-web bump PR"
-            exit 0
-          fi
           version=$(node -p "require('./packages/vendo/package.json').version")
           # EVERY package the bump will pin, not just the umbrella. The lockstep
           # group is exactly the public packages carrying this version, so

--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -19,14 +19,15 @@ name: Version Packages
 # needs no bypass: it is the one shape of this workflow that a tightening of main
 # cannot break, and the only credential it wants is an ordinary one.
 #
-# RELEASE_PAT (fine-grained, this repo only — Contents: read+write, Pull
-# requests: read+write, and NO admin or bypass) is required, not optional.
+# The credential is now the vendo-release-bot GitHub App (this repo and
+# vendo-web only — Contents: read+write, Pull requests: read+write, and NO admin
+# or bypass), minted per run from RELEASE_BOT_APP_ID and RELEASE_BOT_PRIVATE_KEY.
 # GitHub does not run workflows on branches or PRs pushed with the built-in
 # GITHUB_TOKEN, so a version PR opened under it gets zero checks: the four
 # required checks never report, the merge queue never takes it, and the PR sits
-# open forever looking healthy. Everything downstream — tagging, publishing —
-# waits on a merge that cannot happen, which is why its absence fails this job
-# loudly rather than leaving a notice in a green log.
+# open forever looking healthy — run 33125611079 left exactly that behind. An
+# App token does trigger them, and it cannot be stepped over the way a missing
+# secret can: create-github-app-token fails the job when either half is unset.
 #
 # The dispatch at the end is the whole publish automation. GitHub never triggers
 # a workflow from anything pushed with GITHUB_TOKEN, so the tag push alone
@@ -52,13 +53,18 @@ jobs:
     if: github.repository == 'runvendo/vendo'
     runs-on: ubuntu-latest
     steps:
+      - id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
-          # The PAT has to be here too, not just on the action: changesets/action
-          # pushes the version branch with a plain `git push`, so it uses the
-          # credentials checkout persists.
-          token: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
+          # The App token has to be here too, not just on the action:
+          # changesets/action pushes the version branch with a plain `git push`,
+          # so it uses the credentials checkout persists.
+          token: ${{ steps.app-token.outputs.token }}
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
@@ -80,7 +86,7 @@ jobs:
           commit: "chore: version packages"
           title: "chore: version packages"
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       # THE 0.x CEILING — deliberate, not a bug. Vendo does not ship 1.0.0 until
       # Yousef says so, and lifting this ceiling is his call alone: delete this
@@ -99,7 +105,7 @@ jobs:
       - name: Guard the 0.x ceiling
         if: steps.changesets.outputs.pullRequestNumber != ''
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR: ${{ steps.changesets.outputs.pullRequestNumber }}
         run: |
           set -euo pipefail
@@ -129,26 +135,19 @@ jobs:
       # directly. It sits AFTER the 0.x guard on purpose: a version PR that
       # crossed the ceiling must never be armed.
       #
-      # RELEASE_PAT, and only RELEASE_PAT, for both halves of the same rule.
-      # Without it the version PR gets no checks at all, so required checks never
-      # report and auto-merge waits forever; and the merge it eventually performs
-      # is attributed to whoever armed it, so a GITHUB_TOKEN merge would land on
-      # main without re-triggering this workflow — no tag, no publish. Stepping
-      # over a missing secret here is precisely what a green run that releases
-      # nothing looks like, so it fails instead.
+      # The App token, and only it, for both halves of the same rule. Under
+      # GITHUB_TOKEN the version PR gets no checks at all, so required checks
+      # never report and auto-merge waits forever; and the merge it eventually
+      # performs is attributed to whoever armed it, so a GITHUB_TOKEN merge would
+      # land on main without re-triggering this workflow — no tag, no publish.
+      #
+      # Re-arming an armed PR is a no-op, so this is safe on every push.
       - name: Arm auto-merge on the version PR
         if: steps.changesets.outputs.pullRequestNumber != ''
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR: ${{ steps.changesets.outputs.pullRequestNumber }}
-        run: |
-          set -euo pipefail
-          if [ -z "${GH_TOKEN:-}" ]; then
-            echo "::error::RELEASE_PAT is not set, so PR #$PR was opened by GITHUB_TOKEN and GitHub will run no checks on it at all. Its required checks can never report, the merge queue can never take it, and nothing can ever be released. Mint the PAT described at the top of this file — this is not a transient failure."
-            exit 1
-          fi
-          # Re-arming an armed PR is a no-op, so this is safe on every push.
-          gh pr merge "$PR" --auto --squash
+        run: gh pr merge "$PR" --auto --squash
 
       # UNGATED, and the remote's tags are what it decides on — not whether this
       # run versioned anything. That is what makes every push to main a retry of
@@ -201,9 +200,9 @@ jobs:
           git tag "$tag" "$GITHUB_SHA"
           # The URL alone was NOT enough, and v0.38.0 proved it: actions/checkout
           # persists its credential as `http.https://github.com/.extraheader:
-          # AUTHORIZATION: basic <RELEASE_PAT>`, and that header BEATS basic auth
-          # embedded in the URL — git sends both, GitHub honours the header. So
-          # the tag went up as yousefh409 and fired `push: tags` anyway. Emptying
+          # AUTHORIZATION: basic <checkout's token>`, and that header BEATS basic
+          # auth embedded in the URL — git sends both, GitHub honours the header.
+          # So the tag went up as a real identity and fired `push: tags`. Emptying
           # the header for this one command is what actually forces the URL's
           # token; the config itself is left alone for every other git call.
           git -c http.https://github.com/.extraheader= push "$TAG_PUSH_URL" "refs/tags/$tag"


### PR DESCRIPTION
## What

Replaces the two personal PATs in the release chain with the `vendo-release-bot`
GitHub App (App ID 4745087, installed on `runvendo/vendo` and
`runvendo/vendo-web`; Contents read+write, Pull requests read+write, no admin,
no bypass). Credentials arrive as the Actions secrets `RELEASE_BOT_APP_ID` and
`RELEASE_BOT_PRIVATE_KEY`, already set on both repos.

`version-packages.yml` — one `create-github-app-token` step, and its token now
serves the checkout (which is what `changesets/action` force-pushes
`changeset-release/main` with), the action itself, the 0.x disarm, and the
auto-merge arming. Untouched on purpose: the tag push still uses `GITHUB_TOKEN`
with `http.extraheader` blanked, because its silence is the interlock that stops
`release.yml`'s `push: tags` trigger colliding with the dispatch; the dispatch
still uses `GITHUB_TOKEN` too.

`release.yml` — the `bump-console` job mints a token scoped to `vendo-web`
(`owner: runvendo`, `repositories: vendo-web`) instead of `VENDO_WEB_PAT`.

## Why

`RELEASE_PAT` was yousefh409's admin PAT, and the 2026-08-27 bulk rewrite of
this repo's Actions secrets left it out. Every `version-packages` run since has
died at the arming step — the most recent, run 33125611079, opened PR #1679
under `GITHUB_TOKEN`, which is the failure the file's own comments describe: no
checks, no merge queue, no release, twenty-four changesets deep. `VENDO_WEB_PAT`
is gone from this repo too, so the console bump PR has silently not been opened.

An App token is the credential this workflow always wanted: pushes made with it
trigger workflows (which `GITHUB_TOKEN` cannot), it belongs to the project
rather than to a person, and it needs no bypass of anything.

Two deliberate behaviour changes, both in the same direction:

- The `-z "$GH_TOKEN"` guards are gone from both files.
  `create-github-app-token` fails the job when either secret is missing, so
  those branches are unreachable. In `release.yml` that also ends the
  skip-green-on-missing-secret path — the one that let v0.38.0's console bump
  fail quietly for two days.
- No branch-protection or ruleset change was needed. Since #1678 this workflow
  no longer pushes to `main` at all; the version PR goes through the merge queue
  like everything else. `main`'s classic protection (required checks
  ci/integration/conformance/audit, PR required with 0 approvals) and the
  `merge-queue-main` ruleset are both unchanged. The ruleset bypass granted to
  this App is not exercised by anything here and could be withdrawn.

Paired with runvendo/vendo-web#XXX, which moves the merge half of the train to
the same App. Either can merge first: with `VENDO_WEB_PAT` already absent, no
bump PR is being opened today, so there is no live flow to desynchronise.

## Verification

- [x] `actionlint` (with shellcheck) clean on both files, and byte-identical to
      its output on `origin/main` — no new findings
- [x] No changeset: `changeset-required` passed on #1678, the previous
      workflow-only PR, because no publishable package changes
- [ ] `pnpm build && pnpm test && pnpm typecheck && pnpm lint` green — N/A, no
      source touched
- [ ] Screenshots attached (if UI-affecting) — N/A


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the two personal PATs in the release chain with the `vendo-release-bot` GitHub App, fixing the version-PR pipeline that has been failing silently since the secret cleanup dropped `RELEASE_PAT`.

**Key changes**
- One App token per run now serves the checkout, changesets action, 0.x guard, auto-merge arming, and the vendo-web bump PR.
- Missing App secrets now fail the job immediately instead of skipping with a notice; the silent-failure path is gone.
- The tag push and the dispatch to `release.yml` intentionally stay on `GITHUB_TOKEN` to preserve the existing interlock.

<sup>Written for commit 97e5364b0afe5e441334a72fddd2362eb1ffe10e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1681?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

