### PR TITLE
fix(ui,vendo): persist a denied limit turn and hide Regenerate

### DIFF
--- a/packages/ui/e2e/limit-card.spec.ts
+++ b/packages/ui/e2e/limit-card.spec.ts
@@ -40,5 +40,8 @@ test("the limit card says who set the cap, in their words or ours", async ({ pag
   // The turn either side of the denials survives — the thread keeps going.
   await expect(page.getByText("build me a spending breakdown for last quarter")).toBeVisible();
   await expect(page.getByText("just a plain list of last month's charges then")).toBeVisible();
+  // A reached cap is not worth regenerating — the same policy will refuse again.
+  await expect(page.getByRole("button", { name: "Regenerate" })).toHaveCount(0);
+
   await page.screenshot({ path: screenshotPath("limit-card-thread"), fullPage: true, animations: "disabled" });
 });

--- a/packages/ui/src/chrome/thread/message-data.ts
+++ b/packages/ui/src/chrome/thread/message-data.ts
@@ -7,6 +7,16 @@ export function partData(part: UIMessage["parts"][number]): unknown {
   return "data" in part ? part.data : part;
 }
 
+/** A reached cap is not worth regenerating: the same policy will refuse again.
+ *  A meter that could not be CHECKED (`retryable`) is the exception — trying
+ *  again is the whole point of that card. */
+export function isReachedCap(message: UIMessage): boolean {
+  return message.parts.some((part) => {
+    if (part.type !== "data-vendo-limit") return false;
+    return (partData(part) as { retryable?: true }).retryable !== true;
+  });
+}
+
 /** The marker the agent's `wireErrorMessage` puts on its OWN safe error text
  * (VendoError code + operator-crafted message). Only prefixed strings may be
  * shown in detail to an end user; raw transport/provider strings never carry

--- a/packages/ui/src/chrome/thread/message.tsx
+++ b/packages/ui/src/chrome/thread/message.tsx
@@ -4,7 +4,7 @@ import { Fragment, useRef, useState } from "react";
 import { BeatSummary } from "../build-beat.js";
 import { useCopyFeedback } from "../clipboard.js";
 import { SentAttachment, type FilePart } from "./attachments.js";
-import { assistantText, collapseToolRuns, isAgentContext, toolCallIsContent, toolCallParked, toolCallPending, userText } from "./message-data.js";
+import { assistantText, collapseToolRuns, isAgentContext, isReachedCap, toolCallIsContent, toolCallParked, toolCallPending, userText } from "./message-data.js";
 import { ThreadPart } from "./parts.js";
 import { TurnCitations } from "./turn-citations.js";
 
@@ -36,7 +36,8 @@ function CopyTurnButton({ text }: { text: string }) {
 
 /** One turn in the transcript: the user attachments beside the bubble, the
     article with its stream parts, and the settled-turn actions (Copy always;
-    Edit on the last user turn, Regenerate on the last assistant turn). */
+    Edit on the last user turn, Regenerate on the last assistant turn unless
+    that turn is a reached cap). */
 export function ThreadMessage({ message, restored, risks, busy, activeAssistantId, lastUserId, lastAssistantId, onEditLast, onRegenerateLast, sendMessage, respond }: {
   message: UIMessage;
   restored: boolean;
@@ -66,7 +67,10 @@ export function ThreadMessage({ message, restored, risks, busy, activeAssistantI
   // Regenerate on the last assistant turn.
   const streamingTurn = busy && message.role === "assistant" && message.id === activeAssistantId;
   const showEdit = !busy && message.role === "user" && message.id === lastUserId;
-  const showRegenerate = !busy && message.role === "assistant" && message.id === lastAssistantId;
+  // A reached cap will refuse the same turn again ("Calling again gets the
+  // same answer"), so the ordinary last-assistant Regenerate is withheld.
+  const showRegenerate = !busy && message.role === "assistant" && message.id === lastAssistantId
+    && !isReachedCap(message);
   // The turn's beats fold into ONE summary row once the whole turn
   // has settled: while any call is still working (or parked on an approval)
   // every beat stays open, and the fold waits. Restored history arrives folded,

--- a/packages/ui/test/chrome/limit-card.test.tsx
+++ b/packages/ui/test/chrome/limit-card.test.tsx
@@ -82,4 +82,20 @@ describe("the limit card in the thread", () => {
     expect(card.querySelector(".fl-beat-x")).toBeNull();
     expect(document.querySelector("[data-vendo-build-failed]")).toBeNull();
   });
+
+  it("does not offer Regenerate on a reached cap", async () => {
+    await mountDenial({ message: "Daily limit reached." });
+    expect(screen.queryByRole("button", { name: "Regenerate" })).toBeNull();
+  });
+
+  it("still offers Regenerate when the meter could not be checked", async () => {
+    await mountDenial(
+      {
+        message: "Vendo Cloud is busy right now, so this limit could not be checked — this is temporary, not a cap.",
+        retryable: true,
+      },
+      "Couldn’t check your limit",
+    );
+    expect(screen.getByRole("button", { name: "Regenerate" })).toBeTruthy();
+  });
 });

--- a/packages/vendo/src/harness-turn.ts
+++ b/packages/vendo/src/harness-turn.ts
@@ -20,6 +20,7 @@ import {
   emitUsage,
   hostSkillFiles,
   isUnattended,
+  log,
   situationPromptBlock,
   toVendoWirePart,
   WARM_THREAD_PREFIX,
@@ -302,20 +303,29 @@ function modelFamilyOf(models: ResolvedModels<LanguageModel>): string | null {
   return typeof id === "string" ? id : null;
 }
 
-/** The whole of a message the host's policy refused: the card the chat surface
- *  renders, and nothing else. No thread row, no transcript, no model call — the
- *  point of the choke is that a denied message costs nothing. */
-const limitResponse = (verdict: { message?: string; retryable?: true }): Response => createUIMessageStreamResponse({
-  stream: createUIMessageStream<UIMessage>({
-    execute: ({ writer }) => {
-      writer.write(toVendoWirePart({
-        type: "data-vendo-limit",
-        ...(verdict.message === undefined ? {} : { message: verdict.message }),
-        ...(verdict.retryable === undefined ? {} : { retryable: verdict.retryable }),
-      }) as never);
-    },
-  }),
+/** The card a refused message streams, nested in the wire envelope the chrome
+ *  and a persisted transcript both read. */
+const limitCardPart = (verdict: { message?: string; retryable?: true }) => toVendoWirePart({
+  type: "data-vendo-limit",
+  ...(verdict.message === undefined ? {} : { message: verdict.message }),
+  ...(verdict.retryable === undefined ? {} : { retryable: verdict.retryable }),
 });
+
+/** The live stream of a message the host's policy refused: the card the chat
+ *  surface renders. The same pair is persisted beside it so a reload can read
+ *  it back. No model call — the point of the choke is that a denied message
+ *  does not spend one. */
+const limitResponse = (verdict: { message?: string; retryable?: true }, threadId?: ThreadId): Response => {
+  const response = createUIMessageStreamResponse({
+    stream: createUIMessageStream<UIMessage>({
+      execute: ({ writer }) => {
+        writer.write(limitCardPart(verdict) as never);
+      },
+    }),
+  });
+  if (threadId !== undefined) response.headers.set(THREAD_ID_HEADER, threadId);
+  return response;
+};
 
 export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
   const threads = new ThreadRepository(config.store);
@@ -581,6 +591,27 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
     }
   };
 
+  /** The question and the card, written the same way a first turn writes, so
+   *  GET /threads/:id (a reload) reads them back. No model call. */
+  const persistDeniedMessage = async (
+    input: { threadId?: string; message: UIMessage; ctx: RunContext },
+    verdict: { message?: string; retryable?: true },
+  ): Promise<ThreadId> => {
+    const given = input.threadId;
+    if (given !== undefined && !isThreadId(given)) {
+      throw new VendoError("validation", "threadId is malformed");
+    }
+    const thread = await threads.resolve(given as ThreadId | undefined, input.ctx);
+    validateUpsert(thread.messages, input.message);
+    const assistant: UIMessage = {
+      id: `msg_${globalThis.crypto.randomUUID()}`,
+      role: "assistant",
+      parts: [limitCardPart(verdict) as UIMessage["parts"][number]],
+    };
+    await threads.persist(thread, [input.message, assistant], { fresh: thread.messages.length === 0 });
+    return thread.id;
+  };
+
   return {
     threads: {
       get: (id, ctx) => threads.get(id, ctx),
@@ -650,10 +681,25 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
       const timings = createTurnTimings();
       validateMessage(input?.message);
       // The message choke (limits.ts owns the counting, the policy and the
-      // recording): asked BEFORE the thread is resolved, so a refused message
-      // costs no read, no write and no model call.
+      // recording): asked BEFORE the model is called, so a refused message
+      // spends no tokens. The question and the card ARE written, so a reload
+      // can still say why the assistant went quiet.
       const verdict = await config.limiter?.gate("message", input.ctx);
-      if (verdict?.allow === false) return limitResponse(verdict);
+      if (verdict?.allow === false) {
+        let threadId: ThreadId | undefined;
+        try {
+          threadId = await persistDeniedMessage(input, verdict);
+        } catch (error) {
+          if (isVendoError(error)) throw error;
+          log({
+            code: "vendo.limit_denial_not_persisted",
+            level: "error",
+            message: "[vendo] a denied message could not be written to the thread; the card still streams",
+            data: { error },
+          });
+        }
+        return limitResponse(verdict, threadId);
+      }
       // Assembled once, per turn, for WHOEVER thinks. The venue gate and the guard's
       // directions live in here, which is why it is composition's job and not the
       // harness's. Which discovery section it may promise is decided by what is
@@ -665,7 +711,7 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
       // store below can change — so assembling it after the reads meant the turn
       // paid the store's wait and the guard's `directions` wait end to end.
       // Started after the limiter gate, not before: a refused message must still
-      // cost nothing.
+      // skip the model, even though the card is now persisted.
       const rail = discoveryRail(config.harness, config.connectorDiscovery);
       const systemRead = config.system(input.ctx, { discovery: rail });
       // A rejection is delivered where the prompt is awaited below; this only

--- a/packages/vendo/src/harness-turn.ts
+++ b/packages/vendo/src/harness-turn.ts
@@ -13,6 +13,7 @@
  * It decides nothing about how to think. Every value below is a façade or a gate.
  */
 import {
+  STORE_WIRE_APPEND_MESSAGES_OPS,
   STORE_WIRE_TURN_OPS,
   isVendoError,
   VendoError,
@@ -591,10 +592,38 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
     }
   };
 
+  /** Best-effort: a denied turn that moved a drop and then failed to write the
+   *  transcript must not leave the file under the thread with no message
+   *  pointing at it. Staging already erased the original, so this is a delete,
+   *  not a move back. */
+  const dropHomedFiles = async (paths: string[], ctx: RunContext): Promise<void> => {
+    if (paths.length === 0) return;
+    try {
+      const workspace = await sqlDoors().workspaces.open(ctx.principal);
+      for (const path of paths) await workspace.rm(path, { force: true });
+      await workspace.commit();
+      for (const path of paths) await eraseStagedFile(ctx, path);
+    } catch {
+      // Already a failed write; the card still streams.
+    }
+  };
+
+  /** `upsertMany` is one transaction on SQL and on a mount that serves
+   *  `transcripts.appendMessages`. Older StoreOps mounts fall through to two
+   *  `putMessage` calls, which can land the user bubble without the card. */
+  const pairWriteIsAtomic = async (): Promise<boolean> => {
+    if (maybeDbFor(config.store) !== undefined) return true;
+    if (config.ops?.transcripts.appendMessages === undefined) return false;
+    try {
+      return (await config.ops.status()).ops >= STORE_WIRE_APPEND_MESSAGES_OPS;
+    } catch {
+      return false;
+    }
+  };
+
   /** The question and the card, written the same way an ordinary turn writes:
-   *  a staged drop comes home first, then the pair lands through `upsertMany`
-   *  when the store has it (`persist` is the fallback that creates the row).
-   *  No model call. */
+   *  a staged drop comes home first, then the pair lands in one write. No model
+   *  call. */
   const persistDeniedMessage = async (
     input: { threadId?: string; message: UIMessage; ctx: RunContext },
     verdict: { message?: string; retryable?: true },
@@ -605,6 +634,9 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
     }
     const thread = await threads.resolve(given as ThreadId | undefined, input.ctx);
     const fresh = thread.messages.length === 0;
+    const priorFileUrls = new Set(
+      input.message.parts.flatMap((part) => part.type === "file" ? [part.url] : []),
+    );
     const message = await rehomeStagedFiles(input.message, thread.id, input.ctx);
     validateUpsert(thread.messages, message);
     const assistant: UIMessage = {
@@ -612,26 +644,34 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
       role: "assistant",
       parts: [limitCardPart(verdict) as UIMessage["parts"][number]],
     };
-    // Same split an ordinary turn uses: `persist` creates the row (and is the
-    // fallback when the batch verb is absent); once the row exists, the
-    // transcript door's `upsertMany` is the writer. A turn-capable store
-    // without `records.atomic` would throw here if we always went through
-    // the repository.
+    const homed = message.parts.flatMap((part) =>
+      part.type === "file" && !priorFileUrls.has(part.url) ? [part.url] : [],
+    );
+    // `persist` is the pair write (CAS of the whole transcript). `upsertMany`
+    // is used only where that verb is itself one transaction — a SQL store, or
+    // a mount that serves `transcripts.appendMessages`. A turn-capable store
+    // without `records.atomic` still needs the batch verb; an older mount
+    // without it must not split the pair across two `putMessage` calls.
     let batchAppend: ReturnType<typeof sqlDoors>["transcript"]["upsertMany"] | undefined;
     try {
       batchAppend = sqlDoors().transcript.upsertMany;
     } catch (error) {
       if (!isVendoError(error) || error.code !== "not-implemented") throw error;
     }
-    if (fresh || batchAppend === undefined) {
-      await threads.persist(thread, [message, assistant], { fresh });
-    } else {
-      await batchAppend(
-        input.ctx.principal,
-        thread.id,
-        [message, assistant],
-        { title: deriveTitle([...thread.messages, message]) },
-      );
+    try {
+      if (fresh || batchAppend === undefined || !await pairWriteIsAtomic()) {
+        await threads.persist(thread, [message, assistant], { fresh });
+      } else {
+        await batchAppend(
+          input.ctx.principal,
+          thread.id,
+          [message, assistant],
+          { title: deriveTitle([...thread.messages, message]) },
+        );
+      }
+    } catch (error) {
+      await dropHomedFiles(homed, input.ctx);
+      throw error;
     }
     return thread.id;
   };

--- a/packages/vendo/src/harness-turn.ts
+++ b/packages/vendo/src/harness-turn.ts
@@ -591,8 +591,10 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
     }
   };
 
-  /** The question and the card, written the same way a first turn writes, so
-   *  GET /threads/:id (a reload) reads them back. No model call. */
+  /** The question and the card, written the same way an ordinary turn writes:
+   *  a staged drop comes home first, then the pair lands through `upsertMany`
+   *  when the store has it (`persist` is the fallback that creates the row).
+   *  No model call. */
   const persistDeniedMessage = async (
     input: { threadId?: string; message: UIMessage; ctx: RunContext },
     verdict: { message?: string; retryable?: true },
@@ -602,13 +604,35 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
       throw new VendoError("validation", "threadId is malformed");
     }
     const thread = await threads.resolve(given as ThreadId | undefined, input.ctx);
-    validateUpsert(thread.messages, input.message);
+    const fresh = thread.messages.length === 0;
+    const message = await rehomeStagedFiles(input.message, thread.id, input.ctx);
+    validateUpsert(thread.messages, message);
     const assistant: UIMessage = {
       id: `msg_${globalThis.crypto.randomUUID()}`,
       role: "assistant",
       parts: [limitCardPart(verdict) as UIMessage["parts"][number]],
     };
-    await threads.persist(thread, [input.message, assistant], { fresh: thread.messages.length === 0 });
+    // Same split an ordinary turn uses: `persist` creates the row (and is the
+    // fallback when the batch verb is absent); once the row exists, the
+    // transcript door's `upsertMany` is the writer. A turn-capable store
+    // without `records.atomic` would throw here if we always went through
+    // the repository.
+    let batchAppend: ReturnType<typeof sqlDoors>["transcript"]["upsertMany"] | undefined;
+    try {
+      batchAppend = sqlDoors().transcript.upsertMany;
+    } catch (error) {
+      if (!isVendoError(error) || error.code !== "not-implemented") throw error;
+    }
+    if (fresh || batchAppend === undefined) {
+      await threads.persist(thread, [message, assistant], { fresh });
+    } else {
+      await batchAppend(
+        input.ctx.principal,
+        thread.id,
+        [message, assistant],
+        { title: deriveTitle([...thread.messages, message]) },
+      );
+    }
     return thread.id;
   };
 

--- a/packages/vendo/src/harness-turn.ts
+++ b/packages/vendo/src/harness-turn.ts
@@ -592,19 +592,64 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
     }
   };
 
