### PR TITLE
fix(ci): swap deprecated app-id for client-id

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,7 +139,7 @@ jobs:
       - id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
-          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          client-id: ${{ secrets.RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
           owner: runvendo
           repositories: vendo-web

--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -21,7 +21,7 @@ name: Version Packages
 #
 # The credential is now the vendo-release-bot GitHub App (this repo and
 # vendo-web only — Contents: read+write, Pull requests: read+write, and NO admin
-# or bypass), minted per run from RELEASE_BOT_APP_ID and RELEASE_BOT_PRIVATE_KEY.
+# or bypass), minted per run from RELEASE_BOT_CLIENT_ID and RELEASE_BOT_PRIVATE_KEY.
 # GitHub does not run workflows on branches or PRs pushed with the built-in
 # GITHUB_TOKEN, so a version PR opened under it gets zero checks: the four
 # required checks never report, the merge queue never takes it, and the PR sits

--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -56,7 +56,7 @@ jobs:
       - id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
-          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          client-id: ${{ secrets.RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:


### PR DESCRIPTION
Swap deprecated app-id for client-id per action v3 deprecation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Swaps the deprecated `app-id` input for `client-id` in both workflows using `create-github-app-token` v3, which no longer accepts `app-id`, and fixes the stale comment referencing the old secret. The token now reads from `RELEASE_BOT_CLIENT_ID` instead of `RELEASE_BOT_APP_ID`.

- Requires `RELEASE_BOT_CLIENT_ID` to be configured in the repository before merging.

<sup>Written for commit a2ffe42264b1c2bf958cd15e6531363756c286f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

