### PR TITLE
test(apps): make OOM test hit heap limit before boot budget

### DIFF
--- a/packages/vendo/tests/core/apps/genui/component/screen-errors.test.ts
+++ b/packages/vendo/tests/core/apps/genui/component/screen-errors.test.ts
@@ -306,17 +306,11 @@ export default function S() { while (true) {} return <Text text="never" />; }`);
     expect(error.message).toContain("did not finish inside 2000ms");
   });
 
-  // Quarantined 2026-08-11: deterministic-red on the release workflow's serial
-  // single-runner pass while green on sharded CI — on a loaded runner the 5M-row
-  // allocation can trip the 2000ms boot budget before the per-VM heap limit, so
-  // the error kind races between "budget" and "boot". Root-cause + un-skip
-  // tracked in the follow-up issue; do not delete: this guards engine survival.
-  it.skip("raises an out-of-memory screen as a catchable failure, and the engine survives it", () => {
+  it("raises an out-of-memory screen as a catchable failure, and the engine survives it", () => {
     const error = failsBoot(`
 import { Text } from "@vendo/screen";
 export default function S() {
-  const rows = [];
-  for (let index = 0; index < 5000000; index += 1) rows.push({ index: index, label: "row " + index });
+const rows = new Array(50000000).fill(0); // fill avoids JavaScript loop iterations so the heap limit is exceeded before the boot budget.
   return <Text text={String(rows.length)} />;
 }`);
 


### PR DESCRIPTION
Fixes: #1224

## What
Updates the quarantined OOM test in screen-errors.test.ts by using `.fill` to hit the heap limit before the boot budget expires. Unskips the test.

## Why
Previously a loop was used to allocate a large array one value at a time. Populating such a large array like this meant that the loop duration could exceed the boot budget before the array allocation could exceed the heap limit.

## Verification

- [x] `pnpm typecheck && pnpm lint` green
- [x] The test files covering this change run green

CI is the gate of record — it runs the full suite on this PR. Running whole
package suites locally first is optional. Screenshots are welcome on a UI
change but are not required.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unskips the OOM screen-error test and uses `.fill` to allocate a 50M-element array so the heap limit is hit before the 2000ms boot budget expires. This fixes #1224 by making the test deterministic.

<sup>Written for commit 95d1315f0b87b08c352d20f10fd8c5b3724ca55a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runvendo/vendo/pull/1713?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