-  /** Best-effort: a denied turn that moved a drop and then failed to write the
-   *  transcript must not leave the file under the thread with no message
-   *  pointing at it. Staging already erased the original, so this is a delete,
-   *  not a move back. */
-  const dropHomedFiles = async (paths: string[], ctx: RunContext): Promise<void> => {
-    if (paths.length === 0) return;
-    try {
+  /** A denied turn that moved a drop and then failed to write the transcript
+   *  must not leave the file under the thread with no message pointing at it.
+   *  Delete first (retry once); if that still fails, move it back to staging so
+   *  the stray sweep can reclaim it. Never swallow — a leftover at the thread
+   *  path has no janitor. */
+  const dropHomedFiles = async (
+    homes: Map<string, string>,
+    ctx: RunContext,
+  ): Promise<void> => {
+    if (homes.size === 0) return;
+    const paths = [...homes.values()];
+    const remove = async (): Promise<void> => {
       const workspace = await sqlDoors().workspaces.open(ctx.principal);
       for (const path of paths) await workspace.rm(path, { force: true });
       await workspace.commit();
       for (const path of paths) await eraseStagedFile(ctx, path);
-    } catch {
-      // Already a failed write; the card still streams.
+    };
+    let lastError: unknown;
+    for (let attempt = 0; attempt < 2; attempt++) {
+      try {
+        await remove();
+        return;
+      } catch (error) {
+        lastError = error;
+      }
+    }
+    try {
+      const workspace = await sqlDoors().workspaces.open(ctx.principal);
+      let moved = 0;
+      for (const [from, to] of homes) {
+        if (await workspace.exists(to)) {
+          await workspace.mv(to, from);
+          moved += 1;
+        }
+      }
+      if (moved === 0) {
+        log({
+          code: "vendo.limit_denial_file_not_reclaimed",
+          level: "error",
+          message: "[vendo] a denied turn left a rehomed file with no transcript row; the staging sweep cannot see it",
+          data: { error: lastError, paths },
+        });
+        return;
+      }
+      await workspace.commit();
+      log({
+        code: "vendo.limit_denial_file_restaged",
+        level: "error",
+        message: "[vendo] a denied turn could not delete a rehomed file; it was moved back to staging for the stray sweep",
+        data: { error: lastError },
+      });
+    } catch (error) {
+      log({
+        code: "vendo.limit_denial_file_not_reclaimed",
+        level: "error",
+        message: "[vendo] a denied turn left a rehomed file with no transcript row; the staging sweep cannot see it",
+        data: { error, paths },
+      });
     }
   };
 
@@ -634,9 +679,6 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
     }
     const thread = await threads.resolve(given as ThreadId | undefined, input.ctx);
     const fresh = thread.messages.length === 0;
-    const priorFileUrls = new Set(
-      input.message.parts.flatMap((part) => part.type === "file" ? [part.url] : []),
-    );
     const message = await rehomeStagedFiles(input.message, thread.id, input.ctx);
     validateUpsert(thread.messages, message);
     const assistant: UIMessage = {
@@ -644,9 +686,14 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
       role: "assistant",
       parts: [limitCardPart(verdict) as UIMessage["parts"][number]],
     };
-    const homed = message.parts.flatMap((part) =>
-      part.type === "file" && !priorFileUrls.has(part.url) ? [part.url] : [],
-    );
+    const homes = new Map<string, string>();
+    for (let i = 0; i < input.message.parts.length; i++) {
+      const before = input.message.parts[i];
+      const after = message.parts[i];
+      if (before?.type === "file" && after?.type === "file" && before.url !== after.url) {
+        homes.set(before.url, after.url);
+      }
+    }
     // `persist` is the pair write (CAS of the whole transcript). `upsertMany`
     // is used only where that verb is itself one transaction — a SQL store, or
     // a mount that serves `transcripts.appendMessages`. A turn-capable store
@@ -670,7 +717,7 @@ export function createHarnessTurns(config: HarnessTurnsConfig): HarnessTurns {
         );
       }
     } catch (error) {
-      await dropHomedFiles(homed, input.ctx);
+      await dropHomedFiles(homes, input.ctx);
       throw error;
     }
     return thread.id;

