### PR TITLE
ci: ai-dual's vendo lane goes x8 — at x4 it set when ci closed

### DIFF
--- a/.github/workflows/ai-dual.yml
+++ b/.github/workflows/ai-dual.yml
@@ -32,7 +32,11 @@ jobs:
   # SHARDED like test-shards, because unsharded it was the whole PR run's
   # critical path: 31 minutes against every other job's <=9 (main run
   # 32394860278), of which the serial test phase was 27m30s and @vendoai/vendo
-  # alone was 1171s, ui 377s. Same split as the v6 lane — vendo x4, ui x2 — with
+  # alone was 1171s, ui 377s. vendo x8 — twice the v6 lane's x4, because at x4
+  # this cold lane finished last in all five full main runs measured on
+  # 2026-08-30 (worst leg 624s vs test-shards' 489s), so it alone set when the
+  # `ci` check closed; x8 hands the critical path back to test-shards and takes
+  # ~3 minutes off the run for four extra runners. ui x2 as in the v6 lane, with
   # everything else in one `rest` leg, whose own long pole is @vendoai/agents at
   # 320s. `pnpm test:ai7` is still the one-shot a laptop runs; the three halves
   # of it are unrolled below so the last one can shard.
@@ -101,10 +105,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: vendo-1, build: "--filter=@vendoai/vendo", test: "--filter=@vendoai/vendo exec vitest run --shard=1/4" }
-          - { name: vendo-2, build: "--filter=@vendoai/vendo", test: "--filter=@vendoai/vendo exec vitest run --shard=2/4" }
-          - { name: vendo-3, build: "--filter=@vendoai/vendo", test: "--filter=@vendoai/vendo exec vitest run --shard=3/4" }
-          - { name: vendo-4, build: "--filter=@vendoai/vendo", test: "--filter=@vendoai/vendo exec vitest run --shard=4/4" }
+          - { name: vendo-1, build: "--filter=@vendoai/vendo", test: "--filter=@vendoai/vendo exec vitest run --shard=1/8" }
+          - { name: vendo-2, build: "--filter=@vendoai/vendo", test: "--filter=@vendoai/vendo exec vitest run --shard=2/8" }
+          - { name: vendo-3, build: "--filter=@vendoai/vendo", test: "--filter=@vendoai/vendo exec vitest run --shard=3/8" }
+          - { name: vendo-4, build: "--filter=@vendoai/vendo", test: "--filter=@vendoai/vendo exec vitest run --shard=4/8" }
+          - { name: vendo-5, build: "--filter=@vendoai/vendo", test: "--filter=@vendoai/vendo exec vitest run --shard=5/8" }
+          - { name: vendo-6, build: "--filter=@vendoai/vendo", test: "--filter=@vendoai/vendo exec vitest run --shard=6/8" }
+          - { name: vendo-7, build: "--filter=@vendoai/vendo", test: "--filter=@vendoai/vendo exec vitest run --shard=7/8" }
+          - { name: vendo-8, build: "--filter=@vendoai/vendo", test: "--filter=@vendoai/vendo exec vitest run --shard=8/8" }
           - { name: ui-1, build: "--filter=@vendoai/ui", test: "--filter=@vendoai/ui exec vitest run --shard=1/2" }
           - { name: ui-2, build: "--filter=@vendoai/ui", test: "--filter=@vendoai/ui exec vitest run --shard=2/2" }
           # No build filter = the whole tree; this is the leg that carries the


### PR DESCRIPTION
Measured on five consecutive full main runs (2026-08-30): the ai-dual
vendo legs finished last every time, 72–193s after everything else was
done, worst leg 624s against test-shards' 489s. The lane is cold by
construction (flipped lockfile, no cache), so parallelism is the only
lever. x8 matches test-shards' split of the same file set, hands the
critical path back to test-shards, and closes ci ~3 minutes sooner for
four extra runners.

A timing-based splitter was considered and measured first: balancing
test-shards saves 0s while this lane is the long pole, and balancing
this lane at x4 saves less than x8 does. If a splitter ever pays, it is
after this.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increases the ai-dual vendo lane from 4 shards to 8 so this cold lane stops being the job that decides when `ci` closes.

At x4, the vendo lane finished last in five consecutive full main runs, 72–193s after everything else, with a worst leg of 624s vs test-shards' 489s. Matching test-shards' 8-way split of the same file set hands the critical path back to test-shards and closes `ci` about 3 minutes sooner for four extra runners. A timing-based splitter was measured first, but it saves less than this static split until the vendo lane is no longer the long pole.

<sup>Written for commit b96c776c72b3da1ef3d0bd68df069d47c9e8ab7c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1702?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

