### PR TITLE
chore: re-ratchet coverage floors after the CLI fold

### DIFF
--- a/.changeset/coverage-re-ratchet.md
+++ b/.changeset/coverage-re-ratchet.md
@@ -1,0 +1,8 @@
+---
+---
+
+No published behaviour changes: the coverage floors re-ratchet to the numbers CI
+measures. src/cli/ rejoins @vendoai/vendo's coverage — the CLI fold excluded it
+so the then-78 global went on measuring its pre-fold file set — and the umbrella
+goes 78 -> 93 with a src/cli/** floor of 92, @vendoai/ui 90 -> 92. A glob is an
+additive check and not an exclusion, so the CLI's files are held to both.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -509,7 +509,7 @@ jobs:
     if: needs.cone.outputs.heavy == 'true'
     uses: ./.github/workflows/ai-dual.yml
 
-  # The per-package coverage floors (vendo 78 / ui 90, each in the
+  # The per-package coverage floors (vendo 93 / ui 92, each in the
   # package's vitest config) live HERE, because a floor is only meaningful
   # against the whole suite's coverage. vitest replays the shards' blob reports
   # without re-running a single test, then reports and enforces.

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -22,14 +22,15 @@ export default defineConfig({
       // against the whole suite's merged coverage rather than any single shard.
       // RATCHET — this number only ever rises: when it goes red, add coverage,
       // never lower the floor.
-      // Last set 2026-08-08 to 90, against a measured 91.65% lines (11509/12557)
-      // on main — re-measured through the merge path after the undo/rollback
-      // deletion and four ui fixes landed. The 1.65 points of slack are
-      // deliberate: a floor with no room is a floor everyone learns to bypass.
-      // Branches are not floored (88.86% when this was set).
+      // Last set 2026-08-30 to 92, against a measured 93.81% lines on main —
+      // coverage-merge of run 33328955194, the same merge path the floor is
+      // enforced through. The ~1.8 points of slack are deliberate, and are the
+      // same slack the previous setting carried (90 against 91.65 on
+      // 2026-08-08): a floor with no room is a floor everyone learns to bypass.
+      // Branches are not floored (91.53% when this was set).
       // Off inside a shard; enforced by coverage-merge. Same rule as
       // @vendoai/vendo's, and stated the same way.
-      thresholds: process.env.VITEST_SHARD ? {} : { lines: 90 },
+      thresholds: process.env.VITEST_SHARD ? {} : { lines: 92 },
     },
     environment: "jsdom",
     include: ["test/**/*.test.ts?(x)"],

--- a/packages/vendo/vitest.config.ts
+++ b/packages/vendo/vitest.config.ts
@@ -27,27 +27,32 @@ export default defineConfig({
       provider: "v8",
       reporter: ["text", "json-summary"],
       include: ["src/**/*.{ts,tsx}"],
-      exclude: [
-        "src/**/*.test.{ts,tsx}",
-        "src/**/*.test-util.{ts,tsx}",
-        // The CLI folded in here when the `vendo` bin came back to the umbrella.
-        // It carried a floor of 0 as a separate package, so it is EXCLUDED
-        // rather than given a glob of its own: the 78 below then measures the
-        // file set it measured before the fold, instead of moving by whatever
-        // the CLI happens to score. A `{ lines: 0 }` glob would not do that —
-        // a glob adds a second check and still leaves its files in the number
-        // above. The CLI gets a floor of its own at the re-ratchet.
-        "src/cli/**",
-      ],
+      exclude: ["src/**/*.test.{ts,tsx}", "src/**/*.test-util.{ts,tsx}"],
       // Ratcheted line-coverage floor (ENG-255): set at/just below the measured
       // value so it can only rise. Regression below this fails CI.
       //
-      // The two globs are the app-generation code S11d folded in. A fold must
-      // not weaken a gate as a side effect: that code carried its own floor of
-      // 88 as @vendoai/apps, and the globs keep holding it there. Glob-matched
-      // files still count in the global number too — a glob is a second,
-      // stricter check, not an exclusion — which is fine at 88 over 78, and is
-      // why the folded CLI is excluded above instead of given a glob.
+      // A glob entry is an ADDITIVE check, never an exclusion: its files are
+      // held to the glob AND go on counting in the global number. That is why
+      // the CLI fold parked src/cli/ in `exclude` instead of handing it a glob
+      // of 0 — an exclusion was the only thing that could keep the then-78
+      // global measuring its pre-fold file set. This is the re-ratchet that
+      // exclusion was placed for, so src/cli/ comes back in with a floor.
+      //
+      // Measured on main, coverage-merge of run 33328955194 (the fold commit),
+      // 94.51 global without the CLI; the CLI itself last measured 93.57 as
+      // @vendoai/cli in run 33318885615, one commit earlier, over a src/ whose
+      // 71 files and 66 test files the fold moved across unchanged. A 93.57
+      // sixth of the tree blended into a 94.51 rest cannot land below 93.57, so
+      // the global goes 78 -> 93 and the CLI takes 92 — each keeping the point
+      // or so of slack the ui floor argues for: a floor with no room is a floor
+      // everyone learns to bypass.
+      //
+      // src/apps/** and src/sandbox/** are the app-generation code S11d folded
+      // in, held at the 88 it arrived with so a fold cannot weaken a gate as a
+      // side effect. They do NOT re-ratchet here: the text reporter prints one
+      // row per directory and each of those globs spans several, so the
+      // aggregate the threshold actually checks never appears in the log. They
+      // rise when someone measures them, not before.
       //
       // Off inside a shard, which sees a fraction of the files: coverage-merge
       // replays the blobs and enforces these against the whole suite. This gate
@@ -58,8 +63,9 @@ export default defineConfig({
       thresholds: process.env.VITEST_SHARD
         ? {}
         : {
-            lines: 78,
+            lines: 93,
             "src/apps/**": { lines: 88 },
+            "src/cli/**": { lines: 92 },
             "src/sandbox/**": { lines: 88 },
           },
     },


### PR DESCRIPTION
The fold excluded src/cli from vendo's coverage to keep the 78 floor honest; this puts the CLI back in the measured set and ratchets everything to just below CI's measured numbers (coverage-merge runs 33328955194 / 33329585987):

- vendo global 78 → 93 (measured 94.51 without CLI; blended with the CLI's 93.57 the aggregate cannot fall below 93.57)
- new src/cli/** glob floor 92 (measured 93.57 pre-fold, same files and tests byte-for-byte)
- ui 90 → 92 (measured 93.81)
- core stays 94 (measured 94.97 — already at floor(measured))
- apps/sandbox globs untouched: their per-glob aggregates are not printed by the reporter, so no measured basis to move them

Floors only rise; nothing is lowered. First real enforcement is the post-merge coverage-merge on main, as always.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises the coverage floors for `@vendoai/vendo` and `@vendoai/ui` to match what CI currently measures, and re-includes `src/cli/` in `@vendoai/vendo`'s coverage with its own floor. No published behavior changes — only the thresholds move, and they only rise.

Details:
- `@vendoai/vendo` global line floor goes from 78 to 93.
- New `src/cli/**` glob floor of 92; the CLI previously sat outside the measured set.
- `@vendoai/ui` line floor goes from 90 to 92.
- `@vendoai/core` stays at 94 because it's already at the integer floor of its measurement.
- `src/apps/**` and `src/sandbox/**` globs stay at 88 because the reporter never prints their aggregate check.

<sup>Written for commit cd4c0bb9c41543ca1665b22632668cfc8abe8f52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