--- a/packages/vendo/tests/limits-enforcement.e2e.test.ts
+++ b/packages/vendo/tests/limits-enforcement.e2e.test.ts
@@ -125,6 +125,36 @@ describe("the message choke — a denied message costs nothing", () => {
     });
   });
 
+  it("homes a staged drop on a denied turn, so a reload still opens the file", async () => {
+    const { vendo } = await compose({ limits: () => false, turns: [] });
+    const staged = await vendo.harness.stageUpload({
+      principal,
+      name: "ledger.csv",
+      content: "jan,1\n",
+    });
+    const ctx = { principal, venue: "chat" as const, presence: "present" as const, sessionId: "s_limits" };
+    const response = await vendo.handler(new Request("https://host.test/api/vendo/threads", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        threadId: "thr_limits",
+        message: {
+          id: "m_file",
+          role: "user",
+          parts: [
+            { type: "text", text: "what is in this?" },
+            { type: "file", mediaType: "text/csv", filename: "ledger.csv", url: staged.path },
+          ],
+        },
+      }),
+    }));
+    expect(limitCards(await readSse(response))).toEqual([{ type: "data-vendo-limit" }]);
+    const stored = await vendo.harness.threads.get("thr_limits", ctx);
+    const file = stored?.messages[0]?.parts.find((part) => part.type === "file") as { url?: string } | undefined;
+    expect(file?.url).toBe("/user/threads/thr_limits/files/ledger.csv");
+    expect(await (await vendo.harness.workspace(principal)).readFile(file!.url!)).toBe("jan,1\n");
+  });
+
   it("says nothing of its own when the policy gave no sentence", async () => {
     const { chat } = await compose({ limits: () => false, turns: [] });
 

--- a/packages/vendo/tests/limits-enforcement.e2e.test.ts
+++ b/packages/vendo/tests/limits-enforcement.e2e.test.ts
@@ -98,7 +98,7 @@ describe("the message choke — a denied message costs nothing", () => {
   it("turns the third message away with the host's sentence, before any model call", async () => {
     // Two turns scripted, and only two: a third model call is exhaustion, not a
     // pass.
-    const { model, chat } = await compose({ limits: twoMessages, turns: [textTurn("one"), textTurn("two")] });
+    const { vendo, model, chat } = await compose({ limits: twoMessages, turns: [textTurn("one"), textTurn("two")] });
 
     expect(limitCards(await chat("first"))).toEqual([]);
     expect(limitCards(await chat("second"))).toEqual([]);
@@ -108,6 +108,21 @@ describe("the message choke — a denied message costs nothing", () => {
     // THE POINT: the turn was refused at the door, so the provider was never
     // dialed at all.
     expect(model.calls).toBe(2);
+    // The question and the card were written through the real persist path, so
+    // GET /threads/:id (a reload) reads them back — no stub on either side.
+    const stored = await vendo.harness.threads.get("thr_limits", {
+      principal, venue: "chat", presence: "present", sessionId: "s_limits",
+    });
+    expect(stored?.messages.map((message) => message.role)).toEqual([
+      "user", "assistant", "user", "assistant", "user", "assistant",
+    ]);
+    const last = stored?.messages.at(-1);
+    expect(last?.role).toBe("assistant");
+    expect(last?.parts.some((part) => part.type === "data-vendo-limit")).toBe(true);
+    expect(stored?.messages.at(-2)).toMatchObject({
+      role: "user",
+      parts: [{ type: "text", text: "third" }],
+    });
   });
 
   it("says nothing of its own when the policy gave no sentence", async () => {

--- a/packages/vendo/tests/limits-enforcement.e2e.test.ts
+++ b/packages/vendo/tests/limits-enforcement.e2e.test.ts
@@ -155,6 +155,54 @@ describe("the message choke — a denied message costs nothing", () => {
     expect(await (await vendo.harness.workspace(principal)).readFile(file!.url!)).toBe("jan,1\n");
   });
 
+  it("drops a rehomed file if the transcript write fails, and still streams the card", async () => {
+    const store = await tempStore();
+    const original = store.records.bind(store);
+    store.records = ((collection: string) => {
+      const seam = original(collection);
+      if (collection !== "vendo_threads" || seam.atomic === undefined) return seam;
+      return {
+        ...seam,
+        atomic: {
+          insertIfAbsent: async () => { throw new Error("transcript down"); },
+          compareAndSwap: async () => { throw new Error("transcript down"); },
+        },
+      };
+    }) as typeof store.records;
+    const vendo = createVendo({
+      models: { default: scriptedModel([]) as unknown as LanguageModel },
+      principal: async () => principal,
+      store,
+      limits: () => false,
+    } as CreateVendoConfig);
+    const staged = await vendo.harness.stageUpload({
+      principal,
+      name: "ledger.csv",
+      content: "jan,1\n",
+    });
+    const ctx = { principal, venue: "chat" as const, presence: "present" as const, sessionId: "s_limits" };
+    const response = await vendo.handler(new Request("https://host.test/api/vendo/threads", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        threadId: "thr_limits",
+        message: {
+          id: "m_orphan",
+          role: "user",
+          parts: [
+            { type: "text", text: "what is in this?" },
+            { type: "file", mediaType: "text/csv", filename: "ledger.csv", url: staged.path },
+          ],
+        },
+      }),
+    }));
+    expect(limitCards(await readSse(response))).toEqual([{ type: "data-vendo-limit" }]);
+    expect(await vendo.harness.threads.get("thr_limits", ctx)).toBeNull();
+    await expect((await vendo.harness.workspace(principal)).readFile(
+      "/user/threads/thr_limits/files/ledger.csv",
+    )).rejects.toThrow();
+  });
+
   it("says nothing of its own when the policy gave no sentence", async () => {
     const { chat } = await compose({ limits: () => false, turns: [] });
 


### PR DESCRIPTION
## Summary
- Hide **Regenerate** on a reached-cap turn (`data-vendo-limit` without `retryable`). A meter that could not be checked still offers it.
- Persist the denied user bubble and limit card through the real thread write path, with **no model call**, so a reload still shows why the assistant went quiet.

Addresses items 1 and 2 of #1327. Item 3 (the model quoting raw denial JSON) was not reproduced here; unwrapping that tool result lives in `packages/harnesses/src/vendo/` and was left alone.

## Test plan
- [x] `packages/ui` limit-card unit tests: no Regenerate on a reached cap; still shown when `retryable: true`
- [x] `packages/vendo` limits-enforcement e2e: third denied message is written, then read back via `vendo.harness.threads.get` (no stubs)
- [x] Maple live check: cap card with no Regenerate; reload keeps the denied exchange
- [ ] Playwright `packages/ui/e2e/limit-card.spec.ts` (local pre-PR gate, not CI)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persists a denied limit exchange and hides Regenerate on reached caps, so a reload still explains why the assistant went quiet and retrying a turn the policy will refuse again is not offered. Addresses items 1 and 2 of #1327.

**Bug Fixes**
- Regenerate is hidden when a `data-vendo-limit` part is not `retryable`; a meter that could not be checked still shows it.
- Denied turns write through the real thread path with no model call; staged uploads land under the thread first, and only atomic batch writers use `upsertMany` — older stores fall back to a single `persist` write.
- If the write fails, the rehomed file is deleted; if deletion fails too, the file moves back to staging and the failure is logged, while the card still streams.

<sup>Written for commit 8ca4ab0ecfa6c3c3c1b53be6a4c76f822154f7d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1683?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

