### PR TITLE
ci: a red main pages Slack instead of waiting to be noticed

### DIFF
--- a/.github/workflows/ai-dual-nightly.yml
+++ b/.github/workflows/ai-dual-nightly.yml
@@ -7,8 +7,9 @@ name: ai-dual nightly
 # merge_group alike until #1584. This workflow resolves the NEWEST ai@7 every
 # morning instead, on main, so the drift is found here.
 #
-# Red here IS the notification — same as a red main, there is no pager. The fix
-# is a deliberate PR: read the version off the run's "Resolved AI SDK versions"
+# Red here IS the notification: red-main-alert.yml pages Slack for a red main,
+# but it watches CI only, so nothing pages for this workflow. The fix is a
+# deliberate PR: read the version off the run's "Resolved AI SDK versions"
 # step, fix the break or move the pin, land it with a green run behind it.
 #
 # It provides no required check and never runs on a PR, so it cannot block a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ concurrency:
 #   push to main  NO filter. Every shard, every package, plus coverage-merge
 #                 with the real per-package floors. This is the backstop that
 #                 makes cone-only PR CI safe, and the workflow going red on
-#                 main is the whole notification — there is no pager.
+#                 main is what red-main-alert.yml pages Slack for.
 #
 # The gap that backstop is covering, stated plainly: the cone is turbo's
 # dependency graph, and inputs outside the graph are invisible to it.

--- a/.github/workflows/red-main-alert.yml
+++ b/.github/workflows/red-main-alert.yml
@@ -1,0 +1,72 @@
+name: red-main-alert
+
+# The pager for a red main. Until now there wasn't one, deliberately: a red
+# main was found by whoever next opened the Actions tab, and ci.yml said so in
+# as many words. Scope is CI alone — ai-dual-nightly.yml still has no pager,
+# which its own header now says.
+#
+# It watches CI from outside rather than adding a notify job inside ci.yml,
+# because such a job would have to `needs:` every leg, would be skipped rather
+# than run when a leg is cancelled, and would fire on pull_request too. A
+# workflow_run listener sees one conclusion for the whole workflow, which is
+# exactly the question being asked.
+#
+# The channel is Slack, which is why the payload below is the incoming-webhook
+# shape. CI_ALERT_WEBHOOK_URL holds the hook URL, and that URL is itself the
+# credential — anyone holding it can post as the app — so it is a repo secret
+# and is never written down here.
+#
+# Note this cannot fire until it is on the default branch: workflow_run only
+# dispatches from the copy of the workflow that lives on main.
+on:
+  workflow_run:
+    # Matches ci.yml's `name:`, not its filename.
+    workflows: ["CI"]
+    types: [completed]
+    # Filters the triggering run's HEAD branch. Its job is to stop a workflow
+    # run being created at all for the PR and merge_group runs of CI, which
+    # would otherwise show up as skipped noise on every PR.
+    branches: [main]
+
+# Nothing here reads the API or the tree.
+permissions: {}
+
+jobs:
+  alert:
+    # `completed` also fires for success, cancelled and skipped; only failure
+    # is a red main.
+    #
+    # The event check is not redundant with `branches:` above: that filter
+    # matches the head branch, so a fork PR opened from a branch called `main`
+    # satisfies it. merge_group runs are already excluded (their head branch is
+    # gh-readonly-queue/...) and could not redden main anyway — they fail the
+    # queue entry instead.
+    if: >-
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.event == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # Every failing run alerts; no transition tracking, no stored state. main
+      # went red five times on 2026-08-30 alone, so a main that stays red will
+      # repeat itself — the accepted cost of holding no state. Each repeat
+      # names a different commit, which is what bisecting it needs anyway.
+      #
+      # An unset CI_ALERT_WEBHOOK_URL fails this step rather than silently not
+      # alerting, so the missing decision stays visible.
+      - name: Post to the alert channel
+        env:
+          WEBHOOK_URL: ${{ secrets.CI_ALERT_WEBHOOK_URL }}
+          TITLE: ${{ github.event.workflow_run.display_title }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          SHA: ${{ github.event.workflow_run.head_sha }}
+          ACTOR: ${{ github.event.workflow_run.triggering_actor.login }}
+        run: |
+          set -euo pipefail
+          # Via jq --arg from the environment, never expression-interpolated
+          # into the JSON: a commit message carrying a quote would otherwise
+          # break the payload, or run as shell.
+          jq -n --arg t "$TITLE" --arg u "$RUN_URL" --arg s "$SHA" --arg a "$ACTOR" \
+            '{text: "main is RED — \($t)\n\($s[0:7]) pushed by \($a)\n\($u)"}' \
+            | curl --fail-with-body --silent --show-error --max-time 30 \
+                -H 'Content-Type: application/json' --data @- "$WEBHOOK_URL"


### PR DESCRIPTION
A red main was found by whoever next opened the Actions tab — five times on 2026-08-30 alone. This adds a workflow_run listener that posts to Slack via the CI_ALERT_WEBHOOK_URL repo secret when CI on main concludes failure.

Scope: pages for the CI workflow on main only; ai-dual-nightly stays deliberately unpaged (its comment now says so instead of claiming there is no pager at all).

Do not merge until the CI_ALERT_WEBHOOK_URL secret is set — unset, every red main produces a second red run (loud by design).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Slack alert for red main CI runs instead of relying on someone opening the Actions tab.

The new `red-main-alert` workflow watches CI via `workflow_run` and posts commit title, short SHA, actor, and run URL to the `CI_ALERT_WEBHOOK_URL` webhook on failure. It fires on every failing run with no state, so a persistently red main repeats. The `ai-dual-nightly` workflow remains unpaged; its header now says so.

**Migration**
- Set the `CI_ALERT_WEBHOOK_URL` repo secret before merging. If unset, the alert step fails loudly instead of silently skipping.

<sup>Written for commit aeecbed4fb4827bd573372bc7d111035c78c95fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1700?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

